### PR TITLE
Add Cargo config rule to allow Cargo to fetch repositiories with git

### DIFF
--- a/game/.cargo/config
+++ b/game/.cargo/config
@@ -3,3 +3,6 @@ target = "i686-pc-windows-msvc"
 
 [target.i686-pc-windows-msvc]
 rustflags = ["-Ctarget-feature=+crt-static"]
+
+[net]
+git-fetch-with-cli = true


### PR DESCRIPTION
Using `game/build.bat` throws the following error

```
cargo build -v
    Updating crates.io index
error: failed to get `arrayvec` as a dependency of package `shieldbattery v0.1.0 (E:\Prog\ShieldBattery\game)`

Caused by:
  failed to fetch `https://github.com/rust-lang/crates.io-index`

Caused by:
  failed to authenticate when downloading repository: git@github.com:rust-lang/crates.io-index

  * attempted ssh-agent authentication, but no usernames succeeded: `git`

  if the git CLI succeeds then `net.git-fetch-with-cli` may help here
  https://doc.rust-lang.org/cargo/reference/config.html#netgit-fetch-with-cli

Caused by:
  error authenticating: failed connecting agent; class=Ssh (23)
```

After investigating the batch script I found that I had a `cargo build` authentification problem.
Following this https://github.com/rust-lang/cargo/issues/2078#issuecomment-434388584 helped

