### PR TITLE
Set the system tray's tooltip to the actual application name.

### DIFF
--- a/app/system-tray.js
+++ b/app/system-tray.js
@@ -11,7 +11,7 @@ export default class SystemTray {
     this.onQuitClick = quitAppFn
 
     this.systemTray = new Tray(NORMAL_ICON)
-    this.systemTray.setToolTip('ShieldBattery')
+    this.systemTray.setToolTip(app.getName())
     this.systemTray.setContextMenu(this.buildContextMenu())
     this.systemTray.on('click', this.onTrayClick)
   }


### PR DESCRIPTION
Makes the icons a bit easier to distinguish when there are more than
one.