### PR TITLE
Generate a smaller sized image for all maps and use it as a thumbnail.

### DIFF
--- a/client/maps/map-thumbnail.jsx
+++ b/client/maps/map-thumbnail.jsx
@@ -209,6 +209,8 @@ export default class MapThumbnail extends React.Component {
       <Container className={this.props.className}>
         {map.thumbnailUrl ? (
           <picture>
+            <source srcSet={`${map.thumbnailUrl} 1x`} />
+            <source srcSet={`${map.thumbnailx2Url} 2x`} />
             <MapImage src={map.thumbnailUrl} alt={map.name} draggable={false} />
           </picture>
         ) : (

--- a/client/maps/map-thumbnail.jsx
+++ b/client/maps/map-thumbnail.jsx
@@ -207,9 +207,9 @@ export default class MapThumbnail extends React.Component {
 
     return (
       <Container className={this.props.className}>
-        {map.imageUrl ? (
+        {map.thumbnailUrl ? (
           <picture>
-            <MapImage src={map.imageUrl} alt={map.name} draggable={false} />
+            <MapImage src={map.thumbnailUrl} alt={map.name} draggable={false} />
           </picture>
         ) : (
           <NoImage>

--- a/client/maps/maps-reducer.js
+++ b/client/maps/maps-reducer.js
@@ -35,6 +35,7 @@ export const MapRecord = new Record({
   isFavorited: false,
   mapUrl: null,
   imageUrl: null,
+  thumbnailUrl: null,
 })
 const FavoritedMaps = new Record({
   list: new List(),

--- a/client/maps/maps-reducer.js
+++ b/client/maps/maps-reducer.js
@@ -35,7 +35,9 @@ export const MapRecord = new Record({
   isFavorited: false,
   mapUrl: null,
   imageUrl: null,
+  imagex2Url: null,
   thumbnailUrl: null,
+  thumbnailx2Url: null,
 })
 const FavoritedMaps = new Record({
   list: new List(),

--- a/server/lib/api/maps.js
+++ b/server/lib/api/maps.js
@@ -262,6 +262,8 @@ async function removeFromFavorites(ctx, next) {
 }
 
 async function deleteAllMaps(ctx, next) {
-  await dbDeleteAllMaps(() => Promise.all([deleteFiles('maps/'), deleteFiles('map_images/')]))
+  await dbDeleteAllMaps(() =>
+    Promise.all([deleteFiles('maps/'), deleteFiles('map_images/'), deleteFiles('map_thumbnails/')]),
+  )
   ctx.status = 204
 }

--- a/server/lib/api/maps.js
+++ b/server/lib/api/maps.js
@@ -263,7 +263,13 @@ async function removeFromFavorites(ctx, next) {
 
 async function deleteAllMaps(ctx, next) {
   await dbDeleteAllMaps(() =>
-    Promise.all([deleteFiles('maps/'), deleteFiles('map_images/'), deleteFiles('map_thumbnails/')]),
+    Promise.all([
+      deleteFiles('maps/'),
+      deleteFiles('map_images/'),
+      deleteFiles('map_images_x2/'),
+      deleteFiles('map_thumbnails/'),
+      deleteFiles('map_thumbnails_x2/'),
+    ]),
   )
   ctx.status = 204
 }

--- a/server/lib/maps/store.js
+++ b/server/lib/maps/store.js
@@ -16,20 +16,38 @@ const mapQueue = new Queue(MAX_CONCURRENT)
 // and the temppath of compressed mpq, which will be needed
 // when the map is actually stored somewhere.
 export async function storeMap(path, extension, uploadedBy, visibility) {
-  const { mapData, imageStream, thumbnailStream } = await mapQueue.addToQueue(() =>
-    mapParseWorker(path, extension),
-  )
+  const {
+    mapData,
+    imageStream,
+    imagex2Stream,
+    thumbnailStream,
+    thumbnailx2Stream,
+  } = await mapQueue.addToQueue(() => mapParseWorker(path, extension))
   const { hash } = mapData
 
   const mapParams = { mapData, extension, uploadedBy, visibility }
   const map = await addMap(mapParams, async () => {
-    if (imageStream) {
-      await writeFile(imagePath(hash), imageStream, { type: 'image/jpeg' })
-    }
-    if (thumbnailStream) {
-      await writeFile(thumbnailPath(hash), thumbnailStream, { type: 'image/jpeg' })
-    }
-    await writeFile(mapPath(hash, extension), fs.createReadStream(path))
+    const imagePromise = imageStream
+      ? writeFile(imagePath(hash), imageStream, { type: 'image/jpeg' })
+      : Promise.resolve()
+    const imagex2Promise = imagex2Stream
+      ? writeFile(imagex2Path(hash), imagex2Stream, { type: 'image/jpeg' })
+      : Promise.resolve()
+    const thumbnailPromise = thumbnailStream
+      ? writeFile(thumbnailPath(hash), thumbnailStream, { type: 'image/jpeg' })
+      : Promise.resolve()
+    const thumbnailx2Promise = thumbnailx2Stream
+      ? writeFile(thumbnailx2Path(hash), thumbnailx2Stream, { type: 'image/jpeg' })
+      : Promise.resolve()
+    const mapPromise = writeFile(mapPath(hash, extension), fs.createReadStream(path))
+
+    await Promise.all([
+      imagePromise,
+      imagex2Promise,
+      thumbnailPromise,
+      thumbnailx2Promise,
+      mapPromise,
+    ])
   })
 
   return map
@@ -47,22 +65,39 @@ export function imagePath(hash) {
   return `map_images/${firstByte}/${secondByte}/${hash}.jpg`
 }
 
+export function imagex2Path(hash) {
+  const firstByte = hash.substr(0, 2)
+  const secondByte = hash.substr(2, 2)
+  return `map_images_x2/${firstByte}/${secondByte}/${hash}@x2.jpg`
+}
+
 export function thumbnailPath(hash) {
   const firstByte = hash.substr(0, 2)
   const secondByte = hash.substr(2, 2)
   return `map_thumbnails/${firstByte}/${secondByte}/${hash}.jpg`
 }
 
+export function thumbnailx2Path(hash) {
+  const firstByte = hash.substr(0, 2)
+  const secondByte = hash.substr(2, 2)
+  return `map_thumbnails_x2/${firstByte}/${secondByte}/${hash}@x2.jpg`
+}
+
 async function mapParseWorker(path, extension) {
-  const { messages, imageStream, thumbnailStream } = await runChildProcess(
-    require.resolve('./map-parse-worker'),
-    [path, extension, BW_DATA_PATH],
-  )
+  const {
+    messages,
+    imageStream,
+    imagex2Stream,
+    thumbnailStream,
+    thumbnailx2Stream,
+  } = await runChildProcess(require.resolve('./map-parse-worker'), [path, extension, BW_DATA_PATH])
   console.assert(messages.length === 1)
   return {
     mapData: messages[0],
     imageStream: BW_DATA_PATH ? imageStream : null,
+    imagex2Stream: BW_DATA_PATH ? imagex2Stream : null,
     thumbnailStream: BW_DATA_PATH ? thumbnailStream : null,
+    thumbnailx2Stream: BW_DATA_PATH ? thumbnailx2Stream : null,
   }
 }
 
@@ -74,7 +109,7 @@ function runChildProcess(path, args) {
     }
   }
   const result = new Promise(async (resolve, reject) => {
-    const opts = { stdio: [0, 1, 2, 'pipe', 'pipe', 'ipc'] }
+    const opts = { stdio: [0, 1, 2, 'pipe', 'pipe', 'pipe', 'pipe', 'ipc'] }
     const child = childProcess.fork(path, args, opts)
     let error = false
     let inited = false
@@ -101,8 +136,12 @@ function runChildProcess(path, args) {
     // will get lost. Buffering the data with a PassThrough prevents that, without requiring
     // the pipe consumer to send any synchronization messages themselves.
     const imageStream = child.stdio[3].pipe(bl())
-    const thumbnailStream = child.stdio[4].pipe(bl())
-    child.on('exit', () => resolve({ messages, imageStream, thumbnailStream }))
+    const imagex2Stream = child.stdio[4].pipe(bl())
+    const thumbnailStream = child.stdio[5].pipe(bl())
+    const thumbnailx2Stream = child.stdio[6].pipe(bl())
+    child.on('exit', () =>
+      resolve({ messages, imageStream, imagex2Stream, thumbnailStream, thumbnailx2Stream }),
+    )
     child.on('message', message => {
       if (inited) {
         resetTimeout()

--- a/server/lib/models/maps.js
+++ b/server/lib/models/maps.js
@@ -3,7 +3,7 @@ import transact from '../db/transaction'
 import sql from 'sql-template-strings'
 import { tilesetIdToName, SORT_BY_NUM_OF_PLAYERS, SORT_BY_DATE } from '../../../common/maps'
 import { getUrl } from '../file-upload'
-import { mapPath, imagePath } from '../maps/store'
+import { mapPath, imagePath, thumbnailPath } from '../maps/store'
 
 // This model contains information from three separate tables (`maps`, `uploaded_maps` and `users`)
 // and should always be fully constructed, so pieces of code that use it don't have to be defensive
@@ -35,6 +35,7 @@ class MapInfo {
     this.isFavorited = !!props.favorited
     this.mapUrl = null
     this.imageUrl = null
+    this.thumbnailUrl = null
   }
 }
 
@@ -42,9 +43,15 @@ const createMapInfo = async info => {
   const map = new MapInfo(info)
   const hashString = map.hash.toString('hex')
 
+  const [mapUrl, imageUrl, thumbnailUrl] = await Promise.all([
+    getUrl(mapPath(hashString, map.mapData.format)),
+    getUrl(imagePath(hashString)),
+    getUrl(thumbnailPath(hashString)),
+  ])
   map.hash = hashString
-  map.mapUrl = await getUrl(mapPath(hashString, map.mapData.format))
-  map.imageUrl = await getUrl(imagePath(hashString))
+  map.mapUrl = mapUrl
+  map.imageUrl = imageUrl
+  map.thumbnailUrl = thumbnailUrl
 
   return map
 }

--- a/server/lib/models/maps.js
+++ b/server/lib/models/maps.js
@@ -3,7 +3,7 @@ import transact from '../db/transaction'
 import sql from 'sql-template-strings'
 import { tilesetIdToName, SORT_BY_NUM_OF_PLAYERS, SORT_BY_DATE } from '../../../common/maps'
 import { getUrl } from '../file-upload'
-import { mapPath, imagePath, thumbnailPath } from '../maps/store'
+import { mapPath, imagePath, imagex2Path, thumbnailPath, thumbnailx2Path } from '../maps/store'
 
 // This model contains information from three separate tables (`maps`, `uploaded_maps` and `users`)
 // and should always be fully constructed, so pieces of code that use it don't have to be defensive
@@ -35,7 +35,9 @@ class MapInfo {
     this.isFavorited = !!props.favorited
     this.mapUrl = null
     this.imageUrl = null
+    this.imagex2Url = null
     this.thumbnailUrl = null
+    this.thumbnailx2Url = null
   }
 }
 
@@ -43,15 +45,19 @@ const createMapInfo = async info => {
   const map = new MapInfo(info)
   const hashString = map.hash.toString('hex')
 
-  const [mapUrl, imageUrl, thumbnailUrl] = await Promise.all([
+  const [mapUrl, imageUrl, imagex2Url, thumbnailUrl, thumbnailx2Url] = await Promise.all([
     getUrl(mapPath(hashString, map.mapData.format)),
     getUrl(imagePath(hashString)),
+    getUrl(imagex2Path(hashString)),
     getUrl(thumbnailPath(hashString)),
+    getUrl(thumbnailx2Path(hashString)),
   ])
   map.hash = hashString
   map.mapUrl = mapUrl
   map.imageUrl = imageUrl
+  map.imagex2Url = imagex2Url
   map.thumbnailUrl = thumbnailUrl
+  map.thumbnailx2Url = thumbnailx2Url
 
   return map
 }


### PR DESCRIPTION
This PR assumes we're only gonna generate two images for each map, so
it doesn't bother making the code too generic to work for N amount of
images. That seems like a reasonable assumption for now. If it ever
breaks, some kind of an array format will need to be used to work with
the image URLs, and their saving path might need to be rethought.