### PR TITLE
Upgrade the `KeyListener` component to handle exclusive listeners.

### DIFF
--- a/client/activities/activity-overlay.jsx
+++ b/client/activities/activity-overlay.jsx
@@ -129,7 +129,7 @@ export default class ActivityOverlay extends React.Component {
 
     return (
       <Container key={'overlay'}>
-        <KeyListener onKeyDown={this.onKeyDown} />
+        <KeyListener onKeyDown={this.onKeyDown} exclusive={true} />
         <Scrim onClick={this.onScrimClick} />
         <Overlay>{this.getOverlayComponent()}</Overlay>
       </Container>

--- a/client/activities/hotkeyed-activity-button.jsx
+++ b/client/activities/hotkeyed-activity-button.jsx
@@ -33,9 +33,10 @@ export default class HotkeyedActivityButton extends React.Component {
     }
 
     return (
-      <KeyListener onKeyDown={this.onKeyDown}>
+      <>
+        <KeyListener onKeyDown={this.onKeyDown} />
         <ActivityButton {...activityButtonProps} />
-      </KeyListener>
+      </>
     )
   }
 

--- a/client/keyboard/key-listener.jsx
+++ b/client/keyboard/key-listener.jsx
@@ -3,38 +3,30 @@ import PropTypes from 'prop-types'
 
 const mounted = []
 
-function onKeyDown(event) {
+function onKeyEvent(event) {
   if (event.defaultPrevented) return
 
-  let handled = false
-  for (let i = mounted.length - 1; !handled && i >= 0; i--) {
-    handled = mounted[i]._handleKeyDown(event)
+  const exclusiveIndex = mounted.findIndex(m => m.isExclusive)
+  const listeners = exclusiveIndex < 0 ? mounted : mounted.slice(exclusiveIndex)
+
+  let handlerName
+  switch (event.type) {
+    case 'keydown':
+      handlerName = '_handleKeyDown'
+      break
+    case 'keyup':
+      handlerName = '_handleKeyUp'
+      break
+    case 'keypress':
+      handlerName = '_handleKeyPress'
+      break
+    default:
+      throw new Error('Unsupported event: ' + event.type)
   }
-
-  if (handled) {
-    event.preventDefault()
-  }
-}
-
-function onKeyUp(event) {
-  if (event.defaultPrevented) return
-
-  let handled = false
-  for (let i = mounted.length - 1; !handled && i >= 0; i--) {
-    handled = mounted[i]._handleKeyUp(event)
-  }
-
-  if (handled) {
-    event.preventDefault()
-  }
-}
-
-function onKeyPress(event) {
-  if (event.defaultPrevented) return
 
   let handled = false
-  for (let i = mounted.length - 1; !handled && i >= 0; i--) {
-    handled = mounted[i]._handleKeyPress(event)
+  for (let i = listeners.length - 1; !handled && i >= 0; i--) {
+    handled = listeners[i][handlerName](event)
   }
 
   if (handled) {
@@ -45,6 +37,15 @@ function onKeyPress(event) {
 // A component that allows for listening to keypresses in a distributed way, while still giving
 // deeper/like more specific components handling precedence over their more general ancestors.
 //
+// If an `exclusive` prop is sent, the handlers will be executed only for this component and its
+// descendants. When used in this way, this component should not have children because of the way
+// React works, it's possible to end up in a situation where the child is mounted earlier than the
+// parent so the descendants are estimated by the order they registered this component. The
+// `exclusive` prop should be reserved for components that need to hijack key events, like dialogs
+// and overlays. A real example of this use case is an activity overlay and a map browser inside it.
+// Both of those components have `KeyListener` registered, but only activity overlay should have
+// `exclusive` prop set, because map browser component could be used from many different places.
+//
 // All event handler props should return true if they've handled a particular event, and it
 // shouldn't be handled further.
 export default class KeyListener extends React.Component {
@@ -52,6 +53,11 @@ export default class KeyListener extends React.Component {
     onKeyDown: PropTypes.func,
     onKeyUp: PropTypes.func,
     onKeyPress: PropTypes.func,
+    exclusive: PropTypes.bool,
+  }
+
+  get isExclusive() {
+    return this.props.exclusive
   }
 
   _handleKeyDown(event) {
@@ -68,9 +74,9 @@ export default class KeyListener extends React.Component {
 
   componentDidMount() {
     if (!mounted.length) {
-      document.addEventListener('keydown', onKeyDown)
-      document.addEventListener('keyup', onKeyUp)
-      document.addEventListener('keypress', onKeyPress)
+      document.addEventListener('keydown', onKeyEvent)
+      document.addEventListener('keyup', onKeyEvent)
+      document.addEventListener('keypress', onKeyEvent)
     }
     mounted.push(this)
   }
@@ -78,9 +84,9 @@ export default class KeyListener extends React.Component {
   componentWillUnmount() {
     mounted.splice(mounted.indexOf(this), 1)
     if (!mounted.length) {
-      document.removeEventListener('keydown', onKeyDown)
-      document.removeEventListener('keyup', onKeyUp)
-      document.removeEventListener('keypress', onKeyPress)
+      document.removeEventListener('keydown', onKeyEvent)
+      document.removeEventListener('keyup', onKeyEvent)
+      document.removeEventListener('keypress', onKeyEvent)
     }
   }
 

--- a/client/material/dialog.jsx
+++ b/client/material/dialog.jsx
@@ -36,26 +36,23 @@ class Dialog extends React.Component {
     ) : null
 
     return (
-      <KeyListener onKeyDown={this.onKeyDown}>
-        <div role='dialog' className={styles.contents}>
-          <div className={styles.titleBar}>
-            <h3 className={styles.title}>{title}</h3>
-            {closeButton}
-          </div>
-          {scrolledDown ? <div className={styles.titleDivider} /> : null}
-          <ScrollableContent
-            autoHeight={true}
-            autoHeightMin={'100px'}
-            autoHeightMax={'calc(80vh - 132px)'}
-            onUpdate={this.onScrollUpdate}>
-            <div className={styles.body}>{this.props.children}</div>
-          </ScrollableContent>
-          {scrolledUp && buttons && buttons.length ? (
-            <div className={styles.actionsDivider} />
-          ) : null}
-          {buttons && buttons.length ? <div className={styles.actions}>{buttons}</div> : null}
+      <div role='dialog' className={styles.contents}>
+        <KeyListener onKeyDown={this.onKeyDown} exclusive={true} />
+        <div className={styles.titleBar}>
+          <h3 className={styles.title}>{title}</h3>
+          {closeButton}
         </div>
-      </KeyListener>
+        {scrolledDown ? <div className={styles.titleDivider} /> : null}
+        <ScrollableContent
+          autoHeight={true}
+          autoHeightMin={'100px'}
+          autoHeightMax={'calc(80vh - 132px)'}
+          onUpdate={this.onScrollUpdate}>
+          <div className={styles.body}>{this.props.children}</div>
+        </ScrollableContent>
+        {scrolledUp && buttons && buttons.length ? <div className={styles.actionsDivider} /> : null}
+        {buttons && buttons.length ? <div className={styles.actions}>{buttons}</div> : null}
+      </div>
     )
   }
 

--- a/client/material/popover.jsx
+++ b/client/material/popover.jsx
@@ -253,18 +253,17 @@ export default class Popover extends React.Component {
         <span>
           <WindowListener event='resize' listener={this.recalcPopoverPosition} />
           <WindowListener event='scroll' listener={this.recalcPopoverPosition} />
-          <KeyListener onKeyDown={this.onKeyDown}>
-            {open ? (
-              <div key={'popover'} className={styles.popover} style={popoverStyle}>
-                <div className={styles.scaleHorizontal} style={this.state.scaleHorizontalStyle}>
-                  <div className={styles.scaleVertical} style={this.state.scaleVerticalStyle}>
-                    <div className={styles.background} style={this.state.backgroundStyle} />
-                  </div>
+          <KeyListener onKeyDown={this.onKeyDown} exclusive={true} />
+          {open ? (
+            <div key={'popover'} className={styles.popover} style={popoverStyle}>
+              <div className={styles.scaleHorizontal} style={this.state.scaleHorizontalStyle}>
+                <div className={styles.scaleVertical} style={this.state.scaleVerticalStyle}>
+                  <div className={styles.background} style={this.state.backgroundStyle} />
                 </div>
-                {children(state, TIMINGS)}
               </div>
-            ) : null}
-          </KeyListener>
+              {children(state, TIMINGS)}
+            </div>
+          ) : null}
         </span>
       )
     }

--- a/client/messaging/message-input.jsx
+++ b/client/messaging/message-input.jsx
@@ -20,7 +20,8 @@ export default class MessageInput extends React.Component {
     const { className } = this.props
     const { message } = this.state
     return (
-      <KeyListener onKeyPress={this.onKeyPress}>
+      <>
+        <KeyListener onKeyPress={this.onKeyPress} />
         <TextField
           ref={this._setRef}
           className={className}
@@ -33,7 +34,7 @@ export default class MessageInput extends React.Component {
           onEnterKeyDown={this.onEnterKeyDown}
           onChange={this.onChange}
         />
-      </KeyListener>
+      </>
     )
   }
 


### PR DESCRIPTION
This commit fixes an undesired behaviour with previous version of the
way the `KeyListener` component worked, which was that all of the
registered handlers would get executed for each key event. A situation
where this behaviour is undesired is when for example a dialog is opened
and you could still type in a chat behind it or even open an activity
overlay through hotkeys.

Now some components that use `KeyListener` (activity overlay, dialog and
popover) are marked as `exclusive`, which means when a keyboard event
happens and there is even one registered listener who is exclusive, it
will only execute handlers for that listener and its descendants. The
reason why we need to also execute handlers for descendants is because
activity overlays, dialogs and popovers, can have descendants who have
key listeners of their own registered and we want to handle those
events.

The way we figure out which key listeners are actually descendants of
the exclusive one might not be an ideal one, but I couldn't come up with
a better one. We basically rely on the order the key listeners are
registered, which sometimes can be a bit unintuitive because of the way
React works and in which order components are mounted.