### PR TITLE
Trim whitespace from emails in both beta signups and account creation.

### DIFF
--- a/server/api/invites.js
+++ b/server/api/invites.js
@@ -17,7 +17,7 @@ export default function(router) {
 function* createInvite(next) {
   const b = this.request.body
   const invite = {
-    email: b.email,
+    email: b.email.trim(),
     teamliquidName: b.teamliquidName,
     os: b.os,
     browser: b.browser,

--- a/server/api/users.js
+++ b/server/api/users.js
@@ -32,7 +32,8 @@ function* find(next) {
 
 const bcryptHash = thenify(bcrypt.hash)
 function* createUser(next) {
-  const { username, email, password } = this.request.body
+  const { username, password } = this.request.body
+  const email = this.request.body.email.trim()
   const { token } = this.query
 
   if (!token) {


### PR DESCRIPTION
Not sure should we trim spaces _inside_ the email as well (I know of at least one person who entered a space in a middle of his email). In that case we should probably adjust email validator to not allow spaces at all. Although this article[0] says that spaces are allowed under some special conditions, so we probably don't want to do that.

[0] - https://en.wikipedia.org/wiki/Email_address#Local_part
