### PR TITLE
Don't send game results when watching a replay

### DIFF
--- a/client/active-game/active-game-manager.js
+++ b/client/active-game/active-game-manager.js
@@ -255,7 +255,8 @@ export default class ActiveGameManager extends EventEmitter {
     if (
       this.activeGame.status.state >= GAME_STATUS_PLAYING &&
       !this.activeGame.resultSent &&
-      this.activeGame.result
+      this.activeGame.result &&
+      !this.activeGame.config.map.isReplay
     ) {
       // TODO(#542): Retry submission of these results more times/for longer to try and ensure
       // complete resutls on the server

--- a/game/src/app_messages.rs
+++ b/game/src/app_messages.rs
@@ -85,6 +85,12 @@ pub struct GameSetupInfo {
     pub server_url: String,
 }
 
+impl GameSetupInfo {
+    pub fn is_replay(&self) -> bool {
+        self.map.is_replay == Some(true)
+    }
+}
+
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct MapInfo {


### PR DESCRIPTION
I guess it's fine to not have the game send results to app either when watching a replay? App seems to not rely on receiving results before end message atm.

Closes #574