### PR TITLE
Open a snackbar when successfully updated the permissions.

### DIFF
--- a/client/admin/action-creators.js
+++ b/client/admin/action-creators.js
@@ -65,8 +65,6 @@ export function setPermissions(username, permissions) {
           .then(permissions => {
             dispatch(openSnackbar({ message: 'Saved!' }))
             return permissions
-          }, error => {
-            throw new Error('Error while setting the permissions: ' + error)
           }),
       meta: { username, permissions },
     })

--- a/client/admin/permissions-reducer.js
+++ b/client/admin/permissions-reducer.js
@@ -29,7 +29,6 @@ const handlers = {
   [ADMIN_GET_PERMISSIONS](state, action) {
     if (action.error) {
       const data = {
-        lastUpdated: Date.now(),
         lastError: action.payload,
         isRequesting: false,
       }
@@ -52,7 +51,6 @@ const handlers = {
   [ADMIN_SET_PERMISSIONS](state, action) {
     if (action.error) {
       const data = {
-        lastUpdated: Date.now(),
         lastError: action.payload,
         isRequesting: false,
       }


### PR DESCRIPTION
Otherwise, display an error.
