### PR TITLE
Fix custom Github dependencies path for samase_scarf and whack.

### DIFF
--- a/game/Cargo.toml
+++ b/game/Cargo.toml
@@ -52,7 +52,7 @@ features = [
 ]
 
 [dependencies.whack]
-git = "https://github.com/neivv/whack/"
+git = "https://github.com/neivv/whack.git"
 rev = "1adee081ac5ebc8362f92801e2083bbbadd79d57"
 
 [build-dependencies]

--- a/game/scr-analysis/Cargo.toml
+++ b/game/scr-analysis/Cargo.toml
@@ -4,5 +4,5 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies.samase_scarf]
-git = "https://github.com/neivv/samase_scarf/"
+git = "https://github.com/neivv/samase_scarf.git"
 rev = "39c6665a423a84d0f20ac03306ce0bd21def1c35"


### PR DESCRIPTION
The following error arised

```bash
Updating git repository `https://github.com/neivv/samase_scarf/`
error: failed to get `samase_scarf` as a dependency of package `scr-analysis v0.1.0 (E:\Prog\ShieldBattery\game\scr-analysis)`

Caused by:
  failed to load source for dependency `samase_scarf`

Caused by:
  Unable to update https://github.com/neivv/samase_scarf/?rev=39c6665a423a84d0f20ac03306ce0bd21def1c35#39c6665a

Caused by:
  failed to clone into: C:\Users\Coincoin\.cargo\git\db\samase_scarf-70e8ba1a878083d4

Caused by:
  process didn't exit successfully: `git fetch --tags --force --update-head-ok 'https://github.com/neivv/samase_scarf/' 'refs/heads/*:refs/remotes/origin/*' 'HEAD:refs/remotes/origin/HEAD'` (exit code: 128)
  --- stderr
  ERROR: Repository not found.
  fatal: Could not read from remote repository.

  Please make sure you have the correct access rights
  and the repository exists.
```

You can reproduce simply the problem by doing `git fetch 'https://github.com/neivv/samase_scarf/'`
Using `git fetch 'https://github.com/neivv/samase_scarf.git'` works fine.


