### PR TITLE
Create a minidump file every time the inject fails.

### DIFF
--- a/app/build-native-modules.js
+++ b/app/build-native-modules.js
@@ -1,11 +1,15 @@
 const os = require('os')
 const { exec } = require('child_process')
+const packageJson = require('../package.json')
 
-// Build the native modules on Windows platform only
+const VERSION = packageJson.devDependencies.electron
+const DIST_URL = 'https://electronjs.org/headers'
+
+// Build the native modules for the current version of Electron (on Windows platform only).
 // NOTE: This will only affect our own native modules (defined in `binding.gyp`); native
 // modules included in `package.json` will be built based on their own settings.
 if (os.platform() === 'win32') {
-  exec('node-gyp rebuild', (err, stdout, stderr) => {
+  exec(`node-gyp rebuild --target=${VERSION} --dist-url=${DIST_URL}`, (err, stdout, stderr) => {
     if (err) {
       // Msbuild outputs its errors to stdout, so output it as well.
       console.log('stdout:')

--- a/app/native/process/wrapped_process.cpp
+++ b/app/native/process/wrapped_process.cpp
@@ -1142,21 +1142,20 @@ void Process::CreateMiniDump(const string& error_dump_path) {
 
   if (handle == INVALID_HANDLE_VALUE) {
     err = WindowsError("CreateMiniDump -> CreateFile", GetLastError());
-
-    return;
   }
 
-  BOOL success = MiniDumpWriteDump(process_handle_.get(), GetProcessId(process_handle_.get()),
-    file.get(), MiniDumpWithFullMemory, NULL, NULL, NULL);
-  if (!success) {
-    err = WindowsError("CreateMiniDump -> MiniDumpWriteDump", GetLastError());
+  if (!err.is_error()) {
+    BOOL success = MiniDumpWriteDump(process_handle_.get(), GetProcessId(process_handle_.get()),
+      file.get(), MiniDumpWithFullMemory, NULL, NULL, NULL);
+    if (!success) {
+      err = WindowsError("CreateMiniDump -> MiniDumpWriteDump", GetLastError());
+    }
   }
 
   if (err.is_error()) {
-    LogMessage("Failed writing the minidump file with the following error: %s",
-        err.message().c_str());
+    LogMessage("Failed saving the minidump: %s", err.message().c_str());
   } else {
-    LogMessage("Successfully written the minidump file at: %s", error_dump_path.c_str());
+    LogMessage("Successfully saved the minidump at: %s", error_dump_path.c_str());
   }
 }
 

--- a/app/native/process/wrapped_process.cpp
+++ b/app/native/process/wrapped_process.cpp
@@ -518,7 +518,7 @@ void Process::LogMessage(const char *fmt, ...) {
 // not initialized. By creating a dummy thread that just returns, we get Windows to fill out all the
 // things we need, while not actually advancing the threads we want to keep at bay.
 WindowsError Process::NtForceLdrInitializeThunk() {
-  byte injected_code[] = {0xC3 /* RET */};
+  byte injected_code[] = {0xC2, 0x04, 0x00 /* RET 4 */};
   ScopedVirtualAlloc remote_proc(process_handle_.get(), nullptr, sizeof(injected_code), MEM_COMMIT,
       PAGE_EXECUTE_READWRITE);
   if (remote_proc.has_errors()) {

--- a/app/native/process/wrapped_process.h
+++ b/app/native/process/wrapped_process.h
@@ -69,8 +69,7 @@ public:
   bool has_errors() const;
   WindowsError error() const;
 
-  WindowsError InjectDll(const std::wstring& dll_path, const std::string& inject_function_name,
-    const std::string& error_dump_path);
+  WindowsError InjectDll(const std::wstring& dll_path, const std::string& inject_function_name);
   WindowsError Resume();
   WindowsError Terminate();
   WindowsError WaitForExit(uint32_t max_wait_ms = INFINITE, bool* timed_out = nullptr);

--- a/app/native/process/wrapped_process.h
+++ b/app/native/process/wrapped_process.h
@@ -75,6 +75,7 @@ public:
   WindowsError Terminate();
   WindowsError WaitForExit(uint32_t max_wait_ms = INFINITE, bool* timed_out = nullptr);
   WindowsError GetExitCode(uint32_t* exit_code);
+  void CreateMiniDump(const std::string& error_dump_path);
 private:
   WindowsError NtForceLdrInitializeThunk();
   WindowsError DebugUntilTlsCallback(void **tls_callback_entry);


### PR DESCRIPTION
This commit also fixes the script that builds our native deps to build
them for the current version of Electron, so there's no mismatch between
node.js versions in Electron and the host environment.