### PR TITLE
Rectify run server commands. Clarify how to get MQP files.

### DIFF
--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -182,7 +182,7 @@ structure), and set `SB_SPRITE_DATA` in the `.env` file to that directory.
 
 ### Run the server
 
-The standard way to run the server is (assuming you are in the projet root directory):
+The standard way to run the server is (assuming you are in the project root directory):
 
 ```
 yarn run start-server

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -174,8 +174,9 @@ The server needs access to some of BW's data files in order to generate map imag
 editor, such as [this one](http://www.zezula.net/en/mpq/download.html) and make sure to download
 "listfiles" from that website as well, which you'll need to use in the mpq editor. Use the mpq
 editor to extract BW's data files from `stardat.mpq`, `broodat.mpq`, in that order, having
-`broodat.mpq` overwrite any conflicting files from `stardat.mpq`. You can obtain `stardat.mpq` and `broodat.mpq`
-directly from Blizzard by downloading the final release of [StarEdit](http://download.blizzard.com/pub/starcraft/StarEdit/StarEdit.zip).
+`broodat.mpq` overwrite any conflicting files from `stardat.mpq`. You can obtain `stardat.mpq`
+and `broodat.mpq` directly from Blizzard by downloading the final release of
+[StarEdit](http://download.blizzard.com/pub/starcraft/StarEdit/StarEdit.zip).
 The necessary directories in .mpq files are `unit/` and `tileset/`. Extract those files to a directory (keeping the directory
 structure), and set `SB_SPRITE_DATA` in the `.env` file to that directory.
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -176,11 +176,9 @@ editor, such as [this one](http://www.zezula.net/en/mpq/download.html) and make 
 editor to extract BW's data files from `stardat.mpq`, `broodat.mpq`, in that order, having
 `broodat.mpq` overwrite any conflicting files from `stardat.mpq`. 
 You can obtain `stardat.mpq` and `broodat.mpq` directly from Blizzard by downloading the final release of
-[StarEdit](http://download.blizzard.com/pub/starcraft/StarEdit/StarEdit.zip). You can also obtain those files from
-an old Starcraft Broodwar version (such as 1.16) installation folder. Note that you cannot find those files from SC:Remastered.
-The necessary directories in
-.mpq files are `unit/` and `tileset/`. Extract those files to a directory (keeping the directory
-structure), and set `SB_SPRITE_DATA` in the `.env` file to that directory.
+[StarEdit](http://download.blizzard.com/pub/starcraft/StarEdit/StarEdit.zip).
+The necessary directories in .mpq files are `unit/` and `tileset/`. 
+Extract those files to a directory (keeping the directory structure), and set `SB_SPRITE_DATA` in the `.env` file to that directory.
 
 ### Run the server
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -174,24 +174,27 @@ The server needs access to some of BW's data files in order to generate map imag
 editor, such as [this one](http://www.zezula.net/en/mpq/download.html) and make sure to download
 "listfiles" from that website as well, which you'll need to use in the mpq editor. Use the mpq
 editor to extract BW's data files from `stardat.mpq`, `broodat.mpq`, in that order, having
-`broodat.mpq` overwrite any conflicting files from `stardat.mpq`. The necessary directories in
+`broodat.mpq` overwrite any conflicting files from `stardat.mpq`. 
+You can obtain `stardat.mpq` and `broodat.mpq` directly from Blizzard by downloading the final release of
+[StarEdit](http://download.blizzard.com/pub/starcraft/StarEdit/StarEdit.zip). You can also obtain those files from
+an old Starcraft Broodwar version (such as 1.16) installation folder. Note that you cannot find those files from SC:Remastered.
+The necessary directories in
 .mpq files are `unit/` and `tileset/`. Extract those files to a directory (keeping the directory
-structure), and set `SB_SPRITE_DATA` in the `.env` file to that directory. You can obtain `stardat.mpq` 
-and `broodat.mpq` directly from Blizzard by downloading the final release of [StarEdit](http://download.blizzard.com/pub/starcraft/StarEdit/StarEdit.zip).
+structure), and set `SB_SPRITE_DATA` in the `.env` file to that directory.
 
 ### Run the server
 
-The standard way to run the server is (from the `server` directory):
+The standard way to run the server is (assuming you are in the projet root directory):
 
 ```
-yarn start
+yarn run start-server
 ```
 
 This command will format and colorize the log output, but if you want/need the raw output you can
 also use:
 
 ```
-node index.js
+node ./server/index.js
 ```
 
 #### Overriding the server URL (optional)

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -174,11 +174,10 @@ The server needs access to some of BW's data files in order to generate map imag
 editor, such as [this one](http://www.zezula.net/en/mpq/download.html) and make sure to download
 "listfiles" from that website as well, which you'll need to use in the mpq editor. Use the mpq
 editor to extract BW's data files from `stardat.mpq`, `broodat.mpq`, in that order, having
-`broodat.mpq` overwrite any conflicting files from `stardat.mpq`. 
-You can obtain `stardat.mpq` and `broodat.mpq` directly from Blizzard by downloading the final release of
-[StarEdit](http://download.blizzard.com/pub/starcraft/StarEdit/StarEdit.zip).
-The necessary directories in .mpq files are `unit/` and `tileset/`. 
-Extract those files to a directory (keeping the directory structure), and set `SB_SPRITE_DATA` in the `.env` file to that directory.
+`broodat.mpq` overwrite any conflicting files from `stardat.mpq`. You can obtain `stardat.mpq` and `broodat.mpq`
+directly from Blizzard by downloading the final release of [StarEdit](http://download.blizzard.com/pub/starcraft/StarEdit/StarEdit.zip).
+The necessary directories in .mpq files are `unit/` and `tileset/`. Extract those files to a directory (keeping the directory
+structure), and set `SB_SPRITE_DATA` in the `.env` file to that directory.
 
 ### Run the server
 


### PR DESCRIPTION
There is no `package.json` file in the `server/` folder, `yarn start` cannot be available, I suppose it is legacy. 
Both proposed commands worked for me from project directory:

```
yarn run start-server
```

```
node ./server/index.js
```
