### PR TITLE
Force the electron app to only open a single instance in non-dev mode.

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -38,6 +38,7 @@ autoUpdater.logger = logger
 
 // Keep a reference to the window object so that it doesn't get GC'd and closed
 let mainWindow
+export const getMainWindow = () => mainWindow
 
 function applyOriginFilter(curSession, baseUrl) {
   // Modify the origin for all ShieldBattery server requests

--- a/app/index.js
+++ b/app/index.js
@@ -2,4 +2,28 @@ process.env.BABEL_ENV = 'app'
 
 require('babel-register')
 require('babel-polyfill')
-require('./app.js')
+
+const isDev = require('electron-is-dev')
+const app = require('electron').app
+
+let getMainWindow
+
+// Ensure that it's only possible to open a single instance of the application in non-dev mode. If
+// someone tries to open two instances, we just focus the main window
+if (!isDev) {
+  const shouldQuit = app.makeSingleInstance(() => {
+    const mainWindow = getMainWindow()
+    if (mainWindow) {
+      if (mainWindow.isMinimized()) mainWindow.restore()
+      mainWindow.focus()
+    }
+
+    return true
+  })
+
+  if (shouldQuit) {
+    app.quit()
+  } else {
+    getMainWindow = require('./app.js').getMainWindow
+  }
+}


### PR DESCRIPTION
If someone tries to open two instances, we just focus the main window.

Fixes #236 