### PR TITLE
Hook the LoadLibraryA function to properly load local.dll library.

### DIFF
--- a/game/common/win_helpers.cpp
+++ b/game/common/win_helpers.cpp
@@ -131,4 +131,13 @@ wstring GetDocumentsPath() {
   return documents_path;
 }
 
+bool EndsWith(const string checked, const string suffix) {
+  if (suffix.length() > checked.length()) {
+    return false;
+  }
+
+  int index = checked.rfind(suffix);
+  return index != string::npos && (index + suffix.length() == checked.length());
+}
+
 }  // namespace sbat

--- a/game/common/win_helpers.h
+++ b/game/common/win_helpers.h
@@ -92,5 +92,6 @@ private:
 };
 
 std::wstring GetDocumentsPath();
+bool EndsWith(const std::string checked, const std::string suffix);
 
 }  // namespace sbat

--- a/game/node-bw/brood_war.cpp
+++ b/game/node-bw/brood_war.cpp
@@ -208,15 +208,6 @@ void BroodWar::InjectDetours() {
   process_hooks_.Inject();
 }
 
-bool EndsWith(const string checked, const string suffix) {
-  if (suffix.length() > checked.length()) {
-    return false;
-  }
-
-  int index = checked.rfind(suffix);
-  return index != string::npos && (index + suffix.length() == checked.length());
-}
-
 HANDLE __stdcall BroodWar::CreateFileAHook(LPCSTR lpFileName, DWORD dwDesiredAccess,
     DWORD dwShareMode, LPSECURITY_ATTRIBUTES lpSecurityAttributes, DWORD dwCreationDisposition,
     DWORD dwFlagsAndAttributes, HANDLE hTemplateFile) {


### PR DESCRIPTION
When BW tries to load the local.dll library, we need to figure out
whether to load it from StarCraft's root directory (if exists), or from
our downgrade folder (for 1.19+ versions).