### PR TITLE
Change the native deps build order in `yarnall` script.

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "postinstall": "install-app-deps",
     "posttest": "npm run lint",
     "test": "mocha -R spec --compilers js:babel-register --recursive --harmony test/",
-    "yarnall": "yarn && cd server && yarn && cd ../app && yarn && cd ../game && yarn"
+    "yarnall": "cd app && yarn && cd ../game && yarn && cd ../server && yarn && cd .. && yarn"
   },
   "build": {
     "appId": "net.shieldbattery.client",


### PR DESCRIPTION
If the app deps are installed after the root ones, we will wind up with
the incorrect binaries for the native module. This commit makes it so the
app deps are installed before the root ones.