### PR TITLE
Allow setting multiple root folders in a file browser.

### DIFF
--- a/client/file-browser/browse-files.jsx
+++ b/client/file-browser/browse-files.jsx
@@ -320,9 +320,10 @@ export default class Files extends React.Component {
 
   state = {
     focusedPath: window.localStorage.getItem(this.props.browseId + FOCUSED_KEY),
-    rootFolder: this.props.rootFolders[
-      window.localStorage.getItem(this.props.browseId + ROOT_ID) || 'default'
-    ],
+    rootFolder:
+      this.props.rootFolders[
+        window.localStorage.getItem(this.props.browseId + ROOT_ID) || 'default'
+      ] || this.props.rootFolders.default,
   }
 
   contentRef = React.createRef()

--- a/client/file-browser/browse-files.jsx
+++ b/client/file-browser/browse-files.jsx
@@ -393,6 +393,7 @@ export default class Files extends React.Component {
     const { path: prevPath, isRequesting: prevIsRequesting } = prevProps.fileBrowser[browseId]
     if (prevRootFolder !== rootFolder) {
       this._changeInitialPath()
+      return
     }
     if (prevPath !== path) {
       this.props.dispatch(getFiles(browseId, path))

--- a/client/maps/browse-local-maps.jsx
+++ b/client/maps/browse-local-maps.jsx
@@ -2,6 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import path from 'path'
+import { remote } from 'electron'
 import styled from 'styled-components'
 
 import ActivityBackButton from '../activities/activity-back-button'
@@ -54,13 +55,24 @@ export default class LocalMaps extends React.Component {
       scm: { icon: <MapIcon />, onSelect: this.onMapSelect },
       scx: { icon: <MapIcon />, onSelect: this.onMapSelect },
     }
-    const root = path.join(this.props.settings.local.starcraftPath, 'Maps')
+    const defaultFolder = {
+      id: 'default',
+      name: 'Default maps',
+      path: path.join(this.props.settings.local.starcraftPath, 'Maps'),
+    }
+    const downloadsFolder = {
+      id: 'downloads',
+      name: 'Downloaded maps',
+      path: path.join(remote.app.getPath('documents'), 'Starcraft', 'maps', 'Download'),
+    }
     const props = {
       browseId: 'maps',
       title: 'Local Maps',
       titleButton: <ActivityBackButton />,
-      rootFolderName: 'Maps',
-      root,
+      rootFolders: {
+        [defaultFolder.id]: defaultFolder,
+        [downloadsFolder.id]: downloadsFolder,
+      },
       fileTypes,
     }
 

--- a/client/maps/browse-local-maps.jsx
+++ b/client/maps/browse-local-maps.jsx
@@ -57,13 +57,13 @@ export default class LocalMaps extends React.Component {
     }
     const defaultFolder = {
       id: 'default',
-      name: 'Default maps',
+      name: 'Program folder',
       path: path.join(this.props.settings.local.starcraftPath, 'Maps'),
     }
     const downloadsFolder = {
-      id: 'downloads',
-      name: 'Downloaded maps',
-      path: path.join(remote.app.getPath('documents'), 'Starcraft', 'maps', 'Download'),
+      id: 'documents',
+      name: 'Documents folder',
+      path: path.join(remote.app.getPath('documents'), 'Starcraft', 'maps'),
     }
     const props = {
       browseId: 'maps',

--- a/client/replays/watch-replay.jsx
+++ b/client/replays/watch-replay.jsx
@@ -19,11 +19,17 @@ export default class Replays extends React.Component {
     const fileTypes = {
       rep: { icon: <Replay />, onSelect: this.onStartReplay },
     }
+    const defaultFolder = {
+      id: 'default',
+      name: 'Replays',
+      path: getReplayFolder(),
+    }
     const props = {
       browseId: 'replays',
       title: 'Local Replays',
-      rootFolderName: 'Replays',
-      root: getReplayFolder(),
+      rootFolders: {
+        [defaultFolder.id]: defaultFolder,
+      },
       fileTypes,
     }
     return <BrowseFiles {...props} />


### PR DESCRIPTION
File browser now accepts an array of root folders which you can change
when displaying particular browser through a dropdown. If there's only
one root folder sent to the browser, the dropdown is not shown.