### PR TITLE
Hide alternate race icon that matches selected main race

### DIFF
--- a/client/lobbies/race-picker.jsx
+++ b/client/lobbies/race-picker.jsx
@@ -4,9 +4,10 @@ import styled from 'styled-components'
 
 import Button from '../material/button'
 import RaceIcon from './race-icon'
+import { Deselected } from './selected-race'
 
 import { fastOutSlowIn } from '../material/curve-constants'
-import { colorTextFaint, colorDividers } from '../styles/colors'
+import { colorTextFaint } from '../styles/colors'
 
 export const RACE_PICKER_SIZE_MEDIUM = 'MEDIUM'
 export const RACE_PICKER_SIZE_LARGE = 'LARGE'
@@ -82,31 +83,6 @@ export const StyledRaceIcon = styled(RaceIcon)`
 
     return ''
   }};
-`
-
-const Deselected = styled.span`
-  position: relative;
-  display: inline-block;
-  vertical-align: middle;
-  width: 36px;
-  height: 36px;
-  min-height: 32px;
-  padding: 2px;
-
-  &:not(:first-child) {
-    margin-left: 4px;
-  }
-
-  &::after {
-    content: '';
-    position: absolute;
-    left: calc(50% - 6px);
-    top: calc(50% - 6px);
-    width: 12px;
-    height: 12px;
-    border-radius: 50%;
-    background-color: ${colorDividers};
-  }
 `
 
 export default class RacePicker extends React.Component {

--- a/client/lobbies/race-picker.jsx
+++ b/client/lobbies/race-picker.jsx
@@ -4,7 +4,7 @@ import styled from 'styled-components'
 
 import Button from '../material/button'
 import RaceIcon from './race-icon'
-import { Deselected } from './selected-race'
+import { HiddenRaceIcon } from './selected-race'
 
 import { fastOutSlowIn } from '../material/curve-constants'
 import { colorTextFaint } from '../styles/colors'
@@ -66,9 +66,14 @@ export const StyledRaceIcon = styled(RaceIcon)`
     return `
       fill: ${props.active ? color : colorTextFaint};
 
-      &:hover,
-      &:active {
-        fill: ${color};
+      ${
+        props.interactive
+          ? `
+        &:hover,
+        &:active {
+          fill: ${color};
+        }`
+          : ''
       }
     `
   }}
@@ -88,31 +93,40 @@ export const StyledRaceIcon = styled(RaceIcon)`
 export default class RacePicker extends React.Component {
   static propTypes = {
     race: PropTypes.oneOf(['r', 'p', 't', 'z']).isRequired,
-    disableRace: PropTypes.oneOf(['r', 'p', 't', 'z']),
+    hiddenRaces: PropTypes.arrayOf(PropTypes.string),
     size: PropTypes.oneOf([RACE_PICKER_SIZE_MEDIUM, RACE_PICKER_SIZE_LARGE]),
     allowRandom: PropTypes.bool,
     onSetRace: PropTypes.func,
+    allowInteraction: PropTypes.bool,
   }
 
   static defaultProps = {
-    disableRace: null,
     size: RACE_PICKER_SIZE_MEDIUM,
     allowRandom: true,
+    allowInteraction: true,
   }
 
   renderIcon(race) {
-    const { size, disableRace } = this.props
+    const { size, hiddenRaces, allowInteraction } = this.props
     const activeRace = this.props.race
     const onClick = this.props.onSetRace ? () => this.props.onSetRace(race) : null
 
-    return race !== disableRace ? (
+    return hiddenRaces && hiddenRaces.includes(race) ? (
+      <HiddenRaceIcon />
+    ) : (
       <RaceButton
-        label={<StyledRaceIcon active={race === activeRace} race={race} size={size} />}
+        disabled={!allowInteraction}
+        label={
+          <StyledRaceIcon
+            interactive={allowInteraction}
+            active={race === activeRace}
+            race={race}
+            size={size}
+          />
+        }
         size={size}
         onClick={onClick}
       />
-    ) : (
-      <Deselected />
     )
   }
 

--- a/client/lobbies/race-picker.jsx
+++ b/client/lobbies/race-picker.jsx
@@ -4,10 +4,9 @@ import styled from 'styled-components'
 
 import Button from '../material/button'
 import RaceIcon from './race-icon'
-import { HiddenRaceIcon } from './selected-race'
 
 import { fastOutSlowIn } from '../material/curve-constants'
-import { colorTextFaint } from '../styles/colors'
+import { colorTextFaint, colorDividers } from '../styles/colors'
 
 export const RACE_PICKER_SIZE_MEDIUM = 'MEDIUM'
 export const RACE_PICKER_SIZE_LARGE = 'LARGE'
@@ -88,6 +87,31 @@ export const StyledRaceIcon = styled(RaceIcon)`
 
     return ''
   }};
+`
+
+const HiddenRaceIcon = styled.span`
+  position: relative;
+  display: inline-block;
+  vertical-align: middle;
+  width: 36px;
+  height: 36px;
+  min-height: 32px;
+  padding: 2px;
+
+  &:not(:first-child) {
+    margin-left: 4px;
+  }
+
+  &::after {
+    content: '';
+    position: absolute;
+    left: calc(50% - 6px);
+    top: calc(50% - 6px);
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    background-color: ${colorDividers};
+  }
 `
 
 export default class RacePicker extends React.Component {

--- a/client/lobbies/race-picker.jsx
+++ b/client/lobbies/race-picker.jsx
@@ -119,7 +119,7 @@ export default class RacePicker extends React.Component {
   }
 
   static defaultProps = {
-    disableRace: null, 
+    disableRace: null,
     size: RACE_PICKER_SIZE_MEDIUM,
     allowRandom: true,
   }
@@ -129,13 +129,13 @@ export default class RacePicker extends React.Component {
     const activeRace = this.props.race
     const onClick = this.props.onSetRace ? () => this.props.onSetRace(race) : null
 
-    return (
-      race !== disableRace ?
+    return race !== disableRace ? (
       <RaceButton
         label={<StyledRaceIcon active={race === activeRace} race={race} size={size} />}
         size={size}
         onClick={onClick}
-      /> :
+      />
+    ) : (
       <Deselected />
     )
   }

--- a/client/lobbies/race-picker.jsx
+++ b/client/lobbies/race-picker.jsx
@@ -6,7 +6,7 @@ import Button from '../material/button'
 import RaceIcon from './race-icon'
 
 import { fastOutSlowIn } from '../material/curve-constants'
-import { colorTextFaint } from '../styles/colors'
+import { colorTextFaint, colorDividers } from '../styles/colors'
 
 export const RACE_PICKER_SIZE_MEDIUM = 'MEDIUM'
 export const RACE_PICKER_SIZE_LARGE = 'LARGE'
@@ -84,30 +84,59 @@ export const StyledRaceIcon = styled(RaceIcon)`
   }};
 `
 
+const Deselected = styled.span`
+  position: relative;
+  display: inline-block;
+  vertical-align: middle;
+  width: 36px;
+  height: 36px;
+  min-height: 32px;
+  padding: 2px;
+
+  &:not(:first-child) {
+    margin-left: 4px;
+  }
+
+  &::after {
+    content: '';
+    position: absolute;
+    left: calc(50% - 6px);
+    top: calc(50% - 6px);
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    background-color: ${colorDividers};
+  }
+`
+
 export default class RacePicker extends React.Component {
   static propTypes = {
     race: PropTypes.oneOf(['r', 'p', 't', 'z']).isRequired,
+    disableRace: PropTypes.oneOf(['r', 'p', 't', 'z']),
     size: PropTypes.oneOf([RACE_PICKER_SIZE_MEDIUM, RACE_PICKER_SIZE_LARGE]),
     allowRandom: PropTypes.bool,
     onSetRace: PropTypes.func,
   }
 
   static defaultProps = {
+    disableRace: null, 
     size: RACE_PICKER_SIZE_MEDIUM,
     allowRandom: true,
   }
 
   renderIcon(race) {
-    const { size } = this.props
+    const { size, disableRace } = this.props
     const activeRace = this.props.race
     const onClick = this.props.onSetRace ? () => this.props.onSetRace(race) : null
 
     return (
+      race !== disableRace ?
       <RaceButton
         label={<StyledRaceIcon active={race === activeRace} race={race} size={size} />}
         size={size}
         onClick={onClick}
-      />
+      /> :
+      <Deselected />
     )
   }
 

--- a/client/lobbies/selected-race.jsx
+++ b/client/lobbies/selected-race.jsx
@@ -2,11 +2,11 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
 
-import { RaceButton, StyledRaceIcon } from './race-picker'
+import RacePicker from './race-picker'
 
 import { colorDividers } from '../styles/colors'
 
-export const Deselected = styled.span`
+export const HiddenRaceIcon = styled.span`
   position: relative;
   display: inline-block;
   vertical-align: middle;
@@ -37,22 +37,9 @@ export default class SelectedRace extends React.Component {
     race: PropTypes.oneOf(['r', 'p', 't', 'z']).isRequired,
   }
 
-  renderIcon(race) {
-    if (this.props.race === race) {
-      return <RaceButton disabled={true} label={<StyledRaceIcon active={true} race={race} />} />
-    } else {
-      return <Deselected />
-    }
-  }
-
   render() {
-    return (
-      <div className={this.props.className}>
-        {this.renderIcon('z')}
-        {this.renderIcon('p')}
-        {this.renderIcon('t')}
-        {this.renderIcon('r')}
-      </div>
-    )
+    const hiddenRaces = ['r', 'p', 't', 'z'].filter(race => race !== this.props.race)
+
+    return <RacePicker race={this.props.race} hiddenRaces={hiddenRaces} allowInteraction={false} />
   }
 }

--- a/client/lobbies/selected-race.jsx
+++ b/client/lobbies/selected-race.jsx
@@ -1,35 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import styled from 'styled-components'
 
 import RacePicker from './race-picker'
-
-import { colorDividers } from '../styles/colors'
-
-export const HiddenRaceIcon = styled.span`
-  position: relative;
-  display: inline-block;
-  vertical-align: middle;
-  width: 36px;
-  height: 36px;
-  min-height: 32px;
-  padding: 2px;
-
-  &:not(:first-child) {
-    margin-left: 4px;
-  }
-
-  &::after {
-    content: '';
-    position: absolute;
-    left: calc(50% - 6px);
-    top: calc(50% - 6px);
-    width: 12px;
-    height: 12px;
-    border-radius: 50%;
-    background-color: ${colorDividers};
-  }
-`
 
 // Like a RacePicker, but for uncontrollable slots
 export default class SelectedRace extends React.Component {

--- a/client/lobbies/selected-race.jsx
+++ b/client/lobbies/selected-race.jsx
@@ -6,7 +6,7 @@ import { RaceButton, StyledRaceIcon } from './race-picker'
 
 import { colorDividers } from '../styles/colors'
 
-const Deselected = styled.span`
+export const Deselected = styled.span`
   position: relative;
   display: inline-block;
   vertical-align: middle;

--- a/client/matchmaking/find-match.jsx
+++ b/client/matchmaking/find-match.jsx
@@ -224,7 +224,7 @@ class Find1vs1MatchForm extends React.Component {
             </DescriptionText>
             <RaceSelect
               {...bindCustom('alternateRace')}
-              disableRace={race}
+              hiddenRaces={[race]}
               size={RACE_PICKER_SIZE_LARGE}
               allowRandom={false}
             />

--- a/client/matchmaking/find-match.jsx
+++ b/client/matchmaking/find-match.jsx
@@ -224,6 +224,7 @@ class Find1vs1MatchForm extends React.Component {
             </DescriptionText>
             <RaceSelect
               {...bindCustom('alternateRace')}
+              disableRace={race}
               size={RACE_PICKER_SIZE_LARGE}
               allowRandom={false}
             />


### PR DESCRIPTION
I figured it looked a bit odd that you could select your alternate race to be the same as your main race.

Preview:
![hide-race](https://user-images.githubusercontent.com/43507279/111727657-4e1d7980-8839-11eb-9124-a395e27467aa.png)
