### PR TITLE
Fix correct typo for charCodeAt call

### DIFF
--- a/server/lib/maps/map-parse-worker.js
+++ b/server/lib/maps/map-parse-worker.js
@@ -91,7 +91,7 @@ function generateImage(map, bwDataPath, width = 1024) {
 function filterColorCodes(str) {
   return Array.from(str)
     .filter(c => {
-      const code = c.charCodeat(0)
+      const code = c.charCodeAt(0)
       return (
         code > 0x1f ||
         /** newline */


### PR DESCRIPTION
Original code has a typo mistake with `const code = c.charCodeat(0)` instead of `const code = c.charCodeAt(0)`.
In my environment (node version is v14.15.5) , this leads to the below error if using `charCodeat`.

```
TypeError: c.charCodeat is not a function
    at E:\Prog\ShieldBattery\server\lib\maps\map-parse-worker.js:94:22
    at Array.filter (<anonymous>)
    at filterColorCodes (E:\Prog\ShieldBattery\server\lib\maps\map-parse-worker.js:93:6)
    at E:\Prog\ShieldBattery\server\lib\maps\map-parse-worker.js:140:18
    at new Promise (<anonymous>)
    at process.<anonymous> (E:\Prog\ShieldBattery\server\lib\maps\map-parse-worker.js:136:25)
    at processTicksAndRejections (internal/process/task_queues.js:93:5)
Assertion failed
[2021-03-05 21:38:14.592 +0000] ERROR (17048 on Canard): server error
    err: {
      "type": "TypeError",
      "message": "Cannot destructure property 'hash' of 'mapData' as it is undefined.",
      "stack":
          TypeError: Cannot destructure property 'hash' of 'mapData' as it is undefined.
              at storeMap (E:\Prog\ShieldBattery\server\lib\maps\/store.js:26:11)
              at processTicksAndRejections (internal/process/task_queues.js:93:5)
              at upload (E:\Prog\ShieldBattery\server\lib\api\/maps.js:196:15)
              at E:\Prog\ShieldBattery\server\lib\file-upload\/handle-multipart-files.js:11:7
              at handleMultipartFiles (E:\Prog\ShieldBattery\server\lib\file-upload\/handle-multipart-files.js:9:3)
              at ensureLoggedIn (E:\Prog\ShieldBattery\server\lib\session\/ensure-logged-in.js:8:3)
              at E:\Prog\ShieldBattery\server\lib\flags\/feature-enabled.ts:10:5
              at middlewareFunc (E:\Prog\ShieldBattery\server\lib\throttle\/middleware.ts:15:5)
              at E:\Prog\ShieldBattery\node_modules\koa-mount\index.js:52:26
    }
```

Using `charCodeAt` solved the problem. See <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/charCodeAt>.

I have checked other potential typo mistakes on charCodeAt in the whole code, this was the only one.
