### PR TITLE
Support multi-instance psi and handling pre-existing games

### DIFF
--- a/client/active-game/active-game-reducer.js
+++ b/client/active-game/active-game-reducer.js
@@ -17,8 +17,8 @@ export default keyedReducer(new ActiveGame(), {
   [PSI_GAME_STATUS](state, action) {
     if (action.payload.state === 'unknown' || action.payload.state === 'finished') {
       return state.set('isActive', false)
+    } else {
+      return state.set('isActive', true)
     }
-
-    return state
   }
 })

--- a/client/lobbies/game-client-reducer.js
+++ b/client/lobbies/game-client-reducer.js
@@ -20,13 +20,16 @@ export default keyedReducer(new GameClient(), {
       return new GameClient()
     }
 
-    return new GameClient({ gameId: action.payload })
+    return state
   },
 
   [PSI_GAME_STATUS](state, action) {
-    return state.set('status', new GameStatus({
-      state: action.payload.state,
-      extra: action.payload.extra ? Immutable.fromJS(action.payload.extra) : null,
-    }))
+    return new GameClient({
+      gameId: action.payload.id,
+      status: new GameStatus({
+        state: action.payload.state,
+        extra: action.payload.extra ? Immutable.fromJS(action.payload.extra) : null,
+      })
+    })
   },
 })

--- a/client/lobbies/socket-handlers.js
+++ b/client/lobbies/socket-handlers.js
@@ -189,15 +189,16 @@ export default function registerModule({ siteSocket, psiSocket }) {
     })
   })
 
-  psiSocket.registerRoute('/game/status', (route, event) => {
+  psiSocket.registerRoute('/game/status/:origin', (route, event) => {
     dispatch((dispatch, getState) => {
-      const { gameClient } = getState()
-      if (gameClient.gameId === event.id) {
-        dispatch({ type: PSI_GAME_STATUS, payload: event })
+      const { auth: { user } } = getState()
 
-        if (event.state === 'playing') {
+      for (const status of event.filter(x => x.user === user.name)) {
+        dispatch({ type: PSI_GAME_STATUS, payload: status })
+
+        if (status.state === 'playing') {
           siteSocket.invoke('/lobbies/gameLoaded')
-        } else if (event.state === 'error') {
+        } else if (status.state === 'error') {
           siteSocket.invoke('/lobbies/loadFailed')
         }
       }


### PR DESCRIPTION
Necessary changes to work with https://github.com/tec27/shieldbattery/pull/92

I figured it would make sense to add another action for cases when game exists but was started from somewhere else - though that action is currently handled same as PSI_GAME_LAUNCH so it might be pointless?
Anyways, it turns out that psi sends a single status message with state "launching" before it even reports that the game was succesfully started. Before that message was just not handled, but with these changes it makes the client think that every game was started by somewhere else and causes dispatching "incorrect" PSI_GAME_EXISTING. 

What to do?
