### PR TITLE
Matchmaking for random race

### DIFF
--- a/client/matchmaking/find-match.jsx
+++ b/client/matchmaking/find-match.jsx
@@ -186,10 +186,10 @@ class Find1vs1MatchForm extends React.Component {
       getInputValue,
       onSubmit,
     } = this.props
+    const race = getInputValue('race')
     const useAlternateRace = getInputValue('useAlternateRace')
     const preferredMapsItems = Range(0, 2).map(index => {
       const map = preferredMaps.get(index)
-
       return (
         <PreferredMap key={index}>
           {map ? (
@@ -210,10 +210,12 @@ class Find1vs1MatchForm extends React.Component {
       <form noValidate={true} onSubmit={onSubmit}>
         <SectionTitle>Race</SectionTitle>
         <RaceSelect {...bindCustom('race')} size={RACE_PICKER_SIZE_LARGE} />
-        <CheckBox
-          {...bindCheckable('useAlternateRace')}
-          label='Use alternate race to avoid mirror matchups'
-        />
+        {race !== 'r' ? (
+          <CheckBox
+            {...bindCheckable('useAlternateRace')}
+            label='Use alternate race to avoid mirror matchups'
+          />
+        ) : null}
         {useAlternateRace ? (
           <>
             <SectionTitle>Alternate race</SectionTitle>

--- a/client/matchmaking/find-match.jsx
+++ b/client/matchmaking/find-match.jsx
@@ -187,7 +187,7 @@ class Find1vs1MatchForm extends React.Component {
       onSubmit,
     } = this.props
     const race = getInputValue('race')
-    const useAlternateRace = getInputValue('useAlternateRace')
+    const useAlternateRace = race !== 'r' ? getInputValue('useAlternateRace') : false
     const preferredMapsItems = Range(0, 2).map(index => {
       const map = preferredMaps.get(index)
       return (
@@ -211,26 +211,10 @@ class Find1vs1MatchForm extends React.Component {
         <SectionTitle>Race</SectionTitle>
         <RaceSelect {...bindCustom('race')} size={RACE_PICKER_SIZE_LARGE} />
         {race !== 'r' ? (
-          <div>
-            <CheckBox
-              {...bindCheckable('useAlternateRace')}
-              label='Use alternate race to avoid mirror matchups'
-            />
-            {useAlternateRace ? (
-              <>
-                <SectionTitle>Alternate race</SectionTitle>
-                <DescriptionText>
-                  Select a race to be used whenever your opponent has selected the same primary
-                  race.
-                </DescriptionText>
-                <RaceSelect
-                  {...bindCustom('alternateRace')}
-                  size={RACE_PICKER_SIZE_LARGE}
-                  allowRandom={false}
-                />
-              </>
-            ) : null}
-          </div>
+          <CheckBox
+            {...bindCheckable('useAlternateRace')}
+            label='Use alternate race to avoid mirror matchups'
+          />
         ) : (
           <CheckBox
             checked={false}
@@ -238,6 +222,19 @@ class Find1vs1MatchForm extends React.Component {
             label='Use alternate race to avoid mirror matchups (disabled for random)'
           />
         )}
+        {useAlternateRace ? (
+          <>
+            <SectionTitle>Alternate race</SectionTitle>
+            <DescriptionText>
+              Select a race to be used whenever your opponent has selected the same primary race.
+            </DescriptionText>
+            <RaceSelect
+              {...bindCustom('alternateRace')}
+              size={RACE_PICKER_SIZE_LARGE}
+              allowRandom={false}
+            />
+          </>
+        ) : null}
         <PreferredMapsContainer>
           <PreferredHeader>
             <SectionTitle>Preferred maps</SectionTitle>

--- a/client/matchmaking/find-match.jsx
+++ b/client/matchmaking/find-match.jsx
@@ -211,24 +211,33 @@ class Find1vs1MatchForm extends React.Component {
         <SectionTitle>Race</SectionTitle>
         <RaceSelect {...bindCustom('race')} size={RACE_PICKER_SIZE_LARGE} />
         {race !== 'r' ? (
-          <CheckBox
-            {...bindCheckable('useAlternateRace')}
-            label='Use alternate race to avoid mirror matchups'
-          />
-        ) : null}
-        {useAlternateRace ? (
-          <>
-            <SectionTitle>Alternate race</SectionTitle>
-            <DescriptionText>
-              Select a race to be used whenever your opponent has selected the same primary race.
-            </DescriptionText>
-            <RaceSelect
-              {...bindCustom('alternateRace')}
-              size={RACE_PICKER_SIZE_LARGE}
-              allowRandom={false}
+          <div>
+            <CheckBox
+              {...bindCheckable('useAlternateRace')}
+              label='Use alternate race to avoid mirror matchups'
             />
-          </>
-        ) : null}
+            {useAlternateRace ? (
+              <>
+                <SectionTitle>Alternate race</SectionTitle>
+                <DescriptionText>
+                  Select a race to be used whenever your opponent has selected the same primary
+                  race.
+                </DescriptionText>
+                <RaceSelect
+                  {...bindCustom('alternateRace')}
+                  size={RACE_PICKER_SIZE_LARGE}
+                  allowRandom={false}
+                />
+              </>
+            ) : null}
+          </div>
+        ) : (
+          <CheckBox
+            checked={false}
+            disabled={true}
+            label='Use alternate race to avoid mirror matchups (disabled for random)'
+          />
+        )}
         <PreferredMapsContainer>
           <PreferredHeader>
             <SectionTitle>Preferred maps</SectionTitle>

--- a/server/lib/api/matchmakingPreferences.ts
+++ b/server/lib/api/matchmakingPreferences.ts
@@ -57,6 +57,10 @@ async function upsertPreferences(ctx: RouterContext) {
     throw new httpErrors.BadRequest('invalid matchmaking type')
   }
 
+  if (race === 'r' && useAlternateRace === true) {
+    throw new httpErrors.BadRequest('cannot use alternate race as random')
+  }
+
   const preferences = await upsertMatchmakingPreferences(ctx.session!.userId, {
     matchmakingType,
     race,

--- a/server/lib/wsapi/matchmaking.ts
+++ b/server/lib/wsapi/matchmaking.ts
@@ -148,27 +148,28 @@ export class MatchmakingApi {
       let slots: List<Slot>
       const players = matchInfo.players
       const firstPlayer = players.first<MatchmakingPlayer>()
-      const playersHaveSameRace = players.every(p => p.race === firstPlayer.race)
+      const playersHaveSameRace =
+        firstPlayer.race !== 'r' && players.every(p => p.race === firstPlayer.race)
       if (playersHaveSameRace && players.every(p => p.useAlternateRace === true)) {
-        // All players have the same race and want to use an alternate race; select randomly one
-        // player to use the alternate race and everyone else their main race. This is only done for
-        // the first player, as the whole concept of the alternate race doesn't make much sense when
-        // there are more than two players.
+        // All players have the same race other than random and want to use an alternate race;
+        // select randomly one player to use the alternate race and everyone else their main race.
+        // This is only done for the first player, as the whole concept of the alternate race
+        // doesn't make much sense when there are more than two players.
         const randomPlayerIndex = getRandomInt(players.size)
         slots = players.map((p, i) =>
           createHuman(p.name, p.id, i === randomPlayerIndex ? p.alternateRace : p.race),
         )
       } else if (playersHaveSameRace && players.some(p => p.useAlternateRace === true)) {
-        // All players have the same race, but only some of them are choosing to use an alternate
-        // race; find the first player who wants to use the alternate race and have everyone else
-        // use their main. Again, this is only done for the first player.
+        // All players have the same race other than random, but only some of them are choosing
+        // to use an alternate race; find the first player who wants to use the alternate race and
+        // have everyone else use their main. Again, this is only done for the first player.
         const useAlternateRacePlayer = players.find(p => p.useAlternateRace === true)!
         slots = players.map(p =>
           createHuman(p.name, p.id, p.id === useAlternateRacePlayer.id ? p.alternateRace : p.race),
         )
       } else {
-        // All players have different race or don't want to use alternate race; nothing special to
-        // do here.
+        // All players have different races or don't want to use alternate race
+        // or at least one selected random; nothing special to do here and let BW do the rest
         slots = players.map(p => createHuman(p.name, p.id, p.race))
       }
 


### PR DESCRIPTION
Fixes #630  

- [x] Update the find match form such that if random is selected, the alternate race checkbox is disabled and unchecked
- [x] Update the matchmaking preferences API to disallow alternate race selection with random
- [x] Update the matchmaking race resolution logic such that playersHaveSameRace is only true if the players are not random

