### PR TITLE
Add keyboard shortcuts to Select component.

### DIFF
--- a/client/material/select/option.jsx
+++ b/client/material/select/option.jsx
@@ -1,10 +1,16 @@
 import React from 'react'
+import classnames from 'classnames'
 import styles from './select.css'
 
 class Option extends React.Component {
   render() {
+    const classes = classnames(styles.option, {
+      [styles.hover]: this.props.hoveredValue === this.props.value
+    })
+
     return (
-      <div className={styles.option} onClick={this.props.onOptionChange}>
+      <div className={classes} onClick={this.props.onOptionChange}
+        onMouseOver={this.props.onMouseOver} onMouseMove={this.props.onMouseMove}>
         <span className={styles.optionText}>
           { this.props.text }
         </span>

--- a/client/material/select/select.css
+++ b/client/material/select/select.css
@@ -61,7 +61,7 @@
   height: 48px;
 }
 
-.option:hover {
+.option.hover {
   background-color: grey700;
 }
 

--- a/client/material/select/select.jsx
+++ b/client/material/select/select.jsx
@@ -2,6 +2,7 @@ import React from 'react'
 import TransitionGroup from 'react-addons-css-transition-group'
 import classnames from 'classnames'
 import FontIcon from '../font-icon.jsx'
+import keycode from 'keycode'
 import styles from './select.css'
 
 const transitionNames = {
@@ -20,19 +21,37 @@ class Select extends React.Component {
       isFocused: false,
       isOpened: false,
       value: props.defaultValue,
+      hoveredValue: props.defaultValue,
+      hoverSource: null,
       overlayPosition: null
     }
 
     this._positionNeedsUpdating = false
+    this._mousePositionCache = { x: 0, y: 0 }
+    this._mousePositionOnKeypress = { x: 0, y: 0 }
   }
 
-  componentDidUpdate() {
+  componentDidUpdate(prevProps, prevState) {
     if (this.refs.overlay) {
-      // update the scroll position to center (or at least attempt to) the selected value
-      const valueIndex = this._getValueIndex()
-      const firstDisplayed = this._getFirstDisplayedOptionIndex(
-          valueIndex, React.Children.count(this.props.children))
-      this.refs.overlay.scrollTop = firstDisplayed * 48
+      if (!prevState.isOpened && this.state.isOpened) {
+        // update the scroll position to center (or at least attempt to) the selected value
+        const valueIndex = this._getValueIndex()
+        const firstDisplayed = this._getFirstDisplayedOptionIndex(
+            valueIndex, React.Children.count(this.props.children))
+        this.refs.overlay.scrollTop = firstDisplayed * 48
+      } else if (prevState.hoveredValue > this.state.hoveredValue &&
+        this.state.hoverSource === 'keyup') {
+        const valueIndex = this._getHoveredValueIndex()
+        const firstDisplayed = this._getFirstDisplayedOptionIndexWhileScrollingUp(
+            valueIndex, React.Children.count(this.props.children))
+        this.refs.overlay.scrollTop = firstDisplayed * 48
+      } else if (prevState.hoveredValue < this.state.hoveredValue &&
+        this.state.hoverSource === 'keydown') {
+        const valueIndex = this._getHoveredValueIndex()
+        const firstDisplayed = this._getFirstDisplayedOptionIndexWhileScrollingDown(
+            valueIndex, React.Children.count(this.props.children))
+        this.refs.overlay.scrollTop = firstDisplayed * 48
+      }
     }
   }
 
@@ -72,7 +91,8 @@ class Select extends React.Component {
 
     return (
       <div ref='root' className={classes} tabIndex={this.props.disabled ? undefined : 0}
-          onClick={::this.onOpen} onFocus={::this.onFocus} onBlur={::this.onBlur}>
+          onClick={::this.onOpen} onFocus={::this.onFocus} onBlur={::this.onBlur}
+          onKeyUp={::this.onKeyUp}>
         <span className={styles.value} ref='value'>{displayValue}</span>
         <span className={styles.icon}><FontIcon>arrow_drop_down</FontIcon></span>
       </div>
@@ -98,6 +118,9 @@ class Select extends React.Component {
 
     const options = React.Children.map(this.props.children, child => {
       return React.cloneElement(child, {
+        hoveredValue: this.state.hoveredValue,
+        onMouseOver: (event) => this.onMouseOver(event, child.props.value),
+        onMouseMove: (event) => this.onMouseMove(event),
         onOptionChange: () => this.onOptionChanged(child.props.value)
       })
     })
@@ -126,6 +149,32 @@ class Select extends React.Component {
       return 0
     }
     return Math.min(numValues - OPTIONS_SHOWN, valueIndex - midpoint)
+  }
+
+  _getHoveredValueIndex() {
+    let hoveredValueIndex = 0
+    React.Children.forEach(this.props.children, (child, i) => {
+      if (this.state.hoveredValue === child.props.value) {
+        hoveredValueIndex = i
+      }
+    })
+    return hoveredValueIndex
+  }
+
+  _getFirstDisplayedOptionIndexWhileScrollingDown(hoveredValueIndex, numValues) {
+    const bottomPoint = OPTIONS_SHOWN - 1
+    if (hoveredValueIndex < bottomPoint) {
+      return 0
+    }
+    return Math.min(numValues - OPTIONS_SHOWN, hoveredValueIndex - bottomPoint)
+  }
+
+  _getFirstDisplayedOptionIndexWhileScrollingUp(hoveredValueIndex, numValues) {
+    const topPoint = numValues - OPTIONS_SHOWN
+    if (hoveredValueIndex > topPoint) {
+      return topPoint
+    }
+    return Math.max(0, hoveredValueIndex)
   }
 
   focus() {
@@ -161,6 +210,66 @@ class Select extends React.Component {
 
   onOptionChanged(value) {
     this.setState({ value, isOpened: false })
+  }
+
+  onMouseOver(event, value) {
+    if (event.clientX !== this._mousePositionOnKeypress.x ||
+      event.clientY !== this._mousePositionOnKeypress.y) {
+      this.setState({ hoveredValue: value, hoverSource: 'mouseover' })
+    }
+  }
+
+  onMouseMove(event) {
+    this._mousePositionCache = { x: event.clientX, y: event.clientY }
+  }
+
+  onKeyUp(event) {
+    switch (event.keyCode) {
+      case keycode('esc'):
+        if (this.state.isOpened) {
+          this.onClose()
+          event.stopPropagation()
+        }
+        break
+      case keycode('space'):
+      case keycode('enter'):
+        if (!this.state.isOpened) {
+          this.onOpen()
+        } else {
+          this.onOptionChanged(this.state.hoveredValue)
+          this.onClose()
+        }
+        event.stopPropagation()
+        break
+      case keycode('up'):
+        if (!this.state.isOpened) {
+          this.onOpen()
+        } else {
+          if (this.state.hoveredValue > 1) {
+            this.setState({ hoveredValue: this.state.hoveredValue - 1, hoverSource: 'keyup' })
+          }
+          this._mousePositionOnKeypress = {
+            x: this._mousePositionCache.x,
+            y: this._mousePositionCache.y
+          }
+        }
+        event.stopPropagation()
+        break
+      case keycode('down'):
+        if (!this.state.isOpened) {
+          this.onOpen()
+        } else {
+          if (this.state.hoveredValue < React.Children.count(this.props.children)) {
+            this.setState({ hoveredValue: this.state.hoveredValue + 1, hoverSource: 'keydown' })
+          }
+          this._mousePositionOnKeypress = {
+            x: this._mousePositionCache.x,
+            y: this._mousePositionCache.y
+          }
+        }
+        event.stopPropagation()
+        break
+    }
   }
 }
 

--- a/client/settings/settings.jsx
+++ b/client/settings/settings.jsx
@@ -33,7 +33,7 @@ class Settings extends React.Component {
       <div role='dialog' className={styles.contents}>
         <h4 className={styles.title}>Settings</h4>
         <div className={styles.body}>
-          <Select defaultValue={2}>
+          <Select defaultValue={1}>
             <Option value={1} text='Menu option 1' />
             <Option value={2} text='Menu option 2' />
             <Option value={3} text='Menu option 3' />


### PR DESCRIPTION
Things missing from this commit:
- handle scrolling while key is pressed down
- figure out why clicking on the scroll bar loses keyboard focus
- decide what the Tab key should do, if anything
- add ability to search items
- fix the small bug when scrolling with up/down arrows while the scroll
  bar is in non-default position
