### PR TITLE
Allow resizing the observer team

### DIFF
--- a/app/common/lobbies/index.js
+++ b/app/common/lobbies/index.js
@@ -165,12 +165,14 @@ export function isInObserverTeam(lobby, slot) {
 
 // Checks if the lobby has any slots that can be made observers.
 export function canAddObservers(lobby) {
+  if (!hasObservers(lobby)) return false
   const [, observerTeam] = getObserverTeam(lobby)
   return observerTeam && observerTeam.slots.size < 6
 }
 
 // Checks if the lobby has space for moving observers to players
 export function canRemoveObservers(lobby) {
+  if (!hasObservers(lobby)) return false
   return (
     lobby.teams.find(team => {
       return !team.isObserver && team.slots.size !== team.originalSize

--- a/app/common/lobbies/index.js
+++ b/app/common/lobbies/index.js
@@ -162,3 +162,18 @@ export function isInObserverTeam(lobby, slot) {
   const [, observerTeam] = getObserverTeam(lobby)
   return observerTeam.slots.find(s => s.id === slot.id)
 }
+
+// Checks if the lobby has any slots that can be made observers.
+export function canAddObservers(lobby) {
+  const [, observerTeam] = getObserverTeam(lobby)
+  return observerTeam && observerTeam.slots.size < 6
+}
+
+// Checks if the lobby has space for moving observers to players
+export function canRemoveObservers(lobby) {
+  return (
+    lobby.teams.find(team => {
+      return !team.isObserver && team.slots.size !== team.originalSize
+    }) !== undefined
+  )
+}

--- a/app/common/lobbies/index.js
+++ b/app/common/lobbies/index.js
@@ -151,21 +151,23 @@ export function hasObservers(lobby) {
   return lobby.teams.reduce((hasObserver, team) => hasObserver || team.isObserver, false)
 }
 
-// Returns a [teamIndex, team] tuple if the observer team is found. Should usually be used in
-// conjunction with the `hasObserver` function, so you're sure there is an observer team.
+// Returns a [teamIndex, team] tuple if the observer team is found. If the observer team is not
+// found, it returns a [null, null] tuple, so you should always check the return value of this
+// function to make sure you actually received the observer team
 export function getObserverTeam(lobby) {
-  return lobby.teams.map((team, teamIndex) => [teamIndex, team]).find(([, team]) => team.isObserver)
+  return hasObservers(lobby)
+    ? lobby.teams.map((team, teamIndex) => [teamIndex, team]).find(([, team]) => team.isObserver)
+    : [null, null]
 }
 
 // Checks whether a particular slot is inside the observer team
 export function isInObserverTeam(lobby, slot) {
   const [, observerTeam] = getObserverTeam(lobby)
-  return observerTeam.slots.find(s => s.id === slot.id)
+  return observerTeam && observerTeam.slots.find(s => s.id === slot.id)
 }
 
 // Checks if the lobby has any slots that can be made observers.
 export function canAddObservers(lobby) {
-  if (!hasObservers(lobby)) return false
   const [, observerTeam] = getObserverTeam(lobby)
   return observerTeam && observerTeam.slots.size < 6
 }

--- a/client/actions.js
+++ b/client/actions.js
@@ -131,10 +131,18 @@ export const LOBBY_KICK_PLAYER = 'LOBBY_KICK_PLAYER'
 export const LOBBY_LEAVE_BEGIN = 'LOBBY_LEAVE_BEGIN'
 // The server has responded with success/failure to our lobby leaving
 export const LOBBY_LEAVE = 'LOBBY_LEAVE'
+// We are starting a request to add an additional slot to the observer team
+export const LOBBY_MAKE_OBSERVER_BEGIN = 'LOBBY_MAKE_OBSERVER_BEGIN'
+// The server has responded with success/failure to obs team extension
+export const LOBBY_MAKE_OBSERVER = 'LOBBY_MAKE_OBSERVER'
 // We are starting the process of opening a lobby slot
 export const LOBBY_OPEN_SLOT_BEGIN = 'LOBBY_OPEN_SLOT_BEGIN'
 // The server has responded with success/failure to our opening of a lobby slot
 export const LOBBY_OPEN_SLOT = 'LOBBY_OPEN_SLOT'
+// We are starting a request to remove a slot from the observer team
+export const LOBBY_REMOVE_OBSERVER_BEGIN = 'LOBBY_REMOVE_OBSERVER_BEGIN'
+// The server has responded with success/failure to our request of removing an obs slot
+export const LOBBY_REMOVE_OBSERVER = 'LOBBY_REMOVE_OBSERVER'
 // We are sending a chat message to the server
 export const LOBBY_SEND_CHAT_BEGIN = 'LOBBY_SEND_CHAT_BEGIN'
 // The server has replied with success/failure to our sent chat message
@@ -181,6 +189,8 @@ export const LOBBY_UPDATE_RACE_CHANGE = 'LOBBY_UPDATE_RACE_CHANGE'
 export const LOBBY_UPDATE_SLOT_CHANGE = 'LOBBY_UPDATE_SLOT_CHANGE'
 // A new slot has been created in a lobby we're in (this could indicate player joining)
 export const LOBBY_UPDATE_SLOT_CREATE = 'LOBBY_UPDATE_SLOT_CREATE'
+// One of teams in a lobby has had slots deleted (due to creating/removing obs slots)
+export const LOBBY_UPDATE_SLOTS_DELETED = 'LOBBY_UPDATE_SLOTS_DELETED'
 // Our status has changed, ie. one of our clients either joined or left the lobby
 export const LOBBY_UPDATE_STATUS = 'LOBBY_UPDATE_STATUS'
 

--- a/client/actions.js
+++ b/client/actions.js
@@ -189,8 +189,8 @@ export const LOBBY_UPDATE_RACE_CHANGE = 'LOBBY_UPDATE_RACE_CHANGE'
 export const LOBBY_UPDATE_SLOT_CHANGE = 'LOBBY_UPDATE_SLOT_CHANGE'
 // A new slot has been created in a lobby we're in (this could indicate player joining)
 export const LOBBY_UPDATE_SLOT_CREATE = 'LOBBY_UPDATE_SLOT_CREATE'
-// One of teams in a lobby has had slots deleted (due to creating/removing obs slots)
-export const LOBBY_UPDATE_SLOTS_DELETED = 'LOBBY_UPDATE_SLOTS_DELETED'
+// One of teams in a lobby has had a slot deleted (due to creating/removing obs slots)
+export const LOBBY_UPDATE_SLOT_DELETED = 'LOBBY_UPDATE_SLOT_DELETED'
 // Our status has changed, ie. one of our clients either joined or left the lobby
 export const LOBBY_UPDATE_STATUS = 'LOBBY_UPDATE_STATUS'
 

--- a/client/lobbies/action-creators.js
+++ b/client/lobbies/action-creators.js
@@ -22,8 +22,12 @@ import {
   LOBBY_KICK_PLAYER,
   LOBBY_LEAVE_BEGIN,
   LOBBY_LEAVE,
+  LOBBY_MAKE_OBSERVER_BEGIN,
+  LOBBY_MAKE_OBSERVER,
   LOBBY_OPEN_SLOT_BEGIN,
   LOBBY_OPEN_SLOT,
+  LOBBY_REMOVE_OBSERVER_BEGIN,
+  LOBBY_REMOVE_OBSERVER,
   LOBBY_SEND_CHAT_BEGIN,
   LOBBY_SEND_CHAT,
   LOBBY_SET_RACE_BEGIN,
@@ -70,6 +74,19 @@ export const kickPlayer = slotId =>
 
 export const banPlayer = slotId =>
   createSiteSocketAction(LOBBY_BAN_PLAYER_BEGIN, LOBBY_BAN_PLAYER, '/lobbies/banPlayer', { slotId })
+
+export const makeObserver = slotId =>
+  createSiteSocketAction(LOBBY_MAKE_OBSERVER_BEGIN, LOBBY_MAKE_OBSERVER, '/lobbies/makeObserver', {
+    slotId,
+  })
+
+export const removeObserver = slotId =>
+  createSiteSocketAction(
+    LOBBY_REMOVE_OBSERVER_BEGIN,
+    LOBBY_REMOVE_OBSERVER,
+    '/lobbies/removeObserver',
+    { slotId },
+  )
 
 export const leaveLobby = () =>
   createSiteSocketAction(LOBBY_LEAVE_BEGIN, LOBBY_LEAVE, '/lobbies/leave')

--- a/client/lobbies/closed-slot.jsx
+++ b/client/lobbies/closed-slot.jsx
@@ -10,6 +10,8 @@ export default class ClosedSlot extends React.Component {
     onAddComputer: PropTypes.func,
     onSetRace: PropTypes.func,
     onOpenSlot: PropTypes.func,
+    onMakeObserver: PropTypes.func,
+    onRemoveObserver: PropTypes.func,
     // Indicates if this is a `controlledClosed` type slot
     controlledClosed: PropTypes.bool,
     // In `controlledClosed` slots, indicates if it can be set race to
@@ -17,6 +19,8 @@ export default class ClosedSlot extends React.Component {
     isHost: PropTypes.bool,
     race: PropTypes.string,
     isObserver: PropTypes.bool,
+    canMakeObserver: PropTypes.bool,
+    canRemoveObserver: PropTypes.bool,
   }
 
   renderControls() {
@@ -33,12 +37,28 @@ export default class ClosedSlot extends React.Component {
   }
 
   render() {
-    const { isHost, isObserver, controlledClosed, onAddComputer, onOpenSlot } = this.props
+    const {
+      isHost,
+      isObserver,
+      canMakeObserver,
+      canRemoveObserver,
+      controlledClosed,
+      onAddComputer,
+      onOpenSlot,
+      onMakeObserver,
+      onRemoveObserver,
+    } = this.props
     const slotActions = []
     if (isHost) {
       slotActions.push(['Open slot', onOpenSlot])
       if (!controlledClosed && !isObserver && onAddComputer) {
         slotActions.push(['Add computer', onAddComputer])
+      }
+      if (canMakeObserver) {
+        slotActions.push(['Move to observers', onMakeObserver])
+      }
+      if (canRemoveObserver) {
+        slotActions.push(['Move to players', onRemoveObserver])
       }
     }
 

--- a/client/lobbies/closed-slot.jsx
+++ b/client/lobbies/closed-slot.jsx
@@ -65,11 +65,13 @@ export default class ClosedSlot extends React.Component {
     return (
       <div className={styles.slot}>
         <div className={styles.slotLeft}>
-          <span className={styles.slotEmptyAvatar} />
-          <span className={styles.slotEmptyName}>Closed</span>
+          <div className={styles.slotProfile}>
+            <span className={styles.slotEmptyAvatar} />
+            <span className={styles.slotEmptyName}>Closed</span>
+          </div>
+          {slotActions.length > 0 ? <SlotActions slotActions={slotActions} /> : <div />}
         </div>
         <div className={styles.slotRight}>
-          {slotActions.length > 0 ? <SlotActions slotActions={slotActions} /> : <div />}
           {this.renderControls()}
         </div>
       </div>

--- a/client/lobbies/closed-slot.jsx
+++ b/client/lobbies/closed-slot.jsx
@@ -71,9 +71,7 @@ export default class ClosedSlot extends React.Component {
           </div>
           {slotActions.length > 0 ? <SlotActions slotActions={slotActions} /> : <div />}
         </div>
-        <div className={styles.slotRight}>
-          {this.renderControls()}
-        </div>
+        <div className={styles.slotRight}>{this.renderControls()}</div>
       </div>
     )
   }

--- a/client/lobbies/closed-slot.jsx
+++ b/client/lobbies/closed-slot.jsx
@@ -55,10 +55,10 @@ export default class ClosedSlot extends React.Component {
         slotActions.push(['Add computer', onAddComputer])
       }
       if (canMakeObserver) {
-        slotActions.push(['Move to observers', onMakeObserver])
+        slotActions.push(['Make observer', onMakeObserver])
       }
       if (canRemoveObserver) {
-        slotActions.push(['Move to players', onRemoveObserver])
+        slotActions.push(['Make player', onRemoveObserver])
       }
     }
 

--- a/client/lobbies/lobby-reducer.js
+++ b/client/lobbies/lobby-reducer.js
@@ -17,7 +17,7 @@ import {
   LOBBY_UPDATE_RACE_CHANGE,
   LOBBY_UPDATE_SLOT_CHANGE,
   LOBBY_UPDATE_SLOT_CREATE,
-  LOBBY_UPDATE_SLOTS_DELETED,
+  LOBBY_UPDATE_SLOT_DELETED,
   LOBBY_UPDATE_COUNTDOWN_START,
   LOBBY_UPDATE_COUNTDOWN_TICK,
   LOBBY_UPDATE_COUNTDOWN_CANCELED,
@@ -95,9 +95,9 @@ const infoReducer = keyedReducer(undefined, {
     return state.setIn(['teams', teamIndex, 'slots', slotIndex], new Slot(slot))
   },
 
-  [LOBBY_UPDATE_SLOTS_DELETED](state, action) {
-    const { teamIndex, count } = action.payload
-    return state.updateIn(['teams', teamIndex, 'slots'], slots => slots.skipLast(count))
+  [LOBBY_UPDATE_SLOT_DELETED](state, action) {
+    const { teamIndex, slotIndex } = action.payload
+    return state.deleteIn(['teams', teamIndex, 'slots', slotIndex])
   },
 
   [LOBBY_UPDATE_RACE_CHANGE](state, action) {

--- a/client/lobbies/lobby-reducer.js
+++ b/client/lobbies/lobby-reducer.js
@@ -17,6 +17,7 @@ import {
   LOBBY_UPDATE_RACE_CHANGE,
   LOBBY_UPDATE_SLOT_CHANGE,
   LOBBY_UPDATE_SLOT_CREATE,
+  LOBBY_UPDATE_SLOTS_DELETED,
   LOBBY_UPDATE_COUNTDOWN_START,
   LOBBY_UPDATE_COUNTDOWN_TICK,
   LOBBY_UPDATE_COUNTDOWN_CANCELED,
@@ -43,6 +44,7 @@ export const Team = new Record({
   teamId: null,
   isObserver: false,
   slots: new List(),
+  originalSize: null,
   hiddenSlots: new List(),
 })
 export const LobbyInfo = new Record({
@@ -91,6 +93,11 @@ const infoReducer = keyedReducer(undefined, {
   [LOBBY_UPDATE_SLOT_CREATE](state, action) {
     const { teamIndex, slotIndex, slot } = action.payload
     return state.setIn(['teams', teamIndex, 'slots', slotIndex], new Slot(slot))
+  },
+
+  [LOBBY_UPDATE_SLOTS_DELETED](state, action) {
+    const { teamIndex, count } = action.payload
+    return state.updateIn(['teams', teamIndex, 'slots'], slots => slots.skipLast(count))
   },
 
   [LOBBY_UPDATE_RACE_CHANGE](state, action) {

--- a/client/lobbies/lobby.jsx
+++ b/client/lobbies/lobby.jsx
@@ -1,7 +1,14 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { gameTypeToString } from './game-type'
-import { isUms, findSlotByName, hasOpposingSides, isTeamType } from '../../app/common/lobbies'
+import {
+  isUms,
+  findSlotByName,
+  hasOpposingSides,
+  isTeamType,
+  canRemoveObservers,
+  canAddObservers,
+} from '../../app/common/lobbies'
 import styles from './view.css'
 
 import Card from '../material/card.jsx'
@@ -264,6 +271,8 @@ export default class Lobby extends React.Component {
     onCloseSlot: PropTypes.func,
     onKickPlayer: PropTypes.func,
     onBanPlayer: PropTypes.func,
+    onMakeObserver: PropTypes.func,
+    onRemoveObserver: PropTypes.func,
   }
 
   render() {
@@ -278,12 +287,16 @@ export default class Lobby extends React.Component {
       onCloseSlot,
       onKickPlayer,
       onBanPlayer,
+      onMakeObserver,
+      onRemoveObserver,
     } = this.props
 
     const isLobbyUms = isUms(lobby.gameType)
     const slots = []
     const [, , mySlot] = findSlotByName(lobby, user.name)
     const isHost = mySlot && lobby.host.id === mySlot.id
+    const canAddObsSlots = canAddObservers(lobby)
+    const canRemoveObsSlots = canRemoveObservers(lobby)
     for (let teamIndex = 0; teamIndex < lobby.teams.size; teamIndex++) {
       const currentTeam = lobby.teams.get(teamIndex)
       const isObserver = currentTeam.isObserver
@@ -309,11 +322,15 @@ export default class Lobby extends React.Component {
                     race={race}
                     isHost={isHost}
                     isObserver={isObserver}
+                    canMakeObserver={!isObserver && canAddObsSlots && currentTeam.slots.size > 1}
+                    canRemoveObserver={isObserver && canRemoveObsSlots}
                     onAddComputer={
                       onAddComputer && !isLobbyUms ? () => onAddComputer(id) : undefined
                     }
                     onSwitchClick={onSwitchSlot ? () => onSwitchSlot(id) : undefined}
                     onCloseSlot={onCloseSlot ? () => onCloseSlot(id) : undefined}
+                    onMakeObserver={onMakeObserver ? () => onMakeObserver(id) : undefined}
+                    onRemoveObserver={onRemoveObserver ? () => onRemoveObserver(id) : undefined}
                   />
                 )
               case 'closed':
@@ -323,10 +340,14 @@ export default class Lobby extends React.Component {
                     race={race}
                     isHost={isHost}
                     isObserver={isObserver}
+                    canMakeObserver={!isObserver && canAddObsSlots && currentTeam.slots.size > 1}
+                    canRemoveObserver={isObserver && canRemoveObsSlots}
                     onAddComputer={
                       onAddComputer && !isLobbyUms ? () => onAddComputer(id) : undefined
                     }
                     onOpenSlot={onOpenSlot ? () => onOpenSlot(id) : undefined}
+                    onMakeObserver={onMakeObserver ? () => onMakeObserver(id) : undefined}
+                    onRemoveObserver={onRemoveObserver ? () => onRemoveObserver(id) : undefined}
                   />
                 )
               case 'human':
@@ -337,12 +358,14 @@ export default class Lobby extends React.Component {
                     race={race}
                     isHost={isHost}
                     canSetRace={slot === mySlot && !slot.hasForcedRace}
+                    canMakeObserver={canAddObsSlots && currentTeam.slots.size > 1}
                     hasSlotActions={slot !== mySlot}
                     onSetRace={onSetRace ? race => onSetRace(id, race) : undefined}
                     onOpenSlot={onOpenSlot ? () => onOpenSlot(id) : undefined}
                     onCloseSlot={onCloseSlot ? () => onCloseSlot(id) : undefined}
                     onKickPlayer={onKickPlayer ? () => onKickPlayer(id) : undefined}
                     onBanPlayer={onBanPlayer ? () => onBanPlayer(id) : undefined}
+                    onMakeObserver={onMakeObserver ? () => onMakeObserver(id) : undefined}
                   />
                 )
               case 'observer':
@@ -352,11 +375,13 @@ export default class Lobby extends React.Component {
                     name={name}
                     isHost={isHost}
                     isObserver={true}
+                    canRemoveObserver={isObserver && canRemoveObsSlots}
                     hasSlotActions={slot !== mySlot}
                     onOpenSlot={onOpenSlot ? () => onOpenSlot(id) : undefined}
                     onCloseSlot={onCloseSlot ? () => onCloseSlot(id) : undefined}
                     onKickPlayer={onKickPlayer ? () => onKickPlayer(id) : undefined}
                     onBanPlayer={onBanPlayer ? () => onBanPlayer(id) : undefined}
+                    onRemoveObserver={onRemoveObserver ? () => onRemoveObserver(id) : undefined}
                   />
                 )
               case 'computer':

--- a/client/lobbies/lobby.jsx
+++ b/client/lobbies/lobby.jsx
@@ -301,7 +301,7 @@ export default class Lobby extends React.Component {
       const currentTeam = lobby.teams.get(teamIndex)
       const isObserver = currentTeam.isObserver
       const displayTeamName =
-        isObserver || ((isTeamType(lobby.gameType) || isLobbyUms) && currentTeam.slots.size !== 0)
+        (isTeamType(lobby.gameType) || isLobbyUms || isObserver) && currentTeam.slots.size !== 0
       if (displayTeamName) {
         slots.push(
           <span key={'team' + teamIndex} className={styles.teamName}>

--- a/client/lobbies/open-slot.jsx
+++ b/client/lobbies/open-slot.jsx
@@ -60,10 +60,10 @@ export default class OpenSlot extends React.Component {
         slotActions.push(['Add computer', onAddComputer])
       }
       if (canMakeObserver) {
-        slotActions.push(['Move to observers', onMakeObserver])
+        slotActions.push(['Make observer', onMakeObserver])
       }
       if (canRemoveObserver) {
-        slotActions.push(['Move to players', onRemoveObserver])
+        slotActions.push(['Make player', onRemoveObserver])
       }
     }
 

--- a/client/lobbies/open-slot.jsx
+++ b/client/lobbies/open-slot.jsx
@@ -82,9 +82,7 @@ export default class OpenSlot extends React.Component {
           </div>
           {slotActions.length > 0 ? <SlotActions slotActions={slotActions} /> : <div />}
         </div>
-        <div className={styles.slotRight}>
-          {this.renderControls()}
-        </div>
+        <div className={styles.slotRight}>{this.renderControls()}</div>
       </div>
     )
   }

--- a/client/lobbies/open-slot.jsx
+++ b/client/lobbies/open-slot.jsx
@@ -69,18 +69,20 @@ export default class OpenSlot extends React.Component {
 
     return (
       <div className={styles.slot}>
-        <div
-          className={styles.slotLeftOpen}
-          onMouseEnter={this.onLeftMouseEnter}
-          onMouseLeave={this.onLeftMouseLeave}
-          onClick={onSwitchClick}>
-          <span className={styles.slotEmptyAvatar}>
-            {this.state.isHovered ? <SwapSlotsIcon /> : null}
-          </span>
-          <span className={styles.slotEmptyName}>Open</span>
+        <div className={styles.slotLeft}>
+          <div
+            className={styles.slotProfileOpen}
+            onMouseEnter={this.onLeftMouseEnter}
+            onMouseLeave={this.onLeftMouseLeave}
+            onClick={onSwitchClick}>
+            <span className={styles.slotEmptyAvatar}>
+              {this.state.isHovered ? <SwapSlotsIcon /> : null}
+            </span>
+            <span className={styles.slotEmptyName}>Open</span>
+          </div>
+          {slotActions.length > 0 ? <SlotActions slotActions={slotActions} /> : <div />}
         </div>
         <div className={styles.slotRight}>
-          {slotActions.length > 0 ? <SlotActions slotActions={slotActions} /> : <div />}
           {this.renderControls()}
         </div>
       </div>

--- a/client/lobbies/open-slot.jsx
+++ b/client/lobbies/open-slot.jsx
@@ -19,6 +19,8 @@ export default class OpenSlot extends React.Component {
     isHost: PropTypes.bool,
     race: PropTypes.string,
     isObserver: PropTypes.bool,
+    canMakeObserver: PropTypes.bool,
+    canRemoveObserver: PropTypes.bool,
   }
 
   state = {
@@ -42,16 +44,26 @@ export default class OpenSlot extends React.Component {
     const {
       isHost,
       isObserver,
+      canMakeObserver,
+      canRemoveObserver,
       controlledOpen,
       onAddComputer,
       onSwitchClick,
       onCloseSlot,
+      onMakeObserver,
+      onRemoveObserver,
     } = this.props
     const slotActions = []
     if (isHost) {
       slotActions.push(['Close slot', onCloseSlot])
       if (!controlledOpen && !isObserver && onAddComputer) {
         slotActions.push(['Add computer', onAddComputer])
+      }
+      if (canMakeObserver) {
+        slotActions.push(['Move to observers', onMakeObserver])
+      }
+      if (canRemoveObserver) {
+        slotActions.push(['Move to players', onRemoveObserver])
       }
     }
 

--- a/client/lobbies/player-slot.jsx
+++ b/client/lobbies/player-slot.jsx
@@ -25,6 +25,8 @@ export default class PlayerSlot extends React.Component {
     // Whether or not this slot has slot actions
     hasSlotActions: PropTypes.bool,
     isObserver: PropTypes.bool,
+    canMakeObserver: PropTypes.bool,
+    canRemoveObserver: PropTypes.bool,
   }
 
   renderControls() {
@@ -46,10 +48,14 @@ export default class PlayerSlot extends React.Component {
       isComputer,
       avatarImage,
       isHost,
+      canMakeObserver,
+      canRemoveObserver,
       hasSlotActions,
       onCloseSlot,
       onKickPlayer,
       onBanPlayer,
+      onMakeObserver,
+      onRemoveObserver,
     } = this.props
     const avatar = isComputer ? (
       <ComputerAvatar className={styles.slotAvatar} />
@@ -66,6 +72,12 @@ export default class PlayerSlot extends React.Component {
         slotActions.push(['Ban player', onBanPlayer])
       } else {
         slotActions.push(['Remove computer', onKickPlayer])
+      }
+      if (canMakeObserver) {
+        slotActions.push(['Move to observers', onMakeObserver])
+      }
+      if (canRemoveObserver) {
+        slotActions.push(['Move to players', onRemoveObserver])
       }
     }
 

--- a/client/lobbies/player-slot.jsx
+++ b/client/lobbies/player-slot.jsx
@@ -74,10 +74,10 @@ export default class PlayerSlot extends React.Component {
         slotActions.push(['Remove computer', onKickPlayer])
       }
       if (canMakeObserver) {
-        slotActions.push(['Move to observers', onMakeObserver])
+        slotActions.push(['Make observer', onMakeObserver])
       }
       if (canRemoveObserver) {
-        slotActions.push(['Move to players', onRemoveObserver])
+        slotActions.push(['Make player', onRemoveObserver])
       }
     }
 

--- a/client/lobbies/player-slot.jsx
+++ b/client/lobbies/player-slot.jsx
@@ -84,13 +84,13 @@ export default class PlayerSlot extends React.Component {
     return (
       <div className={styles.slot}>
         <div className={styles.slotLeft}>
-          {avatar}
-          <span className={styles.slotName}>{displayName}</span>
-        </div>
-        <div className={styles.slotRight}>
+          <div className={styles.slotProfile}>
+            {avatar}
+            <span className={styles.slotName}>{displayName}</span>
+          </div>
           {slotActions.length > 0 ? <SlotActions slotActions={slotActions} /> : <div />}
-          {this.renderControls()}
         </div>
+        <div className={styles.slotRight}>{this.renderControls()}</div>
       </div>
     )
   }

--- a/client/lobbies/socket-handlers.js
+++ b/client/lobbies/socket-handlers.js
@@ -19,7 +19,7 @@ import {
   LOBBY_UPDATE_RACE_CHANGE,
   LOBBY_UPDATE_SLOT_CHANGE,
   LOBBY_UPDATE_SLOT_CREATE,
-  LOBBY_UPDATE_SLOTS_DELETED,
+  LOBBY_UPDATE_SLOT_DELETED,
   LOBBY_UPDATE_STATUS,
 } from '../actions'
 import { NEW_CHAT_MESSAGE } from '../../app/common/ipc-constants'
@@ -168,8 +168,8 @@ const eventToAction = {
     payload: event,
   }),
 
-  slotsDeleted: (name, event) => ({
-    type: LOBBY_UPDATE_SLOTS_DELETED,
+  slotDeleted: (name, event) => ({
+    type: LOBBY_UPDATE_SLOT_DELETED,
     payload: event,
   }),
 

--- a/client/lobbies/socket-handlers.js
+++ b/client/lobbies/socket-handlers.js
@@ -19,6 +19,7 @@ import {
   LOBBY_UPDATE_RACE_CHANGE,
   LOBBY_UPDATE_SLOT_CHANGE,
   LOBBY_UPDATE_SLOT_CREATE,
+  LOBBY_UPDATE_SLOTS_DELETED,
   LOBBY_UPDATE_STATUS,
 } from '../actions'
 import { NEW_CHAT_MESSAGE } from '../../app/common/ipc-constants'
@@ -164,6 +165,11 @@ const eventToAction = {
 
   slotChange: (name, event) => ({
     type: LOBBY_UPDATE_SLOT_CHANGE,
+    payload: event,
+  }),
+
+  slotsDeleted: (name, event) => ({
+    type: LOBBY_UPDATE_SLOTS_DELETED,
     payload: event,
   }),
 

--- a/client/lobbies/view.css
+++ b/client/lobbies/view.css
@@ -1,7 +1,7 @@
 @value colorTextSecondary, colorTextFaint, colorDividers from '../styles/colors.css';
 @value colorTextPrimary, blue100, blue200, grey700 from '../styles/colors.css';
 @value row, col, grow, shrink, exact, justifySpaceBetween, itemsCenter from '../styles/flex.css';
-@value justifyStart from '../styles/flex.css';
+@value justifyStart, justifyEnd, wrap from '../styles/flex.css';
 @value subhead, headline, body1, body2, singleLine from '../styles/typography.css';
 @value fastOutSlowIn from '../material/curve-constants.css';
 @value shadow1dp from '../material/shadows.css';
@@ -41,8 +41,24 @@
 
 .slots {
   composes: exact;
+  width: 100%;
   padding-top: 8px;
   padding-bottom: 8px;
+}
+
+.regularSlots {
+  composes: col;
+  width: 100%;
+}
+
+.obsSlots {
+  composes: row wrap;
+  width: 100%;
+}
+
+.obsSlots > .slot {
+  width: 50%;
+  padding-right: 8px;
 }
 
 .teamName {
@@ -59,6 +75,7 @@
 
 .slot {
   composes: row itemsCenter justifyStart;
+  width: 100%;
   height: 40px;
 }
 
@@ -70,12 +87,25 @@
 }
 
 .slotLeft {
-  composes: row grow itemsCenter;
-  max-width: 33.33%;
+  composes: row justifySpaceBetween;
 }
 
-.slotLeftOpen {
-  composes: slotLeft;
+.regularSlots .slotLeft {
+  width: 50%;
+  padding-right: 8px;
+}
+
+.obsSlots .slotLeft {
+  width: 100%;
+}
+
+.slotProfile {
+  composes: row grow itemsCenter;
+  margin-right: 8px;
+}
+
+.slotProfileOpen {
+  composes: slotProfile;
   cursor: pointer;
 }
 
@@ -87,9 +117,16 @@
 }
 
 .slotRight {
-  composes: row exact itemsCenter justifySpaceBetween;
-  width: 66.66%;
+  composes: row exact itemsCenter justifyEnd;
+  width: 50%;
   min-width: 156px;
+  padding-right: 64px;
+}
+
+.obsSlots .slotRight {
+  width: 0px;
+  min-width: 0px;
+  padding-right: 0px;
 }
 
 .slotRace {

--- a/client/lobbies/view.jsx
+++ b/client/lobbies/view.jsx
@@ -11,6 +11,8 @@ import {
   closeSlot,
   kickPlayer,
   banPlayer,
+  makeObserver,
+  removeObserver,
   leaveLobby,
   setRace,
   startCountdown,
@@ -103,6 +105,8 @@ export default class LobbyView extends React.Component {
           onCloseSlot={this.onCloseSlot}
           onKickPlayer={this.onKickPlayer}
           onBanPlayer={this.onBanPlayer}
+          onMakeObserver={this.onMakeObserver}
+          onRemoveObserver={this.onRemoveObserver}
           onStartGame={this.onStartGame}
           onSendChatMessage={this.onSendChatMessage}
         />
@@ -207,6 +211,14 @@ export default class LobbyView extends React.Component {
 
   onBanPlayer = slotId => {
     this.props.dispatch(banPlayer(slotId))
+  }
+
+  onMakeObserver = slotId => {
+    this.props.dispatch(makeObserver(slotId))
+  }
+
+  onRemoveObserver = slotId => {
+    this.props.dispatch(removeObserver(slotId))
   }
 
   onSetRace = (slotId, race) => {

--- a/server/lib/lobbies/lobby.js
+++ b/server/lib/lobbies/lobby.js
@@ -564,7 +564,6 @@ export function removeObserver(lobby, slotIndex) {
   // We create a new slot in the team and move human to it, or just replicate the slot there,
   // and then delete the original slot.
   if (slot.type === 'observer') {
-    console.assert(!isUms(lobby.gameType))
     const newSlot = Slots.createOpen()
     lobby = lobby.setIn(['teams', newTeamIndex, 'slots'], newTeam.slots.push(newSlot))
     lobby = movePlayerToSlot(lobby, obsTeamIndex, slotIndex, newTeamIndex, newTeam.slots.size)

--- a/server/lib/lobbies/lobby.js
+++ b/server/lib/lobbies/lobby.js
@@ -43,6 +43,10 @@ export function hasControlledOpens(gameType) {
   return gameType === 'teamMelee' || gameType === 'teamFfa'
 }
 
+export function hasDynamicObsSlots(gameType) {
+  return gameType === 'melee'
+}
+
 export function isTeamEmpty(team) {
   // Team is deemed empty if it's only consisted of open and/or closed type of slots
   return team.slots.every(slot => slot.type === 'open' || slot.type === 'closed')
@@ -519,6 +523,9 @@ export function closeSlot(lobby, teamIndex, slotIndex) {
 
 // Moves a regular slot to the observer team.
 export function makeObserver(lobby, teamIndex, slotIndex) {
+  if (!hasDynamicObsSlots(lobby.gameType)) {
+    throw new Error('Lobby type not supported')
+  }
   if (!canAddObservers(lobby)) {
     throw new Error('Cannot add more observers')
   }
@@ -550,6 +557,9 @@ export function makeObserver(lobby, teamIndex, slotIndex) {
 // Moves a slot from the observer team to players. The team that the slot gets moved to is the
 // smallest one with space for players.
 export function removeObserver(lobby, slotIndex) {
+  if (!hasDynamicObsSlots(lobby.gameType)) {
+    throw new Error('Lobby type not supported')
+  }
   if (!canRemoveObservers(lobby)) {
     throw new Error('Cannot remove more observers')
   }

--- a/server/lib/wsapi/lobbies.js
+++ b/server/lib/wsapi/lobbies.js
@@ -21,7 +21,6 @@ import {
   findSlotByName,
   findSlotById,
   hasOpposingSides,
-  hasObservers,
   getObserverTeam,
 } from '../../../app/common/lobbies'
 
@@ -212,7 +211,7 @@ export class LobbyApi {
 
     let player
     const [, observerTeam] = getObserverTeam(lobby)
-    if (hasObservers(lobby) && observerTeam.slots.find(s => s.id === availableSlot.id)) {
+    if (observerTeam && observerTeam.slots.find(s => s.id === availableSlot.id)) {
       player = Slots.createObserver(client.name)
     } else {
       player = isUms(lobby.gameType)

--- a/server/lib/wsapi/lobbies.js
+++ b/server/lib/wsapi/lobbies.js
@@ -23,7 +23,6 @@ import {
   hasOpposingSides,
   hasObservers,
   getObserverTeam,
-  isInObserverTeam,
 } from '../../../app/common/lobbies'
 
 const LOBBY_START_TIMEOUT = 30 * 1000

--- a/server/test/lobbies/lobby.js
+++ b/server/test/lobbies/lobby.js
@@ -283,6 +283,86 @@ describe('Lobbies - melee', () => {
     expect(() => Lobbies.openSlot(lobby, 0, 0)).to.throw(Error)
     expect(() => Lobbies.openSlot(lobby, 0, 1)).to.throw(Error)
   })
+
+  it('should support adding observer slots', () => {
+    let lobby = BOXER_LOBBY_WITH_OBSERVERS
+    let players = lobby.teams.get(0)
+    let observers = lobby.teams.get(1)
+    expect(players.slots).to.have.size(4)
+    expect(observers.slots).to.have.size(4)
+
+    lobby = Lobbies.makeObserver(lobby, 0, 0)
+    players = lobby.teams.get(0)
+    observers = lobby.teams.get(1)
+    expect(players.slots).to.have.size(3)
+    expect(observers.slots).to.have.size(5)
+    expect(players.slots.get(0).type).to.equal('open')
+    expect(players.slots.get(1).type).to.equal('open')
+    expect(players.slots.get(2).type).to.equal('open')
+    expect(observers.slots.get(4).id).to.equal(lobby.host.id)
+
+    const babo = Slots.createHuman('dronebabo', 'z')
+    const pachi = Slots.createHuman('pachi', 'p')
+    const computer = Slots.createComputer('p')
+    lobby = Lobbies.addPlayer(lobby, 0, 0, babo)
+    lobby = Lobbies.addPlayer(lobby, 0, 1, pachi)
+    lobby = Lobbies.addPlayer(lobby, 0, 2, computer)
+    expect(() => Lobbies.makeObserver(lobby, 0, 2)).to.throw(Error)
+    lobby = Lobbies.makeObserver(lobby, 0, 1)
+    expect(() => Lobbies.makeObserver(lobby, 0, 0)).to.throw(Error)
+
+    players = lobby.teams.get(0)
+    observers = lobby.teams.get(1)
+    expect(players.slots).to.have.size(2)
+    expect(observers.slots).to.have.size(6)
+    expect(players.slots.get(0).type).to.equal('human')
+    expect(players.slots.get(0).name).to.equal('dronebabo')
+    expect(players.slots.get(1).type).to.equal('computer')
+    expect(observers.slots.get(0).type).to.equal('closed')
+    expect(observers.slots.get(1).type).to.equal('closed')
+    expect(observers.slots.get(2).type).to.equal('closed')
+    expect(observers.slots.get(3).type).to.equal('closed')
+    expect(observers.slots.get(4).name).to.equal('Slayers`Boxer')
+    expect(observers.slots.get(5).name).to.equal('pachi')
+
+    expect(() => Lobbies.makeObserver(lobby, 0, 0)).to.throw(Error)
+  })
+
+  it('should support removing observer slots', () => {
+    let lobby = BOXER_LOBBY_WITH_OBSERVERS
+
+    const babo = Slots.createHuman('dronebabo', 'z')
+    lobby = Lobbies.addPlayer(lobby, 0, 1, babo)
+
+    let players = lobby.teams.get(0)
+    let observers = lobby.teams.get(1)
+    expect(players.slots).to.have.size(4)
+    expect(observers.slots).to.have.size(4)
+    expect(() => Lobbies.removeObserver(lobby, 0)).to.throw(Error)
+
+    // Move boxer and open slot to obs
+    lobby = Lobbies.makeObserver(lobby, 0, 0)
+    lobby = Lobbies.makeObserver(lobby, 0, 1)
+    // Move closed and boxer back
+    lobby = Lobbies.removeObserver(lobby, 1)
+    lobby = Lobbies.removeObserver(lobby, 3)
+    players = lobby.teams.get(0)
+    observers = lobby.teams.get(1)
+
+    expect(players.slots).to.have.size(4)
+    expect(observers.slots).to.have.size(4)
+    expect(() => Lobbies.removeObserver(lobby, 0)).to.throw(Error)
+    expect(players.slots.get(0).type).to.equal('human')
+    expect(players.slots.get(1).type).to.equal('open')
+    expect(players.slots.get(2).type).to.equal('closed')
+    expect(players.slots.get(3).type).to.equal('human')
+    expect(players.slots.get(3).name).to.equal('Slayers`Boxer')
+
+    expect(observers.slots.get(0).type).to.equal('closed')
+    expect(observers.slots.get(1).type).to.equal('closed')
+    expect(observers.slots.get(2).type).to.equal('closed')
+    expect(observers.slots.get(3).type).to.equal('open')
+  })
 })
 
 const TEAM_LOBBY = Lobbies.create(


### PR DESCRIPTION
Some thoughts:

This functionality will delete/add slots in the slot list of a team, which leads to any indices becoming invalidated. It feels fragile, but I didn't see any code which uses something but the slot uids to refer slots. The tests are difficult to follow due to this though.

Additionally, when a slot gets deleted, the server has to obviously send a diff for any slots that were located after the deleted one. On the other hand, diff code hardly had to be changed at all and everything works nicely.

Good? Bad?