### PR TITLE
Don't try to deactivate a channel if we were not in that channel.

### DIFF
--- a/client/chat/channel.jsx
+++ b/client/chat/channel.jsx
@@ -180,14 +180,17 @@ export default class ChatChannelView extends React.Component {
       this.props.dispatch(retrieveInitialMessageHistory(routeChannel))
       this.props.dispatch(activateChannel(routeChannel))
     }
-    if (prevProps.routeParams.channel &&
+    if (this.props.chat.byName.has(prevProps.routeParams.channel) &&
+        prevProps.routeParams.channel &&
         prevProps.routeParams.channel !== routeChannel) {
       this.props.dispatch(deactivateChannel(prevProps.routeParams.channel))
     }
   }
 
   componentWillUnmount() {
-    this.props.dispatch(deactivateChannel(this.props.routeParams.channel))
+    if (this._isInChannel()) {
+      this.props.dispatch(deactivateChannel(this.props.routeParams.channel))
+    }
   }
 
   renderJoinChannel() {


### PR DESCRIPTION
An easy way to reproduce a minor bug that this patch fixes: try to log out
from a non-existing channel.
