### PR TITLE
Use tsyringe to inject "updateOrInsertUserIp" function as a dependency

### DIFF
--- a/server/lib/models/user-ips.ts
+++ b/server/lib/models/user-ips.ts
@@ -1,6 +1,6 @@
 import { container } from 'tsyringe'
-import { UpdateOrInsertUserIp } from '../network/user-ips-type'
 import db from '../db'
+import { UpdateOrInsertUserIp } from '../network/user-ips-type'
 
 const MAX_RETRIES = 5
 

--- a/server/lib/models/user-ips.ts
+++ b/server/lib/models/user-ips.ts
@@ -1,3 +1,5 @@
+import { container } from 'tsyringe'
+import { UpdateOrInsertUserIp } from '../network/user-ips-type'
 import db from '../db'
 
 const MAX_RETRIES = 5
@@ -69,3 +71,5 @@ export async function updateOrInsertUserIp(userId: number, ipAddress: string): P
     done()
   }
 }
+
+container.register<UpdateOrInsertUserIp>('updateOrInsertUserIp', { useValue: updateOrInsertUserIp })

--- a/server/lib/network/user-ips-type.ts
+++ b/server/lib/network/user-ips-type.ts
@@ -1,0 +1,8 @@
+/**
+ * Keeps track of the user's IP address in our database. This indirection is necessary so we don't
+ * need database access in tests.
+ *
+ * Meant to be used with tsyringe's dependency injection system, so it can easily be mocked out in
+ * tests. The injection token is the same as the function name, i.e. "updateOrInsertUserIp".
+ */
+export type UpdateOrInsertUserIp = (userId: number, ipAddress: string) => Promise<void>


### PR DESCRIPTION
to user's socket manager.

This allows us to import socket-groups file in tests without also
importing the file that checks whether the database environment variable
is properly set up.