### PR TITLE
Cleanup the settings dialog now that we support SC:R as well.

### DIFF
--- a/client/dialogs/connected-dialog-overlay.jsx
+++ b/client/dialogs/connected-dialog-overlay.jsx
@@ -6,6 +6,7 @@ import Portal from '../material/portal.jsx'
 import SimpleDialog from './simple-dialog.jsx'
 import Settings from '../settings/settings.jsx'
 import StarcraftHealthCheckupDialog from '../starcraft/starcraft-health.jsx'
+import StarcraftPathDialog from '../settings/starcraft-path-dialog.jsx'
 import JoinChannelDialog from '../chat/join-channel.jsx'
 import CreateWhisperSessionDialog from '../whispers/create-whisper.jsx'
 import ChangelogDialog from '../changelog/changelog-dialog.jsx'
@@ -13,7 +14,9 @@ import DownloadDialog from '../download/download-dialog.jsx'
 import UpdateDialog from '../download/update-dialog.jsx'
 import AcceptMatch from '../matchmaking/accept-match.jsx'
 import MapDetailsDialog from '../maps/map-details.jsx'
+
 import { closeDialog } from './action-creators'
+import { isStarcraftHealthy } from '../starcraft/is-starcraft-healthy'
 
 const transitionNames = {
   appear: 'enter',
@@ -24,7 +27,7 @@ const transitionNames = {
   exitActive: 'exitActive',
 }
 
-@connect(state => ({ dialog: state.dialog }))
+@connect(state => ({ dialog: state.dialog, starcraft: state.starcraft }))
 class ConnectedDialogOverlay extends React.Component {
   _focusable = null
   _setFocusable = elem => {
@@ -44,11 +47,15 @@ class ConnectedDialogOverlay extends React.Component {
       case 'mapDetails':
         return { component: MapDetailsDialog, modal: false }
       case 'settings':
-        return { component: Settings, modal: false }
+        return isStarcraftHealthy(this.props)
+          ? { component: Settings, modal: false }
+          : { component: StarcraftPathDialog, modal: false }
       case 'simple':
         return { component: SimpleDialog, modal: false }
       case 'starcraftHealth':
         return { component: StarcraftHealthCheckupDialog, modal: false }
+      case 'starcraftPath':
+        return { component: StarcraftPathDialog, modal: false }
       case 'updateAvailable':
         return { component: UpdateDialog, modal: true }
       case 'whispers':

--- a/client/material/dialog.jsx
+++ b/client/material/dialog.jsx
@@ -96,6 +96,7 @@ class Dialog extends React.Component {
   static propTypes = {
     onCancel: PropTypes.func,
     title: PropTypes.string.isRequired,
+    titleAction: PropTypes.element,
     showCloseButton: PropTypes.bool,
     buttons: PropTypes.arrayOf(PropTypes.element),
   }
@@ -106,7 +107,7 @@ class Dialog extends React.Component {
   }
 
   render() {
-    const { title, showCloseButton, buttons } = this.props
+    const { title, titleAction, showCloseButton, buttons } = this.props
     const { scrolledUp, scrolledDown } = this.state
 
     const closeButton = showCloseButton ? (
@@ -122,6 +123,7 @@ class Dialog extends React.Component {
         <KeyListener onKeyDown={this.onKeyDown} exclusive={true} />
         <TitleBar>
           <Title>{title}</Title>
+          {titleAction}
           {closeButton}
         </TitleBar>
         {scrolledDown ? <ScrollDivider position='top' /> : null}

--- a/client/settings/ipc-handlers.js
+++ b/client/settings/ipc-handlers.js
@@ -11,7 +11,9 @@ import {
   SETTINGS_MERGE_ERROR,
 } from '../../app/common/ipc-constants'
 
-const { checkStarcraftPath } = IS_ELECTRON ? require('../starcraft/check-starcraft-path') : null
+const checkStarcraftPath = IS_ELECTRON
+  ? require('../starcraft/check-starcraft-path').checkStarcraftPath
+  : null
 
 export default function registerModule({ ipcRenderer }) {
   if (!ipcRenderer) {

--- a/client/settings/reducer.js
+++ b/client/settings/reducer.js
@@ -1,5 +1,6 @@
 import { Record } from 'immutable'
-import { LOCAL_SETTINGS_SET, LOCAL_SETTINGS_UPDATE } from '../actions'
+import keyedReducer from '../reducers/keyed-reducer'
+import { LOCAL_SETTINGS_SET_BEGIN, LOCAL_SETTINGS_SET, LOCAL_SETTINGS_UPDATE } from '../actions'
 
 export const LocalSettings = new Record({
   width: -1,
@@ -10,6 +11,8 @@ export const LocalSettings = new Record({
   starcraftPath: null,
   gameWinX: null,
   gameWinY: null,
+
+  lastError: null,
 })
 
 export const Settings = new Record({
@@ -17,26 +20,30 @@ export const Settings = new Record({
   global: null,
 })
 
-export function localSettingsReducer(state = new LocalSettings(), action) {
-  if (action.type === LOCAL_SETTINGS_UPDATE) {
-    if (action.error) {
-      // TODO(tec27): deal with the error
-    } else {
-      return new LocalSettings(action.payload)
-    }
-  } else if (action.type === LOCAL_SETTINGS_SET) {
+export const localSettingsReducer = keyedReducer(new LocalSettings(), {
+  [LOCAL_SETTINGS_SET_BEGIN](state, action) {
+    return state.set('lastError', null)
+  },
+
+  [LOCAL_SETTINGS_SET](state, action) {
     // LOCAL_SETTINGS_UPDATE will update the settings if they change. Only handle the errors here
     if (action.error) {
-      // TODO(2Pac): deal with the error
+      return state.set('lastError', action.error)
     }
-  }
 
-  return state
-}
+    return state
+  },
 
-export function globalSettingsReducer(state = null, action) {
-  return state
-}
+  [LOCAL_SETTINGS_UPDATE](state, action) {
+    if (action.error) {
+      // TODO(tec27): deal with the error
+    }
+
+    return new LocalSettings(action.payload)
+  },
+})
+
+export const globalSettingsReducer = keyedReducer(null, {})
 
 export default function settingsReducer(state = new Settings(), action) {
   return state.withMutations(state => {

--- a/client/settings/starcraft-path-dialog.jsx
+++ b/client/settings/starcraft-path-dialog.jsx
@@ -1,0 +1,158 @@
+import React from 'react'
+import { connect } from 'react-redux'
+import styled from 'styled-components'
+
+import Dialog from '../material/dialog.jsx'
+import FlatButton from '../material/flat-button.jsx'
+import form from '../forms/form.jsx'
+import RaisedButton from '../material/raised-button.jsx'
+import SubmitOnEnter from '../forms/submit-on-enter.jsx'
+import TextField from '../material/text-field.jsx'
+
+import { openDialog } from '../dialogs/action-creators'
+import { mergeLocalSettings } from './action-creators'
+import { checkStarcraftPath } from '../starcraft/check-starcraft-path'
+
+import { colorError } from '../styles/colors'
+import { Subheading } from '../styles/typography'
+
+const currentWindow = IS_ELECTRON ? require('electron').remote.getCurrentWindow() : null
+const dialog = IS_ELECTRON ? require('electron').remote.dialog : null
+
+const starcraftPathValidator = () => {
+  return async starcraftPath => {
+    const checkResult = await checkStarcraftPath(starcraftPath)
+
+    if (!checkResult.path) {
+      return 'Select a valid StarCraft path'
+    }
+    if (!checkResult.version) {
+      return 'Select a valid StarCraft version'
+    }
+
+    return null
+  }
+}
+
+const SelectFolderContainer = styled.div`
+  display: flex;
+`
+
+const PathContainer = styled.div`
+  flex-grow: 1;
+`
+
+const StyledTextField = styled(TextField)`
+  flex-grow: 1;
+  margin-right: 8px;
+`
+
+const BrowseButtonContainer = styled.div`
+  display: flex;
+  align-items: center;
+  height: 56px;
+`
+
+const ErrorText = styled(Subheading)`
+  color: ${colorError};
+`
+
+@form({
+  path: starcraftPathValidator(),
+})
+class StarcraftPathForm extends React.Component {
+  _browseButtonRef = React.createRef()
+
+  render() {
+    const { bindInput, onSubmit } = this.props
+
+    return (
+      <form noValidate={true} onSubmit={onSubmit}>
+        <SubmitOnEnter />
+        <SelectFolderContainer>
+          <PathContainer onClick={this.onBrowseClick}>
+            <StyledTextField {...bindInput('path')} label='StarCraft folder path' disabled={true} />
+          </PathContainer>
+          <BrowseButtonContainer>
+            <RaisedButton ref={this._browseButtonRef} label='Browse' onClick={this.onBrowseClick} />
+          </BrowseButtonContainer>
+        </SelectFolderContainer>
+      </form>
+    )
+  }
+
+  onBrowseClick = async () => {
+    const { getInputValue, setInputValue } = this.props
+    const currentPath = getInputValue('path')
+
+    const selection = await dialog.showOpenDialog(currentWindow, {
+      title: 'Select StarCraft folder',
+      defaultPath: currentPath,
+      properties: ['openDirectory'],
+    })
+    const selectedPath = selection.filePaths[0]
+    this._browseButtonRef.current.blur()
+
+    if (selection.canceled || currentPath.toLowerCase() === selectedPath.toLowerCase()) return
+
+    setInputValue('path', selectedPath)
+  }
+}
+
+@connect(state => ({ settings: state.settings }))
+export default class StarcraftPath extends React.Component {
+  _form = React.createRef()
+  _saveButton = React.createRef()
+
+  componentDidMount() {
+    this._saveButton.current.focus()
+  }
+
+  render() {
+    const { settings, onCancel } = this.props
+
+    const formModel = {
+      path: settings.local.starcraftPath,
+    }
+
+    const buttons = [
+      <FlatButton label='Cancel' key='cancel' color='accent' onClick={this.onSettingsCancel} />,
+      <FlatButton
+        ref={this._saveButton}
+        label='Save'
+        key='save'
+        color='accent'
+        onClick={this.onSettingsSave}
+      />,
+    ]
+
+    return (
+      <Dialog title={'StarCraft Path'} buttons={buttons} onCancel={onCancel}>
+        <StarcraftPathForm ref={this._form} model={formModel} onSubmit={this.onSubmit} />
+        {settings.local.lastError ? (
+          <ErrorText>There was an issue saving the StarCraft path. Please try again.</ErrorText>
+        ) : null}
+      </Dialog>
+    )
+  }
+
+  onSettingsSave = () => {
+    this._form.current.submit()
+  }
+
+  onSettingsCancel = () => {
+    this.props.dispatch(openDialog('settings'))
+  }
+
+  onSubmit = () => {
+    const values = this._form.current.getModel()
+    const newSettings = {
+      starcraftPath: values.path,
+    }
+    this.props.dispatch(mergeLocalSettings(newSettings))
+
+    if (!this.props.settings.local.lastError) {
+      this.props.dispatch(openDialog('settings'))
+    }
+  }
+}

--- a/client/settings/starcraft-path-dialog.jsx
+++ b/client/settings/starcraft-path-dialog.jsx
@@ -11,11 +11,13 @@ import TextField from '../material/text-field.jsx'
 
 import { openDialog } from '../dialogs/action-creators'
 import { mergeLocalSettings } from './action-creators'
-import { checkStarcraftPath } from '../starcraft/check-starcraft-path'
 
 import { colorError } from '../styles/colors'
 import { Subheading } from '../styles/typography'
 
+const checkStarcraftPath = IS_ELECTRON
+  ? require('../starcraft/check-starcraft-path').checkStarcraftPath
+  : null
 const currentWindow = IS_ELECTRON ? require('electron').remote.getCurrentWindow() : null
 const dialog = IS_ELECTRON ? require('electron').remote.dialog : null
 

--- a/client/starcraft/is-starcraft-healthy.js
+++ b/client/starcraft/is-starcraft-healthy.js
@@ -6,6 +6,10 @@ export function hasValidStarcraftVersion({ starcraft }) {
   return starcraft.versionValid
 }
 
+export function isStarcraftRemastered({ starcraft }) {
+  return starcraft.isRemastered
+}
+
 export function isStarcraftHealthy({ starcraft }) {
   return hasValidStarcraftPath({ starcraft }) && hasValidStarcraftVersion({ starcraft })
 }


### PR DESCRIPTION
Basically, this commit makes setting a StarCraft path a separate
process, upon which the Settings dialog display the settings relevant to
the version of selected StarCraft path.

Currently, the SC:R settings only display a display mode option, which
is not yet hooked into StarCraft itself, but that will come in a
separate PR.