### PR TITLE
Fix the server error when the ban reason is undefined.

### DIFF
--- a/server/lib/models/bans.js
+++ b/server/lib/models/bans.js
@@ -22,15 +22,12 @@ export async function getBanHistory(userId) {
   }
 }
 
-export async function banUser(userId, bannedBy, banLengthHours, reason) {
+export async function banUser(userId, bannedBy, banLengthHours, reason = null) {
   const { client, done } = await db()
   const startDate = new Date()
   const endDate = new Date()
   endDate.setHours(endDate.getHours() + banLengthHours)
-  const params = [ userId, startDate, endDate, bannedBy ]
-  if (reason) {
-    params.push(reason)
-  }
+  const params = [ userId, startDate, endDate, bannedBy, reason ]
 
   try {
     const result = await client.queryPromise(


### PR DESCRIPTION
Apparently, node-pg only translates JS `null` values to SQL `NULL`.