### PR TITLE
Start loading the game in lobbies as soon as the countdown starts.

### DIFF
--- a/client/active-game/active-game-manager.js
+++ b/client/active-game/active-game-manager.js
@@ -25,6 +25,7 @@ export default class ActiveGameManager extends EventEmitter {
     this.mapStore = mapStore
     this.activeGame = null
     this.serverPort = 0
+    this.allowStartSent = false
   }
 
   getStatus() {
@@ -129,6 +130,7 @@ export default class ActiveGameManager extends EventEmitter {
     this._setStatus(GAME_STATUS_STARTING)
     setTimeout(() => {
       this.emit('gameCommand', this.activeGame.id, 'allowStart')
+      this.allowStartSent = true
     }, waitTime)
   }
 
@@ -153,6 +155,12 @@ export default class ActiveGameManager extends EventEmitter {
     if (game.routes) {
       this.emit('gameCommand', id, 'routes', game.routes)
       this.emit('gameCommand', id, 'setupGame', game.config.setup)
+    }
+
+    // If the `allowStart` command was already sent by this point, it means it was sent while the
+    // game wasn't even connected; we resend it here, otherwise the game wouldn't start at all.
+    if (this.allowStartSent) {
+      this.emit('gameCommand', this.activeGame.id, 'allowStart')
     }
   }
 

--- a/client/active-game/active-game-manager.js
+++ b/client/active-game/active-game-manager.js
@@ -153,7 +153,6 @@ export default class ActiveGameManager extends EventEmitter {
     if (game.routes) {
       this.emit('gameCommand', id, 'routes', game.routes)
       this.emit('gameCommand', id, 'setupGame', game.config.setup)
-      this.emit('gameCommand', id, 'allowStart')
     }
   }
 

--- a/client/active-game/active-game-manager.js
+++ b/client/active-game/active-game-manager.js
@@ -10,6 +10,7 @@ import {
   GAME_STATUS_UNKNOWN,
   GAME_STATUS_LAUNCHING,
   GAME_STATUS_CONFIGURING,
+  GAME_STATUS_STARTING,
   GAME_STATUS_PLAYING,
   GAME_STATUS_FINISHED,
   GAME_STATUS_ERROR,
@@ -117,8 +118,18 @@ export default class ActiveGameManager extends EventEmitter {
     if (current && current.config) {
       this.emit('gameCommand', gameId, 'routes', routes)
       this.emit('gameCommand', gameId, 'setupGame', current.config.setup)
-      this.emit('gameCommand', gameId, 'allowStart')
     }
+  }
+
+  allowStart(waitTime = 2000) {
+    if (!this.activeGame) {
+      return
+    }
+
+    this._setStatus(GAME_STATUS_STARTING)
+    setTimeout(() => {
+      this.emit('gameCommand', this.activeGame.id, 'allowStart')
+    }, waitTime)
   }
 
   async handleGameConnected(id) {

--- a/client/active-game/active-game-manager.js
+++ b/client/active-game/active-game-manager.js
@@ -122,14 +122,14 @@ export default class ActiveGameManager extends EventEmitter {
     }
   }
 
-  allowStart(waitTime = 2000) {
-    if (!this.activeGame) {
+  allowStart(gameId, waitTime = 2000) {
+    if (this.activeGame && this.activeGame.id !== gameId) {
       return
     }
 
     this._setStatus(GAME_STATUS_STARTING)
     setTimeout(() => {
-      this.emit('gameCommand', this.activeGame.id, 'allowStart')
+      this.emit('gameCommand', gameId, 'allowStart')
       this.allowStartSent = true
     }, waitTime)
   }

--- a/client/lobbies/socket-handlers.js
+++ b/client/lobbies/socket-handlers.js
@@ -174,10 +174,6 @@ const eventToAction = {
   }),
 
   startCountdown: (name, event, { siteSocket }) => (dispatch, getState) => {
-    const {
-      gameClient: { gameId },
-    } = getState()
-
     clearCountdownTimer()
     let tick = 5
     dispatch({
@@ -196,7 +192,6 @@ const eventToAction = {
       if (!tick) {
         clearCountdownTimer(true /* leaveAtmosphere */)
         dispatch({ type: LOBBY_UPDATE_LOADING_START })
-        activeGameManager.allowStart(gameId)
       }
     }, 1000)
   },
@@ -244,6 +239,12 @@ const eventToAction = {
     const { routes, gameId } = event
 
     activeGameManager.setGameRoutes(gameId, routes)
+  },
+
+  allowStart: (name, event) => {
+    const { gameId } = event
+
+    activeGameManager.allowStart(gameId)
   },
 
   cancelLoading: (name, event) => dispatch => {

--- a/client/lobbies/socket-handlers.js
+++ b/client/lobbies/socket-handlers.js
@@ -174,6 +174,10 @@ const eventToAction = {
   }),
 
   startCountdown: (name, event, { siteSocket }) => (dispatch, getState) => {
+    const {
+      gameClient: { gameId },
+    } = getState()
+
     clearCountdownTimer()
     let tick = 5
     dispatch({
@@ -192,7 +196,7 @@ const eventToAction = {
       if (!tick) {
         clearCountdownTimer(true /* leaveAtmosphere */)
         dispatch({ type: LOBBY_UPDATE_LOADING_START })
-        activeGameManager.allowStart()
+        activeGameManager.allowStart(gameId)
       }
     }, 1000)
   },

--- a/client/lobbies/socket-handlers.js
+++ b/client/lobbies/socket-handlers.js
@@ -191,6 +191,8 @@ const eventToAction = {
       })
       if (!tick) {
         clearCountdownTimer(true /* leaveAtmosphere */)
+        dispatch({ type: LOBBY_UPDATE_LOADING_START })
+        activeGameManager.allowStart()
       }
     }, 1000)
   },
@@ -203,13 +205,11 @@ const eventToAction = {
   },
 
   setupGame: (name, event) => (dispatch, getState) => {
-    clearCountdownTimer(true /* leaveAtmosphere */)
     const {
       lobby,
       settings,
       auth: { user },
     } = getState()
-    dispatch({ type: LOBBY_UPDATE_LOADING_START })
     // We tack on `teamId` to each slot here so we don't have to send two different things to game
     const slots = getIngameLobbySlotsWithIndexes(lobby.info).map(
       ([teamIndex, , slot]) =>
@@ -236,11 +236,9 @@ const eventToAction = {
     dispatch({ type: ACTIVE_GAME_LAUNCH, payload: activeGameManager.setGameConfig(config) })
   },
 
-  setRoutes: (name, event) => (dispatch, getState) => {
-    const { routes } = event
-    const {
-      gameClient: { gameId },
-    } = getState()
+  setRoutes: (name, event) => dispatch => {
+    const { routes, gameId } = event
+
     activeGameManager.setGameRoutes(gameId, routes)
   },
 

--- a/client/matchmaking/socket-handlers.js
+++ b/client/matchmaking/socket-handlers.js
@@ -141,6 +141,11 @@ const eventToAction = {
     const { routes, gameId } = event
 
     activeGameManager.setGameRoutes(gameId, routes)
+  },
+
+  allowStart: (name, event) => {
+    const { gameId } = event
+
     activeGameManager.allowStart(gameId)
   },
 

--- a/client/matchmaking/socket-handlers.js
+++ b/client/matchmaking/socket-handlers.js
@@ -141,7 +141,7 @@ const eventToAction = {
     const { routes, gameId } = event
 
     activeGameManager.setGameRoutes(gameId, routes)
-    activeGameManager.allowStart()
+    activeGameManager.allowStart(gameId)
   },
 
   cancelLoading: (name, event) => dispatch => {

--- a/client/matchmaking/socket-handlers.js
+++ b/client/matchmaking/socket-handlers.js
@@ -141,6 +141,7 @@ const eventToAction = {
     const { routes, gameId } = event
 
     activeGameManager.setGameRoutes(gameId, routes)
+    activeGameManager.allowStart()
   },
 
   cancelLoading: (name, event) => dispatch => {

--- a/client/replays/action-creators.js
+++ b/client/replays/action-creators.js
@@ -46,7 +46,7 @@ async function setGameConfig(replay, user, settings) {
 
 function setGameRoutes(gameId) {
   activeGameManager.setGameRoutes(gameId, [])
-  activeGameManager.allowStart()
+  activeGameManager.allowStart(gameId)
 }
 
 export function startReplay(replay) {

--- a/client/replays/action-creators.js
+++ b/client/replays/action-creators.js
@@ -46,6 +46,7 @@ async function setGameConfig(replay, user, settings) {
 
 function setGameRoutes(gameId) {
   activeGameManager.setGameRoutes(gameId, [])
+  activeGameManager.allowStart()
 }
 
 export function startReplay(replay) {

--- a/server/lib/games/game-loader.js
+++ b/server/lib/games/game-loader.js
@@ -88,7 +88,7 @@ export class GameLoader {
       this.maybeCancelLoading(gameId)
     })
 
-    return gameLoad
+    return { gameId, gameLoad }
   }
 
   // The game has successfully loaded for a specific player; once the game is loaded for all

--- a/server/lib/wsapi/matchmaking.js
+++ b/server/lib/wsapi/matchmaking.js
@@ -96,12 +96,14 @@ export class MatchmakingApi {
     },
     onAccepted: async (matchInfo, clients) => {
       const players = clients.map(c => createHuman(c.name))
-      await gameLoader.loadGame(
+      const { gameLoad } = gameLoader.loadGame(
         players,
         setup => this.gameLoaderDelegate.onGameSetup(matchInfo, clients, players, setup),
         (playerName, routes, gameId) =>
           this.gameLoaderDelegate.onRoutesSet(clients, playerName, routes, gameId),
       )
+
+      await gameLoad
       this.gameLoaderDelegate.onGameLoaded(clients)
     },
     onDeclined: (matchInfo, requeueClients, kickClients) => {
@@ -166,6 +168,7 @@ export class MatchmakingApi {
         routes,
         gameId,
       })
+      this._publishToActiveClient(playerName, { type: 'allowStart', gameId })
     },
     onGameLoaded: clients => {
       for (const client of clients) {


### PR DESCRIPTION
This should reduce the loading time of SC:R games considerably. Or 5
seconds to be more exact.

Once the countdown finishes, the loading screen is shown for a minimum
of 2 seconds before launching the users into the game.