### PR TITLE
Extend new replays with extra data

### DIFF
--- a/client/active-game/game-config.ts
+++ b/client/active-game/game-config.ts
@@ -27,6 +27,8 @@ export interface PlayerInfo {
     | 'closed'
   /** The BW id of the type of this slot. */
   typeId: number
+  /** Shieldbattery user ID of the player. Only set for 'human' and 'observer' */
+  userId?: number
 }
 
 export interface ReplayMapInfo {

--- a/client/lobbies/lobby-reducer.js
+++ b/client/lobbies/lobby-reducer.js
@@ -39,6 +39,7 @@ export const Slot = new Record({
   hasForcedRace: false,
   playerId: null,
   typeId: 0,
+  userId: null,
 })
 export const Team = new Record({
   name: null,

--- a/game/Cargo.toml
+++ b/game/Cargo.toml
@@ -43,11 +43,12 @@ tungstenite = { version = "0.11", default-features = false }
 tokio-tungstenite = "0.11"
 
 [dependencies.winapi]
-version = "0.3.3"
+version = "0.3.9"
 features = [
     "combaseapi", "dsound", "debugapi", "d3d11", "dxgi", "errhandlingapi", "handleapi",
     "knownfolders", "libloaderapi", "memoryapi", "processthreadsapi", "shlobj", "stringapiset",
-    "synchapi", "sysinfoapi", "unknwnbase", "winuser", "wingdi", "winsock2", "ws2def", "ws2ipdef",
+    "synchapi", "sysinfoapi", "unknwnbase", "winuser", "wingdi", "winsock2", "winver", "ws2def",
+    "ws2ipdef",
 ]
 
 [dependencies.whack]
@@ -56,6 +57,7 @@ rev = "1adee081ac5ebc8362f92801e2083bbbadd79d57"
 
 [build-dependencies]
 anyhow = "1.0.33"
+serde_json = "1.0.39"
 
 # -- Local helper crates --
 [workspace]

--- a/game/build.rs
+++ b/game/build.rs
@@ -1,5 +1,7 @@
-//! A build script to compile d3d11 shaders for SC:R
-//! Could be extended to also build Forge's 1.16.1 shaders at some point =)
+//! A build script that
+//! 1) Compiles d3d11 shaders for SC:R
+//!     (Could be extended to also build Forge's 1.16.1 shaders at some point)
+//! 2) Gathers version information from package.json
 
 use std::fs;
 use std::path::{Path};
@@ -44,6 +46,18 @@ fn main() {
             ShaderModel::Sm4,
         ).unwrap_or_else(|e| panic!("Failed to compile {}: {:?}", out_name, e));
     }
+    println!("cargo:rustc-env=SHIELDBATTERY_VERSION={}", package_json_version("../package.json"));
+}
+
+fn package_json_version(path: &str) -> String {
+    println!("cargo:rerun-if-changed={}", path);
+    let mut file = fs::File::open(path).unwrap();
+    let json: serde_json::Value = serde_json::from_reader(&mut file).unwrap();
+    json
+        .as_object().expect("package.json root not object")
+        .get("version").expect("package.json version not found")
+        .as_str().expect("package.json version not string")
+        .into()
 }
 
 fn compile_prism_shader(

--- a/game/scr-analysis/src/lib.rs
+++ b/game/scr-analysis/src/lib.rs
@@ -208,6 +208,10 @@ impl<'e> Analysis<'e> {
         self.0.init_game().init_game
     }
 
+    pub fn init_units(&mut self) -> Option<VirtualAddress> {
+        self.0.init_units()
+    }
+
     pub fn file_hook(&mut self) -> Option<VirtualAddress> {
         self.0.file_hook().get(0).copied()
     }

--- a/game/src/app_messages.rs
+++ b/game/src/app_messages.rs
@@ -118,6 +118,7 @@ pub struct PlayerInfo {
     pub id: String,
     pub name: String,
     pub race: Option<String>,
+    pub user_id: Option<u32>,
     pub player_id: Option<u8>,
     pub team_id: Option<u8>,
     // Player type can have shieldbattery-specific players (e.g. "observer"),

--- a/game/src/app_messages.rs
+++ b/game/src/app_messages.rs
@@ -119,10 +119,14 @@ pub struct PlayerInfo {
     pub name: String,
     pub race: Option<String>,
     pub user_id: Option<u32>,
+    /// BW player slot index. Only set in UMS; for other game types the index is equal to
+    /// GameSetupInfo.slots index.
+    /// And either way this value becomes useless after BW randomizes the slots during
+    /// game initialization.
     pub player_id: Option<u8>,
     pub team_id: Option<u8>,
-    // Player type can have shieldbattery-specific players (e.g. "observer"),
-    // player type id is the id in BW structures.
+    /// Player type can have shieldbattery-specific players (e.g. "observer"),
+    /// player type id is the id in BW structures.
     #[serde(rename = "type")]
     pub player_type: String,
     #[serde(rename = "typeId")]

--- a/game/src/bw.rs
+++ b/game/src/bw.rs
@@ -423,7 +423,8 @@ pub struct Rect32 {
 pub struct Game {
     pub minerals: [u32; 0xc],
     pub gas: [u32; 0xc],
-    pub dc60: [u8; 0x7c],
+    pub dc60: [u8; 0x70],
+    pub starting_races: [u8; 0xc],
     pub team_game_main_player: [u8; 4],
     pub screen_pos_x_tiles: u16,
     pub screen_pos_y_tiles: u16,

--- a/game/src/bw_1161.rs
+++ b/game/src/bw_1161.rs
@@ -261,7 +261,7 @@ whack_hooks!(stdcall, 0x00400000,
     0x004A2D60 => UpdateNetTimeoutPlayers();
     0x004CB190 =>
         CenterScreenOnOwnStartLocation(@eax *mut bw::PreplacedUnit, @ecx *mut c_void) -> u32;
-    0x004EEE00 => InitGameData() -> u32;
+    0x004EF100 => InitGameData() -> u32;
     0x0049F380 => InitUnitData();
     0x004D94B0 => StepGame();
     0x00487100 => StepReplayCommands();

--- a/game/src/bw_scr.rs
+++ b/game/src/bw_scr.rs
@@ -1388,7 +1388,12 @@ impl BwScr {
         drop(open_files);
 
         if crate::replay::has_replay_magic_bytes(handle) {
-            if let Err(e) = crate::replay::add_shieldbattery_data(handle, self, self.exe_build) {
+            if let Err(e) = crate::replay::add_shieldbattery_data(
+                handle,
+                self,
+                self.exe_build,
+                game_thread::setup_info(),
+            ) {
                 error!("Unable to write extended replay data: {}", e);
             }
         }

--- a/game/src/bw_scr.rs
+++ b/game/src/bw_scr.rs
@@ -1393,6 +1393,7 @@ impl BwScr {
                 self,
                 self.exe_build,
                 game_thread::setup_info(),
+                game_thread::player_id_mapping(),
             ) {
                 error!("Unable to write extended replay data: {}", e);
             }

--- a/game/src/game_state.rs
+++ b/game/src/game_state.rs
@@ -1,4 +1,5 @@
 use std::ffi::CStr;
+use std::io;
 use std::mem;
 use std::net::Ipv4Addr;
 use std::path::{Path, PathBuf};
@@ -22,9 +23,10 @@ use crate::bw::{self, get_bw, GameType, StormPlayerId};
 use crate::cancel_token::{CancelToken, Canceler, SharedCanceler};
 use crate::forge;
 use crate::game_thread::{
-    GameThreadMessage, GameThreadRequest, GameThreadRequestType, GameThreadResults,
+    self, GameThreadMessage, GameThreadRequest, GameThreadRequestType, GameThreadResults,
 };
 use crate::network_manager::{NetworkError, NetworkManager};
+use crate::replay;
 use crate::snp;
 use crate::windows;
 
@@ -257,6 +259,10 @@ impl GameState {
             .send(())
             .expect("Main thread should be waiting for a wakeup");
         async move {
+            let sbat_replay_data = match info.is_replay() {
+                true => Some(read_sbat_replay_data(Path::new(&info.map_path))),
+                false => None,
+            };
             // We tell BW thread to init, and then it'll stay in forge's WndProc until we're
             // ready to start the game - remaining initialization is done from other threads.
             // Could possibly aim to keep all of BW initialization in the main thread, but this
@@ -337,6 +343,23 @@ impl GameState {
                 }
             }
             debug!("All players have joined");
+            if let Some(sbat_replay_data_promise) = sbat_replay_data {
+                // Assuming that the extra replay data isn't needed in the above lobby
+                // initialization.
+                match sbat_replay_data_promise.await {
+                    Ok(Some(o)) => {
+                        debug!("Loaded shieldbattery replay extension");
+                        game_thread::set_sbat_replay_data(o);
+                    }
+                    Ok(None) => (),
+                    Err(e) => {
+                        // Going to assume that most of the time if we fail to read the
+                        // extra replay data, it won't be fatal, so just log the error
+                        // and continue.
+                        error!("Failed to read shieldbattery replay data: {}", e);
+                    }
+                }
+            }
             allow_start.await;
             unsafe {
                 do_lobby_game_init(&info).await;
@@ -1104,4 +1127,52 @@ fn start_game_request(
 
     sender.send(request).map_err(|_| ())?;
     Ok(wait_done)
+}
+
+async fn read_sbat_replay_data(
+    path: &Path,
+) -> Result<Option<replay::SbatReplayData>, io::Error> {
+    use byteorder::{ByteOrder, LittleEndian};
+    use tokio::io::{AsyncReadExt};
+    use tokio::fs;
+
+    let mut file = fs::File::open(path).await?;
+    let mut buffer = [0u8; 0x14];
+    file.read_exact(&mut buffer).await?;
+    let magic = LittleEndian::read_u32(&buffer[0xc..]);
+    let scr_extension_offset = LittleEndian::read_u32(&buffer[0x10..]);
+    if magic != 0x53526573 {
+        return Ok(None);
+    }
+    let end_pos = file.seek(io::SeekFrom::End(0)).await?;
+    file.seek(io::SeekFrom::Start(scr_extension_offset as u64)).await?;
+    let length = end_pos.saturating_sub(scr_extension_offset as u64) as usize;
+    let mut buffer = vec![0u8; length];
+    file.read_exact(&mut buffer).await?;
+    let mut pos = 0;
+    while pos < length {
+        let header = match buffer.get(pos..(pos + 8)) {
+            Some(s) => s,
+            None => break,
+        };
+        let id = LittleEndian::read_u32(&header);
+        let section_length = LittleEndian::read_u32(&header[4..]) as usize;
+        if id == replay::SECTION_ID {
+            let data = Some(())
+                .and_then(|()| {
+                    Some(buffer.get(pos.checked_add(8)?..)?.get(..section_length)?)
+                })
+                .and_then(|input| replay::parse_shieldbattery_data(input));
+            return match data {
+                Some(o) => Ok(Some(o)),
+                None => Err(io::Error::new(
+                    io::ErrorKind::Other,
+                    "Failed to parse shieldbattery section",
+                )),
+            };
+        } else {
+            pos = pos.saturating_add(section_length).saturating_add(8);
+        }
+    }
+    Ok(None)
 }

--- a/game/src/game_thread.rs
+++ b/game/src/game_thread.rs
@@ -212,6 +212,8 @@ pub unsafe fn after_init_game_data() {
 }
 
 pub fn is_ums() -> bool {
+    // TODO This returns false on replays. Also same thing about looking at BW's
+    // structures as for is_team_game
     SETUP_INFO.get()
         .and_then(|x| x.game_type())
         .filter(|x| x.is_ums())
@@ -219,10 +221,18 @@ pub fn is_ums() -> bool {
 }
 
 pub fn is_team_game() -> bool {
-    SETUP_INFO.get()
-        .and_then(|x| x.game_type())
-        .filter(|x| x.is_team_game())
-        .is_some()
+    // Technically it would be better to look at BW's structures instead, but we don't
+    // have them available for SC:R right now.
+    if is_replay() {
+        sbat_replay_data()
+            .filter(|x| x.team_game_main_players != [0, 0, 0, 0])
+            .is_some()
+    } else {
+        SETUP_INFO.get()
+            .and_then(|x| x.game_type())
+            .filter(|x| x.is_team_game())
+            .is_some()
+    }
 }
 
 pub fn is_replay() -> bool {

--- a/game/src/game_thread.rs
+++ b/game/src/game_thread.rs
@@ -241,6 +241,10 @@ pub fn is_replay() -> bool {
         .unwrap_or(false)
 }
 
+pub fn setup_info() -> &'static GameSetupInfo {
+    &*SETUP_INFO.get().unwrap()
+}
+
 /// Bw impl is expected to call this after step_game,
 /// the function that progresses game objects by a tick/frame/step.
 /// In other words, if the game isn't paused/lagging, this gets ran 24 times in second

--- a/game/src/hook_macro.rs
+++ b/game/src/hook_macro.rs
@@ -16,7 +16,7 @@ use crate::windows;
 // instead, but this was copy-pasted from older code that did it this way so this'll do for now.
 
 macro_rules! hook_winapi_exports {
-    ($active:expr, $expected_name:expr, $($name:expr, $hook:ident, $func:path;)*) => {{
+    ($active:expr, $expected_name:expr, $($name:expr, $hook:ident, $func:ident;)*) => {{
         let lib = crate::windows::load_library($expected_name).unwrap();
         let mut default_patcher = $active.patch_library($expected_name, 0);
         const fn zero(_name: &'static str) -> usize {

--- a/game/src/lib.rs
+++ b/game/src/lib.rs
@@ -21,6 +21,7 @@ mod game_state;
 mod game_thread;
 mod network_manager;
 mod rally_point;
+mod replay;
 mod snp;
 mod udp;
 mod windows;

--- a/game/src/replay.rs
+++ b/game/src/replay.rs
@@ -64,6 +64,7 @@ pub unsafe fn add_shieldbattery_data(
     // 0x1a     u8 starting_races[0xc]
     //      This is also needed for team game replays.
     // 0x26     u128 game_id_uuid
+    // 0x36     u32 user_ids[0x8]
     let game = bw.game();
     let mut buffer = Vec::with_capacity(32);
     buffer.write_u32::<LE>(SECTION_ID)?;
@@ -81,6 +82,13 @@ pub unsafe fn add_shieldbattery_data(
     let starting_races = (*game).starting_races;
     buffer.extend_from_slice(&starting_races);
     write_uuid(&mut buffer, &setup_info.game_id)?;
+    for slot in &setup_info.slots {
+        let user_id = match slot.user_id {
+            Some(user_id) => user_id,
+            None => 0xffffffff as u32,
+        };
+        buffer.write_u32::<LE>(user_id)?;
+    }
     let length = buffer.len() as u32 - 8;
     (&mut buffer[4..]).write_u32::<LE>(length)?;
     windows::file_write(file, &buffer)?;

--- a/game/src/replay.rs
+++ b/game/src/replay.rs
@@ -1,0 +1,97 @@
+//! Fucntions for writing/reading our replay extensions.
+
+use std::convert::TryInto;
+use std::io;
+
+use byteorder::{ReadBytesExt, WriteBytesExt, LE};
+use libc::c_void;
+
+use crate::bw::Bw;
+use crate::windows;
+
+static REPLAY_MAGIC: &[u8] = &[
+    0xc2, 0x19, 0xc2, 0x93, 0x01, 0x00, 0x00, 0x00,
+    0x04, 0x00, 0x00, 0x00, 0x73, 0x65, 0x52, 0x53,
+];
+
+pub static SECTION_ID: u32 = 0x74616253; // Sbat
+
+pub struct SbatReplayData {
+    pub team_game_main_players: [u8; 4],
+    pub starting_races: [u8; 0xc],
+}
+
+/// Checks if the start of file matches what SC:R currently writes to every replay
+/// (This does not check for 1.16.1 / early SC:R magic bytes)
+pub unsafe fn has_replay_magic_bytes(file: *mut c_void) -> bool {
+    match has_replay_magic_bytes_res(file) {
+        Ok(o) => o,
+        Err(e) => {
+            error!("Unable to check file for replay magic: {}", e);
+            false
+        }
+    }
+}
+
+unsafe fn has_replay_magic_bytes_res(file: *mut c_void) -> Result<bool, io::Error> {
+    windows::file_seek(file, std::io::SeekFrom::Start(0))?;
+    let mut buffer = [0u8; 0x10];
+    windows::file_read(file, &mut buffer[..])?;
+    Ok(buffer == REPLAY_MAGIC)
+}
+
+/// Adds shieldbattery replay data to end of a winapi file.
+/// (Seeks to the end if not already)
+pub unsafe fn add_shieldbattery_data(
+    file: *mut c_void,
+    bw: &dyn Bw,
+    exe_build: u32,
+) -> Result<(), io::Error> {
+    windows::file_seek(file, std::io::SeekFrom::End(0))?;
+    // Current format: (The first two u32s are required by SC:R, after that we can have anything)
+    // u32 section_id
+    // u32 data_length (Not counting these first 8 bytes)
+    // u16 format_version (0)
+    // u32 starcraft_exe_build
+    // u8 shieldbattery_version_length
+    // u8 shieldbattery_version_string[..]
+    // u8 team_game_main_players[4]
+    //      Think that relying on it being [0, 0, 0, 0] for non-team games is ok?
+    //      BW shouldn't care at least.
+    // u8 starting_races[0xc]
+    //      This is also needed for team game replays.
+    let game = bw.game();
+    let mut buffer = Vec::with_capacity(32);
+    buffer.write_u32::<LE>(SECTION_ID)?;
+    buffer.write_u32::<LE>(0)?;
+    buffer.write_u16::<LE>(0)?;
+    buffer.write_u32::<LE>(exe_build)?;
+    let version = env!("SHIELDBATTERY_VERSION").as_bytes();
+    let length = version.len().min(255) as u8;
+    buffer.push(length);
+    buffer.extend_from_slice(&version[..length as usize]);
+    let team_game_main_players = (*game).team_game_main_player;
+    buffer.extend_from_slice(&team_game_main_players);
+    let starting_races = (*game).starting_races;
+    buffer.extend_from_slice(&starting_races);
+    let length = buffer.len() as u32 - 8;
+    (&mut buffer[4..]).write_u32::<LE>(length)?;
+    windows::file_write(file, &buffer)?;
+    Ok(())
+}
+
+pub fn parse_shieldbattery_data(data: &[u8]) -> Option<SbatReplayData> {
+    let format = (&data[0..]).read_u16::<LE>().ok()?;
+    if format != 0 {
+        return None;
+    }
+    let &version_string_length = data.get(6)?;
+    let mut offset = 7 + version_string_length as usize;
+    let team_game_main_players = data.get(offset..)?.get(..4)?;
+    offset += 4;
+    let starting_races = data.get(offset..)?.get(..0xc)?;
+    Some(SbatReplayData {
+        team_game_main_players: team_game_main_players.try_into().ok()?,
+        starting_races: starting_races.try_into().ok()?,
+    })
+}

--- a/game/src/replay.rs
+++ b/game/src/replay.rs
@@ -51,14 +51,15 @@ pub unsafe fn add_shieldbattery_data(
     // Current format: (The first two u32s are required by SC:R, after that we can have anything)
     // u32 section_id
     // u32 data_length (Not counting these first 8 bytes)
-    // u16 format_version (0)
-    // u32 starcraft_exe_build
-    // u8 shieldbattery_version_length
-    // u8 shieldbattery_version_string[..]
-    // u8 team_game_main_players[4]
+    // 0x0      u16 format_version (0)
+    // 0x2      u32 starcraft_exe_build
+    //      This is somewhat redundant as GCFG section that SC:R writes by default has it too,
+    //      but may as well have a copy we control.
+    // 0x6      u8 shieldbattery_version_string[0x10]
+    // 0x16     u8 team_game_main_players[4]
     //      Think that relying on it being [0, 0, 0, 0] for non-team games is ok?
     //      BW shouldn't care at least.
-    // u8 starting_races[0xc]
+    // 0x1a     u8 starting_races[0xc]
     //      This is also needed for team game replays.
     let game = bw.game();
     let mut buffer = Vec::with_capacity(32);
@@ -67,9 +68,11 @@ pub unsafe fn add_shieldbattery_data(
     buffer.write_u16::<LE>(0)?;
     buffer.write_u32::<LE>(exe_build)?;
     let version = env!("SHIELDBATTERY_VERSION").as_bytes();
-    let length = version.len().min(255) as u8;
-    buffer.push(length);
-    buffer.extend_from_slice(&version[..length as usize]);
+    let mut version_buf = [0u8; 16];
+    for (out, val) in version_buf.iter_mut().zip(version.iter()) {
+        *out = *val;
+    }
+    buffer.extend_from_slice(&version_buf[..]);
     let team_game_main_players = (*game).team_game_main_player;
     buffer.extend_from_slice(&team_game_main_players);
     let starting_races = (*game).starting_races;
@@ -85,11 +88,8 @@ pub fn parse_shieldbattery_data(data: &[u8]) -> Option<SbatReplayData> {
     if format != 0 {
         return None;
     }
-    let &version_string_length = data.get(6)?;
-    let mut offset = 7 + version_string_length as usize;
-    let team_game_main_players = data.get(offset..)?.get(..4)?;
-    offset += 4;
-    let starting_races = data.get(offset..)?.get(..0xc)?;
+    let team_game_main_players = data.get(0x16..)?.get(..4)?;
+    let starting_races = data.get(0x1a..)?.get(..0xc)?;
     Some(SbatReplayData {
         team_game_main_players: team_game_main_players.try_into().ok()?,
         starting_races: starting_races.try_into().ok()?,

--- a/game/src/replay.rs
+++ b/game/src/replay.rs
@@ -6,6 +6,7 @@ use std::io;
 use byteorder::{ReadBytesExt, WriteBytesExt, LE};
 use libc::c_void;
 
+use crate::app_messages::GameSetupInfo;
 use crate::bw::Bw;
 use crate::windows;
 
@@ -46,6 +47,7 @@ pub unsafe fn add_shieldbattery_data(
     file: *mut c_void,
     bw: &dyn Bw,
     exe_build: u32,
+    setup_info: &GameSetupInfo,
 ) -> Result<(), io::Error> {
     windows::file_seek(file, std::io::SeekFrom::End(0))?;
     // Current format: (The first two u32s are required by SC:R, after that we can have anything)
@@ -61,6 +63,7 @@ pub unsafe fn add_shieldbattery_data(
     //      BW shouldn't care at least.
     // 0x1a     u8 starting_races[0xc]
     //      This is also needed for team game replays.
+    // 0x26     u128 game_id_uuid
     let game = bw.game();
     let mut buffer = Vec::with_capacity(32);
     buffer.write_u32::<LE>(SECTION_ID)?;
@@ -77,10 +80,59 @@ pub unsafe fn add_shieldbattery_data(
     buffer.extend_from_slice(&team_game_main_players);
     let starting_races = (*game).starting_races;
     buffer.extend_from_slice(&starting_races);
+    write_uuid(&mut buffer, &setup_info.game_id)?;
     let length = buffer.len() as u32 - 8;
     (&mut buffer[4..]).write_u32::<LE>(length)?;
     windows::file_write(file, &buffer)?;
     Ok(())
+}
+
+/// Id is expected to be "12345678-9abc-def0-1234-56789abcdef0"
+/// format, otherwise returns error.
+/// Writes as big-endian bytes 0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde, 0xf0, ...
+/// (Just doing this by hand as it's just 30 lines,
+/// could use uuid crate otherwise to be more efficient)
+fn write_uuid<W: io::Write>(mut out: W, id: &str) -> Result<(), io::Error> {
+    fn bad_format() -> io::Error {
+        io::Error::new(io::ErrorKind::Other, "Invalid UUID string")
+    }
+
+    let mut buffer = [0u8; 16];
+    let id = id.as_bytes();
+    if id.len() != 36 {
+        return Err(bad_format());
+    }
+    let mut in_pos = 0;
+    let mut out_pos = 0;
+    for &bytes in &[4, 2, 2, 2, 6] {
+        if in_pos != 0 {
+            if id[in_pos] != b'-' {
+                return Err(bad_format());
+            }
+            in_pos += 1;
+        }
+        for byte in (&id[in_pos..]).chunks_exact(2).take(bytes) {
+            buffer[out_pos] = match std::str::from_utf8(byte).ok()
+                .and_then(|x| u8::from_str_radix(x, 16).ok())
+            {
+                Some(s) => s,
+                None => return Err(bad_format()),
+            };
+            out_pos += 1;
+            in_pos += 2;
+        }
+    }
+    out.write_all(&buffer[..])
+}
+
+#[test]
+fn test_write_uuid() {
+    let mut buf = vec![];
+    write_uuid(&mut buf, "12345678-9abc-def0-1234-56789abcdef0").unwrap();
+    assert_eq!(&buf,
+        &[0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde, 0xf0,
+          0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde, 0xf0],
+    );
 }
 
 pub fn parse_shieldbattery_data(data: &[u8]) -> Option<SbatReplayData> {

--- a/game/src/replay.rs
+++ b/game/src/replay.rs
@@ -1,4 +1,4 @@
-//! Fucntions for writing/reading our replay extensions.
+//! Functions for writing/reading our replay extensions.
 
 use std::convert::TryInto;
 use std::io;

--- a/game/src/windows/version.rs
+++ b/game/src/windows/version.rs
@@ -1,0 +1,54 @@
+use std::path::Path;
+use std::ptr::null_mut;
+
+use libc::c_void;
+use winapi::um::winver::{GetFileVersionInfoW, GetFileVersionInfoSizeW, VerQueryValueW};
+
+use crate::windows::winapi_str;
+
+#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Copy, Clone)]
+pub struct Version(pub u16, pub u16, pub u16, pub u16);
+
+fn file_version_buf(path: &Path) -> Option<Vec<u8>> {
+    unsafe {
+        let path = winapi_str(path);
+        let buf_size = GetFileVersionInfoSizeW(path.as_ptr(), null_mut());
+        let mut buf = vec![0; buf_size as usize];
+        let buf_ptr = buf.as_mut_ptr() as *mut c_void;
+        let ok = GetFileVersionInfoW(path.as_ptr(), 0, buf_size, buf_ptr);
+        if ok == 0 {
+            None
+        } else {
+            Some(buf)
+        }
+    }
+}
+
+pub fn get_version(path: &Path) -> Option<Version> {
+    unsafe {
+        file_version_buf(path)
+            .and_then(|mut buf| {
+                let buf_ptr = buf.as_mut_ptr() as *mut c_void;
+                let mut size = 0u32;
+                let mut info_ptr = null_mut();
+                let ok = VerQueryValueW(
+                    buf_ptr,
+                    winapi_str("\\").as_ptr(),
+                    &mut info_ptr,
+                    &mut size
+                );
+                if ok == 0 {
+                    return None;
+                }
+                let info = info_ptr as *const u32;
+                let high = *info.offset(2);
+                let low = *info.offset(3);
+                Some(Version(
+                    (high >> 16) as u16,
+                    (high & 0xffff) as u16,
+                    (low >> 16) as u16,
+                    (low & 0xffff) as u16
+                ))
+            })
+    }
+}


### PR DESCRIPTION
This adds support for expanding SC:R replays with custom data.

The SC:R replay format already has support for custom sections of data that can be skipped over by users that don't understand the section, so this will just append one more section at the end when the replay is being saved.
Also, as such, 1.16.1 replays don't change at all, maybe it can be patched to support SC:R replays in general if needed? Eventually.

The currently saved data & its format is very simple, uncompressed binary format, contains SC:R patch, shieldbattery version(*), and few bytes that fix team melee replays.
And a version id for future changes. Maybe there would be value in having some "better" format that is trivial to extend without breaking backwards compatibility for future before merging this PR? Though I'm personally not too concerned about it, we probably don't need to change the format too often in the end?

(*) Shieldbattery version is read from package.json when building the dll. Does the new version publishing procedure guarantee that package.json is updated before the game dll is built?

Team melee replays seemed to be pretty simple to fix, and at least a short test played back correctly, but I wouldn't be suprised if there were more bugs with them I missed.
