### PR TITLE
Cleanup a couple of pieces of state after logging in.

### DIFF
--- a/client/lobbies/lobby-state-reducer.js
+++ b/client/lobbies/lobby-state-reducer.js
@@ -3,6 +3,7 @@ import keyedReducer from '../reducers/keyed-reducer'
 import {
   LOBBIES_GET_STATE_BEGIN,
   LOBBIES_GET_STATE,
+  NETWORK_SITE_CONNECTED,
 } from '../actions'
 
 export const LobbyState = new Record({
@@ -31,5 +32,9 @@ export default keyedReducer(new Map(), {
       error: action.error ? action.payload : null,
       isRequesting: false,
     }))
+  },
+
+  [NETWORK_SITE_CONNECTED](state, action) {
+    return new LobbyState()
   },
 })

--- a/client/whispers/whisper-reducer.js
+++ b/client/whispers/whisper-reducer.js
@@ -12,6 +12,7 @@ import {
   WHISPERS_UPDATE_USER_ACTIVE,
   WHISPERS_UPDATE_USER_IDLE,
   WHISPERS_UPDATE_USER_OFFLINE,
+  NETWORK_SITE_CONNECTED,
 } from '../actions'
 import {
   ChatMessage,
@@ -160,5 +161,9 @@ export default keyedReducer(new WhisperState(), {
         text: msg.data.text,
       }))).concat(messages)
     })
-  }
+  },
+
+  [NETWORK_SITE_CONNECTED](state, action) {
+    return new WhisperState()
+  },
 })


### PR DESCRIPTION
This fixes two very minor bugs. First, when logging out from a lobby and
you log back in, you get a message that lobby already exists, even though
it doesn't. Second, when logging out from whispers and logging back in,
all your whisper sessions persist from when you were logged in even though
we fetch a fresh list of whisper sessions from the database.
