### PR TITLE
Send the game results to the server on game end.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,3 +10,6 @@ trim_trailing_whitespace = true
 
 [*.bat]
 end_of_line = crlf
+
+[*.rs]
+indent_size = 4

--- a/client/active-game/game-server.js
+++ b/client/active-game/game-server.js
@@ -80,8 +80,14 @@ class GameServer {
       case '/game/start':
         activeGameManager.handleGameStart(gameId)
         break
-      case '/game/end':
-        activeGameManager.handleGameEnd(gameId, payload.results, payload.time)
+      case '/game/result':
+        activeGameManager.handleGameResult(gameId, payload.results, payload.time)
+        break
+      case '/game/resultSent':
+        activeGameManager.handleGameResultSent(gameId)
+        break
+      case '/game/finished':
+        activeGameManager.handleGameFinished(gameId)
         break
       case '/game/replaySave':
         activeGameManager.handleReplaySave(gameId, payload.path)

--- a/client/lobbies/socket-handlers.js
+++ b/client/lobbies/socket-handlers.js
@@ -33,6 +33,7 @@ import activeGameManager from '../active-game/active-game-manager-instance'
 import audioManager, { SOUNDS } from '../audio/audio-manager-instance'
 import { getIngameLobbySlotsWithIndexes } from '../../common/lobbies'
 import { openSnackbar } from '../snackbars/action-creators'
+import { makeServerUrl } from '../network/server-url'
 
 const ipcRenderer = IS_ELECTRON ? require('electron').ipcRenderer : null
 
@@ -242,6 +243,7 @@ const eventToAction = {
         host,
         seed: event.setup.seed,
         resultCode: event.resultCode,
+        serverUrl: makeServerUrl(''),
       },
     }
 

--- a/client/matchmaking/socket-handlers.js
+++ b/client/matchmaking/socket-handlers.js
@@ -23,6 +23,7 @@ import { openDialog, closeDialog } from '../dialogs/action-creators'
 import { openSnackbar } from '../snackbars/action-creators'
 import { MATCHMAKING_ACCEPT_MATCH_TIME } from '../../common/constants'
 import { USER_ATTENTION_REQUIRED } from '../../common/ipc-constants'
+import { makeServerUrl } from '../network/server-url'
 
 const ipcRenderer = IS_ELECTRON ? require('electron').ipcRenderer : null
 
@@ -177,6 +178,7 @@ const eventToAction = {
         host: event.slots[0], // Arbitrarily set first player as host
         seed: event.setup.seed,
         resultCode: event.resultCode,
+        serverUrl: makeServerUrl(''),
       },
     }
 

--- a/common/game-status.js
+++ b/common/game-status.js
@@ -9,8 +9,10 @@ export const GAME_STATUS_CONFIGURING = 2
 export const GAME_STATUS_AWAITING_PLAYERS = 3
 export const GAME_STATUS_STARTING = 4
 export const GAME_STATUS_PLAYING = 5
-export const GAME_STATUS_FINISHED = 6
-export const GAME_STATUS_ERROR = 7
+export const GAME_STATUS_HAS_RESULT = 6
+export const GAME_STATUS_RESULT_SENT = 7
+export const GAME_STATUS_FINISHED = 8
+export const GAME_STATUS_ERROR = 666
 
 export function statusToString(status) {
   switch (status) {
@@ -26,6 +28,10 @@ export function statusToString(status) {
       return 'starting'
     case GAME_STATUS_PLAYING:
       return 'playing'
+    case GAME_STATUS_HAS_RESULT:
+      return 'hasResult'
+    case GAME_STATUS_RESULT_SENT:
+      return 'resultSent'
     case GAME_STATUS_FINISHED:
       return 'finished'
     case GAME_STATUS_ERROR:
@@ -49,6 +55,10 @@ export function stringToStatus(string) {
       return GAME_STATUS_STARTING
     case 'playing':
       return GAME_STATUS_PLAYING
+    case 'hasResults':
+      return GAME_STATUS_HAS_RESULT
+    case 'resultSent':
+      return GAME_STATUS_RESULT_SENT
     case 'finished':
       return GAME_STATUS_FINISHED
     case 'error':

--- a/game/Cargo.lock
+++ b/game/Cargo.lock
@@ -54,6 +54,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
 
 [[package]]
+name = "base64"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+
+[[package]]
 name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -69,6 +75,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e8c087f005730276d1096a652e92a8bacee2e2472bcc9715a74d2bec38b5820"
+
+[[package]]
 name = "byteorder"
 version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -79,6 +91,12 @@ name = "bytes"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
+
+[[package]]
+name = "cc"
+version = "1.0.66"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c0496836a84f8d0495758516b8621a622beb77c0fed418570e50764093ced48"
 
 [[package]]
 name = "cfg-if"
@@ -115,10 +133,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "console_error_panic_hook"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8d976903543e0c48546a91908f21588a680a8c8f984df9a5d69feccb2b2a211"
+dependencies = [
+ "cfg-if 0.1.10",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "copyless"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2df960f5d869b2dd8532793fde43eb5427cceb126c929747a26823ab0eeb536"
+
+[[package]]
+name = "core-foundation"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a89e2ae426ea83155dccf10c0fa6b1463ef6d5fcb44cee0b224a408fa640a62"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea221b5284a47e40033bf9b66f35f984ec0ea2931eb03505246cd27a963f981b"
 
 [[package]]
 name = "cpuid-bool"
@@ -136,6 +180,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "801bbab217d7f79c0062f4f7205b5d4427c6d1a7bd7aafdd1475f7c59d62b283"
+dependencies = [
+ "cfg-if 1.0.0",
+]
+
+[[package]]
 name = "fern"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -149,6 +202,31 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ece68d15c92e84fa4f19d3780f1294e5ca82a78a6d515f1efaabcc144688be00"
+dependencies = [
+ "matches",
+ "percent-encoding",
+]
 
 [[package]]
 name = "fuchsia-zircon"
@@ -254,7 +332,7 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "memchr",
- "pin-project",
+ "pin-project 0.4.27",
  "pin-utils",
  "proc-macro-hack",
  "proc-macro-nested",
@@ -298,6 +376,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aaf91faf136cb47367fa430cd46e37a788775e7fa104f8b4bcb3861dc389b724"
 
 [[package]]
+name = "h2"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e4728fd124914ad25e99e3d15a9361a879f6620f63cb56bbb08f95abb97a535"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "tracing-futures",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -324,10 +422,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-body"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13d5ff830006f7646652e057693569bfe0d51760c0085a071769d142a205111b"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
 name = "httparse"
 version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd179ae861f0c2e53da70d892f5f3029f9594be0c41dc5269cd371691b1dc2f9"
+
+[[package]]
+name = "httpdate"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "494b4d60369511e7dea41cf646832512a94e542f68bb9c49e54518e0f468eb47"
+
+[[package]]
+name = "hyper"
+version = "0.13.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ad767baac13b44d4529fcf58ba2cd0995e36e7b435bc5b039de6f47e880dbf"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project 1.0.2",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d979acc56dcb5b8dddba3917601745e877576475aa046df3226eabdecef78eed"
+dependencies = [
+ "bytes",
+ "hyper",
+ "native-tls",
+ "tokio",
+ "tokio-tls",
+]
 
 [[package]]
 name = "idna"
@@ -338,6 +489,16 @@ dependencies = [
  "matches",
  "unicode-bidi",
  "unicode-normalization",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55e2e4c765aa53a0424761bf9f41aa7a6ac1efa87238f59560640e27fca028f2"
+dependencies = [
+ "autocfg",
+ "hashbrown",
 ]
 
 [[package]]
@@ -368,10 +529,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47be2f14c678be2fdcab04ab1171db51b2762ce6f0a8ee87c8dd4a04ed216135"
+
+[[package]]
 name = "itoa"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
+
+[[package]]
+name = "js-sys"
+version = "0.3.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf3d7383929f7c9c7c2d0fa596f325832df98c3704f2c60553080f7127a58175"
+dependencies = [
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "kernel32-sys"
@@ -443,6 +619,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a64a92489e2744ce060c349162be1c5f33c6969234104dbd99ddb5feb08b8c15"
 
 [[package]]
+name = "mime"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2684d4c2e97d99848d30b324b00c8fcc7e5c897b7cbb5819b09e7c90e8baf212"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "miniz_oxide"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -492,6 +684,24 @@ dependencies = [
  "net2",
  "winapi 0.2.8",
  "ws2_32-sys",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fcc7939b5edc4e4f86b1b4a04bb1498afaaf871b1a6691838ed06fcb48d3a3f"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
 ]
 
 [[package]]
@@ -553,6 +763,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
+name = "openssl"
+version = "0.10.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d575eff3665419f9b83678ff2815858ad9d11567e082f5ac1814baba4e2bcb4"
+dependencies = [
+ "bitflags",
+ "cfg-if 0.1.10",
+ "foreign-types",
+ "lazy_static",
+ "libc",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a842db4709b604f0fe5d1170ae3565899be2ad3d9cbc72dedc789ac0511f78de"
+dependencies = [
+ "autocfg",
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -590,7 +833,16 @@ version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ffbc8e94b38ea3d2d8ba92aea2983b503cd75d0888d75b86bb37970b5698e15"
 dependencies = [
- "pin-project-internal",
+ "pin-project-internal 0.4.27",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ccc2237c2c489783abd8c4c80e5450fc0e98644555b1364da68cc29aa151ca7"
+dependencies = [
+ "pin-project-internal 1.0.2",
 ]
 
 [[package]]
@@ -605,16 +857,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project-internal"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8e8d2bf0b23038a4424865103a4df472855692821aab4e4f5c3312d461d9e5f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e555d9e657502182ac97b539fb3dae8b79cda19e3e4f8ffb5e8de4f18df93c95"
 
 [[package]]
+name = "pin-project-lite"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b063f57ec186e6140e2b8b6921e5f1bd89c7356dda5b33acc5401203ca6131c"
+
+[[package]]
 name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
 
 [[package]]
 name = "ppv-lite86"
@@ -706,6 +981,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb15d6255c792356a0f578d8a645c677904dc02e862bebe2ecc18e0c01b9a0ce"
+dependencies = [
+ "base64 0.13.0",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-tls",
+ "ipnet",
+ "js-sys",
+ "lazy_static",
+ "log",
+ "mime",
+ "mime_guess",
+ "native-tls",
+ "percent-encoding",
+ "pin-project-lite 0.2.0",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio",
+ "tokio-tls",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test",
+ "web-sys",
+ "winreg",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -752,6 +1073,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75"
+dependencies = [
+ "lazy_static",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -762,6 +1099,29 @@ name = "scr-analysis"
 version = "0.1.0"
 dependencies = [
  "samase_scarf",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1759c2e3c8580017a484a7ac56d3abc5a6c1feadf88db2f3633f12ae4268c69"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f99b9d5e26d2a71633cc4f2ebae7cc9f874044e0c351a27e17892d76dce5678b"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -790,6 +1150,18 @@ version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a230ea9107ca2220eea9d46de97eddcb04cd00e92d13dda78e478dd33fa82bd4"
 dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edfa57a7f8d9c1d260a549e7224100f6c43d43f9103e06dd8b4095a9b2b43ce9"
+dependencies = [
+ "form_urlencoded",
  "itoa",
  "ryu",
  "serde",
@@ -827,6 +1199,7 @@ dependencies = [
  "parking_lot",
  "quick-error",
  "rand",
+ "reqwest",
  "scopeguard",
  "scr-analysis",
  "serde",
@@ -851,6 +1224,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbee7696b84bbf3d89a1c2eccff0850e3047ed46bfcd2e92c29a2d074d57e252"
 
 [[package]]
+name = "socket2"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c29947abdee2a218277abeca306f25789c938e500ea5a9d4b12a5a504466902"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "redox_syscall",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "syn"
 version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -859,6 +1244,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
+dependencies = [
+ "cfg-if 0.1.10",
+ "libc",
+ "rand",
+ "redox_syscall",
+ "remove_dir_all",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -894,8 +1293,18 @@ dependencies = [
  "mio",
  "mio-uds",
  "num_cpus",
- "pin-project-lite",
+ "pin-project-lite 0.1.10",
  "slab",
+]
+
+[[package]]
+name = "tokio-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a70f4fcd7b3b24fb194f837560168208f669ca8cb70d0c4b862944452396343"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]
@@ -906,10 +1315,67 @@ checksum = "6d9e878ad426ca286e4dcae09cbd4e1973a7f8987d97570e2469703dd7f5720c"
 dependencies = [
  "futures-util",
  "log",
- "pin-project",
+ "pin-project 0.4.27",
  "tokio",
  "tungstenite",
 ]
+
+[[package]]
+name = "tokio-util"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be8242891f2b6cbef26a2d7e8605133c2c554cd35b3e4948ea892d6d68436499"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "log",
+ "pin-project-lite 0.1.10",
+ "tokio",
+]
+
+[[package]]
+name = "tower-service"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e987b6bf443f4b5b3b6f38704195592cca41c5bb7aedd3c3693c7081f8289860"
+
+[[package]]
+name = "tracing"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f47026cdc4080c07e49b37087de021820269d996f581aac150ef9e5583eefe3"
+dependencies = [
+ "cfg-if 1.0.0",
+ "log",
+ "pin-project-lite 0.2.0",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f50de3927f93d202783f4513cda820ab47ef17f624b03c096e86ef00c67e6b5f"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
+name = "tracing-futures"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab7bb6f14721aa00656086e9335d363c5c8747bae02ebe32ea2c7dece5689b4c"
+dependencies = [
+ "pin-project 0.4.27",
+ "tracing",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
 name = "tungstenite"
@@ -917,7 +1383,7 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0308d80d86700c5878b9ef6321f020f29b1bb9d5ff3cab25e75e23f3a492a23"
 dependencies = [
- "base64",
+ "base64 0.12.3",
  "byteorder",
  "bytes",
  "http",
@@ -941,6 +1407,15 @@ name = "typenum"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
+
+[[package]]
+name = "unicase"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
+dependencies = [
+ "version_check",
+]
 
 [[package]]
 name = "unicode-bidi"
@@ -968,10 +1443,11 @@ checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
 
 [[package]]
 name = "url"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "829d4a8476c35c9bf0bbce5a3b23f4106f79728039b726d292bb93bc106787cb"
+checksum = "5909f2b0817350449ed73e8bcd81c8c3c8d9a7a5d8acba4b27db277f1868976e"
 dependencies = [
+ "form_urlencoded",
  "idna",
  "matches",
  "percent-encoding",
@@ -984,10 +1460,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05e42f7c18b8f902290b009cde6d651262f956c98bc51bca4cd1d511c9cd85c7"
 
 [[package]]
+name = "vcpkg"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6454029bf181f092ad1b853286f23e2c507d8e8194d01d92da4a55c274a5508c"
+
+[[package]]
 name = "version_check"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
+
+[[package]]
+name = "want"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
+dependencies = [
+ "log",
+ "try-lock",
+]
 
 [[package]]
 name = "wasi"
@@ -1000,6 +1492,108 @@ name = "wasi"
 version = "0.10.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cd364751395ca0f68cafb17666eee36b63077fb5ecd972bbcd74c90c4bf736e"
+dependencies = [
+ "cfg-if 1.0.0",
+ "serde",
+ "serde_json",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1114f89ab1f4106e5b55e688b828c0ab0ea593a1ea7c094b141b14cbaaec2d62"
+dependencies = [
+ "bumpalo",
+ "lazy_static",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fe9756085a84584ee9457a002b7cdfe0bfff169f45d2591d8be1345a6780e35"
+dependencies = [
+ "cfg-if 1.0.0",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6ac8995ead1f084a8dea1e65f194d0973800c7f571f6edd70adf06ecf77084"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5a48c72f299d80557c7c62e37e7225369ecc0c963964059509fbafe917c7549"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e7811dd7f9398f14cc76efd356f98f03aa30419dea46aa810d71e819fc97158"
+
+[[package]]
+name = "wasm-bindgen-test"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0355fa0c1f9b792a09b6dcb6a8be24d51e71e6d74972f9eb4a44c4c004d24a25"
+dependencies = [
+ "console_error_panic_hook",
+ "js-sys",
+ "scoped-tls",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-test-macro"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27e07b46b98024c2ba2f9e83a10c2ef0515f057f2da299c1762a2017de80438b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "222b1ef9334f92a21d3fb53dc3fd80f30836959a90f9274a626d7e06315ba3c3"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "whack"
@@ -1046,6 +1640,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "winreg"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
+dependencies = [
+ "winapi 0.3.9",
+]
 
 [[package]]
 name = "ws2_32-sys"

--- a/game/Cargo.toml
+++ b/game/Cargo.toml
@@ -32,6 +32,7 @@ log = "0.4"
 parking_lot = { version = "0.11", features = ["send_guard"] }
 quick-error = "2.0"
 rand = "0.7"
+reqwest = { version = "0.10.9", features = ["json"] }
 scopeguard = "1.0"
 serde = { version = "1.0.89", features = ["derive", "rc"] }
 serde_json = "1.0.39"

--- a/game/src/app_messages.rs
+++ b/game/src/app_messages.rs
@@ -36,10 +36,20 @@ pub struct WindowMove {
     pub y: i32,
 }
 
+#[derive(Serialize, Copy, Clone)]
+pub enum Race {
+    #[serde(rename = "z")]
+    Zerg,
+    #[serde(rename = "t")]
+    Terran,
+    #[serde(rename = "p")]
+    Protoss,
+}
+
 #[derive(Serialize, Clone)]
 pub struct GamePlayerResult {
     pub result: u8,
-    pub race: char,
+    pub race: Race,
     pub apm: u32,
 }
 

--- a/game/src/app_messages.rs
+++ b/game/src/app_messages.rs
@@ -26,6 +26,7 @@ pub struct SetupProgressInfo {
 
 #[derive(Deserialize, Clone)]
 pub struct LocalUser {
+    pub id: u32,
     pub name: String,
 }
 
@@ -35,11 +36,27 @@ pub struct WindowMove {
     pub y: i32,
 }
 
+#[derive(Serialize, Clone)]
+pub struct GamePlayerResult {
+    pub result: u8,
+    pub race: char,
+    pub apm: u32,
+}
+
 #[derive(Serialize)]
 pub struct GameResults {
     #[serde(rename = "time")]
     pub time_ms: u32,
-    pub results: HashMap<String, u8>,
+    pub results: HashMap<String, GamePlayerResult>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GameResultsReport {
+    pub user_id: u32,
+    pub result_code: String,
+    pub time: u32,
+    pub player_results: Vec<(String, GamePlayerResult)>,
 }
 
 #[derive(Deserialize)]
@@ -53,6 +70,9 @@ pub struct GameSetupInfo {
     pub slots: Vec<PlayerInfo>,
     pub host: PlayerInfo,
     pub seed: u32,
+    pub game_id: String,
+    pub result_code: String,
+    pub server_url: String,
 }
 
 #[derive(Deserialize)]

--- a/game/src/game_state.rs
+++ b/game/src/game_state.rs
@@ -785,15 +785,11 @@ impl InitInProgress {
                         GamePlayerResult {
                             result: results[player.storm_id.0 as usize] as u8,
                             race: match game_results.race[player_id as usize] {
-                                Some(bw::RACE_ZERG) => Race::Zerg,
-                                Some(bw::RACE_TERRAN) => Race::Terran,
-                                Some(bw::RACE_PROTOSS) => Race::Protoss,
+                                bw::RACE_ZERG => Race::Zerg,
+                                bw::RACE_TERRAN => Race::Terran,
+                                bw::RACE_PROTOSS => Race::Protoss,
                                 r => {
-                                    warn!(
-                                        "Invalid race ({}) for player {}",
-                                        r.map_or("None".to_string(), |v| v.to_string()),
-                                        player_id
-                                    );
+                                    warn!("Invalid race ({}) for player {}", r, player_id);
                                     Race::Zerg
                                 }
                             },

--- a/game/src/game_state.rs
+++ b/game/src/game_state.rs
@@ -1,14 +1,18 @@
+use crate::app_messages::GamePlayerResult;
+use crate::app_messages::GameResultsReport;
+use reqwest::header::HeaderMap;
+use reqwest::header::ORIGIN;
 use std::ffi::CStr;
 use std::mem;
 use std::net::Ipv4Addr;
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
 use std::sync::Arc;
-use std::time::{Duration};
+use std::time::Duration;
 
 use bytes::Bytes;
-use futures::{pin_mut, select};
 use futures::prelude::*;
+use futures::{pin_mut, select};
 use quick_error::quick_error;
 use tokio::sync::{mpsc, oneshot};
 
@@ -17,12 +21,12 @@ use crate::app_messages::{
     GAME_STATUS_ERROR,
 };
 use crate::app_socket;
-use crate::bw::{self, GameType, with_bw};
+use crate::bw::{self, with_bw, GameType};
 use crate::cancel_token::{CancelToken, Canceler, SharedCanceler};
 use crate::chat::StormPlayerId;
 use crate::forge;
 use crate::game_thread::{
-    GameThreadRequest, GameThreadRequestType, GameThreadResults, GameThreadMessage,
+    GameThreadMessage, GameThreadRequest, GameThreadRequestType, GameThreadResults,
 };
 use crate::network_manager::{NetworkError, NetworkManager};
 use crate::snp;
@@ -276,9 +280,11 @@ impl GameState {
             }
             start_game_request(&game_request_send, GameThreadRequestType::RunWndProc)
                 .map_err(|()| GameInitError::Closed)?;
-            net_game_info_set_future.await
+            net_game_info_set_future
+                .await
                 .map_err(|e| GameInitError::NetworkInit(e))?;
-            network_ready_future.await
+            network_ready_future
+                .await
                 .map_err(|e| GameInitError::NetworkInit(e))?;
             debug!("Network ready");
             if !is_host {
@@ -290,7 +296,9 @@ impl GameState {
             unsafe {
                 setup_slots(&info.slots, game_type);
             }
-            send_messages_to_state.send(GameStateMessage::InLobby).await
+            send_messages_to_state
+                .send(GameStateMessage::InLobby)
+                .await
                 .map_err(|_| GameInitError::Closed)?;
             loop {
                 unsafe {
@@ -321,7 +329,9 @@ impl GameState {
                     });
 
                     if new_players {
-                        send_messages_to_state.send(GameStateMessage::PlayerJoined).await
+                        send_messages_to_state
+                            .send(GameStateMessage::PlayerJoined)
+                            .await
                             .map_err(|_| GameInitError::Closed)?;
                     }
                 }
@@ -336,17 +346,61 @@ impl GameState {
                 do_lobby_game_init(&info).await;
             }
             forge::end_wnd_proc();
-            app_socket::send_message(&mut ws_send, "/game/start", ()).await
+            app_socket::send_message(&mut ws_send, "/game/start", ())
+                .await
                 .map_err(|_| GameInitError::Closed)?;
 
             let start_game_request = GameThreadRequestType::StartGame;
             let game_done = send_game_request(&game_request_send, start_game_request);
             game_done.await;
             let results = results.await?;
-            app_socket::send_message(&mut ws_send, "/game/end", results).await
+            app_socket::send_message(&mut ws_send, "/game/end", &results)
+                .await
                 .map_err(|_| GameInitError::Closed)?;
+
+            // Attempt to send results to the server, if this fails, we expect
+            // the app to retry in the future
+            let client = reqwest::Client::new();
+            let result_url = format!("{}/api/1/gameResults/{}", info.server_url, info.game_id);
+
+            let sbat_header: &'static str = "x-shield-battery-client";
+            let mut result_headers = HeaderMap::new();
+            result_headers.insert(ORIGIN, "shieldbattery://game".parse().unwrap());
+            result_headers.insert(sbat_header, "true".parse().unwrap());
+
+            let result_body = GameResultsReport {
+                user_id: local_user.id,
+                result_code: info.result_code.clone(),
+                time: results.time_ms,
+                player_results: results
+                    .results
+                    .iter()
+                    .map(|(name, result)| (name.clone(), result.clone()))
+                    .collect(),
+            };
+
+            for _ in 0..3 {
+                let result = client
+                    .post(&result_url)
+                    .headers(result_headers.clone())
+                    .json(&result_body)
+                    .send()
+                    .await;
+
+                if result.is_ok() {
+                    if result.unwrap().status().is_success() {
+                        debug!("Game results sent successfully");
+                        app_socket::send_message(&mut ws_send, "/game/resultSent", ())
+                            .await
+                            .map_err(|_| GameInitError::Closed)?;
+                        break;
+                    }
+                }
+            }
+
             Ok(())
-        }.boxed()
+        }
+        .boxed()
     }
 
     // Message handler, so ideally only return futures that are about sending
@@ -363,16 +417,14 @@ impl GameState {
             SetRoutes(routes) => {
                 return self.set_routes(routes).boxed();
             }
-            AllowStart => {
-                match mem::replace(&mut self.can_start_game, CanStartGame::Yes) {
-                    CanStartGame::Yes => (),
-                    CanStartGame::No(waiting) => {
-                        for sender in waiting {
-                            let _ = sender.send(());
-                        }
+            AllowStart => match mem::replace(&mut self.can_start_game, CanStartGame::Yes) {
+                CanStartGame::Yes => (),
+                CanStartGame::No(waiting) => {
+                    for sender in waiting {
+                        let _ = sender.send(());
                     }
                 }
-            }
+            },
             SetupGame(info) => {
                 let mut ws_send = self.ws_send.clone();
                 let async_stop = self.async_stop.clone();
@@ -388,11 +440,9 @@ impl GameState {
                                 extra: Some(msg),
                             },
                         };
-                        let _ = app_socket::send_message(
-                            &mut ws_send,
-                            "/game/setupProgress",
-                            message,
-                        ).await;
+                        let _ =
+                            app_socket::send_message(&mut ws_send, "/game/setupProgress", message)
+                                .await;
                     }
                     debug!("Game setup & play task ended");
                     tokio::time::delay_for(Duration::from_millis(10000)).await;
@@ -450,8 +500,8 @@ impl GameState {
                 if let InitState::Started(ref mut state) = self.init_state {
                     for player in &mut state.joined_players {
                         let old_id = player.player_id;
-                        player.player_id = new_mapping.get(player.storm_id.0 as usize)
-                            .and_then(|x| *x);
+                        player.player_id =
+                            new_mapping.get(player.storm_id.0 as usize).and_then(|x| *x);
                         if old_id.is_some() != player.player_id.is_some() {
                             warn!(
                                 "Player {} lost/gained player id after randomization: {:?} -> {:?}",
@@ -565,7 +615,9 @@ impl InitInProgress {
         }
     }
 
-    fn wait_for_results(&mut self) -> impl Future<Output = Result<Arc<GameResults>, GameInitError>> {
+    fn wait_for_results(
+        &mut self,
+    ) -> impl Future<Output = Result<Arc<GameResults>, GameInitError>> {
         let (send_done, recv_done) = oneshot::channel();
         self.waiting_for_result.push(send_done);
         recv_done.map_err(|_| GameInitError::Closed)
@@ -668,6 +720,7 @@ impl InitInProgress {
         }
 
         let mut results = [GameResult::Playing; bw::MAX_STORM_PLAYERS];
+        let mut races = ['r'; bw::MAX_STORM_PLAYERS];
         let local_storm_id = self
             .joined_players
             .iter()
@@ -695,6 +748,17 @@ impl InitInProgress {
                         }
                     }
                 };
+                unsafe {
+                    with_bw(|bw| {
+                        let players = bw.players();
+                        races[storm_id] = match (*players.add(player_id as usize)).race {
+                            bw::RACE_ZERG => 'z',
+                            bw::RACE_TERRAN => 't',
+                            bw::RACE_PROTOSS => 'p',
+                            r => panic!("Invalid race ({}) for player {}", player_id, r),
+                        };
+                    });
+                }
             }
         }
 
@@ -725,7 +789,12 @@ impl InitInProgress {
                 if player.player_id.is_some() {
                     Some((
                         player.name.clone(),
-                        results[player.storm_id.0 as usize] as u8,
+                        GamePlayerResult {
+                            result: results[player.storm_id.0 as usize] as u8,
+                            race: races[player.storm_id.0 as usize],
+                            // TODO(tec27): implement APM calculation
+                            apm: 0,
+                        },
                     ))
                 } else {
                     None
@@ -745,8 +814,7 @@ impl InitInProgress {
 
 unsafe fn create_lobby(info: &GameSetupInfo, game_type: GameType) -> Result<(), GameInitError> {
     let map_path = Path::new(&info.map_path);
-    with_bw(|bw| bw.create_lobby(map_path, &info.name, game_type))
-        .map_err(|e| GameInitError::Bw(e))
+    with_bw(|bw| bw.create_lobby(map_path, &info.name, game_type)).map_err(|e| GameInitError::Bw(e))
 }
 
 unsafe fn join_lobby(
@@ -808,9 +876,7 @@ unsafe fn join_lobby(
     let map_path: Bytes = match windows::ansi_codepage_cstring(&info.map_path) {
         Ok(o) => o.into(),
         Err(_) => {
-            return future::err(GameInitError::NonAnsiPath(
-                (&info.map_path).into(),
-            )).boxed();
+            return future::err(GameInitError::NonAnsiPath((&info.map_path).into())).boxed();
         }
     };
     async move {
@@ -834,7 +900,8 @@ unsafe fn join_lobby(
             debug!("Storm player names at join: {:?}", player_names);
         });
         Ok(())
-    }.boxed()
+    }
+    .boxed()
 }
 
 async unsafe fn try_join_lobby_once(
@@ -922,11 +989,14 @@ unsafe fn setup_slots(slots: &[PlayerInfo], game_type: GameType) {
         for i in 0..4 {
             let team = i + 1;
             if players.iter().any(|x| {
-                x.team == team &&
-                    x.player_type == bw::PLAYER_TYPE_LOBBY_COMPUTER &&
-                    x.race == bw::RACE_RANDOM
+                x.team == team
+                    && x.player_type == bw::PLAYER_TYPE_LOBBY_COMPUTER
+                    && x.race == bw::RACE_RANDOM
             }) {
-                if players.iter().any(|x| x.team == team && x.race != bw::RACE_RANDOM) {
+                if players
+                    .iter()
+                    .any(|x| x.team == team && x.race != bw::RACE_RANDOM)
+                {
                     panic!("Computer team {} has both random and non-random slots, which is not allowed", i);
                 }
             }
@@ -936,14 +1006,21 @@ unsafe fn setup_slots(slots: &[PlayerInfo], game_type: GameType) {
 
 unsafe fn storm_player_names(bw: &dyn bw::Bw) -> Vec<Option<String>> {
     let storm_players = bw.storm_players();
-    storm_players.iter().map(|player| {
-        let name_len = player.name.iter().position(|&c| c == 0).unwrap_or(player.name.len());
-        if name_len != 0 {
-            Some(String::from_utf8_lossy(&player.name[..name_len]).into())
-        } else {
-            None
-        }
-    }).collect::<Vec<_>>()
+    storm_players
+        .iter()
+        .map(|player| {
+            let name_len = player
+                .name
+                .iter()
+                .position(|&c| c == 0)
+                .unwrap_or(player.name.len());
+            if name_len != 0 {
+                Some(String::from_utf8_lossy(&player.name[..name_len]).into())
+            } else {
+                None
+            }
+        })
+        .collect::<Vec<_>>()
 }
 
 async unsafe fn do_lobby_game_init(info: &GameSetupInfo) {

--- a/game/src/game_thread.rs
+++ b/game/src/game_thread.rs
@@ -46,7 +46,7 @@ pub enum GameThreadMessage {
     Snp(snp::SnpMessage),
     /// Storm player id (which stays stable) -> game player id mapping.
     /// Once this message is sent, any game player ids used so far should be
-    /// considered invalid and updated to match this mapping.
+    /// considered invalid and updated to match this mappin
     PlayersRandomized([Option<u8>; bw::MAX_STORM_PLAYERS]),
     Results(GameThreadResults),
 }

--- a/game/src/game_thread.rs
+++ b/game/src/game_thread.rs
@@ -106,7 +106,7 @@ pub enum PlayerLoseType {
 pub struct GameThreadResults {
     // Index by ingame player id
     pub victory_state: [u8; 8],
-    pub race: [Option<u8>; 8],
+    pub race: [u8; 8],
     // Index by storm id
     pub player_has_left: [bool; 8],
     pub player_lose_type: Option<PlayerLoseType>,
@@ -120,12 +120,9 @@ unsafe fn game_results() -> GameThreadResults {
     GameThreadResults {
         victory_state: (*game).victory_state,
         race: {
-            let mut arr = [None; 8];
+            let mut arr = [bw::RACE_ZERG; 8];
             for i in 0..8 {
-                let player = players.add(i as usize);
-                if let Some(out) = arr.get_mut((*player).player_id as usize) {
-                    *out = Some((*player).race);
-                }
+                arr[i] = (*players.add(i as usize)).race;
             }
             arr
         },

--- a/server/lib/api/gameResults.ts
+++ b/server/lib/api/gameResults.ts
@@ -54,7 +54,7 @@ const submitGameResultsSchema = Joi.object({
     .min(1)
     .max(8)
     .required(),
-})
+}).required()
 
 // TODO(tec27): This should be put somewhere common so the client code can use the same interface
 // when making the request

--- a/server/lib/models/games-users.ts
+++ b/server/lib/models/games-users.ts
@@ -142,11 +142,11 @@ export async function getCurrentReportedResults(
       SELECT user_id, reported_results
       FROM games_users
       WHERE game_id = ${gameId}
-      ORDER_BY reported_at DESC
+      ORDER BY reported_at DESC
     `)
 
     return result.rows.map(row =>
-      row.reportedResults
+      row.reported_results
         ? {
             reporter: row.user_id,
             time: row.reported_results.time,

--- a/server/lib/models/games.ts
+++ b/server/lib/models/games.ts
@@ -95,11 +95,11 @@ export async function setReconciledResult(
   return client.query(sql`
     UPDATE games
     SET
-      results = ${Array.from(results.results.entries())},
+      results = ${JSON.stringify(Array.from(results.results.entries()))},
       game_length = ${results.time},
       disputable = ${results.disputed},
       dispute_requested = false,
       dispute_reviewed = false
-    WHERE game_id = ${gameId}
+    WHERE id = ${gameId}
   `)
 }

--- a/server/lib/validation/joi-validator.ts
+++ b/server/lib/validation/joi-validator.ts
@@ -20,13 +20,13 @@ interface JoiValidationDescriptor {
 export function joiValidator({ query, body }: JoiValidationDescriptor) {
   return async (ctx: Koa.Context, next: Koa.Next) => {
     if (query) {
-      const { error } = query.validate(ctx.query)
+      const { error } = query.validate(ctx.request.query)
       if (error) {
         throw new httpErrors.BadRequest(`Invalid query string - ${error.message}`)
       }
     }
     if (body) {
-      const { error } = body.validate(ctx.body)
+      const { error } = body.validate(ctx.request.body)
       if (error) {
         throw new httpErrors.BadRequest(`Invalid request body - ${error.message}`)
       }

--- a/server/websockets.js
+++ b/server/websockets.js
@@ -8,7 +8,7 @@ import log from './lib/logging/logger'
 
 const apiHandlers = fs
   .readdirSync(path.join(__dirname, 'lib', 'wsapi'))
-  .filter(filename => /\.js$/.test(filename))
+  .filter(filename => /\.(js|ts)$/.test(filename))
   .map(filename => require('./lib/wsapi/' + filename).default)
 
 // dummy response object, needed for session middleware's cookie setting stuff


### PR DESCRIPTION
This sets things up so we can make this request from the Rust code, as the game finishes. We make 3 attempts, if all 3 fail, the expectation is that the app will retry at some point in the future (but this is NOT implemented yet as of this PR). The app can know to do this by the fact that the game exits without calling `/game/resultSent` (and my plan is to always submit some sort of results if that occurs, to try to give us fewer result timeouts in the case of weird issues).

APM calculation is also not included in this PR, for now everybody is registered as having 0 APM.

Note that there's a number of random Rust reformatting changes in here, as VSCode really wanted to do them. I adjusted our `.editorconfig` to preserve most of the existing formatting.