### PR TITLE
Add a cache for font SDFs

### DIFF
--- a/game/Cargo.lock
+++ b/game/Cargo.lock
@@ -95,6 +95,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "cloudabi"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "copyless"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -306,6 +314,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "iovec"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -346,6 +359,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "libc"
 version = "0.2.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "lock_api"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "scopeguard 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "log"
@@ -461,6 +482,30 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "parking_lot"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "instant 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lock_api 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot_core 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cloudabi 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "instant 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -567,6 +612,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.1.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -664,10 +714,12 @@ dependencies = [
  "chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "fern 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "quick-error 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "samase_scarf 0.1.0 (git+https://github.com/neivv/samase_scarf/?rev=634cf9f)",
@@ -875,6 +927,7 @@ dependencies = [
 "checksum bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "130aac562c0dd69c56b3b1cc8ffd2e17be31d0b6c25b61c96b76231aa23e39e1"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 "checksum chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)" = "80094f509cf8b5ae86a4966a39b3ff66cd7e2a3e594accec3743ff3fabeab5b2"
+"checksum cloudabi 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4344512281c643ae7638bbabc3af17a11307803ec8f0fcad9fae512a8bf36467"
 "checksum copyless 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "6ff9c56c9fb2a49c05ef0e431485a22400af20d33226dc0764d891d09e724127"
 "checksum digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
 "checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
@@ -901,6 +954,7 @@ dependencies = [
 "checksum httparse 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "cd179ae861f0c2e53da70d892f5f3029f9594be0c41dc5269cd371691b1dc2f9"
 "checksum idna 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9"
 "checksum input_buffer 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "19a8a95243d5a0398cae618ec29477c6e3cb631152be5c19481f80bc71559754"
+"checksum instant 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "7777a24a1ce5de49fcdde84ec46efa487c3af49d5b6e6e0a50367cc5c1096182"
 "checksum iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
 "checksum itoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
@@ -908,6 +962,7 @@ dependencies = [
 "checksum lde 0.3.0 (git+https://github.com/CasualX/lde)" = "<none>"
 "checksum lde 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7094800262acbe78630f1fd9725c45e3da32655d1b9652b852fc84a913e3d4da"
 "checksum libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)" = "9457b06509d27052635f90d6466700c65095fdf75409b3fbdd903e988b886f49"
+"checksum lock_api 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "de302ce1fe7482db13738fbaf2e21cfb06a986b89c0bf38d88abf16681aada4e"
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 "checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 "checksum memchr 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
@@ -922,6 +977,8 @@ dependencies = [
 "checksum object 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9cbca9424c482ee628fa549d9c812e2cd22f1180b9222c9200fdfa6eb31aecb2"
 "checksum once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0b631f7e854af39a1739f401cf34a8a013dfe09eac4fa4dba91e9768bd28168d"
 "checksum opaque-debug 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
+"checksum parking_lot 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a4893845fa2ca272e647da5d0e46660a314ead9c2fdd9a883aabc32e481a8733"
+"checksum parking_lot_core 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c361aa727dd08437f2f1447be8b59a33b0edd15e0fcee698f935613d9efbca9b"
 "checksum percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 "checksum pin-project 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)" = "edc93aeee735e60ecb40cf740eb319ff23eab1c5748abfdb5c180e4ce49f7791"
 "checksum pin-project-internal 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)" = "e58db2081ba5b4c93bd6be09c40fd36cb9193a8336c384f3b40012e531aa7e40"
@@ -937,6 +994,7 @@ dependencies = [
 "checksum rand_chacha 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
 "checksum rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 "checksum rand_hc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
+"checksum redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)" = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
 "checksum rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
 "checksum ryu 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "ed3d612bc64430efeb3f7ee6ef26d590dce0c43249217bddc62112540c7941e1"
 "checksum samase_scarf 0.1.0 (git+https://github.com/neivv/samase_scarf/?rev=634cf9f)" = "<none>"

--- a/game/Cargo.toml
+++ b/game/Cargo.toml
@@ -24,16 +24,18 @@ bytes = "0.5"
 chrono = "0.4.6"
 fern = "0.6"
 futures = "0.3"
+fxhash = "0.2.1"
 http = "0.2"
 lazy_static = "1.3"
 libc = "0.2.50"
 log = "0.4"
+parking_lot = { version = "0.11", features = ["send_guard"] }
 quick-error = "1.2.2"
 rand = "0.7"
 scopeguard = "1.0"
 serde = { version = "1.0.89", features = ["derive", "rc"] }
 serde_json = "1.0.39"
-tokio = { version = "0.2", features = ["net", "rt-threaded", "stream", "sync", "time"] }
+tokio = { version = "0.2", features = ["fs", "net", "rt-threaded", "stream", "sync", "time"] }
 tungstenite = { version = "0.10", default-features = false }
 tokio-tungstenite = "0.10"
 

--- a/game/src/bw_1161.rs
+++ b/game/src/bw_1161.rs
@@ -219,7 +219,7 @@ unsafe fn patch_game() {
         CreateFileA(*const i8, u32, u32, *mut c_void, u32, u32, *mut c_void) -> HANDLE
     );
 
-    let mut active_patcher = crate::PATCHER.lock().unwrap();
+    let mut active_patcher = crate::PATCHER.lock();
     crate::forge::init_hooks_1161(&mut active_patcher);
     snp::init_hooks(&mut active_patcher);
 

--- a/game/src/bw_scr.rs
+++ b/game/src/bw_scr.rs
@@ -540,7 +540,7 @@ impl BwScr {
             let async_handle = crate::async_handle();
             let mut sdf_cache = sdf_cache.clone().lock_owned();
             async_handle.spawn(async move {
-                let exe_hash = hash_exe_header(base as *const u8);
+                let exe_hash = pe_image::hash_pe_header(base as *const u8);
                 *sdf_cache = Some(SdfCache::init(exe_hash).await);
             });
 
@@ -588,14 +588,6 @@ impl BwScr {
             }
         }
     }
-}
-
-/// Exe hash for SDF cache.
-///
-/// I believe that the PE header in memory does not change based on relocations or such..
-/// But if I'm wrong then the hash could be just PE section offsets + sizes.
-unsafe fn hash_exe_header(exe_base: *const u8) -> u32 {
-    fxhash::hash32(std::slice::from_raw_parts(exe_base, 0x400))
 }
 
 impl bw::Bw for BwScr {

--- a/game/src/bw_scr/pe_image.rs
+++ b/game/src/bw_scr/pe_image.rs
@@ -44,6 +44,19 @@ pub unsafe fn get_section(base: *const u8, name: &[u8; 8]) -> Option<BinarySecti
     }).next()
 }
 
+/// Exe hash for SDF cache etc.
+///
+/// Hashes section header data, assuming that no meaningful
+/// recompilation of game gives exact same section sizes.
+pub unsafe fn hash_pe_header(base: *const u8) -> u32 {
+    let pe_header_offset = read_u32(base, 0x3c);
+    let pe_header = base.offset(pe_header_offset as isize);
+    let section_count = read_u16(pe_header, 6);
+    let section_headers =
+        std::slice::from_raw_parts(pe_header.add(0xf8), section_count as usize * 0x28);
+    fxhash::hash32(section_headers)
+}
+
 unsafe fn read_u32(base: *const u8, offset: usize) -> u32 {
     (base.add(offset) as *const u32).read_unaligned()
 }

--- a/game/src/bw_scr/sdf_cache.rs
+++ b/game/src/bw_scr/sdf_cache.rs
@@ -1,0 +1,445 @@
+//! Caches font SDFs that are being used to render most of the text.
+//! (SD uses a DDS texture for ASCII in order to look like 1.16.1)
+//! On game launch, they are generated for ASCII characters in range 32
+//! to 127, for 8 different fonts. The time this takes ends up being
+//! considerable enough that caching this ends up being beneficial.
+//!
+//! The cache file read/write operations are done in the async threads
+//! to reduce the cache overhead a bit. (Reading is initiated well before
+//! the cache is actually needed)
+
+use std::collections::hash_map;
+use std::mem::ManuallyDrop;
+use std::sync::Arc;
+use std::path::{Path, PathBuf};
+
+use byteorder::{ByteOrder, LittleEndian, WriteBytesExt};
+use tokio::fs;
+use tokio::io::{self, AsyncReadExt, AsyncWriteExt, BufReader};
+use fxhash::FxHashMap;
+use parking_lot::{MappedMutexGuard, Mutex, MutexGuard};
+
+use super::{BwScr, scr, hooks};
+
+// 2M
+const MAX_CACHE_SIZE_BYTES: usize = 2 * 1024 * 1024;
+
+pub fn apply_sdf_cache_hooks<'e>(
+    scr: &BwScr,
+    exe: &mut whack::ModulePatcher<'_>,
+    base: usize,
+) {
+    let font_cache_render_ascii = scr.font_cache_render_ascii;
+    let ttf_render_sdf = scr.ttf_render_sdf;
+    let ttf_malloc = scr.ttf_malloc;
+    let fonts = scr.fonts;
+
+    let cache = scr.sdf_cache.clone();
+    let cache2 = cache.clone();
+    unsafe {
+        let fonts = fonts.resolve();
+        let relative = font_cache_render_ascii.0 as usize - base;
+        exe.hook_closure_address(hooks::FontCacheRenderAscii, move |this, orig| {
+            orig(this);
+            // Moving this to process exit instead could be better,
+            // now it won't write anything that is cached after initialization.
+            // Also now it writes the cache 4 times if starting from empty,
+            // as FontCacheRenderAscii is called for 4 different fonts.
+            if cache2.lock().is_dirty() {
+                let async_handle = crate::async_handle();
+                let mut cache_locked = cache2.clone().lock_owned();
+                async_handle.spawn(async move {
+                    let cache = cache_locked.as_mut().unwrap();
+                    if let Err(e) = cache.write_to_disk().await {
+                        warn!("Writing SDF cache failed: {}", e);
+                    }
+                });
+            }
+        }, relative);
+        let relative = ttf_render_sdf.0 as usize - base;
+        exe.hook_closure_address(hooks::Ttf_RenderSdf, move |a, b, c, d, e, f, g, h, i, j, orig| {
+            render_sdf(&cache, fonts, ttf_malloc, a, b, c, d, e, f, g, h, i, j, orig)
+        }, relative);
+    }
+}
+
+unsafe fn render_sdf(
+    cache: &Arc<InitSdfCache>,
+    fonts: *mut *mut scr::Font,
+    ttf_malloc: unsafe extern fn(usize) -> *mut u8,
+    font: *mut scr::TtfFont,
+    a2: f32,
+    glyph: u32,
+    border: u32,
+    edge_value: u32,
+    stroke_width: f32,
+    out_w: *mut u32,
+    out_h: *mut u32,
+    out_x: *mut u32,
+    out_y: *mut u32,
+    orig: unsafe extern fn(
+        *mut scr::TtfFont,
+        f32,
+        u32,
+        u32,
+        u32,
+        f32,
+        *mut u32,
+        *mut u32,
+        *mut u32,
+        *mut u32,
+    ) -> *mut u8,
+) -> *mut u8 {
+    let mut cache = cache.lock();
+    let font_id = match font_id_from_ptr(fonts, font) {
+        Some(s) => s,
+        None => {
+            warn!("Unknown font {:p}", font);
+            return std::ptr::null_mut();
+        }
+    };
+    let result = cache.get(font_id, glyph);
+    match result {
+        SdfCacheResult::Cached(sdf) => {
+            *out_w = sdf.width as u32;
+            *out_h = sdf.height as u32;
+            *out_x = 0;
+            *out_y = 0;
+            let data = sdf.data;
+            let out = ttf_malloc(data.len());
+            let out_slice = std::slice::from_raw_parts_mut(out, data.len());
+            out_slice.copy_from_slice(data);
+            out
+        }
+        SdfCacheResult::Missing(entry) => {
+            let result = orig(
+                font, a2, glyph, border, edge_value, stroke_width, out_w, out_h, out_x, out_y,
+            );
+            if result.is_null() {
+                return result;
+            }
+            let size = Some((*out_w, *out_h))
+                .filter(|&(w, h)| w < 0x10000 && h < 0x10000)
+                .and_then(|(w, h)| w.checked_mul(h));
+            let size = match size {
+                Some(s) => s as usize,
+                None => {
+                    warn!("Invalid glyph size {} x {}", *out_w, *out_h);
+                    return result;
+                }
+            };
+            let slice = std::slice::from_raw_parts(result, size);
+            entry.insert(*out_w as u16, *out_h as u16, slice);
+            result
+        }
+    }
+}
+
+unsafe fn font_id_from_ptr(fonts: *mut *mut scr::Font, ttf: *mut scr::TtfFont) -> Option<FontId> {
+    for i in 0..4 {
+        let font = *fonts.add(i);
+        let ttf_set = (*font).ttf;
+        let first_ttf = (*ttf_set).fonts.as_mut_ptr();
+        let last_ttf = first_ttf.add(4);
+        if ttf >= first_ttf && ttf <= last_ttf {
+            for j in 0..5 {
+                if first_ttf.add(j) == ttf {
+                    let ttf_data = std::slice::from_raw_parts((*ttf).raw_ttf, 0x100);
+                    let hash = fxhash::hash64(ttf_data);
+                    let scale = (*ttf).scale.to_bits();
+                    return Some(FontId(hash, scale, j as u8));
+                }
+            }
+        }
+    }
+    None
+}
+
+/// A struct to manage SDF cache being loaded in one thread while
+/// other threads may potentially have to wait for it.
+/// This assumes that init thread calls `InitSdfCache::lock_owned`
+/// before any other thread calls `InitSdfCache::get`, and sets
+/// the initial cache object to `Some` before releasing the lock.
+pub struct InitSdfCache {
+    cache: Mutex<Option<SdfCache>>,
+}
+
+/// Allows passing a locked mutex guard (assuming it is Send)
+/// to another thread - which is good for us as locking mutexes
+/// in async thread can be really problematic.
+pub struct OwnedMutexGuard<O, T: 'static> {
+    object: ManuallyDrop<Arc<O>>,
+    guard: ManuallyDrop<MutexGuard<'static, T>>,
+}
+
+impl<O, T: 'static> std::ops::Deref for OwnedMutexGuard<O, T> {
+    type Target = T;
+    fn deref(&self) -> &Self::Target {
+        &*self.guard
+    }
+}
+
+impl<O, T: 'static> std::ops::DerefMut for OwnedMutexGuard<O, T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut *self.guard
+    }
+}
+
+impl<O, T: 'static> Drop for OwnedMutexGuard<O, T> {
+    fn drop(&mut self) {
+        unsafe {
+            ManuallyDrop::drop(&mut self.guard);
+            ManuallyDrop::drop(&mut self.object);
+        }
+    }
+}
+
+impl InitSdfCache {
+    pub fn new() -> InitSdfCache {
+        InitSdfCache {
+            cache: Mutex::new(None),
+        }
+    }
+
+    pub fn lock_owned(self: Arc<Self>) -> OwnedMutexGuard<Self, Option<SdfCache>> {
+        unsafe {
+            let guard = self.cache.lock();
+            OwnedMutexGuard {
+                guard: ManuallyDrop::new(
+                    std::mem::transmute::<MutexGuard<'_, _>, MutexGuard<'static, _>>(guard)
+                ),
+                object: ManuallyDrop::new(self),
+            }
+        }
+    }
+
+    pub fn lock(&self) -> MappedMutexGuard<SdfCache> {
+        let guard = self.cache.lock();
+        MutexGuard::map(guard, |x| x.as_mut().expect("SDF Cache wasn't initialized?"))
+    }
+}
+
+pub struct SdfCache {
+    path: PathBuf,
+    dirty: bool,
+    load_failed: bool,
+    /// Key is (font id, character)
+    glyphs: FxHashMap<(FontId, u32), SdfBuffer>,
+    data: Vec<u8>,
+    /// Some hash that ideally would change whenever the executable has changed.
+    /// As this cache does not know all parameters that the game uses to render
+    /// SDFs, we'll just assume that the parameters stay same for a single version
+    /// of the exe, and invalidate the cache when the exe is updated.
+    ///
+    /// Deciding what this hash exactly is does not concern this module.
+    /// (But anyway we hash first 0x400 bytes of the exe's PE header for this)
+    exe_hash: u32,
+}
+
+/// SDF data is 8bpp, so data.len() == width * height
+struct SdfBuffer {
+    width: u16,
+    height: u16,
+    data_offset: u32,
+}
+
+struct CachedSdf<'a> {
+    width: u16,
+    height: u16,
+    data: &'a [u8],
+}
+
+struct VacantSdfEntry<'a> {
+    entry: hash_map::VacantEntry<'a, (FontId, u32), SdfBuffer>,
+    data: &'a mut Vec<u8>,
+    dirty: &'a mut bool,
+}
+
+enum SdfCacheResult<'a> {
+    Cached(CachedSdf<'a>),
+    Missing(VacantSdfEntry<'a>),
+}
+
+/// Fonts are identified by hash of 100 first bytes of TTF data,
+/// scale (raw f32)
+/// and TTF variation which is another index withing TTF data
+/// (Though afaik the variation is always same?)
+#[derive(Copy, Clone, Eq, PartialEq, Debug, Hash)]
+struct FontId(u64, u32, u8);
+
+// File format:
+// u32 exe_hash (resetting cache every SCR patch)
+// u32 data_len
+// u32 sdf_count
+// {
+//      (u64, u8) font_id
+//      u32 glyph
+//      u16 width
+//      u16 height
+//      u32 offset
+// } sdfs[sdf_count]
+// u8 data[data_len]
+
+impl SdfCache {
+    /// Initializes the SDF cache from the on-disk file.
+    /// If it fails to load for some reason, initializes a dummy one so that
+    /// we don't have to crash here.
+    pub async fn init(exe_hash: u32) -> SdfCache {
+        let args = crate::parse_args();
+        let mut path = args.user_data_path.clone();
+        path.push("sdf_cache.dat");
+        if !path.exists() {
+            return SdfCache::empty(path, exe_hash);
+        }
+        match SdfCache::open(&path, exe_hash).await {
+            Ok(o) => o,
+            Err(e) => {
+                warn!("Couldn't open SDF cache: {}", e);
+                if e.kind() == io::ErrorKind::PermissionDenied {
+                    // Cache may be being written by another process, so prefer just
+                    // having this process not write cache at all over starting a
+                    // new cache from nothing.
+                    let mut result = SdfCache::empty(PathBuf::new(), 0);
+                    result.load_failed = true;
+                    result
+                } else {
+                    // Assuming corrupted cache, so reset it
+                    SdfCache::empty(path, exe_hash)
+                }
+            }
+        }
+    }
+
+    pub fn empty(path: PathBuf, exe_hash: u32) -> SdfCache {
+        SdfCache {
+            path,
+            dirty: false,
+            load_failed: false,
+            glyphs: Default::default(),
+            data: Default::default(),
+            exe_hash,
+        }
+    }
+
+    pub async fn open(path: &Path, exe_hash: u32) -> io::Result<SdfCache> {
+        let mut file = BufReader::new(fs::File::open(path).await?);
+        let mut header = [0u8; 12];
+        file.read_exact(&mut header).await?;
+        let cache_hash = LittleEndian::read_u32(&header[..4]);
+        let data_len = LittleEndian::read_u32(&header[4..8]) as usize;
+        let sdf_count = LittleEndian::read_u32(&header[8..12]) as usize;
+
+        if exe_hash != cache_hash {
+            info!(
+                "Exe hash has changed, invalidating SDF cache ({:08x} vs {:08x})",
+                exe_hash, cache_hash,
+            );
+            return Ok(SdfCache::empty(path.into(), exe_hash));
+        }
+        let mut glyph_data = vec![0u8; sdf_count * 25];
+        file.read_exact(&mut glyph_data[..]).await?;
+        let mut data = vec![0u8; data_len];
+        file.read_exact(&mut data[..]).await?;
+        drop(file);
+        let mut glyphs = FxHashMap::with_capacity_and_hasher(sdf_count, Default::default());
+        for sdf in glyph_data.chunks_exact(25) {
+            let hash = LittleEndian::read_u64(&sdf[..]);
+            let scale = LittleEndian::read_u32(&sdf[8..]);
+            let key = (FontId(hash, scale, sdf[12]), LittleEndian::read_u32(&sdf[13..]));
+            let value = SdfBuffer {
+                width: LittleEndian::read_u16(&sdf[17..]),
+                height: LittleEndian::read_u16(&sdf[19..]),
+                data_offset: LittleEndian::read_u32(&sdf[21..]),
+            };
+            let end = (value.data_offset as usize)
+                .wrapping_add(value.width as usize * value.height as usize);
+            if value.data_offset as usize >= data.len() || end > data.len() {
+                return Err(io::Error::new(io::ErrorKind::Other, "Corrupted file"));
+            }
+            glyphs.insert(key, value);
+        }
+        Ok(SdfCache {
+            path: path.into(),
+            dirty: false,
+            load_failed: false,
+            glyphs,
+            data,
+            exe_hash,
+        })
+    }
+
+    fn get<'a>(&'a mut self, font_id: FontId, glyph: u32) -> SdfCacheResult<'a> {
+        match self.glyphs.entry((font_id, glyph)) {
+            hash_map::Entry::Vacant(entry) => {
+                SdfCacheResult::Missing(VacantSdfEntry {
+                    entry,
+                    data: &mut self.data,
+                    dirty: &mut self.dirty,
+                })
+            }
+            hash_map::Entry::Occupied(entry) => {
+                let value = entry.get();
+                let length = value.width as usize * value.height as usize;
+                let data = &self.data[(value.data_offset as usize)..][..length];
+                SdfCacheResult::Cached(CachedSdf {
+                    width: value.width,
+                    height: value.height,
+                    data,
+                })
+            }
+        }
+    }
+
+    pub fn is_dirty(&self) -> bool {
+        self.dirty
+    }
+
+    pub async fn write_to_disk(&mut self) -> io::Result<()> {
+        if self.load_failed {
+            // Don't write to disk if reading from there failed for some reason
+            return Ok(());
+        }
+        if self.data.len() > MAX_CACHE_SIZE_BYTES {
+            // Reset the cache if it gets too big
+            self.data.clear();
+            self.glyphs.clear();
+        }
+        debug!("Writing {} pixels of SDF data", self.data.len());
+        let capacity = 12 + self.data.len() + self.glyphs.len() * 25;
+        let mut buffer = Vec::with_capacity(capacity);
+        WriteBytesExt::write_u32::<LittleEndian>(&mut buffer, self.exe_hash)?;
+        WriteBytesExt::write_u32::<LittleEndian>(&mut buffer, self.data.len() as u32)?;
+        WriteBytesExt::write_u32::<LittleEndian>(&mut buffer, self.glyphs.len() as u32)?;
+        let mut glyph_data = [0u8; 25];
+        for (key, val) in self.glyphs.iter() {
+            LittleEndian::write_u64(&mut glyph_data[0..], (key.0).0);
+            LittleEndian::write_u32(&mut glyph_data[8..], (key.0).1);
+            glyph_data[12] = (key.0).2;
+            LittleEndian::write_u32(&mut glyph_data[13..], key.1);
+            LittleEndian::write_u16(&mut glyph_data[17..], val.width);
+            LittleEndian::write_u16(&mut glyph_data[19..], val.height);
+            LittleEndian::write_u32(&mut glyph_data[21..], val.data_offset);
+            buffer.extend_from_slice(&glyph_data[..]);
+        }
+        buffer.extend_from_slice(&self.data);
+        let mut file = fs::File::create(&self.path).await?;
+        file.write_all(&buffer).await?;
+        debug_assert_eq!(buffer.len(), capacity);
+        debug!("SDF cache written");
+        self.dirty = false;
+        Ok(())
+    }
+}
+
+impl<'a> VacantSdfEntry<'a> {
+    pub fn insert(self, width: u16, height: u16, data: &[u8]) {
+        let data_offset = self.data.len() as u32;
+        self.data.extend_from_slice(data);
+        self.entry.insert(SdfBuffer {
+            width,
+            height,
+            data_offset,
+        });
+        *self.dirty = true;
+    }
+}

--- a/game/src/crash_dump.rs
+++ b/game/src/crash_dump.rs
@@ -21,7 +21,7 @@ pub unsafe fn init_crash_handler() {
     SetUnhandledExceptionFilter(Some(exception_handler));
     let kernel32 = windows::load_library("kernel32").unwrap();
     let address = kernel32.proc_address("SetUnhandledExceptionFilter").unwrap();
-    let mut patcher = crate::PATCHER.lock().unwrap();
+    let mut patcher = crate::PATCHER.lock();
     let mut patcher = patcher.patch_library("kernel32", 0);
     patcher.hook_closure_address(
         SetUnhandledExceptionFilterDecl,

--- a/game/src/forge/mod.rs
+++ b/game/src/forge/mod.rs
@@ -1747,7 +1747,9 @@ pub fn hide_window() {
     });
     if let Some(handle) = handle {
         unsafe {
-            ShowWindow(handle, SW_HIDE);
+            with_scr_hooks_disabled(|| {
+                ShowWindow(handle, SW_HIDE);
+            });
         }
     }
 }


### PR DESCRIPTION
Saves some time on SCR loading. Almost 2 seconds on this slow pc.

The font cache is written to `%APPDATA%\shieldbattery\sdf_cache.dat`, there is also a folder named `Cache` but since it is being used by electron I thought that maybe I should not add any files related to game there.