### PR TITLE
Update for 1.23.3

### DIFF
--- a/game/Cargo.lock
+++ b/game/Cargo.lock
@@ -571,7 +571,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "samase_scarf"
 version = "0.1.0"
-source = "git+https://github.com/neivv/samase_scarf/?rev=30ccb70#30ccb70e281af930dbe7913f18e4bf5bca212afe"
+source = "git+https://github.com/neivv/samase_scarf/?rev=89d973d#89d973d66eca08c7de87ae3c6877e2acad171369"
 dependencies = [
  "arrayvec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -658,7 +658,7 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "quick-error 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "samase_scarf 0.1.0 (git+https://github.com/neivv/samase_scarf/?rev=30ccb70)",
+ "samase_scarf 0.1.0 (git+https://github.com/neivv/samase_scarf/?rev=89d973d)",
  "scopeguard 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -921,7 +921,7 @@ dependencies = [
 "checksum redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)" = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
 "checksum rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
 "checksum ryu 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bfa8506c1de11c9c4e4c38863ccbe02a305c8188e85a05a784c9e11e1c3910c8"
-"checksum samase_scarf 0.1.0 (git+https://github.com/neivv/samase_scarf/?rev=30ccb70)" = "<none>"
+"checksum samase_scarf 0.1.0 (git+https://github.com/neivv/samase_scarf/?rev=89d973d)" = "<none>"
 "checksum scarf 0.3.0 (git+https://github.com/neivv/scarf?rev=9b3978fa8b141b968fb2936c22ffc395b5d2369b)" = "<none>"
 "checksum scopeguard 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b42e15e59b18a828bbf5c58ea01debb36b9b096346de35d941dcb89009f24a0d"
 "checksum serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)" = "414115f25f818d7dfccec8ee535d76949ae78584fc4f79a6f45a904bf8ab4449"

--- a/game/Cargo.toml
+++ b/game/Cargo.toml
@@ -50,4 +50,4 @@ rev = "1adee081ac5ebc8362f92801e2083bbbadd79d57"
 
 [dependencies.samase_scarf]
 git = "https://github.com/neivv/samase_scarf/"
-rev = "30ccb70"
+rev = "89d973d"


### PR DESCRIPTION
Two different things broke:

1) SNP can no longer be replaced by just writing over global variables.
Now we hook a function that provides SNPs to BW instead.

Predicting future more than that is probably not possible, we'll see if
there are more SNP changes in future

2) The lobby dialog's vtable got a new function, pushing one we have to
implement to be located at a different offset. This could have been made
more resilient by just filling the vtable with this function (as no other
functions are expected to be called), or having more analysis to figure
out the correct offset instead of just hardcoding it.