### PR TITLE
Basic replay analyzer

### DIFF
--- a/client/dialogs/connected-dialog-overlay.jsx
+++ b/client/dialogs/connected-dialog-overlay.jsx
@@ -5,6 +5,7 @@ import { CSSTransition, TransitionGroup } from 'react-transition-group'
 import EditAccount from '../auth/edit-account'
 import Portal from '../material/portal'
 import SimpleDialog from './simple-dialog'
+import ReplayDialog from '../replays/replay-dialog'
 import Settings from '../settings/settings'
 import StarcraftHealthCheckupDialog from '../starcraft/starcraft-health'
 import StarcraftPathDialog from '../settings/starcraft-path-dialog'
@@ -55,6 +56,8 @@ class ConnectedDialogOverlay extends React.Component {
           : { component: StarcraftPathDialog, modal: false }
       case 'simple':
         return { component: SimpleDialog, modal: false }
+      case 'replay':
+        return { component: ReplayDialog, modal: false }
       case 'starcraftHealth':
         return { component: StarcraftHealthCheckupDialog, modal: false }
       case 'starcraftPath':

--- a/client/replays/replay-dialog.jsx
+++ b/client/replays/replay-dialog.jsx
@@ -1,0 +1,143 @@
+import fs from 'fs'
+import React from 'react'
+import { connect } from 'react-redux'
+// import styled from 'styled-components'
+// import { SubheadingOld } from '../styles/typography'
+import Dialog from '../material/dialog'
+import FlatButton from '../material/flat-button'
+import ReplayParser from 'jssuh'
+import { startReplay } from './action-creators'
+import RaisedButton from '../material/raised-button'
+import { closeDialog } from '../dialogs/action-creators'
+
+// TODO(coin²): Implement game type mapping in jssuh.
+// This mapping is taken from my Python bot and goes from 0x00 to 0x10
+const gameTypeMapping = [
+  'None',
+  'Custom',
+  'Melee',
+  'Free For All',
+  'One on One',
+  'Capture The Flag',
+  'Greed',
+  'Slaughter',
+  'Sudden Death',
+  'Ladder',
+  'Use map settings',
+  'Team Melee',
+  'Team Free For All',
+  'Team Capture The Flag',
+  'Unknown',
+  'Top vs Bottom',
+  'Iron Man Ladder',
+]
+
+// TODO(coin²): Implement color mapping in jssuh (you will have to iterate through players)
+
+const dateFormat = new Intl.DateTimeFormat(navigator.language, {
+  year: 'numeric',
+  month: 'short',
+  day: '2-digit',
+  hour: 'numeric',
+  minute: '2-digit',
+})
+
+@connect()
+export default class ReplayDialog extends React.Component {
+  constructor(props) {
+    super(props)
+    this.state = {
+      replay: this.props.replay,
+    }
+  }
+
+  componentDidMount() {
+    console.log('componentDidMount')
+    const header = this.parseReplay(this.props.replay.path)
+    this.setState({ header })
+  }
+
+  parseReplay(filePath) {
+    const reppi = fs.createReadStream(filePath).pipe(new ReplayParser())
+    reppi.on('replayHeader', replayDetails => {
+      const { players, durationFrames } = replayDetails
+      const minutes = Math.floor(durationFrames / 24 / 60)
+      const seconds = Math.floor(durationFrames / 24) % 60
+      replayDetails.duration = `${minutes} min ${seconds} s`
+      replayDetails.teams = {}
+      for (const { name, id, race, team, isComputer } of players) {
+        if (isComputer) {
+          console.log(`Computer ${name} (${id}): Race ${race}, team ${team}`)
+        } else {
+          console.log(`Player ${name} (${id}): Race ${race}, team ${team}`)
+        }
+        if (team in replayDetails.teams) {
+          replayDetails.teams[team].push(id)
+        } else {
+          replayDetails.teams[team] = [id]
+        }
+      }
+      this.setState({ replayDetails })
+    })
+  }
+
+  onStartReplay = replay => {
+    this.props.dispatch(closeDialog())
+    // NOTE(coin²): I think it's better not to close since we like to watch several replays
+    // this.props.dispatch(closeOverlay()) 
+    this.props.dispatch(startReplay(replay))
+  }
+
+  render() {
+    const { replay, onCancel, hasButton } = this.props
+    const buttons = hasButton
+      ? [
+          <FlatButton label={'Cancel'} key={'okay'} color={'accent'} onClick={onCancel} />,
+          <RaisedButton
+            key={'button'}
+            onClick={() => this.onStartReplay(replay)}
+            label={'Watch Replay'}
+          />,
+        ]
+      : []
+
+    // NOTE(coin²): Surely there are better way to do that
+    // Only render content once we have replay details
+    let content
+    if (this.state.replayDetails !== undefined) {
+      console.log('replay', replay)
+      console.log('replayDetails', this.state.replayDetails)
+
+      const {
+        gameName,
+        mapName,
+        gameType,
+        gameSubtype,
+        players,
+        duration,
+      } = this.state.replayDetails
+      content = (
+        <div>
+          <div>Replay date: {dateFormat.format(replay.date)}</div>
+          <div>Game name: {gameName}</div>
+          <div>Map name: {mapName}</div>
+          <div>Game type: {gameTypeMapping[gameType]}</div>
+          <div>Game subtype: {gameSubtype}</div>
+          <div>Game name: {gameName}</div>
+          <div>Game duration: {duration}</div>
+        </div>
+      )
+      console.log(players)
+    }
+
+    return (
+      <Dialog
+        title={'Replay: ' + replay.name}
+        onCancel={onCancel}
+        showCloseButton={true}
+        buttons={buttons}>
+        {content}
+      </Dialog>
+    )
+  }
+}

--- a/client/replays/watch-replay.jsx
+++ b/client/replays/watch-replay.jsx
@@ -4,8 +4,7 @@ import path from 'path'
 import { remote } from 'electron'
 
 import BrowseFiles from '../file-browser/browse-files'
-import { startReplay } from './action-creators'
-import { closeOverlay } from '../activities/action-creators'
+import { openDialog } from '../dialogs/action-creators'
 
 import Replay from '../icons/material/ic_movie_black_24px.svg'
 
@@ -17,7 +16,7 @@ function getReplayFolder() {
 export default class Replays extends React.Component {
   render() {
     const fileTypes = {
-      rep: { icon: <Replay />, onSelect: this.onStartReplay },
+      rep: { icon: <Replay />, onSelect: this.onOpenDialogReplay },
     }
     const defaultFolder = {
       id: 'default',
@@ -35,8 +34,12 @@ export default class Replays extends React.Component {
     return <BrowseFiles {...props} />
   }
 
-  onStartReplay = replay => {
-    this.props.dispatch(closeOverlay())
-    this.props.dispatch(startReplay(replay))
+  onOpenDialogReplay = replay => {
+    this.props.dispatch(
+      openDialog('replay', {
+        replay,
+        hasButton: true,
+      }),
+    )
   }
 }


### PR DESCRIPTION
Work is in progress but functionnal. I put everything in one component dialog for the moment, because I am sure there will be quite some modifications and I am not comfortable with React.

CI should crash because I have introduced those errors 

```server (webpack 5.25.0) compiled with 3 errors in 2516 ms
webpack building...
webpack built server e36b09157229eefea611 in 1076ms
assets by status 558 KiB [cached] 3 assets
assets by status 11.6 MiB [emitted]
  asset client.js 11.6 MiB [emitted] (name: client)
  asset client.4d054200acade8b7a049.hot-update.js 21.2 KiB [emitted] [immutable] [hmr] (name: client)
  asset client.4d054200acade8b7a049.hot-update.json 30 bytes [emitted] [immutable] [hmr]
Entrypoint client 11.6 MiB = client.js 11.6 MiB client.4d054200acade8b7a049.hot-update.js 21.2 KiB
cached modules 4.42 MiB [cached] 771 modules
runtime modules 29.4 KiB 18 modules
./client/replays/replay-dialog.jsx 7.81 KiB [built] [code generated]

ERROR in ./client/replays/action-creators.js 10:0-20
Module not found: Error: Can't resolve 'fs' in 'E:\Prog\ShieldBattery\client\replays'
 @ ./client/replays/replay-dialog.jsx 20:0-48 60:26-37
 @ ./client/dialogs/connected-dialog-overlay.jsx 20:0-52 164:21-33
 @ ./client/main-layout.jsx 29:0-72 428:376-398
 @ ./client/app.jsx 24:0-39 79:19-29
 @ ./client/index.jsx 21:0-24 153:150-153

ERROR in ./client/replays/replay-dialog.jsx 12:0-20
Module not found: Error: Can't resolve 'fs' in 'E:\Prog\ShieldBattery\client\replays'
 @ ./client/dialogs/connected-dialog-overlay.jsx 20:0-52 164:21-33
 @ ./client/main-layout.jsx 29:0-72 428:376-398
 @ ./client/app.jsx 24:0-39 79:19-29
 @ ./client/index.jsx 21:0-24 153:150-153

ERROR in ./node_modules/jssuh/index.js 8:13-28
Module not found: Error: Can't resolve 'zlib' in 'E:\Prog\ShieldBattery\node_modules\jssuh'

BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.
This is no longer the case. Verify if you need this module and configure a polyfill for it.

If you want to include a polyfill, you need to:
        - add a fallback 'resolve.fallback: { "zlib": require.resolve("browserify-zlib") }'
        - install 'browserify-zlib'
If you don't want to include a polyfill, you can use an empty module like this:
        resolve.fallback: { "zlib": false }
 @ ./client/replays/action-creators.js 13:0-33 25:23-35
 @ ./client/replays/replay-dialog.jsx 20:0-48 60:26-37
 @ ./client/dialogs/connected-dialog-overlay.jsx 20:0-52 164:21-33
 @ ./client/main-layout.jsx 29:0-72 428:376-398
 @ ./client/app.jsx 24:0-39 79:19-29
 @ ./client/index.jsx 21:0-24 153:150-153

3 errors have detailed information that is not shown.
Use 'stats.errorDetails: true' resp. '--stats-error-details' to show it.
```

No idea where it comes from, it also targets a file I have not touched. There might be [this solution](https://github.com/vercel/next.js/issues/7755#issuecomment-508633125) but I am not confident that this [fix](https://github.com/vercel/next.js/issues/7755#issuecomment-508633125) is good for us. 

edit: Hum CI did not crash ? 