### PR TITLE
Don't open a new page when resending a verification email.

### DIFF
--- a/client/app.jsx
+++ b/client/app.jsx
@@ -4,7 +4,7 @@ import { StyleSheetManager } from 'styled-components'
 import loadable from '@loadable/component'
 import { hot } from 'react-hot-loader/root'
 
-import { VerifyEmail, SendVerificationEmail } from './auth/email-verification'
+import { VerifyEmail } from './auth/email-verification'
 import Faq from './beta/faq'
 import { ForgotUser, ForgotPassword, ResetPassword } from './auth/forgot'
 import HasBetaFilter from './beta/has-beta-filter'
@@ -54,7 +54,6 @@ class App extends React.Component {
             <LoginRoute path='/reset-password' component={ResetPassword} />
             <LoginRoute path='/signup' component={Signup} />
             <LoginRoute path='/verify-email' component={VerifyEmail} />
-            <LoginRoute path='/send-verification-email' component={SendVerificationEmail} />
             {!IS_PRODUCTION ? <Route path='/dev' component={LoadableDev} /> : null}
             <ConditionalRoute
               filters={[HasBetaFilter, LoggedInFilter, SiteConnectedFilter, LoadingFilter]}

--- a/client/auth/action-creators.ts
+++ b/client/auth/action-creators.ts
@@ -133,7 +133,7 @@ export function verifyEmail(token: string) {
   return idRequest('@auth/verifyEmail', () => fetch<void>(url, { method: 'post' }))
 }
 
-export function sendVerificationEmail() {
+export function sendVerificationEmail(): ThunkAction {
   return dispatch =>
     fetch<void>('/api/1/users/sendVerification', { method: 'post' }).then(
       () =>

--- a/client/auth/action-creators.ts
+++ b/client/auth/action-creators.ts
@@ -18,7 +18,7 @@ function idRequest<
   ActionType extends Extract<IdRequestable, { type: ActionTypeName }>
 >(
   type: ActionTypeName,
-  fetcher: (dispatch: any) => Promise<ActionType['payload']>,
+  fetcher: () => Promise<ActionType['payload']>,
 ): {
   id: string
   action: ThunkAction<ActionType | AuthChangeBegin>
@@ -35,7 +35,7 @@ function idRequest<
         },
       })
 
-      const payload = fetcher(dispatch)
+      const payload = fetcher()
       const promisified: PromisifiedAction<ActionType> = ({
         type,
         payload,
@@ -134,28 +134,26 @@ export function verifyEmail(token: string) {
 }
 
 export function sendVerificationEmail() {
-  const url = '/api/1/users/sendVerification'
-
-  return idRequest('@auth/sendVerificationEmail', dispatch =>
-    fetch<void>(url, { method: 'post' }).then(
+  return dispatch =>
+    fetch<void>('/api/1/users/sendVerification', { method: 'post' }).then(
       () =>
         dispatch(
           openSnackbar({
-            message: 'Verification email has successfully been sent. Check your email.',
+            message: 'Verification email has been sent successfully.',
             time: TIMING_LONG,
           }),
         ),
       err => {
         dispatch(
           openSnackbar({
-            message: 'Something went wrong while trying to send a verification email.',
+            message:
+              'Something went wrong while sending a verification email, please try again later.',
             time: TIMING_LONG,
           }),
         )
         throw err
       },
-    ),
-  )
+    )
 }
 
 export function updateAccount(userId: number, userProps: Partial<User>) {

--- a/client/auth/action-creators.ts
+++ b/client/auth/action-creators.ts
@@ -143,7 +143,7 @@ export function sendVerificationEmail(): ThunkAction {
             time: TIMING_LONG,
           }),
         ),
-      err => {
+      () => {
         dispatch(
           openSnackbar({
             message:
@@ -151,7 +151,6 @@ export function sendVerificationEmail(): ThunkAction {
             time: TIMING_LONG,
           }),
         )
-        throw err
       },
     )
 }

--- a/client/auth/actions.ts
+++ b/client/auth/actions.ts
@@ -13,8 +13,6 @@ export type AuthActions =
   | ResetPasswordFailure
   | RecoverUsernameSuccess
   | RecoverUsernameFailure
-  | SendVerificationEmailSuccess
-  | SendVerificationEmailFailure
   | StartPasswordResetSuccess
   | StartPasswordResetFailure
   | SignUpSuccess

--- a/client/auth/actions.ts
+++ b/client/auth/actions.ts
@@ -88,11 +88,6 @@ export type RecoverUsernameSuccess = BaseAuthSuccess<'@auth/recoverUsername'>
 /** Recovering a user's name based on their email failed. */
 export type RecoverUsernameFailure = BaseAuthFailure<'@auth/recoverUsername'>
 
-/** Sending a verification email for the current user succeeded. */
-export type SendVerificationEmailSuccess = BaseAuthSuccess<'@auth/sendVerificationEmail'>
-/** Sending a verification email for the current user failed. */
-export type SendVerificationEmailFailure = BaseAuthFailure<'@auth/sendVerificationEmail'>
-
 /** Initiating a password reset for a user was successful. */
 export type StartPasswordResetSuccess = BaseAuthSuccess<'@auth/startPasswordReset'>
 /** Initiating a password reset for a user failed. */

--- a/client/auth/auth-reducer.ts
+++ b/client/auth/auth-reducer.ts
@@ -8,7 +8,6 @@ import {
   LogInFailure,
   LogInSuccess,
   LogOutSuccess,
-  SendVerificationEmailFailure,
   SignUpFailure,
   SignUpSuccess,
   VerifyEmailFailure,
@@ -77,23 +76,6 @@ function handleVerifyEmailError(state: State, action: VerifyEmailFailure) {
   )
 }
 
-function handleSendVerificationEmailError(state: State, action: SendVerificationEmailFailure) {
-  const { body, res } = action.payload
-  let errMessage = body ? body.error : 'Sending verification error'
-  if (res.status === 409) {
-    errMessage =
-      'The provided email is over verification limit. Please use a different email ' +
-      'address or try again later.'
-  }
-
-  return state.withMutations(s =>
-    s.set('authChangeInProgress', false).set('lastFailure', {
-      ...action.meta,
-      err: errMessage,
-    }),
-  )
-}
-
 function accountUpdate(state: State, action: AccountUpdateSuccess) {
   const { email, emailVerified } = action.payload
   return state
@@ -120,8 +102,6 @@ export default keyedReducer(new Auth(), {
     !action.error ? logInSuccess(state, action) : state.set('authChangeInProgress', false),
   ['@auth/resetPassword']: noOpOrError,
   ['@auth/recoverUsername']: noOpOrError,
-  ['@auth/sendVerificationEmail']: (state, action) =>
-    !action.error ? noOpOrError(state, action) : handleSendVerificationEmailError(state, action),
   ['@auth/startPasswordReset']: noOpOrError,
   ['@auth/emailVerified']: state => state.set('emailVerified', true),
   ['@auth/verifyEmail']: (state, action) =>

--- a/client/auth/email-verification-notification.jsx
+++ b/client/auth/email-verification-notification.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { makeServerUrl } from '../network/server-url'
+import PropTypes from 'prop-types'
 import styled from 'styled-components'
 
 import { grey800, colorTextPrimary } from '../styles/colors'
@@ -20,11 +20,15 @@ const VerifyEmailText = styled(Body1Old)`
 `
 
 export default class ContentLayout extends React.Component {
+  static propTypes = {
+    sendVerificationEmail: PropTypes.func.isRequired,
+  }
+
   render() {
     const verifyEmailText = `Your email is unverified! Check for an email from
       ShieldBattery and click the enclosed link. If you don't see one, we can `
     const verifyEmailLink = (
-      <a href={makeServerUrl('/send-verification-email')} target='_blank'>
+      <a href='#' onClick={this.props.sendVerificationEmail}>
         send another.
       </a>
     )

--- a/client/auth/email-verification.jsx
+++ b/client/auth/email-verification.jsx
@@ -17,7 +17,7 @@ import {
 } from './auth-content'
 import LoadingIndicator from '../progress/dots'
 
-import { verifyEmail, sendVerificationEmail } from './action-creators'
+import { verifyEmail } from './action-creators'
 import { isLoggedIn, createNextPath } from './auth-utils'
 
 @connect(state => ({ auth: state.auth }))

--- a/client/auth/email-verification.jsx
+++ b/client/auth/email-verification.jsx
@@ -139,16 +139,3 @@ export const VerifyEmail = ({ location }) => {
     />
   )
 }
-
-const SEND_VERIFICATION_EMAIL_SUCCESS =
-  'Verification email has successfully been sent. Check your email.'
-export const SendVerificationEmail = ({ location }) => {
-  return (
-    <EmailVerification
-      title={'Send verification email'}
-      doSubmit={() => sendVerificationEmail()}
-      successMessage={SEND_VERIFICATION_EMAIL_SUCCESS}
-      location={location}
-    />
-  )
-}

--- a/client/main-layout.jsx
+++ b/client/main-layout.jsx
@@ -50,6 +50,7 @@ import { isStarcraftHealthy } from './starcraft/is-starcraft-healthy'
 import { openChangelogIfNecessary } from './changelog/action-creators'
 import { IsAdminFilter } from './admin/admin-route-filters'
 import { regenMapImage, removeMap } from './maps/action-creators'
+import { sendVerificationEmail } from './auth/action-creators'
 
 import { MATCHMAKING } from '../common/flags'
 import { MatchmakingType } from '../common/matchmaking'
@@ -309,7 +310,9 @@ class MainLayout extends React.Component {
     return (
       <Container>
         <AppBar>{appBarTitle}</AppBar>
-        {!auth.emailVerified ? <EmailVerificationNotification /> : null}
+        {!auth.emailVerified ? (
+          <EmailVerificationNotification sendVerificationEmail={this.sendVerificationEmail} />
+        ) : null}
         <Layout>
           <ConnectedLeftNav />
           <Content>
@@ -341,6 +344,10 @@ class MainLayout extends React.Component {
         </Layout>
       </Container>
     )
+  }
+
+  sendVerificationEmail = () => {
+    this.props.dispatch(sendVerificationEmail().action)
   }
 
   onMatchmakingDisabledOverlayClose = () => {

--- a/client/main-layout.jsx
+++ b/client/main-layout.jsx
@@ -347,7 +347,7 @@ class MainLayout extends React.Component {
   }
 
   sendVerificationEmail = () => {
-    this.props.dispatch(sendVerificationEmail().action)
+    this.props.dispatch(sendVerificationEmail())
   }
 
   onMatchmakingDisabledOverlayClose = () => {


### PR DESCRIPTION
Instead, show the success/failure of the action in a snackbar.

Fixes #585 