### PR TITLE
Create a MapImage component that should be used as a primitive for

### DIFF
--- a/client/lobbies/loading.jsx
+++ b/client/lobbies/loading.jsx
@@ -242,7 +242,7 @@ const GameTypeMapBridge = styled(Display1)`
   color: ${colorTextSecondary};
 `
 
-const MapThumbnail = styled.div`
+const MapImageContainer = styled.div`
   ${shadow1dp};
   width: 256px;
   height: auto;
@@ -301,9 +301,9 @@ export default class LoadingScreen extends React.Component {
           <GameTypeMapBridge as='span'> on </GameTypeMapBridge>
           <Display1 as='span'>{lobby.map.name}</Display1>
         </div>
-        <MapThumbnail>
-          <MapImage map={lobby.map} showNotAvailableText={true} />
-        </MapThumbnail>
+        <MapImageContainer>
+          <MapImage map={lobby.map} />
+        </MapImageContainer>
         <Players>{playerElems}</Players>
         <LoadingMessage />
       </Content>

--- a/client/lobbies/loading.jsx
+++ b/client/lobbies/loading.jsx
@@ -4,6 +4,7 @@ import { getPlayerSlots } from '../../common/lobbies'
 import gameTypeToString from './game-type-to-string'
 import styled from 'styled-components'
 
+import MapImage from '../maps/map-image.jsx'
 import PlayerCard from './player-card.jsx'
 
 import { colorTextSecondary } from '../styles/colors'
@@ -241,12 +242,13 @@ const GameTypeMapBridge = styled(Display1)`
   color: ${colorTextSecondary};
 `
 
-const MapThumbnail = styled.img`
+const MapThumbnail = styled.div`
   ${shadow1dp};
   width: 256px;
   height: auto;
   border-radius: 2px;
   margin-top: 16px;
+  overflow: hidden;
 `
 
 const Players = styled.div`
@@ -299,9 +301,9 @@ export default class LoadingScreen extends React.Component {
           <GameTypeMapBridge as='span'> on </GameTypeMapBridge>
           <Display1 as='span'>{lobby.map.name}</Display1>
         </div>
-        <div>
-          <MapThumbnail src={lobby.map.imageUrl} />
-        </div>
+        <MapThumbnail>
+          <MapImage map={lobby.map} showNotAvailableText={true} />
+        </MapThumbnail>
         <Players>{playerElems}</Players>
         <LoadingMessage />
       </Content>

--- a/client/lobbies/lobby-reducer.js
+++ b/client/lobbies/lobby-reducer.js
@@ -24,6 +24,7 @@ import {
   LOBBY_UPDATE_LOADING_START,
   LOBBY_UPDATE_LOADING_CANCELED,
   LOBBY_UPDATE_CHAT_MESSAGE,
+  MAPS_TOGGLE_FAVORITE,
   NETWORK_SITE_CONNECTED,
 } from '../actions'
 
@@ -152,6 +153,12 @@ const infoReducer = keyedReducer(undefined, {
 
   [NETWORK_SITE_CONNECTED](state, action) {
     return new LobbyInfo()
+  },
+
+  [MAPS_TOGGLE_FAVORITE](state, action) {
+    const { map } = action.meta
+
+    return state.setIn(['map', 'isFavorited'], !map.isFavorited)
   },
 })
 

--- a/client/lobbies/lobby.jsx
+++ b/client/lobbies/lobby.jsx
@@ -335,7 +335,7 @@ const MapName = styled(Headline)`
   margin: 0;
 `
 
-const MapThumbnail = styled.div`
+const MapImageContainer = styled.div`
   ${shadow1dp};
   position: relative;
   width: 256px;
@@ -590,8 +590,8 @@ export default class Lobby extends React.Component {
         <Info>
           <RaisedButton label='Leave lobby' onClick={onLeaveLobbyClick} />
           <MapName>{lobby.map.name}</MapName>
-          <MapThumbnail>
-            <MapImage map={lobby.map} showNotAvailableText={true} />
+          <MapImageContainer>
+            <MapImage map={lobby.map} />
             <MapPreviewIcon
               icon={<PreviewIcon />}
               title={'Show map preview'}
@@ -603,7 +603,7 @@ export default class Lobby extends React.Component {
               title={lobby.map.isFavorited ? 'Remove from favorites' : 'Add to favorites'}
               onClick={onToggleFavoriteMap}
             />
-          </MapThumbnail>
+          </MapImageContainer>
           <InfoItem>
             <InfoLabel as='span'>Game type</InfoLabel>
             <InfoValue as='span'>{gameTypeToString(lobby.gameType)}</InfoValue>

--- a/client/lobbies/lobby.jsx
+++ b/client/lobbies/lobby.jsx
@@ -12,7 +12,10 @@ import {
 } from '../../common/lobbies'
 
 import Card from '../material/card.jsx'
+import IconButton from '../material/icon-button.jsx'
+import { Label } from '../material/button.jsx'
 import RaisedButton from '../material/raised-button.jsx'
+import MapImage from '../maps/map-image.jsx'
 import MessageInput from '../messaging/message-input.jsx'
 import { ScrollableContent } from '../material/scroll-bar.jsx'
 import { ChatMessageLayout, ChatMessage } from '../messaging/message.jsx'
@@ -20,6 +23,10 @@ import OpenSlot from './open-slot.jsx'
 import ClosedSlot from './closed-slot.jsx'
 import PlayerSlot from './player-slot.jsx'
 import { ObserverSlots, RegularSlots, TeamName } from './slot.jsx'
+
+import FavoritedIcon from '../icons/material/baseline-star-24px.svg'
+import PreviewIcon from '../icons/material/zoom_in-24px.svg'
+import UnfavoritedIcon from '../icons/material/baseline-star_border-24px.svg'
 
 import { blue100, blue200, colorTextSecondary } from '../styles/colors'
 import { Body1, Body2, Headline, Subheading, robotoCondensed, Display1 } from '../styles/typography'
@@ -328,12 +335,33 @@ const MapName = styled(Headline)`
   margin: 0;
 `
 
-const MapThumbnail = styled.img`
+const MapThumbnail = styled.div`
   ${shadow1dp};
-
+  position: relative;
   width: 256px;
   border-radius: 2px;
   margin-top: 8px;
+  overflow: hidden;
+`
+
+const MapPreviewIcon = styled(IconButton)`
+  position: absolute;
+  top: 4px;
+  left: 4px;
+
+  & ${Label} {
+    color: ${colorTextSecondary};
+  }
+`
+
+const FavoriteActionIcon = styled(IconButton)`
+  position: absolute;
+  top: 4px;
+  right: 4px;
+
+  & ${Label} {
+    color: ${colorTextSecondary};
+  }
 `
 
 const InfoItem = styled.div`
@@ -365,6 +393,7 @@ export default class Lobby extends React.Component {
     lobby: PropTypes.object.isRequired,
     chat: PropTypes.object.isRequired,
     user: PropTypes.object,
+    isFavoritingMap: PropTypes.bool,
     onLeaveLobbyClick: PropTypes.func,
     onSetRace: PropTypes.func,
     onAddComputer: PropTypes.func,
@@ -376,6 +405,8 @@ export default class Lobby extends React.Component {
     onBanPlayer: PropTypes.func,
     onMakeObserver: PropTypes.func,
     onRemoveObserver: PropTypes.func,
+    onMapPreview: PropTypes.func,
+    onToggleFavoriteMap: PropTypes.func,
   }
 
   getTeamSlots(team, isObserver, isLobbyUms) {
@@ -517,7 +548,14 @@ export default class Lobby extends React.Component {
   }
 
   render() {
-    const { lobby, onLeaveLobbyClick, onSendChatMessage } = this.props
+    const {
+      lobby,
+      isFavoritingMap,
+      onLeaveLobbyClick,
+      onSendChatMessage,
+      onMapPreview,
+      onToggleFavoriteMap,
+    } = this.props
 
     const isLobbyUms = isUms(lobby.gameType)
     const slots = []
@@ -552,7 +590,20 @@ export default class Lobby extends React.Component {
         <Info>
           <RaisedButton label='Leave lobby' onClick={onLeaveLobbyClick} />
           <MapName>{lobby.map.name}</MapName>
-          <MapThumbnail src={lobby.map.imageUrl} />
+          <MapThumbnail>
+            <MapImage map={lobby.map} showNotAvailableText={true} />
+            <MapPreviewIcon
+              icon={<PreviewIcon />}
+              title={'Show map preview'}
+              onClick={onMapPreview}
+            />
+            <FavoriteActionIcon
+              disabled={isFavoritingMap}
+              icon={lobby.map.isFavorited ? <FavoritedIcon /> : <UnfavoritedIcon />}
+              title={lobby.map.isFavorited ? 'Remove from favorites' : 'Add to favorites'}
+              onClick={onToggleFavoriteMap}
+            />
+          </MapThumbnail>
           <InfoItem>
             <InfoLabel as='span'>Game type</InfoLabel>
             <InfoValue as='span'>{gameTypeToString(lobby.gameType)}</InfoValue>

--- a/client/lobbies/view.jsx
+++ b/client/lobbies/view.jsx
@@ -7,6 +7,10 @@ import styled from 'styled-components'
 import Lobby from './lobby.jsx'
 import LoadingScreen from './loading.jsx'
 import LoadingIndicator from '../progress/dots.jsx'
+import MapPreview from '../maps/map-preview.jsx'
+
+import { openSimpleDialog } from '../dialogs/action-creators'
+import { toggleFavoriteMap } from '../maps/action-creators'
 
 import {
   addComputer,
@@ -33,6 +37,7 @@ const mapStateToProps = state => {
     lobby: state.lobby,
     gameClient: state.gameClient,
     activeGame: state.activeGame,
+    maps: state.maps,
   }
 }
 
@@ -116,7 +121,7 @@ export default class LobbyView extends React.Component {
 
   renderLobby = () => {
     const routeLobby = this.props.match.params.lobby
-    const { lobby, user } = this.props
+    const { lobby, maps, user } = this.props
 
     let content
     if (!lobby.inLobby) {
@@ -129,6 +134,7 @@ export default class LobbyView extends React.Component {
           lobby={lobby.info}
           chat={lobby.chat}
           user={user}
+          isFavoritingMap={maps.favoriteStatusRequests.has(lobby.info.map.id)}
           onLeaveLobbyClick={this.onLeaveLobbyClick}
           onAddComputer={this.onAddComputer}
           onSetRace={this.onSetRace}
@@ -141,6 +147,8 @@ export default class LobbyView extends React.Component {
           onRemoveObserver={this.onRemoveObserver}
           onStartGame={this.onStartGame}
           onSendChatMessage={this.onSendChatMessage}
+          onMapPreview={this.onMapPreview}
+          onToggleFavoriteMap={this.onToggleFavoriteMap}
         />
       )
     }
@@ -265,5 +273,19 @@ export default class LobbyView extends React.Component {
 
   onStartGame = () => {
     this.props.dispatch(startCountdown())
+  }
+
+  onMapPreview = () => {
+    const {
+      lobby: {
+        info: { map },
+      },
+    } = this.props
+
+    this.props.dispatch(openSimpleDialog(map.name, <MapPreview map={map} />, false /* hasButton */))
+  }
+
+  onToggleFavoriteMap = () => {
+    this.props.dispatch(toggleFavoriteMap(this.props.lobby.info.map))
   }
 }

--- a/client/maps/browse-server-maps.jsx
+++ b/client/maps/browse-server-maps.jsx
@@ -131,6 +131,7 @@ class MapList extends React.PureComponent {
     byId: PropTypes.instanceOf(Map),
     user: PropTypes.object.isRequired,
     canManageMaps: PropTypes.bool.isRequired,
+    thumbnailSize: PropTypes.number,
     favoriteStatusRequests: PropTypes.instanceOf(Set),
     onMapSelect: PropTypes.func,
     onMapPreview: PropTypes.func,
@@ -145,6 +146,7 @@ class MapList extends React.PureComponent {
       byId,
       user,
       canManageMaps,
+      thumbnailSize,
       favoriteStatusRequests,
       onMapSelect,
       onMapPreview,
@@ -164,6 +166,7 @@ class MapList extends React.PureComponent {
         <MapThumbnail
           key={id}
           map={map}
+          size={THUMBNAIL_SIZES[thumbnailSize].columnCount === 2 ? 512 : 256}
           showMapName={true}
           isFavoriting={favoriteStatusRequests.has(map.id)}
           onClick={onMapSelect ? () => onMapSelect(map) : undefined}
@@ -302,6 +305,7 @@ export default class Maps extends React.Component {
             byId={maps.byId}
             user={auth.user}
             canManageMaps={auth.permissions.manageMaps}
+            thumbnailSize={thumbnailSize}
             favoriteStatusRequests={favoriteStatusRequests}
             onMapSelect={onMapSelect}
             onMapPreview={this.onMapPreview}

--- a/client/maps/map-image.jsx
+++ b/client/maps/map-image.jsx
@@ -1,0 +1,74 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import styled from 'styled-components'
+
+import ImageIcon from '../icons/material/baseline-image-24px.svg'
+
+import { grey800 } from '../styles/colors'
+import { Subheading } from '../styles/typography'
+
+const ImgElement = styled.img`
+  display: block;
+  width: 100%;
+  object-fit: cover;
+`
+
+const NoImage = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  min-height: 220px;
+  background-color: ${grey800};
+
+  & > svg {
+    width: 90px;
+    height: 90px;
+    opacity: 0.5;
+  }
+`
+
+export default class MapImage extends React.Component {
+  static propTypes = {
+    map: PropTypes.object.isRequired,
+    size: PropTypes.number,
+    showNotAvailableText: PropTypes.bool,
+  }
+
+  static defaultProps = {
+    size: 256,
+  }
+
+  render() {
+    const { map, size, showNotAvailableText } = this.props
+    const srcSet = `
+      ${map.image256Url} 256w,
+      ${map.image512Url} 512w,
+      ${map.image1024Url} 1024w,
+      ${map.image2048Url} 2048w
+    `
+
+    // TODO(2Pac): Actually check if the image URL is available instead of just checking it's set.
+    return (
+      <>
+        {map.image256Url ? (
+          <ImgElement
+            className={this.props.className}
+            srcSet={srcSet}
+            sizes={`${size}px`}
+            src={map.image256Url}
+            alt={map.name}
+            draggable={false}
+          />
+        ) : (
+          <NoImage>
+            <ImageIcon />
+            {showNotAvailableText ? <Subheading>Map preview not available</Subheading> : null}
+          </NoImage>
+        )}
+      </>
+    )
+  }
+}

--- a/client/maps/map-image.jsx
+++ b/client/maps/map-image.jsx
@@ -9,11 +9,9 @@ import { Subheading } from '../styles/typography'
 
 const ImgElement = styled.img`
   display: block;
-  width: 100%;
-  object-fit: cover;
 `
 
-const NoImage = styled.div`
+const NoImageContainer = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -30,19 +28,28 @@ const NoImage = styled.div`
   }
 `
 
+const NoImage = () => (
+  <NoImageContainer>
+    <ImageIcon />
+    <Subheading>Map preview not available</Subheading>
+  </NoImageContainer>
+)
+
 export default class MapImage extends React.Component {
   static propTypes = {
     map: PropTypes.object.isRequired,
     size: PropTypes.number,
-    showNotAvailableText: PropTypes.bool,
+    altText: PropTypes.string,
+    noImageElem: PropTypes.element,
   }
 
   static defaultProps = {
     size: 256,
+    noImageElem: <NoImage />,
   }
 
   render() {
-    const { map, size, showNotAvailableText } = this.props
+    const { map, size, altText, noImageElem } = this.props
     const srcSet = `
       ${map.image256Url} 256w,
       ${map.image512Url} 512w,
@@ -50,7 +57,7 @@ export default class MapImage extends React.Component {
       ${map.image2048Url} 2048w
     `
 
-    // TODO(2Pac): Actually check if the image URL is available instead of just checking it's set.
+    // TODO(2Pac): handle 404s
     return (
       <>
         {map.image256Url ? (
@@ -59,14 +66,11 @@ export default class MapImage extends React.Component {
             srcSet={srcSet}
             sizes={`${size}px`}
             src={map.image256Url}
-            alt={map.name}
+            alt={altText || map.name}
             draggable={false}
           />
         ) : (
-          <NoImage>
-            <ImageIcon />
-            {showNotAvailableText ? <Subheading>Map preview not available</Subheading> : null}
-          </NoImage>
+          noImageElem
         )}
       </>
     )

--- a/client/maps/map-preview.jsx
+++ b/client/maps/map-preview.jsx
@@ -1,7 +1,12 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import styled from 'styled-components'
 
 import MapImage from './map-image.jsx'
+
+const StyledMapImage = styled(MapImage)`
+  width: 100%;
+`
 
 export default class MapPreview extends React.Component {
   static propTypes = {
@@ -11,6 +16,6 @@ export default class MapPreview extends React.Component {
   render() {
     const { map } = this.props
 
-    return <MapImage map={map} size={1024} showNotAvailableText={true} />
+    return <StyledMapImage map={map} size={1024} />
   }
 }

--- a/client/maps/map-preview.jsx
+++ b/client/maps/map-preview.jsx
@@ -1,32 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import styled from 'styled-components'
 
-import ImageIcon from '../icons/material/baseline-image-24px.svg'
-
-import { Subheading } from '../styles/typography'
-
-const Container = styled.div`
-  width: 100%;
-`
-
-const MapImage = styled.img`
-  width: 100%;
-`
-
-const NoImage = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  width: 100%;
-
-  & > svg {
-    width: 90px;
-    height: 90px;
-    opacity: 0.5;
-  }
-`
+import MapImage from './map-image.jsx'
 
 export default class MapPreview extends React.Component {
   static propTypes = {
@@ -36,21 +11,6 @@ export default class MapPreview extends React.Component {
   render() {
     const { map } = this.props
 
-    return (
-      <Container className={this.props.className}>
-        {map.imageUrl ? (
-          <picture>
-            <source srcSet={`${map.imageUrl} 1x`} />
-            <source srcSet={`${map.imagex2Url} 2x`} />
-            <MapImage src={map.imageUrl} alt={map.name} draggable={false} />
-          </picture>
-        ) : (
-          <NoImage>
-            <ImageIcon />
-            <Subheading>Map preview not available</Subheading>
-          </NoImage>
-        )}
-      </Container>
-    )
+    return <MapImage map={map} size={1024} showNotAvailableText={true} />
   }
 }

--- a/client/maps/map-select.jsx
+++ b/client/maps/map-select.jsx
@@ -151,6 +151,7 @@ export default class MapSelect extends React.Component {
         <MapThumbnail
           key={id}
           map={map}
+          size={thumbnailSize === 'xlarge' ? 512 : 256}
           showMapName={true}
           canHover={true}
           isSelected={isSelected(map)}
@@ -179,7 +180,7 @@ export default class MapSelect extends React.Component {
           {canBrowseMaps ? (
             <BrowseButton
               onClick={this.onMapBrowse}
-              isFocused={isFocused && focusedIndex === list.length}>
+              isFocused={isFocused && focusedIndex === list.size}>
               <BrowseIcon />
               <BrowseText>Browse maps</BrowseText>
             </BrowseButton>

--- a/client/maps/map-thumbnail.jsx
+++ b/client/maps/map-thumbnail.jsx
@@ -9,10 +9,11 @@ import MapImage from './map-image.jsx'
 import Menu from '../material/menu/menu.jsx'
 import MenuItem from '../material/menu/item.jsx'
 
-import { colorTextPrimary, colorTextSecondary, amberA100 } from '../styles/colors'
+import { colorTextPrimary, colorTextSecondary, amberA100, grey800 } from '../styles/colors'
 import { Subheading, singleLine } from '../styles/typography'
 
 import FavoritedIcon from '../icons/material/baseline-star-24px.svg'
+import ImageIcon from '../icons/material/baseline-image-24px.svg'
 import MapActionsIcon from '../icons/material/ic_more_vert_black_24px.svg'
 import UnfavoritedIcon from '../icons/material/baseline-star_border-24px.svg'
 import ZoomInIcon from '../icons/material/zoom_in-24px.svg'
@@ -29,7 +30,26 @@ const StyledMapImage = styled(MapImage)`
   position: absolute;
   top: 0;
   left: 0;
+  width: 100%;
   height: 100%;
+  object-fit: cover;
+`
+
+const NoImageContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  background-color: ${grey800};
+
+  & > svg {
+    width: 90px;
+    height: 90px;
+    opacity: 0.5;
+    margin-bottom: 24px;
+  }
 `
 
 const Overlay = styled.div`
@@ -114,6 +134,12 @@ const MapActionButton = styled(IconButton)`
   }
 `
 
+const NoImage = () => (
+  <NoImageContainer>
+    <ImageIcon />
+  </NoImageContainer>
+)
+
 export default class MapThumbnail extends React.Component {
   static propTypes = {
     map: PropTypes.object.isRequired,
@@ -193,7 +219,7 @@ export default class MapThumbnail extends React.Component {
 
     return (
       <Container className={this.props.className}>
-        <StyledMapImage map={map} size={size} />
+        <StyledMapImage map={map} size={size} noImageElem={<NoImage />} />
         {onClick ? (
           <Overlay
             isSelected={isSelected}

--- a/client/maps/map-thumbnail.jsx
+++ b/client/maps/map-thumbnail.jsx
@@ -1,16 +1,17 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
+import { rgba } from 'polished'
 
 import IconButton from '../material/icon-button.jsx'
 import { Label } from '../material/button.jsx'
+import MapImage from './map-image.jsx'
 import Menu from '../material/menu/menu.jsx'
 import MenuItem from '../material/menu/item.jsx'
 
-import { colorTextPrimary, colorTextSecondary, grey800 } from '../styles/colors'
+import { colorTextPrimary, colorTextSecondary, amberA100 } from '../styles/colors'
 import { Subheading, singleLine } from '../styles/typography'
 
-import ImageIcon from '../icons/material/baseline-image-24px.svg'
 import FavoritedIcon from '../icons/material/baseline-star-24px.svg'
 import MapActionsIcon from '../icons/material/ic_more_vert_black_24px.svg'
 import UnfavoritedIcon from '../icons/material/baseline-star_border-24px.svg'
@@ -24,33 +25,17 @@ const Container = styled.div`
   overflow: hidden;
 `
 
-const MapImage = styled.img`
+const StyledMapImage = styled(MapImage)`
   position: absolute;
-  width: 100%;
+  top: 0;
+  left: 0;
   height: 100%;
-  object-fit: cover;
-`
-
-const NoImage = styled.div`
-  position: absolute;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  width: 100%;
-  height: 100%;
-  background-color: ${grey800};
-
-  & > svg {
-    width: 90px;
-    height: 90px;
-    margin-bottom: 48px;
-    opacity: 0.5;
-  }
 `
 
 const Overlay = styled.div`
   position: absolute;
+  top: 0;
+  left: 0;
   width: 100%;
   height: 100%;
   display: flex;
@@ -58,16 +43,16 @@ const Overlay = styled.div`
   align-items: center;
   background-color: ${props => {
     let opacity = 0
-    if (props.isFocused) opacity = '0.12'
-    if (props.isSelected) opacity = '0.36'
-    const style = `rgba(255, 229, 127, ${opacity})` /* amberA100 */
+    if (props.isFocused) opacity = 0.12
+    if (props.isSelected) opacity = 0.36
+    const style = rgba(amberA100, opacity)
 
     return props.isSelected || props.isFocused ? style + ' !important' : style
   }};
   transition: background-color 150ms linear;
 
   &:hover {
-    background-color: rgba(255, 229, 127, 0.12); /* amberA100 */
+    background-color: ${rgba(amberA100, 0.12)};
     cursor: pointer;
   }
 
@@ -92,7 +77,6 @@ const FavoriteActionIcon = styled(IconButton)`
   position: absolute;
   top: 4px;
   right: 4px;
-  pointer-events: ${props => (props.isFavoriting ? 'none' : 'auto')};
 
   & ${Label} {
     color: ${colorTextSecondary};
@@ -108,7 +92,7 @@ const TextProtection = styled.div`
   display: flex;
   align-items: center;
   justify-content: space-between;
-  background-color: rgba(0, 0, 0, 0.5);
+  background-color: rgba(0, 0, 0, 0.7);
 `
 
 const MapName = styled(Subheading)`
@@ -133,13 +117,14 @@ const MapActionButton = styled(IconButton)`
 export default class MapThumbnail extends React.Component {
   static propTypes = {
     map: PropTypes.object.isRequired,
+    size: PropTypes.number,
     showMapName: PropTypes.bool,
     isFavoriting: PropTypes.bool,
     isSelected: PropTypes.bool,
     isFocused: PropTypes.bool,
     selectedIcon: PropTypes.element,
     onClick: PropTypes.func,
-    onMapPreview: PropTypes.func,
+    onPreview: PropTypes.func,
     onToggleFavorite: PropTypes.func,
     onMapDetails: PropTypes.func,
     onRemove: PropTypes.func,
@@ -185,6 +170,7 @@ export default class MapThumbnail extends React.Component {
   render() {
     const {
       map,
+      size,
       showMapName,
       isFavoriting,
       isSelected,
@@ -207,17 +193,7 @@ export default class MapThumbnail extends React.Component {
 
     return (
       <Container className={this.props.className}>
-        {map.thumbnailUrl ? (
-          <picture>
-            <source srcSet={`${map.thumbnailUrl} 1x`} />
-            <source srcSet={`${map.thumbnailx2Url} 2x`} />
-            <MapImage src={map.thumbnailUrl} alt={map.name} draggable={false} />
-          </picture>
-        ) : (
-          <NoImage>
-            <ImageIcon />
-          </NoImage>
-        )}
+        <StyledMapImage map={map} size={size} />
         {onClick ? (
           <Overlay
             isSelected={isSelected}

--- a/client/maps/maps-reducer.js
+++ b/client/maps/maps-reducer.js
@@ -34,10 +34,10 @@ export const MapRecord = new Record({
   },
   isFavorited: false,
   mapUrl: null,
-  imageUrl: null,
-  imagex2Url: null,
-  thumbnailUrl: null,
-  thumbnailx2Url: null,
+  image256Url: null,
+  image512Url: null,
+  image1024Url: null,
+  image2048Url: null,
 })
 const FavoritedMaps = new Record({
   list: new List(),

--- a/client/matchmaking/matchmaking-match.jsx
+++ b/client/matchmaking/matchmaking-match.jsx
@@ -127,7 +127,7 @@ export default class MatchmakingMatch extends React.Component {
         <TopHalfContainer>
           <Spacer />
           <MapContainer>
-            <MapThumbnail map={map} />
+            <MapThumbnail map={map} size={512} />
           </MapContainer>
           <StatusContainer>{this.renderStatus()}</StatusContainer>
         </TopHalfContainer>

--- a/server/lib/api/maps.js
+++ b/server/lib/api/maps.js
@@ -262,14 +262,6 @@ async function removeFromFavorites(ctx, next) {
 }
 
 async function deleteAllMaps(ctx, next) {
-  await dbDeleteAllMaps(() =>
-    Promise.all([
-      deleteFiles('maps/'),
-      deleteFiles('map_images/'),
-      deleteFiles('map_images_x2/'),
-      deleteFiles('map_thumbnails/'),
-      deleteFiles('map_thumbnails_x2/'),
-    ]),
-  )
+  await dbDeleteAllMaps(() => Promise.all([deleteFiles('maps/'), deleteFiles('map_images/')]))
   ctx.status = 204
 }

--- a/server/lib/maps/map-parse-worker.js
+++ b/server/lib/maps/map-parse-worker.js
@@ -88,19 +88,19 @@ process.once('message', async msg => {
 
   try {
     const { hash, map } = await parseAndHashMap(path, extension)
-    const [image, imagex2, thumbnail, thumbnailx2] = await Promise.all([
-      generateImage(map, bwDataPath, 1024 /* width */),
-      generateImage(map, bwDataPath, 2048 /* width */),
+    const [image256, image512, image1024, image2048] = await Promise.all([
       generateImage(map, bwDataPath, 256 /* width */),
       generateImage(map, bwDataPath, 512 /* width */),
+      generateImage(map, bwDataPath, 1024 /* width */),
+      generateImage(map, bwDataPath, 2048 /* width */),
     ])
-    const imagePromise = image ? createStreamPromise(image, 3 /* fd */) : Promise.resolve()
-    const imagex2Promise = imagex2 ? createStreamPromise(imagex2, 4 /* fd */) : Promise.resolve()
-    const thumbnailPromise = thumbnail
-      ? createStreamPromise(thumbnail, 5 /* fd */)
+    const image256Promise = image256 ? createStreamPromise(image256, 3 /* fd */) : Promise.resolve()
+    const image512Promise = image512 ? createStreamPromise(image512, 4 /* fd */) : Promise.resolve()
+    const image1024Promise = image1024
+      ? createStreamPromise(image1024, 5 /* fd */)
       : Promise.resolve()
-    const thumbnailx2Promise = thumbnailx2
-      ? createStreamPromise(thumbnailx2, 6 /* fd */)
+    const image2048Promise = image2048
+      ? createStreamPromise(image2048, 6 /* fd */)
       : Promise.resolve()
 
     const sendPromise = new Promise(resolve =>
@@ -122,10 +122,10 @@ process.once('message', async msg => {
 
     await Promise.all([
       sendPromise,
-      imagePromise,
-      imagex2Promise,
-      thumbnailPromise,
-      thumbnailx2Promise,
+      image256Promise,
+      image512Promise,
+      image1024Promise,
+      image2048Promise,
     ])
   } catch (err) {
     console.log(err)

--- a/server/lib/models/maps.js
+++ b/server/lib/models/maps.js
@@ -3,7 +3,7 @@ import transact from '../db/transaction'
 import sql from 'sql-template-strings'
 import { tilesetIdToName, SORT_BY_NUM_OF_PLAYERS, SORT_BY_DATE } from '../../../common/maps'
 import { getUrl } from '../file-upload'
-import { mapPath, imagePath, imagex2Path, thumbnailPath, thumbnailx2Path } from '../maps/store'
+import { mapPath, imagePath } from '../maps/store'
 
 // This model contains information from three separate tables (`maps`, `uploaded_maps` and `users`)
 // and should always be fully constructed, so pieces of code that use it don't have to be defensive
@@ -34,10 +34,10 @@ class MapInfo {
     }
     this.isFavorited = !!props.favorited
     this.mapUrl = null
-    this.imageUrl = null
-    this.imagex2Url = null
-    this.thumbnailUrl = null
-    this.thumbnailx2Url = null
+    this.image256Url = null
+    this.image512Url = null
+    this.image1024Url = null
+    this.image2048Url = null
   }
 }
 
@@ -45,19 +45,19 @@ const createMapInfo = async info => {
   const map = new MapInfo(info)
   const hashString = map.hash.toString('hex')
 
-  const [mapUrl, imageUrl, imagex2Url, thumbnailUrl, thumbnailx2Url] = await Promise.all([
+  const [mapUrl, image256Url, image512Url, image1024Url, image2048Url] = await Promise.all([
     getUrl(mapPath(hashString, map.mapData.format)),
-    getUrl(imagePath(hashString)),
-    getUrl(imagex2Path(hashString)),
-    getUrl(thumbnailPath(hashString)),
-    getUrl(thumbnailx2Path(hashString)),
+    getUrl(imagePath(hashString, 256)),
+    getUrl(imagePath(hashString, 512)),
+    getUrl(imagePath(hashString, 1024)),
+    getUrl(imagePath(hashString, 2048)),
   ])
   map.hash = hashString
   map.mapUrl = mapUrl
-  map.imageUrl = imageUrl
-  map.imagex2Url = imagex2Url
-  map.thumbnailUrl = thumbnailUrl
-  map.thumbnailx2Url = thumbnailx2Url
+  map.image256Url = image256Url
+  map.image512Url = image512Url
+  map.image1024Url = image1024Url
+  map.image2048Url = image2048Url
 
   return map
 }


### PR DESCRIPTION
displaying map images.

Also uses it throughout the app. There are two components that are a
level higher than MapImage component, which are MapThumbnail and
MapPreview. They can be used in places where some common functionality
is required to make things easier (though MapPreview is pretty bare
atm).

This PR also updates the naming scheme of the map image names and URLs
to be a bit more cleaner and consistent. They are also saved in the same
folder now.