### PR TITLE
Implement a multi-line and text area variants to the TextField

### DIFF
--- a/client/auth/auth-content.jsx
+++ b/client/auth/auth-content.jsx
@@ -73,12 +73,11 @@ export const FieldRow = styled.div`
 
 export const RowEdge = styled.div`
   flex: 1 1 24%;
+  align-self: flex-start;
+  display: flex;
+  justify-content: flex-end;
   max-width: 24%;
-  max-height: 100%;
-
-  & > * {
-    float: right;
-  }
+  height: 56px;
 `
 
 export const ForgotActionButton = styled(FlatButton)`

--- a/client/material/devonly/text-field-test.jsx
+++ b/client/material/devonly/text-field-test.jsx
@@ -34,6 +34,11 @@ export default class TextFieldTest extends React.Component {
     value9: '',
     value10: '',
     value11: '',
+    value12: '',
+    value13: '',
+    value14: '',
+    value15: '',
+    value16: '',
     changeError: null,
   }
 
@@ -127,6 +132,42 @@ export default class TextFieldTest extends React.Component {
             floatingLabel={false}
             label='No errors, no float'
             allowErrors={false}
+            onChange={this.onChange}
+          />
+          <TextField
+            name='13'
+            value={this.state.value13}
+            floatingLabel={true}
+            label='Multi-line'
+            multiline={true}
+            onChange={this.onChange}
+          />
+          <TextField
+            name='14'
+            value={this.state.value14}
+            floatingLabel={true}
+            label='Text area'
+            multiline={true}
+            rows={4}
+            maxRows={4}
+            onChange={this.onChange}
+          />
+          <TextField
+            name='15'
+            value={this.state.value15}
+            floatingLabel={false}
+            label='Multi-line, no float'
+            multiline={true}
+            onChange={this.onChange}
+          />
+          <TextField
+            name='16'
+            value={this.state.value16}
+            floatingLabel={false}
+            label='Text area, no float'
+            multiline={true}
+            rows={4}
+            maxRows={4}
             onChange={this.onChange}
           />
         </StyledCard>

--- a/client/material/input-base.jsx
+++ b/client/material/input-base.jsx
@@ -1,16 +1,14 @@
-import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
 
 import { colorTextFaint, colorTextPrimary } from '../styles/colors'
-import { Subheading, singleLine } from '../styles/typography'
+import { Subheading } from '../styles/typography'
 
-export const InputWrapper = styled(Subheading)`
+export const InputBase = styled(Subheading)`
   flex-grow: 1;
   order: 2;
   width: 100%;
-  height: 100%;
-  padding: ${props => (props.floatingLabel ? '20px 12px 4px' : '12px')};
+  padding: ${props => (props.floatingLabel ? '17px 12px 4px' : '12px')};
   border: none;
   border-radius: 0;
   outline: none;
@@ -18,7 +16,6 @@ export const InputWrapper = styled(Subheading)`
   color: ${props => (props.disabled ? colorTextFaint : colorTextPrimary)};
   line-height: inherit;
   -ms-flex-preferred-size: inherit;
-  ${singleLine};
 
   &:focus {
     outline: none;
@@ -33,15 +30,11 @@ export const InputWrapper = styled(Subheading)`
   ${props => (props.trailingIcon ? 'padding-right: 48px' : '')};
 `
 
-const Input = React.forwardRef((props, ref) => (
-  <InputWrapper as='input' ref={ref} className={props.className} {...props} />
-))
-
-Input.propTypes = {
+InputBase.propTypes = {
   floatingLabel: PropTypes.bool,
   disabled: PropTypes.bool,
   leadingIcon: PropTypes.bool,
   trailingIcon: PropTypes.bool,
 }
 
-export default Input
+export default InputBase

--- a/client/material/input-floating-label.jsx
+++ b/client/material/input-floating-label.jsx
@@ -7,7 +7,7 @@ import { amberA400, colorTextFaint, colorTextSecondary, colorError } from '../st
 const FloatingLabel = styled.label`
   position: absolute;
   left: ${props => (props.leadingIcon ? '48px' : '12px')};
-  top: 50%;
+  top: 0;
   z-index: 1;
   color: ${props => {
     if (props.error) {
@@ -25,8 +25,8 @@ const FloatingLabel = styled.label`
   pointer-events: none;
   transform: ${props =>
     props.hasValue || props.focused
-      ? 'translate3d(0, -22px, 0) scale(0.75)'
-      : 'translate3d(0, -50%, 0)'};
+      ? 'translate3d(0, 7px, 0) scale(0.75)'
+      : 'translate3d(0, 16px, 0)'};
   transform-origin: left top;
   ${fastOutSlowInShort};
 

--- a/client/material/input-label.jsx
+++ b/client/material/input-label.jsx
@@ -6,8 +6,8 @@ import { colorTextFaint, colorTextSecondary } from '../styles/colors'
 const Label = styled.label`
   position: absolute;
   left: ${props => (props.leadingIcon ? '48px' : '12px')};
-  top: 50%;
-  transform: translate3d(0, -50%, 0);
+  top: 0;
+  transform: translate3d(0, 16px, 0);
   z-index: 1;
   color: ${props => (props.disabled ? colorTextFaint : colorTextSecondary)};
   pointer-events: none;

--- a/client/material/input-underline.jsx
+++ b/client/material/input-underline.jsx
@@ -7,11 +7,14 @@ import { amberA400, colorError, colorDividers } from '../styles/colors'
 
 const UnderlineContainer = styled.div`
   order: 3;
-  pointer-events: none;
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  right: 0;
   width: 100%;
   margin: 0;
+  pointer-events: none;
   color: ${props => (props.error ? colorError : amberA400)};
-  position: relative;
 `
 
 const Underline = styled.hr`

--- a/client/material/select/select.jsx
+++ b/client/material/select/select.jsx
@@ -4,7 +4,7 @@ import keycode from 'keycode'
 import styled from 'styled-components'
 
 import FloatingLabel from '../input-floating-label.jsx'
-import { InputWrapper } from '../input.jsx'
+import InputBase from '../input-base.jsx'
 import InputError from '../input-error.jsx'
 import InputUnderline from '../input-underline.jsx'
 import KeyListener from '../../keyboard/key-listener.jsx'
@@ -67,7 +67,7 @@ const SelectContainer = styled.div`
       : ''}
 `
 
-const DisplayValue = styled(InputWrapper)`
+const DisplayValue = styled(InputBase)`
   display: flex;
   align-items: center;
   // I have no idea why, but using flex to center the input value is 1 pixel off from using the


### PR DESCRIPTION
component.

Multi-line/text area variants can be controlled with 3 properties on a
TextField component:
1. `multiline` prop - turns the TextField into a multi-line one
2. `rows` prop - how many initial lines will be displayed (default: 1)
3. `maxRows` prop - how many lines will TextField expand to before
starting to show a scrollbar (default: 4)