### PR TITLE
Implement the UX/UI of the matchmaking loading process.

### DIFF
--- a/client/actions.js
+++ b/client/actions.js
@@ -292,6 +292,16 @@ export const MATCHMAKING_GET_CURRENT_MAP_POOL = 'MATCHMAKING_GET_CURRENT_MAP_POO
 export const MATCHMAKING_UPDATE_ACCEPT_MATCH_FAILED = 'MATCHMAKING_UPDATE_ACCEPT_MATCH_FAILED'
 // The accept match time has changed
 export const MATCHMAKING_UPDATE_ACCEPT_MATCH_TIME = 'MATCHMAKING_UPDATE_ACCEPT_MATCH_TIME'
+// A match we're in is starting the game countdown
+export const MATCHMAKING_UPDATE_COUNTDOWN_START = 'MATCHMAKING_UPDATE_COUNTDOWN_START'
+// A second has ticked off the countdown for a match we're in
+export const MATCHMAKING_UPDATE_COUNTDOWN_TICK = 'MATCHMAKING_UPDATE_COUNTDOWN_TICK'
+// The game is being started and is the final step before the loading process completes
+export const MATCHMAKING_UPDATE_GAME_STARTING = 'MATCHMAKING_UPDATE_GAME_STARTING'
+// The game has been started and the loading process is now complete
+export const MATCHMAKING_UPDATE_GAME_STARTED = 'MATCHMAKING_UPDATE_GAME_STARTED'
+// The matchmaking has canceled out of the loading phase (because of timeout or load failure)
+export const MATCHMAKING_UPDATE_LOADING_CANCELED = 'MATCHMAKING_UPDATE_LOADING_CANCELED'
 // The server has responded that a player has accepted the match
 export const MATCHMAKING_UPDATE_MATCH_ACCEPTED = 'MATCHMAKING_UPDATE_MATCH_ACCEPTED'
 // The server has responded with a found match

--- a/client/active-game/active-game-reducer.js
+++ b/client/active-game/active-game-reducer.js
@@ -13,10 +13,10 @@ export default keyedReducer(new ActiveGame(), {
 
   [ACTIVE_GAME_STATUS](state, action) {
     const { state: status } = action.payload
-    if (status === 'unknown' || status === 'finished' || status === 'error') {
-      return state.set('isActive', false)
-    } else {
+    if (status === 'playing') {
       return state.set('isActive', true)
+    } else {
+      return state.set('isActive', false)
     }
   },
 })

--- a/client/dev.jsx
+++ b/client/dev.jsx
@@ -5,6 +5,7 @@ import styled from 'styled-components'
 import DevActivities from './activities/devonly/routes.jsx'
 import DevLists from './lists/devonly/routes.jsx'
 import DevLobbies from './lobbies/devonly/routes.jsx'
+import DevMatchmaking from './matchmaking/devonly/routes.jsx'
 import DevMaterial from './material/devonly/routes.jsx'
 
 const Container = styled.div`
@@ -31,7 +32,10 @@ class DevDashboard extends React.Component {
             <Link to='/dev/lists'>List components</Link>
           </li>
           <li>
-            <Link to='/dev/lobbies'>Lobby-related components</Link>
+            <Link to='/dev/lobbies'>Lobby components</Link>
+          </li>
+          <li>
+            <Link to='/dev/matchmaking'>Matchmaking components</Link>
           </li>
           <li>
             <Link to='/dev/material'>Material components</Link>
@@ -52,6 +56,7 @@ export default class Dev extends React.Component {
           <Route path='/dev/activities' component={DevActivities} />
           <Route path='/dev/lists' component={DevLists} />
           <Route path='/dev/lobbies' component={DevLobbies} />
+          <Route path='/dev/matchmaking' component={DevMatchmaking} />
           <Route path='/dev/material' component={DevMaterial} />
         </Switch>
       </Container>

--- a/client/main-layout.jsx
+++ b/client/main-layout.jsx
@@ -26,6 +26,8 @@ import LeftNav from './material/left-nav/left-nav.jsx'
 import LoadingIndicator from './progress/dots.jsx'
 import LobbyView from './lobbies/view.jsx'
 import LobbyTitle from './lobbies/app-bar-title.jsx'
+import MatchmakingView from './matchmaking/view.jsx'
+import MatchmakingTitle from './matchmaking/app-bar-title.jsx'
 import Menu from './material/menu/menu.jsx'
 import MenuItem from './material/menu/item.jsx'
 import ProfileNavEntry from './profile/nav-entry.jsx'
@@ -104,9 +106,11 @@ const StyledMapsIcon = styled(MapsIcon)`
 
 let activeGameRoute
 let lobbyRoute
+let matchmakingRoute
 if (IS_ELECTRON) {
   activeGameRoute = <Route path='/active-game' component={ActiveGame} />
   lobbyRoute = <Route path='/lobbies/:lobby' component={LobbyView} />
+  matchmakingRoute = <Route path='/matchmaking' component={MatchmakingView} />
 }
 
 const LoadableAdminPanel = loadable(() => import('./admin/panel.jsx'), {
@@ -260,6 +264,8 @@ class MainLayout extends React.Component {
       appBarTitle = <ChatTitle />
     } else if (pathname.startsWith('/lobbies')) {
       appBarTitle = <LobbyTitle />
+    } else if (pathname.startsWith('/matchmaking')) {
+      appBarTitle = <MatchmakingTitle />
     } else if (pathname.startsWith('/whispers')) {
       appBarTitle = <WhispersTitle />
     }
@@ -423,6 +429,7 @@ class MainLayout extends React.Component {
               <Route path='/chat' exact={true} component={ChatList} />
               <Route path='/chat/:channel' component={ChatChannel} />
               {lobbyRoute}
+              {matchmakingRoute}
               <Route path='/whispers/:target' component={Whisper} />
               {/* If no paths match, redirect the page to the "index". Note: this means that we
                   can't actually have a 404 page, but I don't think we really need one? */}

--- a/client/matchmaking/accept-match.jsx
+++ b/client/matchmaking/accept-match.jsx
@@ -59,18 +59,18 @@ const FilledTimerBar = styled.div`
 
 @connect(state => ({ matchmaking: state.matchmaking }))
 export default class AcceptMatch extends React.Component {
-  componentWillMount() {
-    this.maybeClose(this.props)
+  componentDidMount() {
+    this.maybeClose()
   }
 
-  componentWillUpdate(nextProps) {
-    this.maybeClose(nextProps)
+  componentDidUpdate() {
+    this.maybeClose()
   }
 
-  maybeClose(props) {
+  maybeClose() {
     const {
       matchmaking: { isFinding, failedToAccept, match },
-    } = props
+    } = this.props
     if (!isFinding && !failedToAccept && !match) {
       this.props.dispatch(closeDialog())
     }

--- a/client/matchmaking/app-bar-title.jsx
+++ b/client/matchmaking/app-bar-title.jsx
@@ -1,0 +1,26 @@
+import React from 'react'
+import { connect } from 'react-redux'
+import styled from 'styled-components'
+
+import { AppBarTitle } from '../app-bar/app-bar.jsx'
+
+const Container = styled.div`
+  max-width: 1140px;
+  margin: 0 auto;
+  padding-left: 32px;
+`
+
+@connect(state => ({ matchmaking: state.matchmaking }))
+export default class LobbyTitle extends React.Component {
+  render() {
+    const matchmakingTitle = this.props.matchmaking.isLoading
+      ? 'Loading game...'
+      : 'Game in progress...'
+
+    return (
+      <Container>
+        <AppBarTitle as='span'>{matchmakingTitle}</AppBarTitle>
+      </Container>
+    )
+  }
+}

--- a/client/matchmaking/devonly/map-selection-test.jsx
+++ b/client/matchmaking/devonly/map-selection-test.jsx
@@ -1,0 +1,34 @@
+import React from 'react'
+
+import MapSelection from '../map-selection.jsx'
+import { MapRecord } from '../../maps/maps-reducer'
+
+export default class MapSelectionTest extends React.Component {
+  render() {
+    const preferredMaps = [
+      new MapRecord({
+        id: 1,
+        name: 'Fighting Spirit',
+      }),
+      new MapRecord({
+        id: 2,
+        name: 'Blue Storm',
+      }),
+    ]
+    const randomMaps = [
+      new MapRecord({
+        id: 3,
+        name: 'Longinus',
+      }),
+      new MapRecord({
+        id: 4,
+        name: 'Tau Cross',
+      }),
+    ]
+    const chosenMap = preferredMaps[0]
+
+    return (
+      <MapSelection preferredMaps={preferredMaps} randomMaps={randomMaps} chosenMap={chosenMap} />
+    )
+  }
+}

--- a/client/matchmaking/devonly/match-test.jsx
+++ b/client/matchmaking/devonly/match-test.jsx
@@ -1,0 +1,100 @@
+import React from 'react'
+
+import MatchmakingMatch from '../matchmaking-match.jsx'
+import { MapRecord } from '../../maps/maps-reducer'
+import { Player } from '../matchmaking-reducer'
+
+export default class MapSelectionTest extends React.Component {
+  state = {
+    isLoading: true,
+    isCountingDown: false,
+    countdownTimer: -1,
+    isStarting: false,
+  }
+
+  _loadingTimer = null
+  _countdownTimer = null
+  _startingTimer = null
+
+  componentDidMount() {
+    this._loadingTimer = setInterval(() => {
+      this.setState({ isLoading: true })
+      this._startCountdown()
+    }, 15000)
+    this._startCountdown()
+  }
+
+  componentWillUnmount() {
+    this._clearCountdownTimer()
+    this._clearStartingTimer()
+    this._clearLoadingTimer()
+  }
+
+  _startCountdown() {
+    this._clearCountdownTimer()
+    let tick = 5
+    this.setState({ isCountingDown: true, countdownTimer: tick })
+
+    this._countdownTimer = setInterval(() => {
+      tick -= 1
+      this.setState({ countdownTimer: tick })
+      if (!tick) {
+        this._clearCountdownTimer()
+        this.setState({ isCountingDown: false, isStarting: true })
+        this._startGameStarting()
+      }
+    }, 1000)
+  }
+
+  _startGameStarting() {
+    this._startingTimer = setTimeout(
+      () => this.setState({ isStarting: false, isLoading: false }),
+      5000,
+    )
+  }
+
+  _clearCountdownTimer() {
+    if (this._countdownTimer) {
+      clearInterval(this._countdownTimer)
+      this._countdownTimer = null
+    }
+  }
+
+  _clearStartingTimer() {
+    if (this._startingTimer) {
+      clearTimeout(this._startingTimer)
+      this._startingTimer = null
+    }
+  }
+
+  _clearLoadingTimer() {
+    if (this._loadingTimer) {
+      clearInterval(this._loadingTimer)
+      this._loadingTimer = null
+    }
+  }
+
+  render() {
+    const { isLoading, isCountingDown, countdownTimer, isStarting } = this.state
+
+    const map = new MapRecord({
+      id: 1,
+      name: 'Fighting Spirit',
+    })
+    const players = [
+      new Player({ id: 1, name: 'tec27', race: 'p' }),
+      new Player({ id: 2, name: 'Excalibur_Z', race: 'r' }),
+    ]
+
+    return (
+      <MatchmakingMatch
+        isLoading={isLoading}
+        isCountingDown={isCountingDown}
+        countdownTimer={countdownTimer}
+        isStarting={isStarting}
+        map={map}
+        players={players}
+      />
+    )
+  }
+}

--- a/client/matchmaking/devonly/routes.jsx
+++ b/client/matchmaking/devonly/routes.jsx
@@ -1,0 +1,37 @@
+import React from 'react'
+import { Link, Route, Switch } from 'react-router-dom'
+
+import MapSelectionTest from './map-selection-test.jsx'
+import MatchTest from './match-test.jsx'
+
+class DevMatchmakingDashboard extends React.Component {
+  render() {
+    const { baseUrl } = this.props
+
+    return (
+      <ul>
+        <li>
+          <Link to={baseUrl + '/map-selection'}>Map selection</Link>
+        </li>
+        <li>
+          <Link to={baseUrl + '/match'}>Matchmaking match</Link>
+        </li>
+      </ul>
+    )
+  }
+}
+
+export default props => {
+  const baseUrl = props.match.url
+  return (
+    <Switch>
+      <Route
+        path={baseUrl}
+        exact={true}
+        render={() => <DevMatchmakingDashboard baseUrl={baseUrl} />}
+      />
+      <Route path={baseUrl + '/map-selection'} component={MapSelectionTest} />
+      <Route path={baseUrl + '/match'} component={MatchTest} />
+    </Switch>
+  )
+}

--- a/client/matchmaking/map-selection.jsx
+++ b/client/matchmaking/map-selection.jsx
@@ -1,0 +1,98 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import styled from 'styled-components'
+import { rgba } from 'polished'
+
+import MapThumbnail from '../maps/map-thumbnail.jsx'
+
+import RandomIcon from '../icons/material/ic_casino_black_24px.svg'
+
+import { shadowDef2dp } from '../material/shadow-constants'
+import { blue200, grey800 } from '../styles/colors'
+import { Display3, Subheading } from '../styles/typography'
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`
+
+const MapsContainer = styled.div`
+  display: grid;
+  grid-template-columns: auto auto;
+  grid-template-rows: auto auto;
+  grid-gap: 32px;
+  margin-top: 40px;
+`
+
+const MapContainer = styled.div`
+  width: 256px;
+  height: 256px;
+  border-radius: 2px;
+  box-shadow: ${shadowDef2dp};
+
+  ${props => {
+    if (props.glowing) {
+      return `
+        box-shadow: 0px 0px 32px 8px ${rgba(blue200, 0.5)};
+      `
+    }
+
+    return ''
+  }}
+`
+
+const RandomThumbnail = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  background-color: ${grey800};
+`
+
+const StyledRandomIcon = styled(RandomIcon)`
+  width: 128px;
+  height: 128px;
+  opacity: 0.5;
+`
+
+export default class MapSelection extends React.Component {
+  static propTypes = {
+    preferredMaps: PropTypes.array.isRequired,
+    randomMaps: PropTypes.array.isRequired,
+    chosenMap: PropTypes.object.isRequired,
+  }
+
+  render() {
+    const { preferredMaps, randomMaps, chosenMap } = this.props
+    const preferredMapsItems = preferredMaps.map(m => {
+      return (
+        <MapContainer key={m.id} glowing={m.id === chosenMap.id}>
+          <MapThumbnail map={m} showMapName={true} />
+        </MapContainer>
+      )
+    })
+    const randomMapsItems = randomMaps.map(m => {
+      return (
+        <MapContainer key={m.id} glowing={m.id === chosenMap.id}>
+          <RandomThumbnail>
+            <StyledRandomIcon />
+            <Subheading>Random map</Subheading>
+          </RandomThumbnail>
+        </MapContainer>
+      )
+    })
+
+    return (
+      <Container>
+        <Display3>Map pool</Display3>
+        <MapsContainer>
+          {preferredMapsItems}
+          {randomMapsItems}
+        </MapsContainer>
+      </Container>
+    )
+  }
+}

--- a/client/matchmaking/matchmaking-match.jsx
+++ b/client/matchmaking/matchmaking-match.jsx
@@ -17,6 +17,7 @@ const Container = styled.div`
   align-items: center;
   max-width: 1140px;
   margin: 0 auto;
+  padding: 24px 40px;
 `
 
 const TopHalfContainer = styled.div`
@@ -62,7 +63,13 @@ const TeamContainer = styled.div`
   flex: 1 1 0;
   display: flex;
   flex-direction: column;
-  align-items: center;
+
+  &:first-child {
+    align-items: flex-end;
+  }
+  &:last-child {
+    align-items: flex-start;
+  }
 `
 
 const PlayerCard = styled(Card)`

--- a/client/matchmaking/matchmaking-match.jsx
+++ b/client/matchmaking/matchmaking-match.jsx
@@ -1,0 +1,174 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import styled from 'styled-components'
+
+import Avatar from '../avatars/avatar.jsx'
+import Card from '../material/card.jsx'
+import MapThumbnail from '../maps/map-thumbnail.jsx'
+import RaceIcon from '../lobbies/race-icon.jsx'
+
+import { shadowDef2dp } from '../material/shadow-constants'
+import { colorTextSecondary } from '../styles/colors'
+import { Display1, Display3, Display4, Headline, robotoCondensed } from '../styles/typography'
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  max-width: 1140px;
+  margin: 0 auto;
+`
+
+const TopHalfContainer = styled.div`
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  grid-gap: 16px;
+  max-width: calc(3 * 320px);
+  margin-top: 16px;
+`
+
+const Spacer = styled.div``
+
+const MapContainer = styled.div`
+  width: 320px;
+  height: 320px;
+  border-radius: 2px;
+  box-shadow: ${shadowDef2dp};
+`
+
+const StatusContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`
+
+const CountdownText = styled(Display4)`
+  ${robotoCondensed};
+  font-weight: 700;
+`
+
+const StatusText = styled(Display1)`
+  ${robotoCondensed};
+  color: ${colorTextSecondary};
+`
+
+const PlayersContainer = styled.div`
+  display: flex;
+  width: 100%;
+  margin-top: 32px;
+`
+
+const TeamContainer = styled.div`
+  flex: 1 1 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`
+
+const PlayerCard = styled(Card)`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+  max-width: 360px;
+  height: 88px;
+  padding: 12px;
+
+  &:not(:first-child) {
+    margin-top: 16px;
+  }
+`
+
+const StyledAvatar = styled(Avatar)`
+  flex-shrink: 0;
+  width: 64px;
+  height: 64px;
+`
+
+const PlayerName = styled(Headline)`
+  flex-grow: 1;
+  ${robotoCondensed};
+  font-weight: 700;
+  margin: 0 12px;
+`
+
+const StyledRaceIcon = styled(RaceIcon)`
+  flex-shrink: 0;
+
+  & svg {
+    width: 48px;
+    height: 48px;
+  }
+`
+
+const VsContainer = styled.div`
+  flex: 0 0 220px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`
+
+const VsText = styled(Display1)`
+  ${robotoCondensed};
+  font-weight: 700;
+`
+
+export default class MatchmakingMatch extends React.Component {
+  static propTypes = {
+    isLoading: PropTypes.bool,
+    isCountingDown: PropTypes.bool,
+    countdownTimer: PropTypes.number,
+    isStarting: PropTypes.bool,
+    map: PropTypes.object,
+    players: PropTypes.array,
+  }
+
+  renderStatus() {
+    const { isLoading, isCountingDown, countdownTimer, isStarting } = this.props
+
+    if (isLoading && isCountingDown) {
+      return <CountdownText>{countdownTimer}</CountdownText>
+    } else if (isLoading && isStarting) {
+      return <StatusText>Game starting...</StatusText>
+    } else {
+      return <StatusText>Game in progress...</StatusText>
+    }
+  }
+
+  renderPlayerCard(player) {
+    return (
+      <PlayerCard key={player.id}>
+        <StyledAvatar user={player.name} />
+        <PlayerName>{player.name}</PlayerName>
+        <StyledRaceIcon race={player.race} />
+      </PlayerCard>
+    )
+  }
+
+  render() {
+    const { map, players } = this.props
+    // TODO(2Pac): Split the teams by their parties once we support team matchmaking
+    const team1 = players.slice(0, players.length / 2).map(p => this.renderPlayerCard(p))
+    const team2 = players.slice(players.length / 2).map(p => this.renderPlayerCard(p))
+
+    return (
+      <Container>
+        <Display3>{map.name}</Display3>
+        <TopHalfContainer>
+          <Spacer />
+          <MapContainer>
+            <MapThumbnail map={map} />
+          </MapContainer>
+          <StatusContainer>{this.renderStatus()}</StatusContainer>
+        </TopHalfContainer>
+        <PlayersContainer>
+          <TeamContainer>{team1}</TeamContainer>
+          <VsContainer>
+            <VsText>vs</VsText>
+          </VsContainer>
+          <TeamContainer>{team2}</TeamContainer>
+        </PlayersContainer>
+      </Container>
+    )
+  }
+}

--- a/client/matchmaking/view.jsx
+++ b/client/matchmaking/view.jsx
@@ -1,0 +1,65 @@
+import React from 'react'
+import { connect } from 'react-redux'
+import { Route, Switch } from 'react-router-dom'
+import { replace } from 'connected-react-router'
+
+import Index from '../navigation/index.jsx'
+import MapSelection from './map-selection.jsx'
+import MatchmakingMatch from './matchmaking-match.jsx'
+
+@connect(state => ({ hasActiveGame: state.activeGame.isActive, matchmaking: state.matchmaking }))
+export default class MatchmakingView extends React.Component {
+  componentDidMount() {
+    if (!this.props.matchmaking.isLoading && !this.props.hasActiveGame) {
+      this.props.dispatch(replace('/'))
+    }
+  }
+
+  componentDidUpdate(prevProps) {
+    if (prevProps.hasActiveGame && !this.props.hasActiveGame) {
+      // TODO(2Pac): handle this in socket-handlers once we start tracking game ending on the server
+      this.props.dispatch(replace('/'))
+    }
+  }
+
+  renderMapSelection = () => {
+    const { isLoading, match } = this.props.matchmaking
+    if (!isLoading) return null
+
+    return (
+      <MapSelection
+        preferredMaps={match.preferredMaps.toJS()}
+        randomMaps={match.randomMaps.toJS()}
+        chosenMap={match.chosenMap}
+      />
+    )
+  }
+
+  renderMatchmakingMatch = () => {
+    const { isLoading, isCountingDown, countdownTimer, isStarting, match } = this.props.matchmaking
+    if (!isLoading && !match) return null
+
+    return (
+      <MatchmakingMatch
+        isLoading={isLoading}
+        isCountingDown={isCountingDown}
+        countdownTimer={countdownTimer}
+        isStarting={isStarting}
+        map={match.chosenMap}
+        players={match.players.toJS()}
+      />
+    )
+  }
+
+  render() {
+    return (
+      <Switch>
+        <Route path='/matchmaking/map-selection' render={this.renderMapSelection} />
+        <Route path='/matchmaking/countdown' render={this.renderMatchmakingMatch} />
+        <Route path='/matchmaking/game-starting' render={this.renderMatchmakingMatch} />
+        <Route path='/matchmaking/active-game' render={this.renderMatchmakingMatch} />
+        <Index transitionFn={replace} />
+      </Switch>
+    )
+  }
+}

--- a/server/lib/wsapi/matchmaking.js
+++ b/server/lib/wsapi/matchmaking.js
@@ -173,10 +173,10 @@ export class MatchmakingApi {
       })
 
       const [preferredMaps, randomMaps] = await Promise.all([
-        await getMapInfo(preferredMapsHashes.toJS()),
-        await getMapInfo(randomMapsHashes),
+        getMapInfo(preferredMapsHashes.toJS()),
+        getMapInfo(randomMapsHashes),
       ])
-      if (!preferredMaps.length && !randomMaps.length) {
+      if (!(preferredMaps.length + randomMaps.length)) {
         throw new Error('no maps found')
       }
 

--- a/server/lib/wsapi/matchmaking.js
+++ b/server/lib/wsapi/matchmaking.js
@@ -1,4 +1,4 @@
-import { List, Map, Record } from 'immutable'
+import { List, Map, Range, Record, Set } from 'immutable'
 import errors from 'http-errors'
 import { Mount, Api, registerApiRoutes } from '../websockets/api-decorators'
 import validateBody from '../websockets/validate-body'
@@ -9,6 +9,7 @@ import { getMapInfo } from '../models/maps'
 import { getCurrentMapPool } from '../models/matchmaking-map-pools'
 import { Interval, TimedMatchmaker } from '../matchmaking/matchmaker'
 import MatchAcceptor from '../matchmaking/match-acceptor'
+import createDeferred from '../../../common/async/deferred'
 import {
   MATCHMAKING_ACCEPT_MATCH_TIME,
   MATCHMAKING_TYPES,
@@ -22,6 +23,8 @@ const Player = new Record({
   rating: 0,
   interval: null,
   race: 'r',
+  alternateRace: 'p',
+  preferredMaps: new Set(),
 })
 
 const Match = new Record({
@@ -33,6 +36,13 @@ const QueueEntry = new Record({
   username: null,
   type: null,
 })
+
+const Timers = new Record({
+  mapSelectionTimer: null,
+  countdownTimer: null,
+})
+
+const getRandomInt = max => Math.floor(Math.random() * Math.floor(max))
 
 // How often to run the matchmaker 'find match' process
 const MATCHMAKING_INTERVAL = 7500
@@ -60,6 +70,7 @@ export class MatchmakingApi {
     )
 
     this.queueEntries = new Map()
+    this.clientTimers = new Map()
   }
 
   matchmakerDelegate = {
@@ -95,6 +106,12 @@ export class MatchmakingApi {
       }
     },
     onAccepted: async (matchInfo, clients) => {
+      this.queueEntries = this.queueEntries.withMutations(map => {
+        for (const client of clients) {
+          map.delete(client.name)
+        }
+      })
+
       const players = clients.map(c => createHuman(c.name))
       const { gameLoad } = gameLoader.loadGame(
         players,
@@ -129,7 +146,7 @@ export class MatchmakingApi {
       for (const client of clients) {
         this._publishToActiveClient(client.name, {
           type: 'cancelLoading',
-          reason: err.message,
+          reason: err && err.message,
         })
         this._unregisterActivity(client)
       }
@@ -138,29 +155,79 @@ export class MatchmakingApi {
 
   gameLoaderDelegate = {
     onGameSetup: async (matchInfo, clients, players, setup = {}) => {
-      // TODO(2Pac): Select map intelligently based on user's preference
-      const mapPool = await getCurrentMapPool(matchInfo.type)
-      if (!mapPool) {
+      const currentMapPool = await getCurrentMapPool(matchInfo.type)
+      if (!currentMapPool) {
         throw new Error('invalid map pool')
       }
 
-      const mapInfo = (await getMapInfo(mapPool.maps))[0]
-      if (!mapInfo) {
-        throw new Error('invalid map')
+      const mapPool = new Set(currentMapPool.maps)
+      const preferredMapsHashes = matchInfo.players
+        .reduce((acc, p) => acc.concat(p.preferredMaps), new Set())
+        .filter(m => mapPool.includes(m))
+
+      const randomMapsHashes = []
+      Range(preferredMapsHashes.size, 4).forEach(() => {
+        const availableMaps = mapPool.subtract(preferredMapsHashes.concat(randomMapsHashes))
+        const randomMap = availableMaps.toList().get(getRandomInt(availableMaps.size))
+        randomMapsHashes.push(randomMap)
+      })
+
+      const [preferredMaps, randomMaps] = await Promise.all([
+        await getMapInfo(preferredMapsHashes.toJS()),
+        await getMapInfo(randomMapsHashes),
+      ])
+      if (!preferredMaps.length && !randomMaps.length) {
+        throw new Error('no maps found')
       }
 
-      this.queueEntries = this.queueEntries.withMutations(map => {
-        for (const client of clients) {
-          map.delete(client.name)
+      const chosenMap = [...preferredMaps, ...randomMaps][
+        getRandomInt(preferredMaps.length + randomMaps.length)
+      ]
+
+      // Using `map` with `Promise.all` here instead of `forEach`, so our general error handler
+      // catches any of the errors inside.
+      await Promise.all(
+        clients.map(async client => {
           this._publishToActiveClient(client.name, {
             type: 'matchReady',
             setup,
             players,
             matchInfo,
-            mapInfo,
+            preferredMaps,
+            randomMaps,
+            chosenMap,
           })
-        }
-      })
+
+          let mapSelectionTimerId
+          let countdownTimerId
+          try {
+            const mapSelectionTimer = createDeferred()
+            this.clientTimers = this.clientTimers.update(client.name, new Timers(), timers =>
+              timers.merge({ mapSelectionTimer }),
+            )
+            mapSelectionTimerId = setTimeout(() => mapSelectionTimer.resolve(), 5000)
+            await mapSelectionTimer
+            this._publishToActiveClient(client.name, { type: 'startCountdown' })
+
+            const countdownTimer = createDeferred()
+            this.clientTimers = this.clientTimers.update(client.name, new Timers(), timers =>
+              timers.merge({ countdownTimer }),
+            )
+            countdownTimerId = setTimeout(() => countdownTimer.resolve(), 5000)
+            await countdownTimer
+            this._publishToActiveClient(client.name, { type: 'allowStart', gameId: setup.gameId })
+          } finally {
+            if (mapSelectionTimerId) {
+              clearTimeout(mapSelectionTimerId)
+              mapSelectionTimerId = null
+            }
+            if (countdownTimerId) {
+              clearTimeout(countdownTimerId)
+              countdownTimerId = null
+            }
+          }
+        }),
+      )
     },
     onRoutesSet: (clients, playerName, routes, gameId) => {
       this._publishToActiveClient(playerName, {
@@ -168,20 +235,39 @@ export class MatchmakingApi {
         routes,
         gameId,
       })
-      this._publishToActiveClient(playerName, { type: 'allowStart', gameId })
     },
     onGameLoaded: clients => {
       for (const client of clients) {
+        this._publishToActiveClient(client.name, { type: 'gameStarted' })
         this._unregisterActivity(client)
       }
     },
   }
 
   _handleLeave = client => {
+    // NOTE(2Pac): Client can leave, i.e. disconnect, during the queueing process, during the
+    // loading process, or even during the game process.
     const entry = this.queueEntries.get(client.name)
-    this.queueEntries = this.queueEntries.delete(client.name)
-    this.matchmakers.get(entry.type).removeFromQueue(entry.username)
-    this.acceptor.registerDisconnect(client)
+    // Means the client disconnected during the queueing process
+    if (entry) {
+      this.queueEntries = this.queueEntries.delete(client.name)
+      this.matchmakers.get(entry.type).removeFromQueue(entry.username)
+      this.acceptor.registerDisconnect(client)
+    }
+
+    // Means the client disconnected during the loading process
+    if (this.clientTimers.has(client.name)) {
+      const { mapSelectionTimer, countdownTimer } = this.clientTimers.get(client.name)
+      if (countdownTimer) {
+        countdownTimer.reject(new Error('Countdown cancelled'))
+      }
+      if (mapSelectionTimer) {
+        mapSelectionTimer.reject(new Error('Map selection cancelled'))
+      }
+
+      this.clientTimers = this.clientTimers.delete(client.name)
+    }
+
     this._unregisterActivity(client)
   }
 
@@ -207,7 +293,7 @@ export class MatchmakingApi {
     }),
   )
   async find(data, next) {
-    const { type, race } = data.get('body')
+    const { type, race, alternateRace, preferredMaps } = data.get('body')
     const user = this.getUser(data)
     const client = this.getClient(data)
 
@@ -230,6 +316,8 @@ export class MatchmakingApi {
       rating,
       interval,
       race,
+      alternateRace,
+      preferredMaps,
     })
     this.matchmakers.get(type).addToQueue(player)
 


### PR DESCRIPTION
The matchmaking loading process starts once all the players accept the
game, and is executed in the following order:
- The players are moved to the "map selection" screen, where the map
  pool for that match is shown and the chosen map is highlighted. That
  screen is shown for 5 seconds and then...
- The players are moved to the "countdown" screen, which is counting
  down from 5 down to a 0, at which point...
- The `allowStart` command is sent to the game (game process was started
  at the beginning of the loading process), and if the game process
  didn't manage to start yet, a "Game is starting..." message is shown
  to the user until it does, after which...
- The game has fully loaded and the users are shown the "Game in
  progress..." message, while being moved to the game to start playing.

Couple of notes about this PR:
- The left nav entry for the matchmaking game while it's loading /
  in-progress is currently broken. It will be fixed in the next PR.
- The map selection screen only highlights the chosen map for the 5
  seconds. It might be more fun to have a highlight indicator randomly
  switch between all of the maps, before settling on the chosen one. PRs
  welcome for this ;)
- The way we display the players will have to change, soon. Currently
  we're only sending player *slots* when the match is ready (since it's
  needed for the game to actually start), but eventually we should send
  actual player's info as well (e.g. their rank, profile image, etc.).