### PR TITLE
Add a basic implementation of an Aws file store.

### DIFF
--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -167,10 +167,10 @@ editor, such as [this one](http://www.zezula.net/en/mpq/download.html) and make 
 editor to extract BW's data files from `stardat.mpq`, `broodat.mpq`, in that order, having
 `broodat.mpq` overwrite any conflicting files from `stardat.mpq`. The necessary directories in
 .mpq files are `unit/` and `tileset/`. Extract those files to a directory (keeping the directory
-structure), and set `config.bwData` in server's `config.js` to that directory.
+structure), and set `SB_SPRITE_DATA` in the `.env` file to that directory.
 
-Set `config.fileStore` in the `config.js` to the directory that you wish to use for uploaded maps
-and their images (see example in `config.example.js`). Now you can use the admin panel and
+Set `SB_FILE_STORE` in the `.env` to the file store implementation that you wish to use for uploaded
+maps and their images (see example in `sample.env`). Now you can use the admin panel and
 "Mass map upload" feature to upload any map(s) from your hard disk to the server. If you wish to
 upload official maps, you can download them from
 [here](https://drive.google.com/file/d/0B76qCUchMgsnb0dla2V2NEdDVTQ/).

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -159,7 +159,16 @@ yarn run migrate-up
 You will need to run this command after pulling in commits that change the database structure as
 well.
 
+### Set up file storage
+
+To make sure the uploading of various files (e.g. maps, replays) is possible, ensure that the
+`SB_FILE_STORE` environment variable is set correctly. Currently, files can be saved on the server's
+filesystem, or on the DigitalOcean Spaces. See `sample.env` for more information on how to configure
+each of those.
+
 ### Set up map system
+
+**NOTE**: File storage must be properly configured beforehand for the map system to correctly work.
 
 The server needs access to some of BW's data files in order to generate map images. Download an mpq
 editor, such as [this one](http://www.zezula.net/en/mpq/download.html) and make sure to download
@@ -168,12 +177,6 @@ editor to extract BW's data files from `stardat.mpq`, `broodat.mpq`, in that ord
 `broodat.mpq` overwrite any conflicting files from `stardat.mpq`. The necessary directories in
 .mpq files are `unit/` and `tileset/`. Extract those files to a directory (keeping the directory
 structure), and set `SB_SPRITE_DATA` in the `.env` file to that directory.
-
-Set `SB_FILE_STORE` in the `.env` to the file store implementation that you wish to use for uploaded
-maps and their images (see example in `sample.env`). Now you can use the admin panel and
-"Mass map upload" feature to upload any map(s) from your hard disk to the server. If you wish to
-upload official maps, you can download them from
-[here](https://drive.google.com/file/d/0B76qCUchMgsnb0dla2V2NEdDVTQ/).
 
 ### Run the server
 

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@babel/preset-env": "^7.7.7",
     "@babel/register": "^7.7.7",
     "@koa/router": "^8.0.8",
+    "aws-sdk": "^2.730.0",
     "bcrypt": "^4.0.1",
     "bl": "^4.0.0",
     "bw-chk": "^1.1.0",

--- a/sample.env
+++ b/sample.env
@@ -50,15 +50,11 @@ SB_RALLY_POINT_SERVERS={"local":{"desc":"Local","address":"::ffff:127.0.0.1","po
 #SB_ROUTE_CREATOR_PORT=14099
 
 
-# A string denoting which file store implementation to use. Must match one of
-# the implementations below (either "filesystem" or "dospaces" for now).
-SB_FILE_STORE="filesystem"
 # JSON string configuring the storage of uploaded files. Currently there are
 # two options, storing to the filesystem and storing to the DigitalOcean Spaces.
-# For the filesystem option, you can change the path (relative to the server
-# directory) to change where it writes to. For the Spaces option, you *must* set
-# the URL to the correct endpoint, and matching access keys.
-SB_FILE_STORE_IMPLEMENTATIONS={"filesystem":{"path":"server/uploaded_files"},"dospaces":{"endpoint":"region.digitaloceanspaces.com","accessKeyId":"ACCESS_KEY_ID","secretAccessKey":"SUPER_SECRET_ACCESS_KEY","bucket":"shieldbattery"}}
+SB_FILE_STORE={"filesystem":{"path":"server/uploaded_files"}}
+# Example DigitalOcean Spaces configuration
+#SB_FILE_STORE={"doSpaces":{"endpoint":"region.digitaloceanspaces.com","accessKeyId":"ACCESS_KEY_ID","secretAccessKey":"SUPER_SECRET_ACCESS_KEY","bucket":"shieldbattery"}}
 
 
 # Configuration for BW sprite data used for map thumbnail generation

--- a/sample.env
+++ b/sample.env
@@ -50,10 +50,15 @@ SB_RALLY_POINT_SERVERS={"local":{"desc":"Local","address":"::ffff:127.0.0.1","po
 #SB_ROUTE_CREATOR_PORT=14099
 
 
-# JSON string configuring the storage of uploaded files. Currently there is only
-# one option, storing to the filesystem. You can change the path (relative to
-# the server directory) to change where it writes to.
-SB_FILE_STORE={"filesystem":{"path":"server/uploaded_files"}}
+# A string denoting which file store implementation to use. Must match one of
+# the implementations below (either "filesystem" or "dospaces" for now).
+SB_FILE_STORE="filesystem"
+# JSON string configuring the storage of uploaded files. Currently there are
+# two options, storing to the filesystem and storing to the DigitalOcean Spaces.
+# For the filesystem option, you can change the path (relative to the server
+# directory) to change where it writes to. For the Spaces option, you *must* set
+# the URL to the correct endpoint, and matching access keys.
+SB_FILE_STORE_IMPLEMENTATIONS={"filesystem":{"path":"server/uploaded_files"},"dospaces":{"endpoint":"region.digitaloceanspaces.com","accessKeyId":"ACCESS_KEY_ID","secretAccessKey":"SUPER_SECRET_ACCESS_KEY","bucket":"shieldbattery"}}
 
 
 # Configuration for BW sprite data used for map thumbnail generation

--- a/server/app.js
+++ b/server/app.js
@@ -75,7 +75,7 @@ if (!process.env.SB_FILE_STORE) {
   throw new Error('SB_FILE_STORE must be specified')
 }
 const fileStoreSettings = JSON.parse(process.env.SB_FILE_STORE)
-if (!(fileStoreSettings.filesystem || fileStoreSettings.doSpaces)) {
+if (!fileStoreSettings) {
   throw new Error('SB_FILE_STORE is invalid')
 }
 if (fileStoreSettings.filesystem) {
@@ -96,6 +96,8 @@ if (fileStoreSettings.filesystem) {
     throw new Error('Invalid "doSpaces" store settings')
   }
   setStore(new AwsStore(settings))
+} else {
+  throw new Error('no valid key could be found in SB_FILE_STORE')
 }
 
 const asyncLookup = thenify(dns.lookup)

--- a/server/app.js
+++ b/server/app.js
@@ -71,18 +71,21 @@ if (rallyPointServers.local) {
     })
 }
 
-if (!process.env.SB_FILE_STORE || !process.env.SB_FILE_STORE_IMPLEMENTATIONS) {
-  throw new Error('SB_FILE_STORE and SB_FILE_STORE_IMPLEMENTATIONS must be specified')
+if (!process.env.SB_FILE_STORE) {
+  throw new Error('SB_FILE_STORE must be specified')
 }
-const fileStoreSettings = JSON.parse(process.env.SB_FILE_STORE_IMPLEMENTATIONS)
-if (process.env.SB_FILE_STORE === 'filesystem') {
+const fileStoreSettings = JSON.parse(process.env.SB_FILE_STORE)
+if (!(fileStoreSettings.filesystem || fileStoreSettings.doSpaces)) {
+  throw new Error('SB_FILE_STORE is invalid')
+}
+if (fileStoreSettings.filesystem) {
   const settings = fileStoreSettings.filesystem
   if (!settings || !settings.path) {
     throw new Error('Invalid "filesystem" store settings')
   }
   setStore(new LocalFileStore(settings))
-} else if (process.env.SB_FILE_STORE === 'dospaces') {
-  const settings = fileStoreSettings.dospaces
+} else if (fileStoreSettings.doSpaces) {
+  const settings = fileStoreSettings.doSpaces
   if (
     !settings ||
     !settings.endpoint ||
@@ -90,11 +93,9 @@ if (process.env.SB_FILE_STORE === 'filesystem') {
     !settings.secretAccessKey ||
     !settings.bucket
   ) {
-    throw new Error('Invalid "dospaces" store settings')
+    throw new Error('Invalid "doSpaces" store settings')
   }
   setStore(new AwsStore(settings))
-} else {
-  throw new Error('SB_FILE_STORE must be either "filesystem" or "dospaces"')
 }
 
 const asyncLookup = thenify(dns.lookup)

--- a/server/lib/file-upload/aws.js
+++ b/server/lib/file-upload/aws.js
@@ -40,7 +40,8 @@ export default class Aws {
   }
 
   _getNormalizedPath(filename) {
-    const normalized = path.normalize(filename)
+    // Force posix path separators on aws-compatible services which use it to create faux folders.
+    const normalized = path.posix.normalize(filename)
     if (path.isAbsolute(normalized) || normalized[0] === '.') {
       throw new Error('Invalid directory')
     }

--- a/server/lib/file-upload/aws.js
+++ b/server/lib/file-upload/aws.js
@@ -1,5 +1,4 @@
 import path from 'path'
-import util from 'util'
 import aws from 'aws-sdk'
 
 // This is a generic implementation of a file-store using the aws-sdk. Note however, that it can be
@@ -22,7 +21,6 @@ export default class Aws {
 
     this.bucket = bucket
     this.client = new aws.S3(options)
-    this.getSignedUrlAsync = util.promisify(this.client.getSignedUrl.bind(this.client))
   }
 
   _getNormalizedPath(filename) {
@@ -48,6 +46,6 @@ export default class Aws {
   async url(filename, options = {}) {
     const normalized = this._getNormalizedPath(filename)
     const params = { Key: normalized, Bucket: this.bucket, ...options }
-    return this.getSignedUrlAsync('getObject', params)
+    return this.client.getSignedUrlPromise('getObject', params)
   }
 }

--- a/server/lib/file-upload/aws.js
+++ b/server/lib/file-upload/aws.js
@@ -1,11 +1,13 @@
 import path from 'path'
 import aws from 'aws-sdk'
 
-import { FILE_MAX_AGE_MS } from './index.js'
+// How long browsers can cache resources for (in seconds). These resources should all be pretty
+// static, so this can be a long time
+export const FILE_MAX_AGE_SECONDS = 14 * 24 * 60 * 60
 
 // Convert some of the more frequently used options to the AWS formatting
 function formatOptions(options = {}) {
-  const formatted = {}
+  const formatted = { ...options }
   if (options.cache) {
     formatted.CacheControl = options.cache
   }
@@ -50,24 +52,34 @@ export default class Aws {
     return normalized
   }
 
+  // Options object can contain any of the valid keys specified in the AWS SDK for the `upload`
+  // function. Besides those, we allow sending some of the more frequently used options in a more
+  // friendlier format, e.g. `cache` can be sent instead of `CacheControl`, and `type` can be sent
+  // instead of `ContentType`.
   async write(filename, stream, options = {}) {
     const normalized = this._getNormalizedPath(filename)
     const params = {
       Key: normalized,
       Bucket: this.bucket,
       Body: stream,
-      CacheControl: `max-age=${FILE_MAX_AGE_MS / 1000}`,
+      CacheControl: `max-age=${FILE_MAX_AGE_SECONDS}`,
       ...formatOptions(options),
     }
     return this.client.upload(params).promise()
   }
 
+  // Options object can contain any of the valid keys specified in the AWS SDK for the
+  // `deleteObject` function.
   async delete(filename, options = {}) {
     const normalized = this._getNormalizedPath(filename)
     const params = { Key: normalized, Bucket: this.bucket, ...formatOptions(options) }
     return this.client.deleteObject(params).promise()
   }
 
+  // Options object can contain any of the valid keys specified in the AWS SDK for the
+  // `getSignedUrlPromise` function. Besides those, we allow sending some of the more frequently
+  // used options in a more friendlier format, e.g. `expires` can be sent instead of `Expires`
+  // which defines how long the fetched URL will be accessible for (default is 15mins).
   async url(filename, options = {}) {
     const normalized = this._getNormalizedPath(filename)
     const params = { Key: normalized, Bucket: this.bucket, ...formatOptions(options) }

--- a/server/lib/file-upload/aws.js
+++ b/server/lib/file-upload/aws.js
@@ -22,6 +22,7 @@ export default class Aws {
 
     this.bucket = bucket
     this.client = new aws.S3(options)
+    this.getSignedUrlAsync = util.promisify(this.client.getSignedUrl.bind(this.client))
   }
 
   _getNormalizedPath(filename) {
@@ -47,7 +48,6 @@ export default class Aws {
   async url(filename, options = {}) {
     const normalized = this._getNormalizedPath(filename)
     const params = { Key: normalized, Bucket: this.bucket, ...options }
-    const getSignedUrlAsPromise = util.promisify(this.client.getSignedUrl.bind(this.client))
-    return getSignedUrlAsPromise('getObject', params)
+    return this.getSignedUrlAsync('getObject', params)
   }
 }

--- a/server/lib/file-upload/aws.js
+++ b/server/lib/file-upload/aws.js
@@ -1,6 +1,22 @@
 import path from 'path'
 import aws from 'aws-sdk'
 
+// Convert some of the more frequently used options to the AWS formatting
+function formatOptions(options = {}) {
+  const formatted = {}
+  if (options.cache) {
+    formatted.CacheControl = options.cache
+  }
+  if (options.type) {
+    formatted.ContentType = options.type
+  }
+  if (options.expires) {
+    formatted.Expires = options.expires
+  }
+
+  return formatted
+}
+
 // This is a generic implementation of a file-store using the aws-sdk. Note however, that it can be
 // used by any compatible storage provider, e.g. DigitalOcean Spaces or Amazon S3.
 export default class Aws {
@@ -33,19 +49,19 @@ export default class Aws {
 
   async write(filename, stream, options = {}) {
     const normalized = this._getNormalizedPath(filename)
-    const params = { Key: normalized, Bucket: this.bucket, Body: stream, ...options }
+    const params = { Key: normalized, Bucket: this.bucket, Body: stream, ...formatOptions(options) }
     return this.client.upload(params).promise()
   }
 
   async delete(filename, options = {}) {
     const normalized = this._getNormalizedPath(filename)
-    const params = { Key: normalized, Bucket: this.bucket, ...options }
+    const params = { Key: normalized, Bucket: this.bucket, ...formatOptions(options) }
     return this.client.deleteObject(params).promise()
   }
 
   async url(filename, options = {}) {
     const normalized = this._getNormalizedPath(filename)
-    const params = { Key: normalized, Bucket: this.bucket, ...options }
+    const params = { Key: normalized, Bucket: this.bucket, ...formatOptions(options) }
     return this.client.getSignedUrlPromise('getObject', params)
   }
 }

--- a/server/lib/file-upload/aws.js
+++ b/server/lib/file-upload/aws.js
@@ -1,6 +1,8 @@
 import path from 'path'
 import aws from 'aws-sdk'
 
+import { FILE_MAX_AGE_MS } from './index.js'
+
 // Convert some of the more frequently used options to the AWS formatting
 function formatOptions(options = {}) {
   const formatted = {}
@@ -50,7 +52,13 @@ export default class Aws {
 
   async write(filename, stream, options = {}) {
     const normalized = this._getNormalizedPath(filename)
-    const params = { Key: normalized, Bucket: this.bucket, Body: stream, ...formatOptions(options) }
+    const params = {
+      Key: normalized,
+      Bucket: this.bucket,
+      Body: stream,
+      CacheControl: `max-age=${FILE_MAX_AGE_MS / 1000}`,
+      ...formatOptions(options),
+    }
     return this.client.upload(params).promise()
   }
 

--- a/server/lib/file-upload/aws.js
+++ b/server/lib/file-upload/aws.js
@@ -1,0 +1,53 @@
+import path from 'path'
+import util from 'util'
+import aws from 'aws-sdk'
+
+// This is a generic implementation of a file-store using the aws-sdk. Note however, that it can be
+// used by any compatible storage provider, e.g. DigitalOcean Spaces or Amazon S3.
+export default class Aws {
+  constructor({ endpoint, accessKeyId, secretAccessKey, region, bucket }) {
+    const options = {
+      accessKeyId,
+      secretAccessKey,
+    }
+
+    // DO Spaces use endpoints
+    if (endpoint) {
+      options.endpoint = new aws.Endpoint(endpoint)
+    }
+    // Amazon S3 uses regions
+    if (region) {
+      options.region = region
+    }
+
+    this.bucket = bucket
+    this.client = new aws.S3(options)
+  }
+
+  _getNormalizedPath(filename) {
+    const normalized = path.normalize(filename)
+    if (path.isAbsolute(normalized) || normalized[0] === '.') {
+      throw new Error('Invalid directory')
+    }
+    return normalized
+  }
+
+  async write(filename, stream, options = {}) {
+    const normalized = this._getNormalizedPath(filename)
+    const params = { Key: normalized, Bucket: this.bucket, Body: stream, ...options }
+    return this.client.upload(params).promise()
+  }
+
+  async delete(filename, options = {}) {
+    const normalized = this._getNormalizedPath(filename)
+    const params = { Key: normalized, Bucket: this.bucket, ...options }
+    return this.client.deleteObject(params).promise()
+  }
+
+  async url(filename, options = {}) {
+    const normalized = this._getNormalizedPath(filename)
+    const params = { Key: normalized, Bucket: this.bucket, ...options }
+    const getSignedUrlAsPromise = util.promisify(this.client.getSignedUrl.bind(this.client))
+    return getSignedUrlAsPromise('getObject', params)
+  }
+}

--- a/server/lib/file-upload/index.js
+++ b/server/lib/file-upload/index.js
@@ -1,9 +1,5 @@
 import { Readable } from 'stream'
 
-// How long browsers can cache resources for (in milliseconds). These resources should all be pretty
-// static, so this can be a long time
-export const FILE_MAX_AGE_MS = 14 * 24 * 60 * 60 * 1000
-
 let store = null
 
 export function setStore(obj) {

--- a/server/lib/file-upload/index.js
+++ b/server/lib/file-upload/index.js
@@ -1,5 +1,9 @@
 import { Readable } from 'stream'
 
+// How long browsers can cache resources for (in milliseconds). These resources should all be pretty
+// static, so this can be a long time
+export const FILE_MAX_AGE_MS = 14 * 24 * 60 * 60 * 1000
+
 let store = null
 
 export function setStore(obj) {
@@ -7,28 +11,25 @@ export function setStore(obj) {
 }
 
 // Accepts either `Buffer` or a `Readable` for `data`
-export async function writeFile(filename, data) {
-  if (Buffer.isBuffer(data)) {
-    return store.write(
-      filename,
-      new Readable({
+export async function writeFile(filename, data, options) {
+  const stream = Buffer.isBuffer(data)
+    ? new Readable({
         read() {
           this.push(data)
           this.push(null)
         },
-      }),
-    )
-  } else {
-    return store.write(filename, data)
-  }
+      })
+    : data
+
+  return store.write(filename, stream, options)
 }
 
-export async function deleteFile(filename) {
-  return store.delete(filename)
+export async function deleteFile(filename, options) {
+  return store.delete(filename, options)
 }
 
-export async function getUrl(filename) {
-  return store.url(filename)
+export async function getUrl(filename, options) {
+  return store.url(filename, options)
 }
 
 export function addMiddleware(app) {

--- a/server/lib/file-upload/local-filesystem.js
+++ b/server/lib/file-upload/local-filesystem.js
@@ -6,9 +6,7 @@ import path from 'path'
 import thenify from 'thenify'
 import util from 'util'
 
-// How long browsers can cache resources for (in milliseconds). These resources should all be pretty
-// static, so this can be a long time
-const FILE_MAX_AGE_MS = 14 * 24 * 60 * 60 * 1000
+import { FILE_MAX_AGE_MS } from './index.js'
 
 const access = thenify(fs.access)
 const mkdir = thenify(fs.mkdir)

--- a/server/lib/file-upload/local-filesystem.js
+++ b/server/lib/file-upload/local-filesystem.js
@@ -6,7 +6,9 @@ import path from 'path'
 import thenify from 'thenify'
 import util from 'util'
 
-import { FILE_MAX_AGE_MS } from './index.js'
+// How long browsers can cache resources for (in milliseconds). These resources should all be pretty
+// static, so this can be a long time
+export const FILE_MAX_AGE_MS = 14 * 24 * 60 * 60 * 1000
 
 const access = thenify(fs.access)
 const mkdir = thenify(fs.mkdir)

--- a/server/lib/maps/store.js
+++ b/server/lib/maps/store.js
@@ -16,7 +16,7 @@ export async function storeMap(path, extension, uploadedBy, visibility) {
   const mapParams = { mapData, extension, uploadedBy, visibility }
   const map = await addMap(mapParams, async () => {
     if (imageStream) {
-      await writeFile(imagePath(hash), imageStream)
+      await writeFile(imagePath(hash), imageStream, { type: 'image/jpeg' })
     }
     await writeFile(mapPath(hash, extension), fs.createReadStream(path))
   })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1766,6 +1766,21 @@ available-typed-arrays@^1.0.0, available-typed-arrays@^1.0.2:
   dependencies:
     array-filter "^1.0.0"
 
+aws-sdk@^2.730.0:
+  version "2.730.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.730.0.tgz#5b2775bb0c3cd7764031a17a9bcac3f1aafc385e"
+  integrity sha512-hYHplsbgUDP0XuaVJaHx2L/nC0E1i+4dGlkAQpkJz3qQ4NDfLnrbUFsA2g3AyWAsrnjrBNCkexPvwnV82Qng1g==
+  dependencies:
+    buffer "4.9.2"
+    events "1.1.1"
+    ieee754 "1.1.13"
+    jmespath "0.15.0"
+    querystring "0.2.0"
+    sax "1.2.1"
+    url "0.10.3"
+    uuid "3.3.2"
+    xml2js "0.4.19"
+
 babel-eslint@^10.0.3:
   version "10.1.0"
   resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-10.1.0.tgz#6968e568a910b78fb3779cdd8b6ac2f479943232"
@@ -2133,7 +2148,7 @@ buffer-xor@^1.0.3:
   resolved "https://registry.yarnpkg.com/buffer-xor/-/buffer-xor-1.0.3.tgz#26e61ed1422fb70dd42e6e36729ed51d855fe8d9"
   integrity sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=
 
-buffer@^4.3.0:
+buffer@4.9.2, buffer@^4.3.0:
   version "4.9.2"
   resolved "https://registry.yarnpkg.com/buffer/-/buffer-4.9.2.tgz#230ead344002988644841ab0244af8c44bbe3ef8"
   integrity sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==
@@ -4257,6 +4272,11 @@ etag@~1.8.1:
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
   integrity sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=
 
+events@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
+  integrity sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=
+
 events@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/events/-/events-3.1.0.tgz#84279af1b34cb75aa88bf5ff291f6d0bd9b31a59"
@@ -5337,7 +5357,7 @@ icss-utils@^4.0.0, icss-utils@^4.1.1:
   dependencies:
     postcss "^7.0.14"
 
-ieee754@^1.1.4:
+ieee754@1.1.13, ieee754@^1.1.4:
   version "1.1.13"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.13.tgz#ec168558e95aa181fd87d37f55c32bbcb6708b84"
   integrity sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==
@@ -5988,7 +6008,7 @@ jest-worker@^26.0.0:
     merge-stream "^2.0.0"
     supports-color "^7.0.0"
 
-jmespath@^0.15.0:
+jmespath@0.15.0, jmespath@^0.15.0:
   version "0.15.0"
   resolved "https://registry.yarnpkg.com/jmespath/-/jmespath-0.15.0.tgz#a3f222a9aae9f966f5d27c796510e28091764217"
   integrity sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=
@@ -9742,7 +9762,12 @@ sanitize-filename@^1.6.2, sanitize-filename@^1.6.3:
   dependencies:
     truncate-utf8-bytes "^1.0.0"
 
-sax@^1.2.4, sax@~1.2.4:
+sax@1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.1.tgz#7b8e656190b228e81a66aea748480d828cd2d37a"
+  integrity sha1-e45lYZCyKOgaZq6nSEgNgozS03o=
+
+sax@>=0.6.0, sax@^1.2.4, sax@~1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
@@ -11109,6 +11134,14 @@ url-parse-lax@^3.0.0:
   dependencies:
     prepend-http "^2.0.0"
 
+url@0.10.3:
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/url/-/url-0.10.3.tgz#021e4d9c7705f21bbf37d03ceb58767402774c64"
+  integrity sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=
+  dependencies:
+    punycode "1.3.2"
+    querystring "0.2.0"
+
 url@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/url/-/url-0.11.0.tgz#3838e97cfc60521eb73c525a8e55bfdd9e2e28f1"
@@ -11172,6 +11205,11 @@ utils-merge@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=
+
+uuid@3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
+  integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
 
 uuid@^3.1.0, uuid@^3.3.2:
   version "3.4.0"
@@ -11561,6 +11599,19 @@ xdg-basedir@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/xdg-basedir/-/xdg-basedir-4.0.0.tgz#4bc8d9984403696225ef83a1573cbbcb4e79db13"
   integrity sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==
+
+xml2js@0.4.19:
+  version "0.4.19"
+  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.19.tgz#686c20f213209e94abf0d1bcf1efaa291c7827a7"
+  integrity sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==
+  dependencies:
+    sax ">=0.6.0"
+    xmlbuilder "~9.0.1"
+
+xmlbuilder@~9.0.1:
+  version "9.0.7"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-9.0.7.tgz#132ee63d2ec5565c557e20f4c22df9aca686b10d"
+  integrity sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=
 
 xmlhttprequest-ssl@~1.5.4:
   version "1.5.5"


### PR DESCRIPTION
Aws file store can be used by any service that is compatible with
aws-sdk. For now, we're only allowing the usage of DigitalOcean Spaces,
but it shouldn't be much of a problem to support Amazon S3 as well, if
needed.