### PR TITLE
Clear the unread notification icon on the 'show' event as well.

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -394,6 +394,11 @@ async function createWindow(localSettings, curSession) {
         systemTray.clearUnreadIcon()
       }
     })
+    .on('show', () => {
+      if (systemTray) {
+        systemTray.clearUnreadIcon()
+      }
+    })
 
   mainWindow.webContents
     .on('new-window', (event, url) => {


### PR DESCRIPTION
It seems that there is a bug in Electron which makes it not emit 'focus'
event anymore when the application is closed to system tray. The 'show'
event is emitted fine so we use that.