### PR TITLE
Remove GA.

### DIFF
--- a/client/app.jsx
+++ b/client/app.jsx
@@ -1,10 +1,7 @@
 import React from 'react'
 import { Route, Switch } from 'react-router-dom'
-import ga from 'react-ga'
 import { StyleSheetManager } from 'styled-components'
 import loadable from '@loadable/component'
-import { makeServerUrl } from './network/server-url'
-
 import { hot } from 'react-hot-loader/root'
 
 import { VerifyEmail, SendVerificationEmail } from './auth/email-verification.jsx'
@@ -37,32 +34,6 @@ const LoadableDev = IS_PRODUCTION
     })
 
 class App extends React.Component {
-  initialized = false
-  onUpdate = () => {
-    if (!this.initialized) {
-      return
-    }
-
-    // TODO(2Pac): Make GA work.
-    // See: https://github.com/react-ga/react-ga/wiki/React-Router-v4-withTracker
-    if (IS_ELECTRON) {
-      ga.pageview(window.location.hash.slice(1))
-    } else {
-      ga.pageview(window.location.pathname)
-    }
-  }
-
-  componentDidMount() {
-    if (this.props.analyticsId) {
-      ga.initialize(this.props.analyticsId)
-      if (IS_ELECTRON) {
-        ga.set({ location: makeServerUrl('') })
-        ga.set({ checkProtocolTask: null })
-      }
-      this.initialized = true
-    }
-  }
-
   render() {
     return (
       // NOTE(2Pac): These are only the top-level routes. More specific routes are declared where

--- a/package.json
+++ b/package.json
@@ -110,7 +110,6 @@
   },
   "devDependencies": {
     "@babel/preset-react": "^7.7.4",
-    "@exponent/electron-cookies": "^2.0.0",
     "@hot-loader/react-dom": "^16.13.0",
     "@loadable/component": "^5.12.0",
     "@types/body-parser": "^1.19.0",
@@ -168,7 +167,6 @@
     "react": "^16.12.0",
     "react-custom-scrollbars": "^4.2.1",
     "react-dom": "^16.12.0",
-    "react-ga": "^3.1.2",
     "react-hot-loader": "^4.12.18",
     "react-is": "^16.8.0",
     "react-redux": "^7.1.3",

--- a/server/routes.js
+++ b/server/routes.js
@@ -37,7 +37,6 @@ export default function applyRoutes(app, nydus, userSockets) {
 
   router.get('/config', async (ctx, next) => {
     ctx.body = {
-      analyticsId: process.env.SB_ANALYTICS_ID,
       feedbackUrl: process.env.SB_FEEDBACK_URL,
     }
     ctx.type = 'application/json'
@@ -64,7 +63,6 @@ export default function applyRoutes(app, nydus, userSockets) {
       }
       await ctx.render('index', {
         initData,
-        analyticsId: process.env.SB_ANALYTICS_ID,
         feedbackUrl: process.env.SB_FEEDBACK_URL,
         cspNonce: getCspNonce(ctx),
       })

--- a/server/views/index.jade
+++ b/server/views/index.jade
@@ -4,9 +4,6 @@ block headScripts
   if initData
     script(type='text/javascript', nonce=cspNonce).
       window._sbInitData=!{JSON.stringify(initData)}
-  if analyticsId
-    script(type='text/javascript', nonce=cspNonce).
-      window._sbAnalyticsId=!{JSON.stringify(analyticsId)}
   if feedbackUrl
     script(type='text/javascript', nonce=cspNonce).
       window._sbFeedbackUrl=!{JSON.stringify(feedbackUrl)}
@@ -17,7 +14,7 @@ block metaTags
   meta(property='og:title', content='ShieldBattery - Modern Starcraft: Brood War')
   meta(property='og:description', content='Play Starcraft: Brood War with improved networking, modern operating system support, ladder, matchmaking, and more!')
   meta(property='og:image', content='/images/logo-and-text-1200x630.png')
-  
+
   meta(name='twitter:card', content='summary_large_image')
   meta(name='twitter:title', content='ShieldBattery - Modern Starcraft: Brood War')
   meta(name='twitter:description', content='Play Starcraft: Brood War with improved networking, modern operating system support, ladder, matchmaking, and more!')

--- a/yarn.lock
+++ b/yarn.lock
@@ -1002,14 +1002,6 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@exponent/electron-cookies@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@exponent/electron-cookies/-/electron-cookies-2.0.0.tgz#4cf8dcf851454036cc524c40e9e482fc4e23f2d9"
-  integrity sha1-TPjc+FFFQDbMUkxA6eSC/E4j8tk=
-  dependencies:
-    tough-cookie "^2.2.2"
-    tough-cookie-web-storage-store "^1.0.0"
-
 "@hapi/bourne@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@hapi/bourne/-/bourne-2.0.0.tgz#5bb2193eb685c0007540ca61d166d4e1edaf918d"
@@ -3149,9 +3141,6 @@ core-js-compat@^3.8.0:
   version "3.8.1"
   resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.8.1.tgz#8d1ddd341d660ba6194cbe0ce60f4c794c87a36e"
   integrity sha512-a16TLmy9NVD1rkjUGbwuyWkiDoN0FDpAwrfLONvHFQx0D9k7J9y0srwMT8QP/Z6HE3MIFaVynEeYwZwPX1o5RQ==
-  dependencies:
-    browserslist "^4.15.0"
-    semver "7.0.0"
 
 core-js@^3.6.1, core-js@^3.6.5:
   version "3.8.1"
@@ -6369,7 +6358,7 @@ lodash.isplainobject@^4.0.6:
   resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
   integrity sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=
 
-lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.4, lodash@^4.6.1:
+lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.4:
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
@@ -7941,11 +7930,6 @@ pseudomap@^1.0.1, pseudomap@^1.0.2:
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
   integrity sha1-8FKijacOYYkX7wqKw0wa5aaChrM=
 
-psl@^1.1.28:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/psl/-/psl-1.8.0.tgz#9326f8bcfb013adcc005fdff056acce020e51c24"
-  integrity sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==
-
 public-encrypt@^4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/public-encrypt/-/public-encrypt-4.0.3.tgz#4fcc9d77a07e48ba7527e7cbe0de33d0701331e0"
@@ -8001,7 +7985,7 @@ punycode@^1.2.4, punycode@^1.3.2:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
   integrity sha1-wNWmOycYgArY4esPpSachN1BhF4=
 
-punycode@^2.1.0, punycode@^2.1.1:
+punycode@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
@@ -8154,11 +8138,6 @@ react-dom@^16.12.0:
     object-assign "^4.1.1"
     prop-types "^15.6.2"
     scheduler "^0.19.1"
-
-react-ga@^3.1.2:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/react-ga/-/react-ga-3.3.0.tgz#c91f407198adcb3b49e2bc5c12b3fe460039b3ca"
-  integrity sha512-o8RScHj6Lb8cwy3GMrVH6NJvL+y0zpJvKtc0+wmH7Bt23rszJmnqEQxRbyrqUzk9DTJIHoP42bfO5rswC9SWBQ==
 
 react-hot-loader@^4.12.18:
   version "4.13.0"
@@ -9633,21 +9612,6 @@ tokenthrottle@^1.3.0, tokenthrottle@~1.3.0:
   dependencies:
     assert-plus "~1.0.0"
     lru-cache "~4.0.0"
-
-tough-cookie-web-storage-store@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/tough-cookie-web-storage-store/-/tough-cookie-web-storage-store-1.0.0.tgz#8021fce24290bf0b6151e491d7312343451d390d"
-  integrity sha1-gCH84kKQvwthUeSR1zEjQ0UdOQ0=
-  dependencies:
-    lodash "^4.6.1"
-
-tough-cookie@^2.2.2:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.5.0.tgz#cd9fb2a0aa1d5a12b473bd9fb96fa3dcff65ade2"
-  integrity sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==
-  dependencies:
-    psl "^1.1.28"
-    punycode "^2.1.1"
 
 transformers@2.1.0:
   version "2.1.0"


### PR DESCRIPTION
This commit removes the Google Analytics integration we had (though it
didn't even work since last react-router upgrade anyway). It's
questionable how useful GA would be to us, and not integrating it has a
nice bonus that we now don't need add a cookie consent form.

Closes #387