### PR TITLE
Fix textfield highlighting in Firefox

### DIFF
--- a/client/material/input-base.jsx
+++ b/client/material/input-base.jsx
@@ -19,6 +19,7 @@ export const InputBase = styled(Subheading)`
   color: ${props => (props.disabled ? colorTextFaint : colorTextPrimary)};
   line-height: inherit;
   -ms-flex-preferred-size: inherit;
+  user-select: inherit;
 
   &:focus {
     outline: none;

--- a/client/material/text-field.jsx
+++ b/client/material/text-field.jsx
@@ -31,6 +31,7 @@ const TextFieldContainer = styled.div`
   background-color: rgba(255, 255, 255, 0.1);
   border-radius: 4px 4px 0 0;
   contain: layout paint style;
+  user-select: text;
 
   ${props => {
     const spacing = props.floatingLabel ? 34 : 28 /* textfield padding + input margin */


### PR DESCRIPTION
I noticed it was possible to highlight text inside of text-fields in Chrome, but not in Firefox.
I used inherit for input-base so that it did not allow highlighting text in select components.