### PR TITLE
Fix and improve lobby tests.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -67,7 +67,7 @@
     "max-depth": 0,
     "max-len": [2, 100],
     "max-nested-callbacks": [2, 5],
-    "max-params": [2, 7],
+    "max-params": [2, 8],
     "max-statements": 0,
     "new-cap": 0,
     "new-parens": 2,

--- a/client/lobbies/action-creators.js
+++ b/client/lobbies/action-creators.js
@@ -32,12 +32,13 @@ import {
   LOBBY_START_COUNTDOWN,
 } from '../actions'
 
-export const createLobby = (name, map, gameType, gameSubType) =>
+export const createLobby = (name, map, gameType, gameSubType, allowObservers = true) =>
   createSiteSocketAction(LOBBY_CREATE_BEGIN, LOBBY_CREATE, '/lobbies/create', {
     name,
     map,
     gameType,
     gameSubType,
+    allowObservers,
   })
 
 export const joinLobby = name =>

--- a/server/lib/lobbies/lobby.js
+++ b/server/lib/lobbies/lobby.js
@@ -136,9 +136,7 @@ export function findAvailableSlot(lobby) {
       const [teamIndex, observerTeam] = getObserverTeam(lobby)
       // Find the first available slot in the observer team
       const slotIndex = observerTeam.slots.findIndex(slot => slot.type === 'open')
-      return slotIndex !== undefined
-        ? [teamIndex, slotIndex, observerTeam.slots.get(slotIndex)]
-        : [-1, -1]
+      return slotIndex !== -1 ? [teamIndex, slotIndex, observerTeam.slots.get(slotIndex)] : [-1, -1]
     } else {
       // There is no available slot in the lobby
       return [-1, -1]
@@ -172,7 +170,16 @@ export function findAvailableSlot(lobby) {
 }
 
 // Creates a new lobby, and an initial host player in the first slot.
-export function create(name, map, gameType, gameSubType = 0, numSlots, hostName, hostRace = 'r') {
+export function create(
+  name,
+  map,
+  gameType,
+  gameSubType = 0,
+  numSlots,
+  hostName,
+  hostRace = 'r',
+  allowObservers,
+) {
   // When creating a lobby, we first create all the individual slots for the lobby, and then we
   // distribute each of the slots into their respective teams. This distribution of slots shouldn't
   // change at all during the lifetime of a lobby, except when creating/deleting observer slots,
@@ -237,8 +244,8 @@ export function create(name, map, gameType, gameSubType = 0, numSlots, hostName,
     })
     .toList()
 
-  if (gameType === 'melee') {
-    const observerSlots = Range(slots.size, 8).map(() => Slots.createOpen()).toList()
+  if (gameType === 'melee' && allowObservers) {
+    const observerSlots = Range(slots.size, 8).map(() => Slots.createClosed()).toList()
     const observerTeam = new Team({
       name: 'Observers',
       isObserver: true,

--- a/server/lib/wsapi/lobbies.js
+++ b/server/lib/wsapi/lobbies.js
@@ -143,7 +143,7 @@ export class LobbyApi {
     }),
   )
   async create(data, next) {
-    const { name, map, gameType, gameSubType } = data.get('body')
+    const { name, map, gameType, gameSubType, allowObservers } = data.get('body')
     const user = this.getUser(data)
     const client = this.getClient(data)
 
@@ -160,7 +160,16 @@ export class LobbyApi {
     // Team Melee and FFA always provide 8 player slots, divided amongst the teams evenly
     const numSlots = gameType === 'teamMelee' || gameType === 'teamFfa' ? 8 : mapData.slots
 
-    const lobby = Lobbies.create(name, mapData, gameType, gameSubType, numSlots, client.name)
+    const lobby = Lobbies.create(
+      name,
+      mapData,
+      gameType,
+      gameSubType,
+      numSlots,
+      client.name,
+      undefined,
+      allowObservers,
+    )
     if (!activityRegistry.registerActiveClient(user.name, client)) {
       throw new errors.Conflict('user is already active in a gameplay activity')
     }

--- a/server/lib/wsapi/lobbies.js
+++ b/server/lib/wsapi/lobbies.js
@@ -167,7 +167,7 @@ export class LobbyApi {
       gameSubType,
       numSlots,
       client.name,
-      undefined,
+      undefined /* hostRace */,
       allowObservers,
     )
     if (!activityRegistry.registerActiveClient(user.name, client)) {


### PR DESCRIPTION
This commit fixes all the errors in our lobby tests, as well as
refactors some of the tests to be more readable.

There are also a few more tests added to test some of the edge cases
around the lobbies with observers and hidden slots (UMS-related).

As a part of these lobby tests fixes and improvements, there were a
couple of things changed in our lobby code as well:
- fixed a bug when finding the available slot in observer team
- make the presence of observeres in melee lobbies configurable
- make the observer slots 'closed' by default

Fixes #361 