### PR TITLE
Add user IP tracking on each request.

### DIFF
--- a/app.js
+++ b/app.js
@@ -25,7 +25,7 @@ import logMiddleware from './server/logging/log-middleware'
 import secureHeaders from './server/security/headers'
 import secureJson from './server/security/json'
 import sessionMiddleware from './server/session/middleware'
-import userIpsMiddleware from './server/user-ips/middleware'
+import userIpsMiddleware from './server/network/user-ips-middleware'
 import views from 'koa-views'
 
 import pingRegistry from './server/rally-point/ping-registry'

--- a/migrations/20161219063920-add-user-ip-counter.js
+++ b/migrations/20161219063920-add-user-ip-counter.js
@@ -1,0 +1,13 @@
+exports.up = function(db) {
+  return db.runSql('TRUNCATE user_ips;')
+    .then(() => {
+      return db.runSql('ALTER TABLE user_ips ADD COLUMN user_ip_counter integer NOT NULL;')
+    }).then(() => {
+      return db.addIndex('user_ips', 'user_ips_unique_user_ip_counter_index',
+          ['user_id', 'ip_address', 'user_ip_counter'])
+    })
+}
+
+exports.down = function(db) {
+  return db.runSql('ALTER TABLE user_ips DROP COLUMN user_ip_counter;')
+}

--- a/server/models/user-ips.js
+++ b/server/models/user-ips.js
@@ -1,35 +1,58 @@
 import db from '../db'
 
+const MAX_RETRIES = 5
+
 export async function updateOrInsertUserIp(userId, ipAddress) {
   const { client, done } = await db()
+  const curDate = new Date()
   const anHourAgo = new Date()
   anHourAgo.setHours(anHourAgo.getHours() - 1)
 
   try {
-    const result = await client.queryPromise(
-        `SELECT * FROM user_ips
-        WHERE user_id = $1 AND ip_address = $2 AND last_used >= $3
-        ORDER BY last_used DESC`,
-        [ userId, ipAddress, anHourAgo ])
+    let caughtErr
+    // Attempt to get a row created/updated for this user/IP combo. We decide whether to insert or
+    // update based on the results of a SELECT, but since no locks are present, other requests could
+    // interleave for a user and insert/update a row in the meantime. If they do, the keys present
+    // in the table will cause our request to fail. At that point, we'll re-do the SELECT and retry
+    // our logic. If we fail MAX_RETRIES times, we just give up (because this really isn't a life or
+    // death thing)
+    for (let i = 0; i < MAX_RETRIES; i++) {
+      try {
+        const result = await client.queryPromise(
+            `SELECT * FROM user_ips
+            WHERE user_id = $1 AND ip_address = $2
+            ORDER BY user_ip_counter DESC`,
+            [ userId, ipAddress ])
 
-    if (result.rows.length > 0) {
-      // This user has already made a request within one hour to our website with this ip address
-      return client.queryPromise(
-        `UPDATE user_ips SET last_used = $5
-        WHERE user_id = $1 AND ip_address = $2 AND first_used = $3 AND last_used = $4`,
-        [
-          result.rows[0].user_id,
-          result.rows[0].ip_address,
-          result.rows[0].first_used,
-          result.rows[0].last_used,
-          new Date(),
-        ])
-    } else {
-      // We don't have a record of this user visiting with this IP address in the last hour
-      return client.queryPromise(
-          'INSERT INTO user_ips (user_id, ip_address, first_used, last_used) SELECT $1, $2, $3, $4',
-          [ userId, ipAddress, new Date(), new Date() ])
+        if (result.rows.length > 0 && result.rows[0].last_used > anHourAgo) {
+          // This user has already made a request with this IP address within the last hour, update
+          // the previous entry
+          return await client.queryPromise(
+            `UPDATE user_ips SET last_used = $1
+            WHERE user_id = $2 AND ip_address = $3 AND user_ip_counter = $4 AND last_used < $5`,
+            [
+              curDate,
+              result.rows[0].user_id,
+              result.rows[0].ip_address,
+              result.rows[0].user_ip_counter,
+              curDate,
+            ])
+        } else {
+          // We don't have a record of this user visiting with this IP address in the last hour,
+          // insert a new row with an increased counter (if the IP previously existed for this
+          // user), or with counter = 0 otherwise
+          const counter = result.rows.length > 0 ? (result.rows[0].user_ip_counter + 1) : 0
+          return await client.queryPromise(
+              `INSERT INTO user_ips (user_id, ip_address, first_used, last_used, user_ip_counter)
+              VALUES ($1, $2, $3, $4, $5)`,
+              [ userId, ipAddress, curDate, curDate, counter ])
+        }
+      } catch (err) {
+        caughtErr = err
+      }
     }
+
+    throw caughtErr
   } finally {
     done()
   }

--- a/server/network/user-ips-middleware.js
+++ b/server/network/user-ips-middleware.js
@@ -1,18 +1,16 @@
 // Middleware that tracks user's ip addresses over time. Used to make moderatoring the website
 // easier; nothing nefarious, we promise!
-import log from '../logging/logger'
 import { updateOrInsertUserIp } from '../models/user-ips'
 
 // This middleware must be placed *after* the session middleware in the chain of middlewares
 export default function() {
-  return async function userIps(ctx, next) {
+  return async (ctx, next) => {
     if (ctx.session.userId) {
-      try {
-        updateOrInsertUserIp(ctx.session.userId, ctx.ip)
-      } catch (err) {
-        log.error('Error inserting user ip record: ' + { err })
-      }
+      updateOrInsertUserIp(ctx.session.userId, ctx.ip).catch(err => {
+        ctx.log.error({ err }, 'Error inserting user ip record')
+      })
     }
+
     await next()
   }
 }

--- a/server/websockets/user-sockets.js
+++ b/server/websockets/user-sockets.js
@@ -1,8 +1,7 @@
 import { List, Map, Set } from 'immutable'
 import { EventEmitter } from 'events'
-
-import log from '../logging/logger'
 import { updateOrInsertUserIp } from '../models/user-ips'
+import getAddress from './get-address'
 
 function defaultDataGetter() {}
 
@@ -106,11 +105,9 @@ export class UserManager extends EventEmitter {
         this.users.get(userName).add(socket)
       }
 
-      try {
-        updateOrInsertUserIp(session.userId, socket.conn.remoteAddress)
-      } catch (err) {
-        log.error('Error inserting user ip record: ' + { err })
-      }
+      updateOrInsertUserIp(session.userId, getAddress(socket.conn.request)).catch(() => {
+        // Can't log without creating a context here, so we just drop these. Bleh.
+      })
     })
   }
 


### PR DESCRIPTION
There are 3 cases that we differentiate when a user makes a request:
- This user ID / IP combo doesn't exist in our database -> insert new
  record with first_used and last_used set to current time
- User ID / IP combo exists and most recent last_used time is more than 1
  hour -> insert new record with first_used copied from existing record
  and last_used set to current time
- User ID / IP combo exists and most recent last_used time is less than 1
  hour -> update the existing record and set last_used to current time