### PR TITLE
Add a standalone map browser available from activity bar.

### DIFF
--- a/client/activities/activity-overlay.jsx
+++ b/client/activities/activity-overlay.jsx
@@ -136,7 +136,7 @@ export default class ActivityOverlay extends React.Component {
     }
 
     const OverlayComponent = this.getOverlayComponent()
-    const overlayComponent = <OverlayComponent initData={this.props.activityOverlay.initData} />
+    const overlayComponent = <OverlayComponent {...this.props.activityOverlay.initData.toJS()} />
     return (
       <Container key={'overlay'}>
         <KeyListener onKeyDown={this.onKeyDown} exclusive={true} />

--- a/client/activities/activity-overlay.jsx
+++ b/client/activities/activity-overlay.jsx
@@ -65,20 +65,22 @@ const Overlay = styled.div`
 const Container = styled.div`
   &.enter ${Overlay} {
     transform: translate3d(100%, 0, 0);
-    transition: transform 350ms ${linearOutSlowIn};
   }
 
   &.enter ${Scrim} {
     opacity: 0;
-    transition: opacity 250ms ${fastOutSlowIn};
   }
 
   &.enterActive ${Overlay} {
     transform: translate3d(0, 0, 0);
+    /* transition rule should always be put in the active class as there's a bug that can happen
+    if it's not; see this issue: https://github.com/reactjs/react-transition-group/issues/10 */
+    transition: transform 350ms ${linearOutSlowIn};
   }
 
   &.enterActive ${Scrim} {
     opacity: 0.42;
+    transition: opacity 250ms ${fastOutSlowIn};
   }
 
   &.leave {
@@ -87,20 +89,20 @@ const Container = styled.div`
 
   &.leave ${Overlay} {
     transform: translate3d(0, 0, 0);
-    transition: transform 250ms ${fastOutLinearIn};
   }
 
   &.leave ${Scrim} {
     opacity: 0.42;
-    transition: opacity 200ms ${fastOutSlowIn};
   }
 
   &.leaveActive ${Overlay} {
     transform: translate3d(100%, 0, 0);
+    transition: transform 250ms ${fastOutLinearIn};
   }
 
   &.leaveActive ${Scrim} {
     opacity: 0;
+    transition: opacity 200ms ${fastOutSlowIn};
   }
 `
 

--- a/client/lobbies/create-lobby.jsx
+++ b/client/lobbies/create-lobby.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { Map, Range } from 'immutable'
+import { Range } from 'immutable'
 import { connect } from 'react-redux'
 import styled from 'styled-components'
 
@@ -227,7 +227,7 @@ class CreateLobbyForm extends React.Component {
 @connect(state => ({ lobbyPreferences: state.lobbyPreferences }))
 export default class CreateLobby extends React.Component {
   static propTypes = {
-    initData: PropTypes.instanceOf(Map),
+    map: PropTypes.object,
   }
 
   _autoFocusTimer = null
@@ -276,8 +276,7 @@ export default class CreateLobby extends React.Component {
   componentDidUpdate(prevProps) {
     const { isRequesting: prevIsRequesting } = prevProps.lobbyPreferences
     const { isRequesting, recentMaps } = this.props.lobbyPreferences
-    const { initData } = this.props
-    const initialMap = initData.get('map')
+    const { map: initialMap } = this.props
 
     if (prevIsRequesting && !isRequesting) {
       let newRecentMaps = recentMaps
@@ -312,7 +311,7 @@ export default class CreateLobby extends React.Component {
   }
 
   render() {
-    const { initData, lobbyPreferences } = this.props
+    const { map: initialMap, lobbyPreferences } = this.props
     const { scrolledUp, scrolledDown, recentMaps } = this.state
 
     if (lobbyPreferences.isRequesting) {
@@ -324,7 +323,6 @@ export default class CreateLobby extends React.Component {
     }
 
     const { name, gameType, gameSubType } = lobbyPreferences
-    const initialMap = initData.get('map')
     const selectedMap = (initialMap && initialMap.hash) || lobbyPreferences.selectedMap
     const model = {
       name,
@@ -373,7 +371,11 @@ export default class CreateLobby extends React.Component {
   }
 
   onMapBrowse = () => {
-    this.props.dispatch(openOverlay('browseServerMaps'))
+    this.props.dispatch(openOverlay('browseServerMaps', { onMapSelect: this.onMapSelect }))
+  }
+
+  onMapSelect = map => {
+    this.props.dispatch(openOverlay('createLobby', { map }))
   }
 
   onCreateClick = () => {

--- a/client/main-layout.jsx
+++ b/client/main-layout.jsx
@@ -45,6 +45,7 @@ import FeedbackIcon from './icons/material/ic_feedback_black_24px.svg'
 import FindMatchIcon from './icons/material/ic_cake_black_36px.svg'
 import JoinGameIcon from './icons/material/ic_call_merge_black_36px.svg'
 import LogoutIcon from './icons/material/ic_power_settings_new_black_24px.svg'
+import MapsIcon from './icons/material/ic_terrain_black_24px.svg'
 import ReplaysIcon from './icons/material/ic_movie_black_36px.svg'
 import SettingsIcon from './icons/material/ic_settings_black_36px.svg'
 
@@ -71,6 +72,7 @@ import { DEV_INDICATOR, MULTI_CHANNEL, MATCHMAKING } from '../app/common/flags'
 const KEY_C = keycode('c')
 const KEY_F = keycode('f')
 const KEY_J = keycode('j')
+const KEY_M = keycode('m')
 const KEY_R = keycode('r')
 const KEY_S = keycode('s')
 
@@ -87,6 +89,11 @@ const ContentLayout = styled.div`
 
 const AdminLink = styled.p`
   width: 100%;
+`
+
+const StyledMapsIcon = styled(MapsIcon)`
+  width: 36px;
+  height: 36px;
 `
 
 let activeGameRoute
@@ -310,6 +317,14 @@ class MainLayout extends React.Component {
             altKey={true}
           />,
           <HotkeyedActivityButton
+            key='maps'
+            icon={<StyledMapsIcon />}
+            label='Maps'
+            onClick={this.onMapsClick}
+            keycode={KEY_M}
+            altKey={true}
+          />,
+          <HotkeyedActivityButton
             key='replays'
             icon={<ReplaysIcon />}
             label='Replays'
@@ -443,6 +458,14 @@ class MainLayout extends React.Component {
       this.props.dispatch(openDialog('psiHealth'))
     } else {
       this.props.dispatch(openOverlay('joinLobby'))
+    }
+  }
+
+  onMapsClick = () => {
+    if (!isPsiHealthy(this.props)) {
+      this.props.dispatch(openDialog('psiHealth'))
+    } else {
+      this.props.dispatch(openOverlay('browseServerMaps'))
     }
   }
 

--- a/client/maps/action-creators.js
+++ b/client/maps/action-creators.js
@@ -1,7 +1,6 @@
 import fetch from '../network/fetch'
 import upload from './upload'
 
-import { openOverlay } from '../activities/action-creators'
 import {
   MAPS_LIST_CLEAR,
   MAPS_LIST_GET_BEGIN,
@@ -10,14 +9,16 @@ import {
   LOCAL_MAPS_SELECT,
 } from '../actions'
 
-export function selectLocalMap(path) {
+export function selectLocalMap(path, onMapSelect) {
   return async dispatch => {
     dispatch({ type: LOCAL_MAPS_SELECT_BEGIN })
 
     dispatch({
       type: LOCAL_MAPS_SELECT,
       payload: upload(path, '/api/1/maps').then(({ map }) => {
-        dispatch(openOverlay('createLobby', { map }))
+        if (onMapSelect) {
+          onMapSelect(map)
+        }
       }),
     })
   }

--- a/client/maps/browse-local-maps.jsx
+++ b/client/maps/browse-local-maps.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import path from 'path'
 import styled from 'styled-components'
@@ -28,6 +29,10 @@ const BackButton = styled(IconButton)`
 
 @connect(state => ({ localMaps: state.localMaps, settings: state.settings }))
 export default class LocalMaps extends React.Component {
+  static propTypes = {
+    onMapSelect: PropTypes.func,
+  }
+
   componentDidUpdate(prevProps) {
     const { localMaps: prevMaps } = prevProps
     const { localMaps: curMaps } = this.props
@@ -54,8 +59,8 @@ export default class LocalMaps extends React.Component {
     }
 
     const fileTypes = {
-      scm: { icon: <MapIcon />, onSelect: this.onSelectMap },
-      scx: { icon: <MapIcon />, onSelect: this.onSelectMap },
+      scm: { icon: <MapIcon />, onSelect: this.onMapSelect },
+      scx: { icon: <MapIcon />, onSelect: this.onMapSelect },
     }
     const root = path.join(this.props.settings.local.starcraftPath, 'Maps')
     const props = {
@@ -72,8 +77,8 @@ export default class LocalMaps extends React.Component {
     return <BrowseFiles {...props} />
   }
 
-  onSelectMap = map => {
-    this.props.dispatch(selectLocalMap(map.path))
+  onMapSelect = map => {
+    this.props.dispatch(selectLocalMap(map.path, this.props.onMapSelect))
   }
 
   onBackClick = () => {


### PR DESCRIPTION
So far, the only way to get to the map browser was through 'create lobby'
workflow, which could be used to select a map to host. Now, both the
server and local map browsers have been extended to be able to be used
as a standalone browsers, which will in future allow for more actions on
the maps than the create lobby workflow will allow.