### PR TITLE
Correctly handle Korean text ingame

### DIFF
--- a/game/forge/forge.h
+++ b/game/forge/forge.h
@@ -74,7 +74,7 @@ private:
     return static_cast<int>((val * (480.0 / mouse_resolution_height_)) + 0.5);
   }
 
-  
+
 
   // hooks
   static HWND __stdcall CreateWindowExAHook(DWORD dwExStyle, LPCSTR lpClassName,
@@ -99,6 +99,10 @@ private:
   static BOOL __stdcall ReleaseCaptureHook();
   static BOOL __stdcall ShowWindowHook(HWND hwnd, int nCmdShow);
   static SHORT __stdcall GetKeyStateHook(int nVirtKey);
+  static LONG __stdcall GetBitmapBitsHook(HBITMAP hbmp, LONG cbBuffer, LPVOID lpvBits);
+  static HBITMAP __stdcall CreateCompatibleBitmapHook(HDC dc, int width, int height);
+  static BOOL __stdcall DeleteObjectHook(HGDIOBJ object);
+  static int __stdcall GetObjectHook(HGDIOBJ object, int cbBuffer, LPVOID lpvObject);
   static void __stdcall RenderScreenHook();
 
   // callable from JS
@@ -136,6 +140,7 @@ private:
   bool bw_window_active_;
   HWND captured_window_;
   std::unique_ptr<RECT> stored_cursor_rect_;
+  HBITMAP active_bitmap_;
   IndirectDraw* indirect_draw_;
 
   uv_mutex_t event_publish_mutex_;

--- a/game/node-bw/brood_war.cpp
+++ b/game/node-bw/brood_war.cpp
@@ -81,7 +81,7 @@ void __stdcall BroodWar::OnGameLoopIteration() {
 
 static std::string Utf8FromBwCodepage(const char *in) {
   // This is the same check that bw uses.
-  int codepage = GetUserDefaultLangID() == LANG_KOREAN ? 949 : 1252;
+  int codepage = GetUserDefaultLangID() == 0x412 ? 949 : 1252;
   wchar_t buf[512];
   int result = MultiByteToWideChar(codepage, 0, in, -1, buf, 512);
   if (result == 0) {
@@ -96,7 +96,7 @@ static std::string Utf8FromBwCodepage(const char *in) {
 }
 
 static std::string Utf8ToBwCodepage(const char *in) {
-  int codepage = GetUserDefaultLangID() == LANG_KOREAN ? 949 : 1252;
+  int codepage = GetUserDefaultLangID() == 0x412 ? 949 : 1252;
   wchar_t buf[512];
   int result = MultiByteToWideChar(CP_UTF8, 0, in, -1, buf, 512);
   if (result == 0) {


### PR DESCRIPTION
Fixes #341

Hopefully.

There were 2 separate things here to fix
1) LANG_KOREAN apparently wasn't the relevant LangID, it should have just
been the constant 0x412.
2) BW calls GDI text drawing functions to render Korean text, and bitmaps
created under forge have different depth than what BW expects, so that
had to be fixed. I feel these bit depth details change on different
windows versions, since I have the same rendering bug in Xen's wmode, and
I'm quite certain it had worked before. Hopefully the code is robust
enough to handle different Windows defaults.