### PR TITLE
Replace SC:R mask shader with one that shows unexplored areas.

### DIFF
--- a/game/Cargo.lock
+++ b/game/Cargo.lock
@@ -16,6 +16,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee2a4ec343196209d6594e19543ae87a39f96d5534d7174822a3ad825dd6ed7e"
 
 [[package]]
+name = "anyhow"
+version = "1.0.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1fd36ffbb1fb7c834eac128ea8d0e310c5aeb635548f9d58861e1308d46e71c"
+
+[[package]]
 name = "array-init"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -133,13 +139,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "console_error_panic_hook"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8d976903543e0c48546a91908f21588a680a8c8f984df9a5d69feccb2b2a211"
+name = "compile-shaders"
+version = "0.1.0"
 dependencies = [
- "cfg-if 0.1.10",
- "wasm-bindgen",
+ "scopeguard",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -493,9 +497,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55e2e4c765aa53a0424761bf9f41aa7a6ac1efa87238f59560640e27fca028f2"
+checksum = "4fb1fa934250de4de8aef298d81c729a7d33d8c239daa3a7575e6b92bfc7313b"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -752,9 +756,9 @@ checksum = "37fd5004feb2ce328a52b0b3d01dbf4ffff72583493900ed15f22d4111c51693"
 
 [[package]]
 name = "once_cell"
-version = "1.4.1"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "260e51e7efe62b592207e9e13a68e43692a7a279171d6ba57abd208bf23645ad"
+checksum = "13bd41f508810a131401606d54ac32a467c97172d74ba7662562ebba5ad07fa0"
 
 [[package]]
 name = "opaque-debug"
@@ -764,12 +768,12 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.30"
+version = "0.10.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d575eff3665419f9b83678ff2815858ad9d11567e082f5ac1814baba4e2bcb4"
+checksum = "8d008f51b1acffa0d3450a68606e6a51c123012edaacb0f4e1426bd978869187"
 dependencies = [
  "bitflags",
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "foreign-types",
  "lazy_static",
  "libc",
@@ -784,9 +788,9 @@ checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.58"
+version = "0.9.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a842db4709b604f0fe5d1170ae3565899be2ad3d9cbc72dedc789ac0511f78de"
+checksum = "de52d8eabd217311538a39bba130d7dea1f1e118010fee7a033d966845e7d5fe"
 dependencies = [
  "autocfg",
  "cc",
@@ -991,9 +995,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.10.9"
+version = "0.10.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb15d6255c792356a0f578d8a645c677904dc02e862bebe2ecc18e0c01b9a0ce"
+checksum = "0718f81a8e14c4dbb3b34cf23dc6aaf9ab8a0dfec160c534b3dbca1aaa21f47c"
 dependencies = [
  "base64 0.13.0",
  "bytes",
@@ -1021,7 +1025,6 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-bindgen-test",
  "web-sys",
  "winreg",
 ]
@@ -1041,9 +1044,10 @@ checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 [[package]]
 name = "samase_scarf"
 version = "0.1.0"
-source = "git+https://github.com/neivv/samase_scarf/?rev=d7ecee5f7bd014f6e0fbf2c5f2fd8a02514cc281#d7ecee5f7bd014f6e0fbf2c5f2fd8a02514cc281"
+source = "git+https://github.com/neivv/samase_scarf/?rev=9114a849cc5066dee92dc2b91480df8a6621499a#9114a849cc5066dee92dc2b91480df8a6621499a"
 dependencies = [
  "arrayvec",
+ "bumpalo",
  "byteorder",
  "fxhash",
  "lde 0.3.0 (git+https://github.com/CasualX/lde)",
@@ -1051,13 +1055,12 @@ dependencies = [
  "memchr",
  "memmem",
  "scarf",
- "smallvec",
 ]
 
 [[package]]
 name = "scarf"
 version = "0.3.0"
-source = "git+https://github.com/neivv/scarf?rev=4da6facdc16e2b4ca77552d6dd88412fb473af65#4da6facdc16e2b4ca77552d6dd88412fb473af65"
+source = "git+https://github.com/neivv/scarf?rev=30a43f5ece2024e913800e0088196d42bf192107#30a43f5ece2024e913800e0088196d42bf192107"
 dependencies = [
  "array-init",
  "arrayvec",
@@ -1081,12 +1084,6 @@ dependencies = [
  "lazy_static",
  "winapi 0.3.9",
 ]
-
-[[package]]
-name = "scoped-tls"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
 
 [[package]]
 name = "scopeguard"
@@ -1184,11 +1181,13 @@ dependencies = [
 name = "shieldbattery"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "arrayvec",
  "backtrace",
  "byteorder",
  "bytes",
  "chrono",
+ "compile-shaders",
  "fern",
  "futures",
  "fxhash",
@@ -1196,6 +1195,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "log",
+ "once_cell",
  "parking_lot",
  "quick-error",
  "rand",
@@ -1204,6 +1204,7 @@ dependencies = [
  "scr-analysis",
  "serde",
  "serde_json",
+ "smallvec",
  "tokio",
  "tokio-tungstenite",
  "tungstenite",
@@ -1225,13 +1226,12 @@ checksum = "fbee7696b84bbf3d89a1c2eccff0850e3047ed46bfcd2e92c29a2d074d57e252"
 
 [[package]]
 name = "socket2"
-version = "0.3.17"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c29947abdee2a218277abeca306f25789c938e500ea5a9d4b12a5a504466902"
+checksum = "122e570113d28d773067fab24266b66753f6ea915758651696b6e35e49f88d6e"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "redox_syscall",
  "winapi 0.3.9",
 ]
 
@@ -1461,9 +1461,9 @@ checksum = "05e42f7c18b8f902290b009cde6d651262f956c98bc51bca4cd1d511c9cd85c7"
 
 [[package]]
 name = "vcpkg"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6454029bf181f092ad1b853286f23e2c507d8e8194d01d92da4a55c274a5508c"
+checksum = "b00bca6106a5e23f3eee943593759b7fcddb00554332e856d990c893966879fb"
 
 [[package]]
 name = "version_check"
@@ -1560,30 +1560,6 @@ name = "wasm-bindgen-shared"
 version = "0.2.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e7811dd7f9398f14cc76efd356f98f03aa30419dea46aa810d71e819fc97158"
-
-[[package]]
-name = "wasm-bindgen-test"
-version = "0.3.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0355fa0c1f9b792a09b6dcb6a8be24d51e71e6d74972f9eb4a44c4c004d24a25"
-dependencies = [
- "console_error_panic_hook",
- "js-sys",
- "scoped-tls",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "wasm-bindgen-test-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-test-macro"
-version = "0.3.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27e07b46b98024c2ba2f9e83a10c2ef0515f057f2da299c1762a2017de80438b"
-dependencies = [
- "proc-macro2",
- "quote",
-]
 
 [[package]]
 name = "web-sys"

--- a/game/Cargo.toml
+++ b/game/Cargo.toml
@@ -29,13 +29,15 @@ http = "0.2"
 lazy_static = "1.3"
 libc = "0.2.50"
 log = "0.4"
+once_cell = "1.5"
 parking_lot = { version = "0.11", features = ["send_guard"] }
 quick-error = "2.0"
 rand = "0.7"
 reqwest = { version = "0.10.9", features = ["json"] }
-scopeguard = "1.0"
+scopeguard = "1.1"
 serde = { version = "1.0.89", features = ["derive", "rc"] }
 serde_json = "1.0.39"
+smallvec = "1.4"
 tokio = { version = "0.2", features = ["fs", "net", "rt-threaded", "stream", "sync", "time"] }
 tungstenite = { version = "0.11", default-features = false }
 tokio-tungstenite = "0.11"
@@ -52,11 +54,20 @@ features = [
 git = "https://github.com/neivv/whack/"
 rev = "1adee081ac5ebc8362f92801e2083bbbadd79d57"
 
+[build-dependencies]
+anyhow = "1.0.33"
+
 # -- Local helper crates --
 [workspace]
 
 [dependencies.scr-analysis]
 path = "./scr-analysis"
+
+[dependencies.compile-shaders]
+path = "./compile-shaders"
+
+[build-dependencies.compile-shaders]
+path = "./compile-shaders"
 
 [profile.dev.package.scr-analysis]
 # Optimize scr-analysis subcrate as its code takes quite a lot of time to run

--- a/game/build.rs
+++ b/game/build.rs
@@ -1,0 +1,81 @@
+//! A build script to compile d3d11 shaders for SC:R
+//! Could be extended to also build Forge's 1.16.1 shaders at some point =)
+
+use std::fs;
+use std::path::{Path};
+
+use anyhow::{Context, Error};
+
+use compile_shaders::{ShaderModel, ShaderType};
+
+static SOURCES: &[(&str, &str, &[(&str, &str)])] = &[
+    ("mask", "mask.hlsl", &[]),
+];
+
+fn main() {
+    let out_path = std::env::var("OUT_DIR").unwrap();
+    let out_path = Path::new(&out_path);
+    assert!(out_path.exists());
+    let shader_dir = Path::new("src/bw_scr/shaders");
+    for &(out_name, source, defines) in SOURCES.iter() {
+        let source_path = shader_dir.join(source);
+        println!("cargo:rerun-if-changed={}", source_path.to_str().unwrap());
+        let bin_path = out_path.join(&format!("{}.sm5.bin", out_name));
+        let asm_path = out_path.join(&format!("{}.sm5.asm", out_name));
+        compile_prism_shader(
+            &source_path,
+            &bin_path,
+            &asm_path,
+            defines,
+            shader_dir,
+            ShaderType::Pixel,
+            ShaderModel::Sm5,
+        ).unwrap_or_else(|e| panic!("Failed to compile {}: {:?}", out_name, e));
+
+        let bin_path = out_path.join(&format!("{}.sm4.bin", out_name));
+        let asm_path = out_path.join(&format!("{}.sm4.asm", out_name));
+        compile_prism_shader(
+            &source_path,
+            &bin_path,
+            &asm_path,
+            defines,
+            shader_dir,
+            ShaderType::Pixel,
+            ShaderModel::Sm4,
+        ).unwrap_or_else(|e| panic!("Failed to compile {}: {:?}", out_name, e));
+    }
+}
+
+fn compile_prism_shader(
+    source_path: &Path,
+    out_path: &Path,
+    disasm_path: &Path,
+    defines: &[(&str, &str)],
+    include_root: &Path,
+    shader_type: ShaderType,
+    model: ShaderModel,
+) -> Result<(), Error> {
+    let text_bytes = fs::read(source_path)
+        .with_context(|| format!("Failed to read {}", source_path.display()))?;
+    let result =
+        compile_shaders::compile(&text_bytes, defines, include_root, shader_type, model)?;
+    for path in result.include_files {
+        println!("cargo:rerun-if-changed={}", path);
+    }
+    let shader_bytes = result.shader;
+    let wrapped = compile_shaders::wrap_prism_shader(&shader_bytes);
+    fs::write(&out_path, &wrapped)
+        .with_context(|| format!("Failed to write {}", out_path.display()))?;
+    disasm_shader(&shader_bytes, disasm_path)
+        .context("Failed to disassemble the result")?;
+    Ok(())
+}
+
+/// Output disassembly if needed for debugging.
+/// Not necessary for actually building.
+fn disasm_shader(shader_bytes: &[u8], out_path: &Path) -> Result<(), Error> {
+    let disasm = compile_shaders::disassemble(shader_bytes)?;
+    fs::write(&out_path, &disasm)
+        .with_context(|| format!("Failed to write {}", out_path.display()))?;
+    Ok(())
+}

--- a/game/compile-shaders/Cargo.toml
+++ b/game/compile-shaders/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "compile-shaders"
+version = "0.1.0"
+edition = "2018"
+
+[dependencies]
+scopeguard = "1.1"
+
+[dependencies.winapi]
+version = "0.3"
+features = ["d3dcompiler"]

--- a/game/compile-shaders/src/lib.rs
+++ b/game/compile-shaders/src/lib.rs
@@ -1,0 +1,238 @@
+//! A crate to contain shader compilation code that is used by both main librarys's
+//! build script (When adding precompiled shaders to .dll), and main library itself
+//! (When loading shaders at runtime)
+
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::ptr::{null, null_mut};
+
+use winapi::um::d3dcompiler::*;
+use winapi::um::d3dcommon::*;
+use winapi::um::winnt::HRESULT;
+use winapi::shared::winerror::{E_FAIL, S_OK};
+
+pub enum ShaderModel {
+    Sm4,
+    Sm5,
+}
+
+pub enum ShaderType {
+    Vertex,
+    Pixel,
+}
+
+/// Wraps a D3D shader into the format that SC:R's prism renderer expects them in.
+pub fn wrap_prism_shader(bytes: &[u8]) -> Vec<u8> {
+    let mut out = vec![0u8; 0x38];
+    out[0] = 0x3;
+    out[0x10] = 0x3;
+    out[0x20] = 0x3;
+    out[0x28] = 0x1;
+    (&mut out[0x30..0x34]).copy_from_slice(&(bytes.len() as u32).to_le_bytes());
+    out[0x34] = 0x4;
+    out.extend_from_slice(bytes);
+    out
+}
+
+/// Disassembles a compiled D3D shader.
+pub fn disassemble(bytes: &[u8]) -> io::Result<Vec<u8>> {
+    unsafe {
+        let mut blob = std::ptr::null_mut();
+        let error = D3DDisassemble(
+            bytes.as_ptr() as *const _,
+            bytes.len(),
+            0,
+            b"\0".as_ptr() as *const _,
+            &mut blob,
+        );
+        if error != 0 {
+            return Err(io::Error::from_raw_os_error(error).into());
+        }
+        scopeguard::defer! {
+            (*blob).Release();
+        }
+        Ok(blob_to_bytes(blob))
+    }
+}
+
+pub struct CompileResults {
+    pub shader: Vec<u8>,
+    /// List of include files opened.
+    /// Used so that build script can tell cargo that they are build inputs
+    /// that must be tracked for changes.
+    pub include_files: Vec<String>,
+}
+
+pub fn compile(
+    bytes: &[u8],
+    in_defines: &[(&str, &str)],
+    shader_dir: &Path,
+    shader_type: ShaderType,
+    model: ShaderModel,
+) -> io::Result<CompileResults> {
+    unsafe {
+        let mut defines = vec![];
+        // Hold define strings for the compilation
+        let mut strings = vec![];
+        for &(name, val) in in_defines {
+            let name = format!("{}\0", name);
+            let val = format!("{}\0", val);
+            defines.push(D3D_SHADER_MACRO {
+                Name: name.as_ptr() as *const i8,
+                Definition: val.as_ptr() as *const i8,
+            });
+            strings.push(name);
+            strings.push(val);
+        }
+        defines.push(D3D_SHADER_MACRO {
+            Name: null(),
+            Definition: null(),
+        });
+        let mut code = null_mut();
+        let mut errors = null_mut();
+        let include = IncludeHandler::new(shader_dir.into());
+        let model_string = match (model, shader_type) {
+            (ShaderModel::Sm4, ShaderType::Vertex) => "vs_4_0\0".as_ptr() as *const i8,
+            (ShaderModel::Sm5, ShaderType::Vertex) => "vs_5_0\0".as_ptr() as *const i8,
+            (ShaderModel::Sm4, ShaderType::Pixel) => "ps_4_0\0".as_ptr() as *const i8,
+            (ShaderModel::Sm5, ShaderType::Pixel) => "ps_5_0\0".as_ptr() as *const i8,
+        };
+        let error = D3DCompile2(
+            bytes.as_ptr() as *const _,
+            bytes.len(),
+            null(),
+            defines.as_ptr(),
+            include.0 as *mut ID3DInclude,
+            b"main\0".as_ptr() as *const i8,
+            model_string,
+            D3DCOMPILE_OPTIMIZATION_LEVEL3 | D3DCOMPILE_WARNINGS_ARE_ERRORS,
+            0,
+            0,
+            null(),
+            0,
+            &mut code,
+            &mut errors,
+        );
+        scopeguard::defer! {
+            if !code.is_null() {
+                (*code).Release();
+            }
+            if !errors.is_null() {
+                (*errors).Release();
+            }
+        }
+        if let Some(error) = (*include.0).error.take() {
+            return Err(error);
+        }
+        if error != 0 {
+            if !errors.is_null() {
+                let errors = blob_to_bytes(errors);
+                let error_msg = String::from_utf8_lossy(&errors);
+                if !error_msg.is_empty() {
+                    return Err(io::Error::new(io::ErrorKind::InvalidInput, error_msg));
+                }
+            }
+            return Err(io::Error::from_raw_os_error(error));
+        }
+        let include_files = std::mem::replace(&mut (*include.0).opened_files, Vec::new());
+        Ok(CompileResults {
+            shader: blob_to_bytes(code),
+            include_files,
+        })
+    }
+}
+
+unsafe fn blob_to_bytes(blob: *mut ID3D10Blob) -> Vec<u8> {
+    let slice = std::slice::from_raw_parts(
+        (*blob).GetBufferPointer() as *const u8,
+        (*blob).GetBufferSize(),
+    );
+    slice.into()
+}
+
+static INCLUDE_VTABLE: ID3DIncludeVtbl = ID3DIncludeVtbl {
+    Open: IncludeHandler::open,
+    Close: IncludeHandler::close,
+};
+
+#[repr(C)]
+struct IncludeHandler {
+    interface: ID3DInclude,
+    path: PathBuf,
+    buffers: Vec<Vec<u8>>,
+    opened_files: Vec<String>,
+    error: Option<io::Error>,
+}
+
+struct IncludeHandlerHandle(*mut IncludeHandler);
+
+impl Drop for IncludeHandlerHandle {
+    fn drop(&mut self) {
+        unsafe { Box::from_raw(self.0); }
+    }
+}
+
+/// Resolves shader includes to a filesystem file relative from the path passed to the
+/// constructor.
+impl IncludeHandler {
+    fn new(path: PathBuf) -> IncludeHandlerHandle {
+        let ptr = Box::into_raw(Box::new(IncludeHandler {
+            interface: ID3DInclude {
+                lpVtbl: &INCLUDE_VTABLE,
+            },
+            path,
+            opened_files: Vec::new(),
+            buffers: Vec::new(),
+            error: None,
+        }));
+        IncludeHandlerHandle(ptr)
+    }
+
+    unsafe extern "system" fn open(
+        s: *mut ID3DInclude,
+        _include_type: D3D_INCLUDE_TYPE,
+        filename: *const i8,
+        _parent_data: *const winapi::ctypes::c_void,
+        out_data: *mut *const winapi::ctypes::c_void,
+        out_size: *mut u32,
+    ) -> HRESULT {
+        *out_data = null_mut();
+        *out_size = 0;
+        let s = s as *mut IncludeHandler;
+        let filename_len = (0..).position(|i| *filename.add(i) == 0).unwrap();
+        let filename = std::slice::from_raw_parts(filename as *const u8, filename_len);
+        let filename = match std::str::from_utf8(filename) {
+            Ok(o) => o,
+            Err(_) => return E_FAIL,
+        };
+        let path = (*s).path.join(filename);
+        (*s).opened_files.push(path.to_str().unwrap().into());
+        let result = match fs::read(&path) {
+            Ok(o) => o,
+            Err(e) => {
+                (*s).error = Some(e);
+                return E_FAIL;
+            }
+        };
+        let ptr = result.as_ptr();
+        let len = result.len();
+        (*s).buffers.push(result);
+        *out_data = ptr as *const _;
+        *out_size = len as u32;
+        S_OK
+    }
+
+    unsafe extern "system" fn close(
+        s: *mut ID3DInclude,
+        data: *const winapi::ctypes::c_void,
+    ) -> HRESULT {
+        let s = s as *mut IncludeHandler;
+        let pos = match (*s).buffers.iter().position(|x| x.as_ptr() == data as *const u8) {
+            Some(s) => s,
+            None => return E_FAIL,
+        };
+        (*s).buffers.swap_remove(pos);
+        S_OK
+    }
+}

--- a/game/scr-analysis/Cargo.toml
+++ b/game/scr-analysis/Cargo.toml
@@ -5,4 +5,4 @@ edition = "2018"
 
 [dependencies.samase_scarf]
 git = "https://github.com/neivv/samase_scarf/"
-rev = "d7ecee5f7bd014f6e0fbf2c5f2fd8a02514cc281"
+rev = "9114a849cc5066dee92dc2b91480df8a6621499a"

--- a/game/scr-analysis/src/lib.rs
+++ b/game/scr-analysis/src/lib.rs
@@ -10,12 +10,15 @@
 
 pub use samase_scarf::scarf;
 
-use scarf::{BinaryFile, ExecutionStateX86, Operand, OperandCtx, VirtualAddress};
+use scarf::{BinaryFile, ExecutionStateX86, MemAccessSize, Operand, OperandCtx, VirtualAddress};
 use scarf::exec_state::VirtualAddress as VirtualAddressTrait;
+
+pub type Patch = samase_scarf::Patch<VirtualAddress>;
 
 pub struct Analysis<'e>(
     samase_scarf::Analysis<'e, ExecutionStateX86<'e>>,
     &'e BinaryFile<VirtualAddress>,
+    OperandCtx<'e>,
 );
 
 impl<'e> Analysis<'e> {
@@ -23,7 +26,18 @@ impl<'e> Analysis<'e> {
         binary: &'e BinaryFile<VirtualAddress>,
         ctx: OperandCtx<'e>,
     ) -> Analysis<'e> {
-        Analysis(samase_scarf::Analysis::new(binary, ctx), binary)
+        Analysis(samase_scarf::Analysis::new(binary, ctx), binary, ctx)
+    }
+
+    fn eud(&mut self, address: u32) -> Option<Operand<'e>> {
+        let euds = self.0.eud_table();
+        let index = euds.euds.binary_search_by_key(&address, |x| x.address).ok()?;
+        Some(euds.euds.get(index)?.operand)
+    }
+
+    #[cfg(target_arch = "x86")]
+    fn mem_word(&self, op: Operand<'e>) -> Operand<'e> {
+        self.2.mem32(op)
     }
 
     pub fn game(&mut self) -> Option<Operand<'e>> {
@@ -208,5 +222,79 @@ impl<'e> Analysis<'e> {
         let tls_address = base + tls_offset;
         let tls_ptr = binary.read_u32(tls_address + 0x8).ok()?;
         Some(tls_ptr as *mut u32)
+    }
+
+    pub fn prism_pixel_shaders(&mut self) -> Option<Vec<VirtualAddress>> {
+        // As of this writing, there are 0x2b pixel shaders in SC:R;
+        // assume that finding any less is an error.
+        Some((*self.0.prism_pixel_shaders()).clone())
+            .filter(|x| x.len() >= 0x2b)
+    }
+
+    pub fn prism_renderer_vtable(&mut self) -> Option<VirtualAddress> {
+        Some(self.0.vtables_for_class(b".?AVPrismRenderer@@"))
+            .filter(|x| x.len() == 1)
+            .map(|x| x[0])
+    }
+
+    pub fn first_active_unit(&mut self) -> Option<Operand<'e>> {
+        self.0.active_hidden_units().first_active_unit
+    }
+
+    pub fn sprites_by_y_tile_start(&mut self) -> Option<Operand<'e>> {
+        self.0.sprites().sprite_hlines
+    }
+
+    pub fn sprites_by_y_tile_end(&mut self) -> Option<Operand<'e>> {
+        self.0.sprites().sprite_hlines_end
+    }
+
+    pub fn first_free_sprite(&mut self) -> Option<Operand<'e>> {
+        self.0.sprites().first_free_sprite
+    }
+
+    pub fn last_free_sprite(&mut self) -> Option<Operand<'e>> {
+        self.0.sprites().last_free_sprite
+    }
+
+    pub fn first_active_fow_sprite(&mut self) -> Option<Operand<'e>> {
+        self.0.fow_sprites().first_active
+    }
+
+    pub fn last_active_fow_sprite(&mut self) -> Option<Operand<'e>> {
+        self.0.fow_sprites().last_active
+    }
+
+    pub fn first_free_fow_sprite(&mut self) -> Option<Operand<'e>> {
+        self.0.fow_sprites().first_free
+    }
+
+    pub fn last_free_fow_sprite(&mut self) -> Option<Operand<'e>> {
+        self.0.fow_sprites().last_free
+    }
+
+    pub fn first_free_image(&mut self) -> Option<Operand<'e>> {
+        self.eud(0x0057eb68).map(|x| self.mem_word(x))
+    }
+
+    pub fn last_free_image(&mut self) -> Option<Operand<'e>> {
+        self.eud(0x0057eb70).map(|x| self.mem_word(x))
+    }
+
+    pub fn sprite_x(&mut self) -> Option<(Operand<'e>, u32, MemAccessSize)> {
+        self.0.sprites().sprite_x_position
+    }
+
+    pub fn sprite_y(&mut self) -> Option<(Operand<'e>, u32, MemAccessSize)> {
+        self.0.sprites().sprite_y_position
+    }
+
+    pub fn replay_minimap_unexplored_fog_patch(&mut self) -> Option<Patch> {
+        self.0.replay_minimap_unexplored_fog_patch()
+            .map(|x| (*x).clone())
+    }
+
+    pub fn step_game(&mut self) -> Option<VirtualAddress> {
+        self.0.step_objects()
     }
 }

--- a/game/src/bw/list.rs
+++ b/game/src/bw/list.rs
@@ -1,0 +1,127 @@
+use std::ptr::null_mut;
+
+use crate::bw;
+use crate::bw_scr::scr;
+
+pub struct LinkedList<T> {
+    pub start: *mut *mut T,
+    pub end: *mut *mut T,
+}
+
+impl<T> Clone for LinkedList<T> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl<T> Copy for LinkedList<T> { }
+
+impl<T: BwListEntry> LinkedList<T> {
+    unsafe fn add(&self, value: *mut T) {
+        if (*self.start).is_null() {
+            *self.start = value;
+            *self.end = value;
+            *BwListEntry::next(value) = null_mut();
+            *BwListEntry::prev(value) = null_mut();
+        } else {
+            let next = *self.start;
+            *self.start = value;
+            *BwListEntry::next(value) = next;
+            *BwListEntry::prev(next) = value;
+            *BwListEntry::prev(value) = null_mut();
+        }
+    }
+
+    unsafe fn remove(&self, value: *mut T) {
+        let prev = *BwListEntry::prev(value);
+        let next = *BwListEntry::next(value);
+        if prev.is_null() {
+            assert!(*self.start == value);
+            *self.start = next;
+        } else {
+            *BwListEntry::next(prev) = next;
+        }
+        if next.is_null() {
+            assert!(*self.end == value);
+            *self.end = prev;
+        } else {
+            *BwListEntry::prev(next) = prev;
+        }
+    }
+
+    pub unsafe fn alloc(&self) -> Option<Allocation<T>> {
+        let value = *self.start;
+        if value.is_null() {
+            None
+        } else {
+            self.remove(value);
+            Some(Allocation {
+                value,
+                list: *self,
+            })
+        }
+    }
+}
+
+/// An allocation that has been taken out of a linked list
+/// (Generally a list storing the unallocated objects),
+/// if dropped without calling move_to, it gets placed back to the
+/// list it was allocated from.
+pub struct Allocation<T: BwListEntry> {
+    value: *mut T,
+    list: LinkedList<T>
+}
+
+impl<T: BwListEntry> Allocation<T> {
+    pub fn value(&self) -> *mut T {
+        self.value
+    }
+
+    pub unsafe fn move_to(self, dest: &LinkedList<T>) {
+        let value = self.value;
+        std::mem::forget(self);
+        dest.add(value);
+    }
+}
+
+impl<T: BwListEntry> Drop for Allocation<T> {
+    fn drop(&mut self) {
+        unsafe {
+            self.list.add(self.value);
+        }
+    }
+}
+
+pub trait BwListEntry {
+    unsafe fn next(this: *mut Self) -> *mut *mut Self;
+    unsafe fn prev(this: *mut Self) -> *mut *mut Self;
+}
+
+impl BwListEntry for scr::Sprite {
+    unsafe fn next(this: *mut Self) -> *mut *mut Self {
+        &mut (*this).next
+    }
+
+    unsafe fn prev(this: *mut Self) -> *mut *mut Self {
+        &mut (*this).prev
+    }
+}
+
+impl BwListEntry for bw::Image {
+    unsafe fn next(this: *mut Self) -> *mut *mut Self {
+        &mut (*this).next
+    }
+
+    unsafe fn prev(this: *mut Self) -> *mut *mut Self {
+        &mut (*this).prev
+    }
+}
+
+impl BwListEntry for bw::FowSprite {
+    unsafe fn next(this: *mut Self) -> *mut *mut Self {
+        &mut (*this).next
+    }
+
+    unsafe fn prev(this: *mut Self) -> *mut *mut Self {
+        &mut (*this).prev
+    }
+}

--- a/game/src/bw/unit.rs
+++ b/game/src/bw/unit.rs
@@ -1,0 +1,65 @@
+//! A bit higher-level functions for working with `*mut bw::Unit`
+//!
+//! `Unit` just wraps the raw pointer, and since it's not worth the effort
+//! to implement getters/setters for every less-used field of `bw::Unit`,
+//! you can get the inner pointer by dereferencing it, as in `*unit`.
+//!
+//! While the raw struct `bw::Unit` is exported by this module's parent,
+//! it's probably clearer to keep refering it as `bw::Unit` and import
+//! this `crate::bw::unit::Unit` to `Unit` where it's used.
+
+use std::ptr::{NonNull};
+use crate::bw;
+
+/// There are three main lists,
+/// one for active units (Anything selectable or something that is drawn),
+/// one for hidden units (Inside building, transport, or similarly not interacting with map),
+/// one for revealers (Scanner sweeps, map revealers)
+pub struct UnitIterator(Option<Unit>);
+
+impl UnitIterator {
+    pub fn new(first: Option<Unit>) -> UnitIterator {
+        UnitIterator(first)
+    }
+}
+
+impl Iterator for UnitIterator {
+    type Item = Unit;
+    fn next(&mut self) -> Option<Unit> {
+        let unit = self.0?;
+        unsafe {
+            self.0 = Unit::from_ptr((**unit).next);
+        }
+        Some(unit)
+    }
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct Unit(NonNull<bw::Unit>);
+
+impl std::ops::Deref for Unit {
+    type Target = *mut bw::Unit;
+    fn deref(&self) -> &Self::Target {
+        unsafe {
+            std::mem::transmute(&self.0)
+        }
+    }
+}
+
+impl Unit {
+    pub unsafe fn from_ptr(ptr: *mut bw::Unit) -> Option<Unit> {
+        NonNull::new(ptr).map(Unit)
+    }
+
+    pub fn player(self) -> u8 {
+        unsafe { (**self).player }
+    }
+
+    pub fn id(self) -> u16 {
+        unsafe { (**self).unit_id }
+    }
+
+    pub fn is_landed_building(self) -> bool {
+        unsafe { (**self).flags & 0x2 != 0 }
+    }
+}

--- a/game/src/bw_scr/shader_replaces.rs
+++ b/game/src/bw_scr/shader_replaces.rs
@@ -1,0 +1,196 @@
+//! SC:R shader replacing code. Debug builds are compiled to support hot reloading
+//! of shaders, release builds always just serve precompiled binary data.
+
+use super::scr;
+
+#[cfg(debug_assertions)]
+use std::path::{Path, PathBuf};
+#[cfg(debug_assertions)]
+use std::time::{Duration, Instant, SystemTime};
+#[cfg(debug_assertions)]
+use parking_lot::Mutex;
+
+const fn pixel_sm4(wrapper: &[u8]) -> scr::PrismShader {
+    scr::PrismShader {
+        api_type: scr::PRISM_SHADER_API_SM4,
+        shader_type: scr::PRISM_SHADER_TYPE_PIXEL,
+        unk: [0; 6],
+        data: wrapper.as_ptr(),
+        data_len: wrapper.len() as u32,
+    }
+}
+
+const fn pixel_sm5(wrapper: &[u8]) -> scr::PrismShader {
+    scr::PrismShader {
+        api_type: scr::PRISM_SHADER_API_SM5,
+        shader_type: scr::PRISM_SHADER_TYPE_PIXEL,
+        unk: [0; 6],
+        data: wrapper.as_ptr(),
+        data_len: wrapper.len() as u32,
+    }
+}
+
+static MASK_SM4_BIN: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/mask.sm4.bin"));
+static MASK_SM5_BIN: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/mask.sm5.bin"));
+static MASK: &[scr::PrismShader] = &[
+    pixel_sm4(MASK_SM4_BIN),
+    pixel_sm5(MASK_SM5_BIN),
+];
+
+static PATCHED_SHADERS: &[(u8, &[scr::PrismShader], &str)] = &[
+    (0x1c, MASK, "mask"),
+];
+
+#[cfg(debug_assertions)]
+pub struct ShaderReplaces {
+    shaders: Mutex<Vec<(u8, &'static [scr::PrismShader], Option<(PathBuf, SystemTime)>)>>,
+    // Update checking requires windows i/o for every shader file, doing that every
+    // rendered frame is likely a bit excessive.
+    update_throttle: Mutex<Instant>,
+}
+
+#[cfg(not(debug_assertions))]
+pub struct ShaderReplaces;
+
+#[cfg(debug_assertions)]
+impl ShaderReplaces {
+    pub fn new() -> ShaderReplaces {
+        let shaders_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("src/bw_scr/shaders");
+        let shaders = PATCHED_SHADERS
+            .iter()
+            .map(|&(id, default_source, name)| {
+                let path = shaders_root.join(format!("{}.hlsl", name));
+                if let Some((shader, timestamp)) = compile_shader_retry_on_err(&path) {
+                    (id, shader, Some((path.into(), timestamp)))
+                } else {
+                    (id, default_source, None)
+                }
+            })
+            .collect();
+
+        ShaderReplaces {
+            shaders: Mutex::new(shaders),
+            update_throttle: Mutex::new(Instant::now()),
+        }
+    }
+
+    pub fn iter_shaders(&self) -> impl Iterator<Item = (u8, &'static [scr::PrismShader])> {
+        let result = {
+            let mut shaders = self.shaders.lock();
+            for &mut (_, ref mut data, ref mut path_time) in shaders.iter_mut() {
+                if let Some((ref path, ref mut time)) = *path_time {
+                    if let Some(new_time) = file_changed_time(path) {
+                        if new_time != *time {
+                            if let Some((shader, new_time)) =
+                                compile_shader_retry_on_err(&path)
+                            {
+                                debug!("Recompiled shader {}", path.display());
+                                *data = shader;
+                                *time = new_time;
+                            }
+                        }
+                    }
+                }
+            }
+            shaders.iter().map(|&(id, data, _)| (id, data)).collect::<Vec<_>>()
+        };
+        result.into_iter()
+    }
+
+    pub fn has_changed(&self) -> bool {
+        let now = Instant::now();
+        let mut last_check = self.update_throttle.lock();
+        if now.duration_since(*last_check) < Duration::from_millis(500) {
+            return false;
+        }
+        *last_check = now;
+        let shaders = self.shaders.lock();
+        shaders
+            .iter()
+            .filter_map(|x| x.2.as_ref())
+            .any(|(path, time)| {
+                if let Some(new_time) = file_changed_time(&path) {
+                    new_time != *time
+                } else {
+                    false
+                }
+            })
+    }
+}
+
+/// Returns None if the shader file does not exist. (That is, the debug dll was distributed
+/// to some other system than the one it was compiled on)
+/// On compile errors shows the error with a message box and rereads the until
+/// the shader compiles
+#[cfg(debug_assertions)]
+fn compile_shader_retry_on_err(path: &Path) -> Option<(&'static [scr::PrismShader], SystemTime)> {
+    use std::fs;
+    use std::io::Read;
+    use compile_shaders::{ShaderType, ShaderModel};
+    if !path.exists() {
+        return None;
+    }
+    let dir = path.parent()?;
+    loop {
+        let result = fs::File::open(path)
+            .and_then(|mut file| {
+                let metadata = file.metadata()?;
+                let modified = metadata.modified()?;
+                let mut buffer = Vec::new();
+                file.read_to_end(&mut buffer)?;
+                let sm4 = compile_shaders::compile(
+                    &buffer,
+                    &[],
+                    dir,
+                    ShaderType::Pixel,
+                    ShaderModel::Sm4,
+                )?;
+                let sm5 = compile_shaders::compile(
+                    &buffer,
+                    &[],
+                    dir,
+                    ShaderType::Pixel,
+                    ShaderModel::Sm5,
+                )?;
+
+                // Just leak the shaders as I cannot be too sure
+                // that deallocating old shaders is safe; SC:R may keep
+                // some handles to them for a while or something.
+                // And the memory leaked isn't that many bytes.
+                let result = vec![
+                    pixel_sm4(compile_shaders::wrap_prism_shader(&sm4.shader).leak()),
+                    pixel_sm5(compile_shaders::wrap_prism_shader(&sm5.shader).leak()),
+                ];
+                Ok((&*result.leak(), modified))
+            });
+        match result {
+            Ok(o) => return Some(o),
+            Err(e) => {
+                let msg = format!("Shader compilation failed.\n\
+                    File {}\n\
+                    {}", path.display(), e);
+                crate::windows::message_box("Shieldbattery", &msg);
+            }
+        }
+    }
+}
+
+#[cfg(debug_assertions)]
+fn file_changed_time(path: &Path) -> Option<SystemTime> {
+    std::fs::metadata(&path).and_then(|x| x.modified()).ok()
+}
+
+#[cfg(not(debug_assertions))]
+impl ShaderReplaces {
+    pub fn new() -> ShaderReplaces {
+        ShaderReplaces
+    }
+
+    pub fn iter_shaders(&self) -> impl Iterator<Item = (u8, &'static [scr::PrismShader])> {
+        PATCHED_SHADERS.iter().map(|x| (x.0, x.1))
+    }
+
+    pub fn has_changed(&self) -> bool {
+        false
+    }
+}

--- a/game/src/bw_scr/shaders/mask.hlsl
+++ b/game/src/bw_scr/shaders/mask.hlsl
@@ -1,0 +1,53 @@
+struct VS_OUTPUT
+{
+    float4 pos : SV_POSITION;
+    float2 texCoord : TEXCOORD0;
+};
+
+SamplerState maskSampler : register(s0);
+Texture2D <float4> mask: register(t0);
+
+struct PS_OUTPUT
+{
+    float4 frag_color : SV_Target0;
+};
+
+cbuffer constants
+{
+    // if 0, uses the normal BW behaviour where unexplored areas are black (For UMS),
+    // otherwise makes unexplored areas somewhat visible as well.
+    float useNewMask;
+};
+
+#define MAX_FOG_MASK 0.81
+#define MIN_FOG_MASK 0.67
+
+PS_OUTPUT main(VS_OUTPUT v)
+{
+    PS_OUTPUT o;
+    float maskValue = mask.Sample(maskSampler, v.texCoord).x;
+    if (useNewMask == 0.0) 
+    {
+        o.frag_color = float4(0.0, 0.0, 0.0, maskValue);
+    }
+    else
+    {
+        // We calculate the fog mask as a piecewise function:
+        //  - For the low parts (below MIN_FOG_MASK) we leave the linear function intact
+        float lowMaskValue = min(maskValue, MIN_FOG_MASK);
+        //  - For high parts (above MIN_FOG_MASK), we compress the range into
+        //    (MIN_FOG_MASK, MAX_FOG_MASK) and increase the contrast in the transition (to better
+        //    separate unexplored from explored fog areas)
+        float highMaskValue = tanh(max(maskValue - MIN_FOG_MASK, 0.0) / (1.0 - MIN_FOG_MASK) * 6) *
+            (MAX_FOG_MASK - MIN_FOG_MASK);
+        maskValue = lowMaskValue + highMaskValue;
+        o.frag_color = float4(
+            0.0,
+            0.0,
+            // We add a slight amount of blue to unexplored areas to further increase the contrast
+            smoothstep(MIN_FOG_MASK, MAX_FOG_MASK, maskValue) * 0.03,
+            maskValue);
+    }
+    return o;
+}
+

--- a/game/src/game_thread.rs
+++ b/game/src/game_thread.rs
@@ -1,10 +1,13 @@
 //! Hooks and other code that is running on the game/main thread (As opposed to async threads).
 
 use std::sync::mpsc::Receiver;
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 
+use fxhash::FxHashSet;
 use lazy_static::lazy_static;
+use once_cell::sync::OnceCell;
 
+use crate::app_messages::{GameSetupInfo};
 use crate::bw::{self, with_bw};
 use crate::forge;
 use crate::snp;
@@ -15,6 +18,9 @@ lazy_static! {
     pub static ref GAME_RECEIVE_REQUESTS: Mutex<Option<Receiver<GameThreadRequest>>> =
         Mutex::new(None);
 }
+
+// Global for accessing game type/slots/etc from hooks.
+static SETUP_INFO: OnceCell<Arc<GameSetupInfo>> = OnceCell::new();
 
 // Async tasks request game thread to do some work
 pub struct GameThreadRequest {
@@ -38,6 +44,7 @@ pub enum GameThreadRequestType {
     RunWndProc,
     StartGame,
     ExitCleanup,
+    SetupInfo(Arc<GameSetupInfo>),
 }
 
 // Game thread sends something to async tasks
@@ -93,6 +100,11 @@ unsafe fn handle_game_request(request: GameThreadRequestType) {
         // Saves registry settings etc.
         ExitCleanup => {
             with_bw(|bw| bw.clean_up_for_exit());
+        }
+        SetupInfo(info) => {
+            if let Err(_) = SETUP_INFO.set(info) {
+                warn!("Received second SetupInfo");
+            }
         }
     }
 }
@@ -155,16 +167,16 @@ unsafe fn init_bw() {
 
 /// Bw impl is expected to hook the point after init_game_data and call this.
 pub unsafe fn after_init_game_data() {
-    // Let async thread know about player randomization.
-    // The function that bw_1161/bw_scr refer to as init_game_data mainly initializes global
-    // data structures used in a game. Player randomization seems to have been done before that,
-    // so if it ever in future ends up being the case that the async thread has a point where it
-    // uses wrong game player ids, a more exact point for this hook should be decided.
-    //
-    // But for now it should be fine, and this should also be late enough in initialization that
-    // any possible alternate branches for save/replay/ums randomization should have been executed
-    // as well.
     with_bw(|bw| {
+        // Let async thread know about player randomization.
+        // The function that bw_1161/bw_scr refer to as init_game_data mainly initializes global
+        // data structures used in a game. Player randomization seems to have been done before that,
+        // so if it ever in future ends up being the case that the async thread has a point where it
+        // uses wrong game player ids, a more exact point for this hook should be decided.
+        //
+        // But for now it should be fine, and this should also be late enough in initialization that
+        // any possible alternate branches for save/replay/ums randomization should have been executed
+        // as well.
         let mut mapping = [None; bw::MAX_STORM_PLAYERS];
         let players = bw.players();
         for i in 0..8 {
@@ -174,5 +186,70 @@ pub unsafe fn after_init_game_data() {
             }
         }
         send_game_msg_to_async(GameThreadMessage::PlayersRandomized(mapping));
+        // Create fog-of-war sprites for any neutral buildings
+        if !is_ums() {
+            for unit in bw.active_units() {
+                if unit.player() == 11 && unit.is_landed_building() {
+                    bw.create_fow_sprite(unit);
+                }
+            }
+        }
+    });
+}
+
+pub fn is_ums() -> bool {
+    SETUP_INFO.get()
+        .and_then(|x| x.game_type())
+        .filter(|x| x.is_ums())
+        .is_some()
+}
+
+pub fn is_replay() -> bool {
+    SETUP_INFO.get()
+        .and_then(|x| x.map.is_replay)
+        .unwrap_or(false)
+}
+
+/// Bw impl is expected to call this after step_game,
+/// the function that progresses game objects by a tick/frame/step.
+/// In other words, if the game isn't paused/lagging, this gets ran 24 times in second
+/// on fastest game speed.
+/// This function can be used for hooks that change gameplay state after BW has done (most of)
+/// its once-per-gameplay-frame processing but before anything gets rendered. It probably
+/// isn't too useful to us unless we end up having a need to change game rules.
+pub unsafe fn after_step_game() {
+    with_bw(|bw| {
+        if is_replay() && !is_ums() {
+            // One thing BW's step_game does is that it removes any fog sprites that were
+            // no longer in fog. Unfortunately now that we show fog sprites for unexplored
+            // resources as well, removing those fog sprites ends up being problematic if
+            // the user switches vision off from a player who had those resources explored.
+            // In such case the unexplored fog sprites would not appear and some of the
+            // expansions would show up as empty while other unexplored bases keep their
+            // fog sprites as usual.
+            // To get around this issue, check which neutral buildings don't have fog
+            // sprites and add them back.
+            // (Adding fog sprites on visible area is fine, at least in replays)
+
+            let mut fow_sprites = FxHashSet::with_capacity_and_hasher(256, Default::default());
+            for fow in bw.fow_sprites() {
+                let sprite = (*fow).sprite;
+                let pos = bw.sprite_position(sprite);
+                fow_sprites.insert((pos.x, pos.y, (*fow).unit_id));
+            }
+            for unit in bw.active_units() {
+                if unit.player() == 11 && unit.is_landed_building() {
+                    // This currently adds fow sprites even for buildings that became
+                    // neutral after player left. It's probably fine, but if it wasn't
+                    // desired, checking that `sprite.player == 11` should only include
+                    // buildings that existed from map start
+                    let sprite = (**unit).sprite;
+                    let pos = bw.sprite_position(sprite);
+                    if fow_sprites.insert((pos.x, pos.y, unit.id())) {
+                        bw.create_fow_sprite(unit);
+                    }
+                }
+            }
+        }
     });
 }


### PR DESCRIPTION
Unexplored areas are displayed slightly darker than obscured but FoW'd
ones. Resources/neutral units still display in unexplored areas. This
functionality is disabled for UMS games.

Also adds shader hot reloading support to debug builds.