### PR TITLE
Fix some of the things that were missed in the map pools PR.

### DIFF
--- a/server/lib/api/matchmakingMapPools.js
+++ b/server/lib/api/matchmakingMapPools.js
@@ -55,8 +55,8 @@ async function setNewMapPool(ctx, next) {
     throw new httpErrors.BadRequest('invalid matchmaking type')
   } else if (!Array.isArray(maps) || maps.length < 1) {
     throw new httpErrors.BadRequest('maps must be a non-empty array')
-  } else if (!startDate || !Number.isInteger(startDate) || startDate < 0) {
-    throw new httpErrors.BadRequest('startDate must be a valid timestamp value')
+  } else if (!startDate || !Number.isInteger(startDate) || startDate < Date.now()) {
+    throw new httpErrors.BadRequest('startDate must be a valid timestamp value in the future')
   }
 
   await addMapPool(matchmakingType, maps, new Date(startDate))
@@ -70,9 +70,12 @@ async function getCurrent(ctx, next) {
     throw new httpErrors.BadRequest('invalid matchmaking type')
   }
 
-  const maps = await getCurrentMapPool(matchmakingType)
-  if (!maps) {
+  const mapPool = await getCurrentMapPool(matchmakingType)
+  if (!mapPool) {
     throw new httpErrors.NotFound('no matchmaking map pool for this type')
   }
-  ctx.body = await mapInfo(...maps)
+  ctx.body = {
+    ...mapPool,
+    maps: await mapInfo(...mapPool.maps),
+  }
 }

--- a/server/lib/models/matchmaking-map-pools.js
+++ b/server/lib/models/matchmaking-map-pools.js
@@ -5,7 +5,7 @@ export async function getMapPoolHistory(matchmakingType, limit, pageNumber) {
     SELECT start_date, maps
     FROM matchmaking_map_pools
     WHERE matchmaking_type = $1
-    ORDER BY start_date
+    ORDER BY start_date DESC
     LIMIT $2
     OFFSET $3
   `
@@ -43,18 +43,21 @@ export async function addMapPool(matchmakingType, maps, startDate) {
 
 export async function getCurrentMapPool(matchmakingType) {
   const query = `
-    SELECT maps
+    SELECT id, maps
     FROM matchmaking_map_pools
-    WHERE matchmaking_type = $1
+    WHERE matchmaking_type = $1 AND start_date <= $2
     ORDER BY start_date DESC
     LIMIT 1
   `
-  const params = [matchmakingType]
+  const params = [matchmakingType, new Date()]
 
   const { client, done } = await db()
   try {
     const result = await client.query(query, params)
-    return result.rows.length > 0 ? result.rows[0].maps.map(map => map.toString('hex')) : null
+    return result.rows.length > 0 ? {
+      id: result.rows[0].id,
+      maps: result.rows[0].maps.map(map => map.toString('hex')),
+    } : null
   } finally {
     done()
   }


### PR DESCRIPTION
- properly gets the current map pool (filters map pools in the future)
- returns ID of a map pool when fetching the current map pool
- throws an error when trying to set the startDate in the past
- order the map pool history in descending order (newer first)