### PR TITLE
Refactor the handling of chat message types.

### DIFF
--- a/client/chat/channel.tsx
+++ b/client/chat/channel.tsx
@@ -4,7 +4,7 @@ import { connect } from 'react-redux'
 import { List as VirtualizedList } from 'react-virtualized'
 import styled, { css } from 'styled-components'
 import { MULTI_CHANNEL } from '../../common/flags'
-import { User } from '../auth/auth-records'
+import { SelfUserRecord } from '../auth/auth-records'
 import Avatar from '../avatars/avatar'
 import { DispatchFunction } from '../dispatch-registry'
 import WindowListener from '../dom/window-listener'
@@ -403,16 +403,16 @@ const ChatInput = styled(MessageInput)<ChatInputProps>`
   }
 `
 
-function renderMessages(msg: Message) {
+function renderMessage(msg: Message) {
   switch (msg.type) {
     case ChatMessageType.JoinChannel:
-      return <JoinChannelMessage key={msg.id} record={msg} />
+      return <JoinChannelMessage key={msg.id} time={msg.time} user={msg.user} />
     case ChatMessageType.LeaveChannel:
-      return <LeaveChannelMessage key={msg.id} record={msg} />
+      return <LeaveChannelMessage key={msg.id} time={msg.time} user={msg.user} />
     case ChatMessageType.NewChannelOwner:
-      return <NewChannelOwnerMessage key={msg.id} record={msg} />
+      return <NewChannelOwnerMessage key={msg.id} time={msg.time} newOwner={msg.newOwner} />
     case ChatMessageType.SelfJoinChannel:
-      return <SelfJoinChannelMessage key={msg.id} record={msg} />
+      return <SelfJoinChannelMessage key={msg.id} channel={msg.channel} />
     default:
       return null
   }
@@ -444,7 +444,7 @@ class Channel extends React.Component<ChannelProps> {
         <MessagesAndInput>
           <StyledMessageList
             messages={channel.messages}
-            renderMessages={renderMessages}
+            renderMessage={renderMessage}
             loading={channel.loadingHistory}
             hasMoreHistory={channel.hasHistory}
             onScrollUpdate={this.onScrollUpdate}
@@ -483,7 +483,7 @@ const mapStateToProps = (state: RootState) => {
 }
 
 interface ChatChannelViewProps {
-  user: typeof User
+  user: SelfUserRecord
   chat: typeof ChatState
   dispatch: DispatchFunction<any> // TODO(2Pac): Type this better
   params: any // TODO(2Pac): Type this better

--- a/client/chat/chat-message-layout.tsx
+++ b/client/chat/chat-message-layout.tsx
@@ -1,16 +1,8 @@
-import PropTypes from 'prop-types'
 import React from 'react'
 import styled from 'styled-components'
 import { InfoMessageLayout, TimestampMessageLayout } from '../messaging/message-layout'
 import { blue100, blue200, colorTextFaint, colorTextSecondary } from '../styles/colors'
 import { body2 } from '../styles/typography'
-import {
-  ChatMessage,
-  JoinChannelMessageRecord,
-  LeaveChannelMessageRecord,
-  NewChannelOwnerMessageRecord,
-  SelfJoinChannelMessageRecord,
-} from './chat-message-records'
 
 const SystemMessage = styled(TimestampMessageLayout)`
   color: ${blue200};
@@ -36,68 +28,46 @@ const SeparatedInfoMessage = styled(InfoMessageLayout)`
   color: ${colorTextFaint};
 `
 
-interface BaseMessageProps {
-  record: ChatMessage
-}
+export const JoinChannelMessage = React.memo<{ time: number; user: string }>(props => {
+  const { time, user } = props
+  return (
+    <SystemMessage time={time}>
+      <span>
+        <SystemImportant>{user}</SystemImportant> has joined the channel
+      </span>
+    </SystemMessage>
+  )
+})
 
-class BaseMessage extends React.Component<BaseMessageProps> {
-  static propTypes = {
-    record: PropTypes.object.isRequired,
-  }
+export const LeaveChannelMessage = React.memo<{ time: number; user: string }>(props => {
+  const { time, user } = props
+  return (
+    <SystemMessage time={time}>
+      <span>
+        <SystemImportant>{user}</SystemImportant> has left the channel
+      </span>
+    </SystemMessage>
+  )
+})
 
-  shouldComponentUpdate(nextProps: BaseMessageProps) {
-    return this.props.record !== nextProps.record
-  }
-}
+export const NewChannelOwnerMessage = React.memo<{ time: number; newOwner: string }>(props => {
+  const { time, newOwner } = props
+  return (
+    <SystemMessage time={time}>
+      <span>
+        <SystemImportant>{newOwner}</SystemImportant> is the new owner of the channel
+      </span>
+    </SystemMessage>
+  )
+})
 
-export class JoinChannelMessage extends BaseMessage {
-  render() {
-    const { time, user } = this.props.record as JoinChannelMessageRecord
-    return (
-      <SystemMessage time={time}>
-        <span>
-          <SystemImportant>{user}</SystemImportant> has joined the channel
-        </span>
-      </SystemMessage>
-    )
-  }
-}
-
-export class LeaveChannelMessage extends BaseMessage {
-  render() {
-    const { time, user } = this.props.record as LeaveChannelMessageRecord
-    return (
-      <SystemMessage time={time}>
-        <span>
-          <SystemImportant>{user}</SystemImportant> has left the channel
-        </span>
-      </SystemMessage>
-    )
-  }
-}
-
-export class NewChannelOwnerMessage extends BaseMessage {
-  render() {
-    const { time, newOwner } = this.props.record as NewChannelOwnerMessageRecord
-    return (
-      <SystemMessage time={time}>
-        <span>
-          <SystemImportant>{newOwner}</SystemImportant> is the new owner of the channel
-        </span>
-      </SystemMessage>
-    )
-  }
-}
-
-export class SelfJoinChannelMessage extends BaseMessage {
-  render() {
-    const { channel } = this.props.record as SelfJoinChannelMessageRecord
-    return (
-      <SeparatedInfoMessage>
-        <span>
-          You joined <InfoImportant>#{channel}</InfoImportant>
-        </span>
-      </SeparatedInfoMessage>
-    )
-  }
-}
+export const SelfJoinChannelMessage = React.memo<{ channel: string }>(props => {
+  const { channel } = props
+  return (
+    <SeparatedInfoMessage>
+      <span>
+        You joined <InfoImportant>#{channel}</InfoImportant>
+      </span>
+    </SeparatedInfoMessage>
+  )
+})

--- a/client/chat/chat-message-layout.tsx
+++ b/client/chat/chat-message-layout.tsx
@@ -1,13 +1,18 @@
-import React from 'react'
 import PropTypes from 'prop-types'
+import React from 'react'
 import styled from 'styled-components'
-
-import { ChatMessageLayout, InfoMessageLayout } from './message'
-
-import { blue100, blue200, colorTextSecondary, colorTextFaint } from '../styles/colors'
+import { InfoMessageLayout, TimestampMessageLayout } from '../messaging/message-layout'
+import { blue100, blue200, colorTextFaint, colorTextSecondary } from '../styles/colors'
 import { body2 } from '../styles/typography'
+import {
+  ChatMessage,
+  JoinChannelMessageRecord,
+  LeaveChannelMessageRecord,
+  NewChannelOwnerMessageRecord,
+  SelfJoinChannelMessageRecord,
+} from './chat-message-records'
 
-const SystemMessage = styled(ChatMessageLayout)`
+const SystemMessage = styled(TimestampMessageLayout)`
   color: ${blue200};
 `
 
@@ -31,19 +36,23 @@ const SeparatedInfoMessage = styled(InfoMessageLayout)`
   color: ${colorTextFaint};
 `
 
-class BaseMessage extends React.Component {
+interface BaseMessageProps {
+  record: ChatMessage
+}
+
+class BaseMessage extends React.Component<BaseMessageProps> {
   static propTypes = {
     record: PropTypes.object.isRequired,
   }
 
-  shouldComponentUpdate(nextProps) {
-    return this.record !== nextProps.record
+  shouldComponentUpdate(nextProps: BaseMessageProps) {
+    return this.props.record !== nextProps.record
   }
 }
 
 export class JoinChannelMessage extends BaseMessage {
   render() {
-    const { time, user } = this.props.record
+    const { time, user } = this.props.record as JoinChannelMessageRecord
     return (
       <SystemMessage time={time}>
         <span>
@@ -56,7 +65,7 @@ export class JoinChannelMessage extends BaseMessage {
 
 export class LeaveChannelMessage extends BaseMessage {
   render() {
-    const { time, user } = this.props.record
+    const { time, user } = this.props.record as LeaveChannelMessageRecord
     return (
       <SystemMessage time={time}>
         <span>
@@ -69,7 +78,7 @@ export class LeaveChannelMessage extends BaseMessage {
 
 export class NewChannelOwnerMessage extends BaseMessage {
   render() {
-    const { time, newOwner } = this.props.record
+    const { time, newOwner } = this.props.record as NewChannelOwnerMessageRecord
     return (
       <SystemMessage time={time}>
         <span>
@@ -82,39 +91,13 @@ export class NewChannelOwnerMessage extends BaseMessage {
 
 export class SelfJoinChannelMessage extends BaseMessage {
   render() {
-    const { channel } = this.props.record
+    const { channel } = this.props.record as SelfJoinChannelMessageRecord
     return (
       <SeparatedInfoMessage>
         <span>
           You joined <InfoImportant>#{channel}</InfoImportant>
         </span>
       </SeparatedInfoMessage>
-    )
-  }
-}
-
-export class UserOnlineMessage extends BaseMessage {
-  render() {
-    const { time, user } = this.props.record
-    return (
-      <SystemMessage time={time}>
-        <span>
-          &gt;&gt; <SystemImportant>{user}</SystemImportant> has come online
-        </span>
-      </SystemMessage>
-    )
-  }
-}
-
-export class UserOfflineMessage extends BaseMessage {
-  render() {
-    const { time, user } = this.props.record
-    return (
-      <SystemMessage time={time}>
-        <span>
-          &lt;&lt; <SystemImportant>{user}</SystemImportant> has gone offline
-        </span>
-      </SystemMessage>
     )
   }
 }

--- a/client/chat/chat-message-records.ts
+++ b/client/chat/chat-message-records.ts
@@ -11,7 +11,7 @@ export enum ChatMessageType {
 export class JoinChannelMessageRecord
   extends Record({
     id: '',
-    type: ChatMessageType.JoinChannel,
+    type: ChatMessageType.JoinChannel as typeof ChatMessageType.JoinChannel,
     time: 0,
     user: '',
   })
@@ -20,7 +20,7 @@ export class JoinChannelMessageRecord
 export class LeaveChannelMessageRecord
   extends Record({
     id: '',
-    type: ChatMessageType.LeaveChannel,
+    type: ChatMessageType.LeaveChannel as typeof ChatMessageType.LeaveChannel,
     time: 0,
     user: '',
   })
@@ -29,7 +29,7 @@ export class LeaveChannelMessageRecord
 export class NewChannelOwnerMessageRecord
   extends Record({
     id: '',
-    type: ChatMessageType.NewChannelOwner,
+    type: ChatMessageType.NewChannelOwner as typeof ChatMessageType.NewChannelOwner,
     time: 0,
     newOwner: '',
   })
@@ -38,7 +38,7 @@ export class NewChannelOwnerMessageRecord
 export class SelfJoinChannelMessageRecord
   extends Record({
     id: '',
-    type: ChatMessageType.SelfJoinChannel,
+    type: ChatMessageType.SelfJoinChannel as typeof ChatMessageType.SelfJoinChannel,
     time: 0,
     channel: '',
   })

--- a/client/chat/chat-message-records.tsx
+++ b/client/chat/chat-message-records.tsx
@@ -1,0 +1,51 @@
+import { Record } from 'immutable'
+import { BaseMessage } from '../messaging/message-records'
+
+export enum ChatMessageType {
+  JoinChannel = 'joinChannel',
+  LeaveChannel = 'leaveChannel',
+  NewChannelOwner = 'newOwner',
+  SelfJoinChannel = 'selfJoinChannel',
+}
+
+export class JoinChannelMessageRecord
+  extends Record({
+    id: '',
+    type: ChatMessageType.JoinChannel,
+    time: 0,
+    user: '',
+  })
+  implements BaseMessage {}
+
+export class LeaveChannelMessageRecord
+  extends Record({
+    id: '',
+    type: ChatMessageType.LeaveChannel,
+    time: 0,
+    user: '',
+  })
+  implements BaseMessage {}
+
+export class NewChannelOwnerMessageRecord
+  extends Record({
+    id: '',
+    type: ChatMessageType.NewChannelOwner,
+    time: 0,
+    newOwner: '',
+  })
+  implements BaseMessage {}
+
+export class SelfJoinChannelMessageRecord
+  extends Record({
+    id: '',
+    type: ChatMessageType.SelfJoinChannel,
+    time: 0,
+    channel: '',
+  })
+  implements BaseMessage {}
+
+export type ChatMessage =
+  | JoinChannelMessageRecord
+  | LeaveChannelMessageRecord
+  | NewChannelOwnerMessageRecord
+  | SelfJoinChannelMessageRecord

--- a/client/chat/chat-reducer.js
+++ b/client/chat/chat-reducer.js
@@ -20,12 +20,12 @@ import {
   NETWORK_SITE_CONNECTED,
 } from '../actions'
 import {
-  TextMessage,
-  JoinChannelMessage,
-  LeaveChannelMessage,
-  NewChannelOwnerMessage,
-  SelfJoinChannelMessage,
-} from '../messaging/message-records'
+  JoinChannelMessageRecord,
+  LeaveChannelMessageRecord,
+  NewChannelOwnerMessageRecord,
+  SelfJoinChannelMessageRecord,
+} from '../chat/chat-message-records'
+import { TextMessageRecord } from '../messaging/message-records'
 
 // How many messages should be kept for inactive channels
 const INACTIVE_CHANNEL_MAX_HISTORY = 150
@@ -123,7 +123,7 @@ export default keyedReducer(new ChatState(), {
 
     return updateMessages(updated, channel, false, m => {
       return m.push(
-        new SelfJoinChannelMessage({
+        new SelfJoinChannelMessageRecord({
           id: cuid(),
           channel,
         }),
@@ -143,7 +143,7 @@ export default keyedReducer(new ChatState(), {
     // TODO(2Pac): make this configurable
     return updateMessages(updated, channel, true, m => {
       return m.push(
-        new JoinChannelMessage({
+        new JoinChannelMessageRecord({
           id: cuid(),
           time: Date.now(),
           user,
@@ -165,7 +165,7 @@ export default keyedReducer(new ChatState(), {
     // TODO(2Pac): make this configurable
     updated = updateMessages(updated, channel, true, m => {
       return m.push(
-        new LeaveChannelMessage({
+        new LeaveChannelMessageRecord({
           id: cuid(),
           time: Date.now(),
           user,
@@ -176,7 +176,7 @@ export default keyedReducer(new ChatState(), {
     return newOwner
       ? updateMessages(updated, channel, true, m => {
           return m.push(
-            new NewChannelOwnerMessage({
+            new NewChannelOwnerMessageRecord({
               id: cuid(),
               time: Date.now(),
               newOwner,
@@ -197,7 +197,7 @@ export default keyedReducer(new ChatState(), {
   [CHAT_UPDATE_MESSAGE](state, action) {
     const { id, channel, time, user, message } = action.payload
     const lowerCaseChannel = channel.toLowerCase()
-    const newMessage = new TextMessage({
+    const newMessage = new TextMessageRecord({
       id,
       time,
       from: user,
@@ -251,7 +251,7 @@ export default keyedReducer(new ChatState(), {
     const newMessages = new List(
       action.payload.map(
         msg =>
-          new TextMessage({
+          new TextMessageRecord({
             id: msg.id,
             time: msg.sent,
             from: msg.user,

--- a/client/lobbies/lobby-message-layout.tsx
+++ b/client/lobbies/lobby-message-layout.tsx
@@ -1,0 +1,136 @@
+import React from 'react'
+import styled from 'styled-components'
+import { TimestampMessageLayout } from '../messaging/message-layout'
+import { blue100, blue200 } from '../styles/colors'
+import { body2 } from '../styles/typography'
+import {
+  BanLobbyPlayerMessageRecord,
+  JoinLobbyMessageRecord,
+  KickLobbyPlayerMessageRecord,
+  LeaveLobbyMessageRecord,
+  LobbyCountdownCanceledMessageRecord,
+  LobbyCountdownStartedMessageRecord,
+  LobbyCountdownTickMessageRecord,
+  LobbyHostChangeMessageRecord,
+  LobbyLoadingCanceledMessageRecord,
+  LobbyMessage,
+  SelfJoinLobbyMessageRecord,
+} from './lobby-message-records'
+
+const ChatSystemMessage = styled(TimestampMessageLayout)`
+  color: ${blue200};
+`
+
+const ChatImportant = styled.span`
+  ${body2};
+  line-height: inherit;
+  color: ${blue100};
+`
+
+interface LobbyMessageProps {
+  record: LobbyMessage
+}
+
+export function JoinLobbyMessage(props: LobbyMessageProps) {
+  const { time, name } = props.record as JoinLobbyMessageRecord
+  return (
+    <ChatSystemMessage time={time}>
+      <span>
+        &gt;&gt; <ChatImportant>{name}</ChatImportant> has joined the lobby
+      </span>
+    </ChatSystemMessage>
+  )
+}
+
+export function LeaveLobbyMessage(props: LobbyMessageProps) {
+  const { time, name } = props.record as LeaveLobbyMessageRecord
+  return (
+    <ChatSystemMessage time={time}>
+      <span>
+        &lt;&lt; <ChatImportant>{name}</ChatImportant> has left the lobby
+      </span>
+    </ChatSystemMessage>
+  )
+}
+
+export function KickLobbyPlayerMessage(props: LobbyMessageProps) {
+  const { time, name } = props.record as KickLobbyPlayerMessageRecord
+  return (
+    <ChatSystemMessage time={time}>
+      <span>
+        &lt;&lt; <ChatImportant>{name}</ChatImportant> has been kicked from the lobby
+      </span>
+    </ChatSystemMessage>
+  )
+}
+
+export function BanLobbyPlayerMessage(props: LobbyMessageProps) {
+  const { time, name } = props.record as BanLobbyPlayerMessageRecord
+  return (
+    <ChatSystemMessage time={time}>
+      <span>
+        &lt;&lt; <ChatImportant>{name}</ChatImportant> has been banned from the lobby
+      </span>
+    </ChatSystemMessage>
+  )
+}
+
+export function SelfJoinLobbyMessage(props: LobbyMessageProps) {
+  const { time, lobby, host } = props.record as SelfJoinLobbyMessageRecord
+  return (
+    <ChatSystemMessage time={time}>
+      <span>
+        You have joined <ChatImportant>{lobby}</ChatImportant>. The host is{' '}
+        <ChatImportant>{host}</ChatImportant>.
+      </span>
+    </ChatSystemMessage>
+  )
+}
+
+export function LobbyHostChangeMessage(props: LobbyMessageProps) {
+  const { time, name } = props.record as LobbyHostChangeMessageRecord
+  return (
+    <ChatSystemMessage time={time}>
+      <span>
+        <ChatImportant>{name}</ChatImportant> is now the host
+      </span>
+    </ChatSystemMessage>
+  )
+}
+
+export function LobbyCountdownStartedMessage(props: LobbyMessageProps) {
+  const { time } = props.record as LobbyCountdownStartedMessageRecord
+  return (
+    <ChatSystemMessage time={time}>
+      <span>The game countdown has begun</span>
+    </ChatSystemMessage>
+  )
+}
+
+export function LobbyCountdownTickMessage(props: LobbyMessageProps) {
+  const { time, timeLeft } = props.record as LobbyCountdownTickMessageRecord
+  return (
+    <ChatSystemMessage time={time}>
+      <span>{timeLeft}&hellip;</span>
+    </ChatSystemMessage>
+  )
+}
+
+export function LobbyCountdownCanceledMessage(props: LobbyMessageProps) {
+  const { time } = props.record as LobbyCountdownCanceledMessageRecord
+  return (
+    <ChatSystemMessage time={time}>
+      <span>The game countdown has been canceled</span>
+    </ChatSystemMessage>
+  )
+}
+
+export function LobbyLoadingCanceledMessage(props: LobbyMessageProps) {
+  // TODO(tec27): We really need to pass a reason back here
+  const { time } = props.record as LobbyLoadingCanceledMessageRecord
+  return (
+    <ChatSystemMessage time={time}>
+      <span>Game initialization has been canceled</span>
+    </ChatSystemMessage>
+  )
+}

--- a/client/lobbies/lobby-message-layout.tsx
+++ b/client/lobbies/lobby-message-layout.tsx
@@ -3,134 +3,118 @@ import styled from 'styled-components'
 import { TimestampMessageLayout } from '../messaging/message-layout'
 import { blue100, blue200 } from '../styles/colors'
 import { body2 } from '../styles/typography'
-import {
-  BanLobbyPlayerMessageRecord,
-  JoinLobbyMessageRecord,
-  KickLobbyPlayerMessageRecord,
-  LeaveLobbyMessageRecord,
-  LobbyCountdownCanceledMessageRecord,
-  LobbyCountdownStartedMessageRecord,
-  LobbyCountdownTickMessageRecord,
-  LobbyHostChangeMessageRecord,
-  LobbyLoadingCanceledMessageRecord,
-  LobbyMessage,
-  SelfJoinLobbyMessageRecord,
-} from './lobby-message-records'
 
 const ChatSystemMessage = styled(TimestampMessageLayout)`
   color: ${blue200};
 `
 
-const ChatImportant = styled.span`
+const Important = styled.span`
   ${body2};
   line-height: inherit;
   color: ${blue100};
 `
 
-interface LobbyMessageProps {
-  record: LobbyMessage
-}
-
-export function JoinLobbyMessage(props: LobbyMessageProps) {
-  const { time, name } = props.record as JoinLobbyMessageRecord
+export const JoinLobbyMessage = React.memo<{ time: number; name: string }>(props => {
+  const { time, name } = props
   return (
     <ChatSystemMessage time={time}>
       <span>
-        &gt;&gt; <ChatImportant>{name}</ChatImportant> has joined the lobby
+        &gt;&gt; <Important>{name}</Important> has joined the lobby
       </span>
     </ChatSystemMessage>
   )
-}
+})
 
-export function LeaveLobbyMessage(props: LobbyMessageProps) {
-  const { time, name } = props.record as LeaveLobbyMessageRecord
+export const LeaveLobbyMessage = React.memo<{ time: number; name: string }>(props => {
+  const { time, name } = props
   return (
     <ChatSystemMessage time={time}>
       <span>
-        &lt;&lt; <ChatImportant>{name}</ChatImportant> has left the lobby
+        &lt;&lt; <Important>{name}</Important> has left the lobby
       </span>
     </ChatSystemMessage>
   )
-}
+})
 
-export function KickLobbyPlayerMessage(props: LobbyMessageProps) {
-  const { time, name } = props.record as KickLobbyPlayerMessageRecord
+export const KickLobbyPlayerMessage = React.memo<{ time: number; name: string }>(props => {
+  const { time, name } = props
   return (
     <ChatSystemMessage time={time}>
       <span>
-        &lt;&lt; <ChatImportant>{name}</ChatImportant> has been kicked from the lobby
+        &lt;&lt; <Important>{name}</Important> has been kicked from the lobby
       </span>
     </ChatSystemMessage>
   )
-}
+})
 
-export function BanLobbyPlayerMessage(props: LobbyMessageProps) {
-  const { time, name } = props.record as BanLobbyPlayerMessageRecord
+export const BanLobbyPlayerMessage = React.memo<{ time: number; name: string }>(props => {
+  const { time, name } = props
   return (
     <ChatSystemMessage time={time}>
       <span>
-        &lt;&lt; <ChatImportant>{name}</ChatImportant> has been banned from the lobby
+        &lt;&lt; <Important>{name}</Important> has been banned from the lobby
       </span>
     </ChatSystemMessage>
   )
-}
+})
 
-export function SelfJoinLobbyMessage(props: LobbyMessageProps) {
-  const { time, lobby, host } = props.record as SelfJoinLobbyMessageRecord
+export const SelfJoinLobbyMessage = React.memo<{ time: number; lobby: string; host: string }>(
+  props => {
+    const { time, lobby, host } = props
+    return (
+      <ChatSystemMessage time={time}>
+        <span>
+          You have joined <Important>{lobby}</Important>. The host is <Important>{host}</Important>.
+        </span>
+      </ChatSystemMessage>
+    )
+  },
+)
+
+export const LobbyHostChangeMessage = React.memo<{ time: number; name: string }>(props => {
+  const { time, name } = props
   return (
     <ChatSystemMessage time={time}>
       <span>
-        You have joined <ChatImportant>{lobby}</ChatImportant>. The host is{' '}
-        <ChatImportant>{host}</ChatImportant>.
+        <Important>{name}</Important> is now the host
       </span>
     </ChatSystemMessage>
   )
-}
+})
 
-export function LobbyHostChangeMessage(props: LobbyMessageProps) {
-  const { time, name } = props.record as LobbyHostChangeMessageRecord
-  return (
-    <ChatSystemMessage time={time}>
-      <span>
-        <ChatImportant>{name}</ChatImportant> is now the host
-      </span>
-    </ChatSystemMessage>
-  )
-}
-
-export function LobbyCountdownStartedMessage(props: LobbyMessageProps) {
-  const { time } = props.record as LobbyCountdownStartedMessageRecord
+export const LobbyCountdownStartedMessage = React.memo<{ time: number }>(props => {
+  const { time } = props
   return (
     <ChatSystemMessage time={time}>
       <span>The game countdown has begun</span>
     </ChatSystemMessage>
   )
-}
+})
 
-export function LobbyCountdownTickMessage(props: LobbyMessageProps) {
-  const { time, timeLeft } = props.record as LobbyCountdownTickMessageRecord
+export const LobbyCountdownTickMessage = React.memo<{ time: number; timeLeft: number }>(props => {
+  const { time, timeLeft } = props
   return (
     <ChatSystemMessage time={time}>
       <span>{timeLeft}&hellip;</span>
     </ChatSystemMessage>
   )
-}
+})
 
-export function LobbyCountdownCanceledMessage(props: LobbyMessageProps) {
-  const { time } = props.record as LobbyCountdownCanceledMessageRecord
+export const LobbyCountdownCanceledMessage = React.memo<{ time: number }>(props => {
+  const { time } = props
   return (
     <ChatSystemMessage time={time}>
       <span>The game countdown has been canceled</span>
     </ChatSystemMessage>
   )
-}
+})
 
-export function LobbyLoadingCanceledMessage(props: LobbyMessageProps) {
+export const LobbyLoadingCanceledMessage = React.memo<{ time: number }>(props => {
   // TODO(tec27): We really need to pass a reason back here
-  const { time } = props.record as LobbyLoadingCanceledMessageRecord
+  const { time } = props
   return (
     <ChatSystemMessage time={time}>
       <span>Game initialization has been canceled</span>
     </ChatSystemMessage>
   )
-}
+})

--- a/client/lobbies/lobby-message-records.ts
+++ b/client/lobbies/lobby-message-records.ts
@@ -17,7 +17,7 @@ export enum LobbyMessageType {
 export class JoinLobbyMessageRecord
   extends Record({
     id: '',
-    type: LobbyMessageType.JoinLobby,
+    type: LobbyMessageType.JoinLobby as typeof LobbyMessageType.JoinLobby,
     time: 0,
     name: '',
   })
@@ -26,7 +26,7 @@ export class JoinLobbyMessageRecord
 export class LeaveLobbyMessageRecord
   extends Record({
     id: '',
-    type: LobbyMessageType.LeaveLobby,
+    type: LobbyMessageType.LeaveLobby as typeof LobbyMessageType.LeaveLobby,
     time: 0,
     name: '',
   })
@@ -35,7 +35,7 @@ export class LeaveLobbyMessageRecord
 export class KickLobbyPlayerMessageRecord
   extends Record({
     id: '',
-    type: LobbyMessageType.KickLobbyPlayer,
+    type: LobbyMessageType.KickLobbyPlayer as typeof LobbyMessageType.KickLobbyPlayer,
     time: 0,
     name: '',
   })
@@ -44,7 +44,7 @@ export class KickLobbyPlayerMessageRecord
 export class BanLobbyPlayerMessageRecord
   extends Record({
     id: '',
-    type: LobbyMessageType.BanLobbyPlayer,
+    type: LobbyMessageType.BanLobbyPlayer as typeof LobbyMessageType.BanLobbyPlayer,
     time: 0,
     name: '',
   })
@@ -53,7 +53,7 @@ export class BanLobbyPlayerMessageRecord
 export class SelfJoinLobbyMessageRecord
   extends Record({
     id: '',
-    type: LobbyMessageType.SelfJoinLobby,
+    type: LobbyMessageType.SelfJoinLobby as typeof LobbyMessageType.SelfJoinLobby,
     time: 0,
     lobby: '',
     host: '',
@@ -63,7 +63,7 @@ export class SelfJoinLobbyMessageRecord
 export class LobbyHostChangeMessageRecord
   extends Record({
     id: '',
-    type: LobbyMessageType.LobbyHostChange,
+    type: LobbyMessageType.LobbyHostChange as typeof LobbyMessageType.LobbyHostChange,
     time: 0,
     name: '',
   })
@@ -72,7 +72,7 @@ export class LobbyHostChangeMessageRecord
 export class LobbyCountdownStartedMessageRecord
   extends Record({
     id: '',
-    type: LobbyMessageType.LobbyCountdownStarted,
+    type: LobbyMessageType.LobbyCountdownStarted as typeof LobbyMessageType.LobbyCountdownStarted,
     time: 0,
   })
   implements BaseMessage {}
@@ -80,7 +80,7 @@ export class LobbyCountdownStartedMessageRecord
 export class LobbyCountdownTickMessageRecord
   extends Record({
     id: '',
-    type: LobbyMessageType.LobbyCountdownTick,
+    type: LobbyMessageType.LobbyCountdownTick as typeof LobbyMessageType.LobbyCountdownTick,
     time: 0,
     timeLeft: 0,
   })
@@ -89,7 +89,7 @@ export class LobbyCountdownTickMessageRecord
 export class LobbyCountdownCanceledMessageRecord
   extends Record({
     id: '',
-    type: LobbyMessageType.LobbyCountdownCanceled,
+    type: LobbyMessageType.LobbyCountdownCanceled as typeof LobbyMessageType.LobbyCountdownCanceled,
     time: 0,
   })
   implements BaseMessage {}
@@ -97,7 +97,7 @@ export class LobbyCountdownCanceledMessageRecord
 export class LobbyLoadingCanceledMessageRecord
   extends Record({
     id: '',
-    type: LobbyMessageType.LobbyLoadingCanceled,
+    type: LobbyMessageType.LobbyLoadingCanceled as typeof LobbyMessageType.LobbyLoadingCanceled,
     time: 0,
   })
   implements BaseMessage {}

--- a/client/lobbies/lobby-message-records.tsx
+++ b/client/lobbies/lobby-message-records.tsx
@@ -1,0 +1,115 @@
+import { Record } from 'immutable'
+import { BaseMessage } from '../messaging/message-records'
+
+export enum LobbyMessageType {
+  JoinLobby = 'joinLobby',
+  LeaveLobby = 'leaveLobby',
+  KickLobbyPlayer = 'kickLobbyPlayer',
+  BanLobbyPlayer = 'banLobbyPlayer',
+  SelfJoinLobby = 'selfJoinLobby',
+  LobbyHostChange = 'lobbyHostChange',
+  LobbyCountdownStarted = 'lobbyCountdownStarted',
+  LobbyCountdownTick = 'lobbyCountdownTick',
+  LobbyCountdownCanceled = 'lobbyCountdownCanceled',
+  LobbyLoadingCanceled = 'lobbyLoadingCanceled',
+}
+
+export class JoinLobbyMessageRecord
+  extends Record({
+    id: '',
+    type: LobbyMessageType.JoinLobby,
+    time: 0,
+    name: '',
+  })
+  implements BaseMessage {}
+
+export class LeaveLobbyMessageRecord
+  extends Record({
+    id: '',
+    type: LobbyMessageType.LeaveLobby,
+    time: 0,
+    name: '',
+  })
+  implements BaseMessage {}
+
+export class KickLobbyPlayerMessageRecord
+  extends Record({
+    id: '',
+    type: LobbyMessageType.KickLobbyPlayer,
+    time: 0,
+    name: '',
+  })
+  implements BaseMessage {}
+
+export class BanLobbyPlayerMessageRecord
+  extends Record({
+    id: '',
+    type: LobbyMessageType.BanLobbyPlayer,
+    time: 0,
+    name: '',
+  })
+  implements BaseMessage {}
+
+export class SelfJoinLobbyMessageRecord
+  extends Record({
+    id: '',
+    type: LobbyMessageType.SelfJoinLobby,
+    time: 0,
+    lobby: '',
+    host: '',
+  })
+  implements BaseMessage {}
+
+export class LobbyHostChangeMessageRecord
+  extends Record({
+    id: '',
+    type: LobbyMessageType.LobbyHostChange,
+    time: 0,
+    name: '',
+  })
+  implements BaseMessage {}
+
+export class LobbyCountdownStartedMessageRecord
+  extends Record({
+    id: '',
+    type: LobbyMessageType.LobbyCountdownStarted,
+    time: 0,
+  })
+  implements BaseMessage {}
+
+export class LobbyCountdownTickMessageRecord
+  extends Record({
+    id: '',
+    type: LobbyMessageType.LobbyCountdownTick,
+    time: 0,
+    timeLeft: 0,
+  })
+  implements BaseMessage {}
+
+export class LobbyCountdownCanceledMessageRecord
+  extends Record({
+    id: '',
+    type: LobbyMessageType.LobbyCountdownCanceled,
+    time: 0,
+  })
+  implements BaseMessage {}
+
+export class LobbyLoadingCanceledMessageRecord
+  extends Record({
+    id: '',
+    type: LobbyMessageType.LobbyLoadingCanceled,
+    time: 0,
+  })
+  implements BaseMessage {}
+
+export type LobbyMessage =
+  | JoinLobbyMessageRecord
+  | LeaveLobbyMessageRecord
+  | KickLobbyPlayerMessageRecord
+  | BanLobbyPlayerMessageRecord
+  | SelfJoinLobbyMessageRecord
+  | LobbyHostChangeMessageRecord
+  | LobbyCountdownStartedMessageRecord
+  | LobbyCountdownTickMessageRecord
+  | LobbyCountdownCanceledMessageRecord
+  | LobbyLoadingCanceledMessageRecord

--- a/client/lobbies/lobby-reducer.js
+++ b/client/lobbies/lobby-reducer.js
@@ -27,6 +27,19 @@ import {
   MAPS_TOGGLE_FAVORITE,
   NETWORK_SITE_CONNECTED,
 } from '../actions'
+import {
+  BanLobbyPlayerMessageRecord,
+  JoinLobbyMessageRecord,
+  KickLobbyPlayerMessageRecord,
+  LeaveLobbyMessageRecord,
+  LobbyCountdownCanceledMessageRecord,
+  LobbyCountdownStartedMessageRecord,
+  LobbyCountdownTickMessageRecord,
+  LobbyHostChangeMessageRecord,
+  LobbyLoadingCanceledMessageRecord,
+  SelfJoinLobbyMessageRecord,
+} from './lobby-message-records'
+import { TextMessageRecord } from '../messaging/message-records'
 
 export const Slot = new Record({
   type: null,
@@ -167,73 +180,6 @@ const infoReducer = keyedReducer(undefined, {
   },
 })
 
-// id, type, and time need to be present for ALL message types
-export const ChatMessage = Record({
-  id: null,
-  type: 'message',
-  time: 0,
-  from: null,
-  text: null,
-})
-export const CountdownCanceledMessage = Record({
-  id: null,
-  type: 'countdownCanceled',
-  time: 0,
-})
-export const CountdownStartedMessage = Record({
-  id: null,
-  type: 'countdownStarted',
-  time: 0,
-})
-export const CountdownTickMessage = Record({
-  id: null,
-  type: 'countdownTick',
-  time: 0,
-  timeLeft: 0,
-})
-export const HostChangeMessage = Record({
-  id: null,
-  type: 'hostChange',
-  time: 0,
-  name: null,
-})
-export const JoinMessage = Record({
-  id: null,
-  type: 'join',
-  time: 0,
-  name: null,
-})
-export const LeaveMessage = Record({
-  id: null,
-  type: 'leave',
-  time: 0,
-  name: null,
-})
-export const KickMessage = Record({
-  id: null,
-  type: 'kick',
-  time: 0,
-  name: null,
-})
-export const BanMessage = Record({
-  id: null,
-  type: 'ban',
-  time: 0,
-  name: null,
-})
-export const LoadingCanceledMessage = Record({
-  id: null,
-  type: 'loadingCanceled',
-  time: 0,
-})
-export const SelfJoinMessage = Record({
-  id: null,
-  type: 'selfJoin',
-  time: 0,
-  lobby: null,
-  host: null,
-})
-
 function prune(chatList) {
   return chatList.size > 200 ? chatList.shift() : chatList
 }
@@ -242,7 +188,7 @@ const chatHandlers = {
   [LOBBY_UPDATE_CHAT_MESSAGE](lobbyInfo, lastLobbyInfo, state, action) {
     const event = action.payload
     return state.push(
-      new ChatMessage({
+      new TextMessageRecord({
         id: cuid(),
         time: event.time,
         from: event.from,
@@ -255,7 +201,7 @@ const chatHandlers = {
     const { slot } = action.payload
     if (slot.type === 'human') {
       return state.push(
-        new JoinMessage({
+        new JoinLobbyMessageRecord({
           id: cuid(),
           time: Date.now(),
           name: slot.name,
@@ -269,7 +215,7 @@ const chatHandlers = {
   [LOBBY_UPDATE_LEAVE](lobbyInfo, lastLobbyInfo, state, action) {
     const { player } = action.payload
     return state.push(
-      new LeaveMessage({
+      new LeaveLobbyMessageRecord({
         id: cuid(),
         time: Date.now(),
         name: player.name,
@@ -280,7 +226,7 @@ const chatHandlers = {
   [LOBBY_UPDATE_KICK](lobbyInfo, lastLobbyInfo, state, action) {
     const { player } = action.payload
     return state.push(
-      new KickMessage({
+      new KickLobbyPlayerMessageRecord({
         id: cuid(),
         time: Date.now(),
         name: player.name,
@@ -291,7 +237,7 @@ const chatHandlers = {
   [LOBBY_UPDATE_BAN](lobbyInfo, lastLobbyInfo, state, action) {
     const { player } = action.payload
     return state.push(
-      new BanMessage({
+      new BanLobbyPlayerMessageRecord({
         id: cuid(),
         time: Date.now(),
         name: player.name,
@@ -301,7 +247,7 @@ const chatHandlers = {
 
   [LOBBY_INIT_DATA](lobbyInfo, lastLobbyInfo, state, action) {
     return state.push(
-      new SelfJoinMessage({
+      new SelfJoinLobbyMessageRecord({
         id: cuid(),
         time: Date.now(),
         lobby: lobbyInfo.name,
@@ -312,7 +258,7 @@ const chatHandlers = {
 
   [LOBBY_UPDATE_HOST_CHANGE](lobbyInfo, lastLobbyInfo, state, action) {
     return state.push(
-      new HostChangeMessage({
+      new LobbyHostChangeMessageRecord({
         id: cuid(),
         time: Date.now(),
         name: lobbyInfo.host.name,
@@ -323,13 +269,13 @@ const chatHandlers = {
   [LOBBY_UPDATE_COUNTDOWN_START](lobbyInfo, lastLobbyInfo, state, action) {
     return state
       .push(
-        new CountdownStartedMessage({
+        new LobbyCountdownStartedMessageRecord({
           id: cuid(),
           time: Date.now(),
         }),
       )
       .push(
-        new CountdownTickMessage({
+        new LobbyCountdownTickMessageRecord({
           id: cuid(),
           time: Date.now(),
           timeLeft: lobbyInfo.countdownTimer,
@@ -339,7 +285,7 @@ const chatHandlers = {
 
   [LOBBY_UPDATE_COUNTDOWN_TICK](lobbyInfo, lastLobbyInfo, state, action) {
     return state.push(
-      new CountdownTickMessage({
+      new LobbyCountdownTickMessageRecord({
         id: cuid(),
         time: Date.now(),
         timeLeft: lobbyInfo.countdownTimer,
@@ -349,7 +295,7 @@ const chatHandlers = {
 
   [LOBBY_UPDATE_COUNTDOWN_CANCELED](lobbyInfo, lastLobbyInfo, state, action) {
     return state.push(
-      new CountdownCanceledMessage({
+      new LobbyCountdownCanceledMessageRecord({
         id: cuid(),
         time: Date.now(),
       }),
@@ -358,7 +304,7 @@ const chatHandlers = {
 
   [LOBBY_UPDATE_LOADING_CANCELED](lobbyInfo, lastLobbyInfo, state, action) {
     return state.push(
-      new LoadingCanceledMessage({
+      new LobbyLoadingCanceledMessageRecord({
         id: cuid(),
         time: Date.now(),
       }),

--- a/client/lobbies/lobby.tsx
+++ b/client/lobbies/lobby.tsx
@@ -1,5 +1,4 @@
 import { List } from 'immutable'
-import PropTypes from 'prop-types'
 import React from 'react'
 import styled from 'styled-components'
 import {
@@ -155,7 +154,7 @@ const Countdown = styled.div`
   margin: 16px 0;
 `
 
-function renderChatMessages(msg: Message) {
+function renderChatMessage(msg: Message) {
   switch (msg.type) {
     case LobbyMessageType.JoinLobby:
       return <JoinLobbyMessage key={msg.id} time={msg.time} name={msg.name} />
@@ -183,7 +182,7 @@ function renderChatMessages(msg: Message) {
 }
 
 interface LobbyProps {
-  lobby: typeof LobbyInfo
+  lobby: ReturnType<typeof LobbyInfo>
   chat: List<Message>
   user: SelfUserRecord
   isFavoritingMap: boolean
@@ -204,28 +203,7 @@ interface LobbyProps {
 }
 
 export default class Lobby extends React.Component<LobbyProps> {
-  static propTypes = {
-    lobby: PropTypes.object.isRequired,
-    chat: PropTypes.object.isRequired,
-    user: PropTypes.object,
-    isFavoritingMap: PropTypes.bool,
-    onLeaveLobbyClick: PropTypes.func,
-    onSetRace: PropTypes.func,
-    onAddComputer: PropTypes.func,
-    onSendChatMessage: PropTypes.func,
-    onSwitchSlot: PropTypes.func,
-    onOpenSlot: PropTypes.func,
-    onCloseSlot: PropTypes.func,
-    onKickPlayer: PropTypes.func,
-    onBanPlayer: PropTypes.func,
-    onMakeObserver: PropTypes.func,
-    onRemoveObserver: PropTypes.func,
-    onMapPreview: PropTypes.func,
-    onToggleFavoriteMap: PropTypes.func,
-    onStartGame: PropTypes.func,
-  }
-
-  getTeamSlots(team: typeof Team, isObserver: boolean, isLobbyUms: boolean) {
+  getTeamSlots(team: ReturnType<typeof Team>, isObserver: boolean, isLobbyUms: boolean) {
     const {
       lobby,
       user,
@@ -246,7 +224,7 @@ export default class Lobby extends React.Component<LobbyProps> {
     const canRemoveObsSlots = canRemoveObservers(lobby)
 
     return team.slots
-      .map((slot: typeof Slot) => {
+      .map((slot: ReturnType<typeof Slot>) => {
         const { type, name, race, id, controlledBy } = slot
         switch (type) {
           case 'open':
@@ -258,11 +236,11 @@ export default class Lobby extends React.Component<LobbyProps> {
                 isObserver={isObserver}
                 canMakeObserver={!isObserver && canAddObsSlots && team.slots.size > 1}
                 canRemoveObserver={isObserver && canRemoveObsSlots}
-                onAddComputer={!isLobbyUms && onAddComputer ? () => onAddComputer(id) : undefined}
-                onSwitchClick={onSwitchSlot ? () => onSwitchSlot(id) : undefined}
-                onCloseSlot={onCloseSlot ? () => onCloseSlot(id) : undefined}
-                onMakeObserver={onMakeObserver ? () => onMakeObserver(id) : undefined}
-                onRemoveObserver={onRemoveObserver ? () => onRemoveObserver(id) : undefined}
+                onAddComputer={!isLobbyUms ? () => onAddComputer(id) : undefined}
+                onSwitchClick={() => onSwitchSlot(id)}
+                onCloseSlot={() => onCloseSlot(id)}
+                onMakeObserver={() => onMakeObserver(id)}
+                onRemoveObserver={() => onRemoveObserver(id)}
               />
             )
           case 'closed':
@@ -274,10 +252,10 @@ export default class Lobby extends React.Component<LobbyProps> {
                 isObserver={isObserver}
                 canMakeObserver={!isObserver && canAddObsSlots && team.slots.size > 1}
                 canRemoveObserver={isObserver && canRemoveObsSlots}
-                onAddComputer={!isLobbyUms && onAddComputer ? () => onAddComputer(id) : undefined}
-                onOpenSlot={onOpenSlot ? () => onOpenSlot(id) : undefined}
-                onMakeObserver={onMakeObserver ? () => onMakeObserver(id) : undefined}
-                onRemoveObserver={onRemoveObserver ? () => onRemoveObserver(id) : undefined}
+                onAddComputer={!isLobbyUms ? () => onAddComputer(id) : undefined}
+                onOpenSlot={() => onOpenSlot(id)}
+                onMakeObserver={() => onMakeObserver(id)}
+                onRemoveObserver={() => onRemoveObserver(id)}
               />
             )
           case 'human':
@@ -290,12 +268,12 @@ export default class Lobby extends React.Component<LobbyProps> {
                 canSetRace={slot === mySlot && !slot.hasForcedRace}
                 canMakeObserver={canAddObsSlots && team.slots.size > 1}
                 hasSlotActions={slot !== mySlot}
-                onSetRace={onSetRace ? (race: RaceChar) => onSetRace(id, race) : undefined}
-                onOpenSlot={onOpenSlot ? () => onOpenSlot(id) : undefined}
-                onCloseSlot={onCloseSlot ? () => onCloseSlot(id) : undefined}
-                onKickPlayer={onKickPlayer ? () => onKickPlayer(id) : undefined}
-                onBanPlayer={onBanPlayer ? () => onBanPlayer(id) : undefined}
-                onMakeObserver={onMakeObserver ? () => onMakeObserver(id) : undefined}
+                onSetRace={(race: RaceChar) => onSetRace(id, race)}
+                onOpenSlot={() => onOpenSlot(id)}
+                onCloseSlot={() => onCloseSlot(id)}
+                onKickPlayer={() => onKickPlayer(id)}
+                onBanPlayer={() => onBanPlayer(id)}
+                onMakeObserver={() => onMakeObserver(id)}
               />
             )
           case 'observer':
@@ -307,11 +285,11 @@ export default class Lobby extends React.Component<LobbyProps> {
                 isObserver={true}
                 canRemoveObserver={isObserver && canRemoveObsSlots}
                 hasSlotActions={slot !== mySlot}
-                onOpenSlot={onOpenSlot ? () => onOpenSlot(id) : undefined}
-                onCloseSlot={onCloseSlot ? () => onCloseSlot(id) : undefined}
-                onKickPlayer={onKickPlayer ? () => onKickPlayer(id) : undefined}
-                onBanPlayer={onBanPlayer ? () => onBanPlayer(id) : undefined}
-                onRemoveObserver={onRemoveObserver ? () => onRemoveObserver(id) : undefined}
+                onOpenSlot={() => onOpenSlot(id)}
+                onCloseSlot={() => onCloseSlot(id)}
+                onKickPlayer={() => onKickPlayer(id)}
+                onBanPlayer={() => onBanPlayer(id)}
+                onRemoveObserver={() => onRemoveObserver(id)}
               />
             )
           case 'computer':
@@ -324,10 +302,10 @@ export default class Lobby extends React.Component<LobbyProps> {
                 canSetRace={isHost}
                 isHost={isHost}
                 hasSlotActions={true}
-                onSetRace={onSetRace ? (race: RaceChar) => onSetRace(id, race) : undefined}
-                onOpenSlot={onOpenSlot ? () => onOpenSlot(id) : undefined}
-                onCloseSlot={onCloseSlot ? () => onCloseSlot(id) : undefined}
-                onKickPlayer={onKickPlayer ? () => onKickPlayer(id) : undefined}
+                onSetRace={(race: RaceChar) => onSetRace(id, race)}
+                onOpenSlot={() => onOpenSlot(id)}
+                onCloseSlot={() => onCloseSlot(id)}
+                onKickPlayer={() => onKickPlayer(id)}
               />
             )
           case 'umsComputer':
@@ -340,9 +318,9 @@ export default class Lobby extends React.Component<LobbyProps> {
                 controlledOpen={true}
                 canSetRace={mySlot && controlledBy === mySlot.id}
                 isHost={isHost}
-                onSetRace={onSetRace ? (race: RaceChar) => onSetRace(id, race) : undefined}
-                onSwitchClick={onSwitchSlot ? () => onSwitchSlot(id) : undefined}
-                onCloseSlot={onCloseSlot ? () => onCloseSlot(id) : undefined}
+                onSetRace={(race: RaceChar) => onSetRace(id, race)}
+                onSwitchClick={() => onSwitchSlot(id)}
+                onCloseSlot={() => onCloseSlot(id)}
               />
             )
           case 'controlledClosed':
@@ -353,7 +331,7 @@ export default class Lobby extends React.Component<LobbyProps> {
                 controlledClosed={true}
                 canSetRace={mySlot && controlledBy === mySlot.id}
                 isHost={isHost}
-                onOpenSlot={onOpenSlot ? () => onOpenSlot(id) : undefined}
+                onOpenSlot={() => onOpenSlot(id)}
               />
             )
           default:
@@ -400,7 +378,7 @@ export default class Lobby extends React.Component<LobbyProps> {
             <RegularSlots>{slots}</RegularSlots>
             <ObserverSlots>{obsSlots}</ObserverSlots>
           </SlotsCard>
-          <StyledMessageList messages={this.props.chat} renderMessage={renderChatMessages} />
+          <StyledMessageList messages={this.props.chat} renderMessage={renderChatMessage} />
           <StyledMessageInput onSend={onSendChatMessage} />
         </Left>
         <Info>

--- a/client/lobbies/lobby.tsx
+++ b/client/lobbies/lobby.tsx
@@ -11,7 +11,7 @@ import {
   isUms,
 } from '../../common/lobbies'
 import { RaceChar } from '../../common/races'
-import { User } from '../auth/auth-records'
+import { SelfUserRecord } from '../auth/auth-records'
 import FavoritedIcon from '../icons/material/baseline-star-24px.svg'
 import UnfavoritedIcon from '../icons/material/baseline-star_border-24px.svg'
 import PreviewIcon from '../icons/material/zoom_in-24px.svg'
@@ -158,25 +158,25 @@ const Countdown = styled.div`
 function renderChatMessages(msg: Message) {
   switch (msg.type) {
     case LobbyMessageType.JoinLobby:
-      return <JoinLobbyMessage key={msg.id} record={msg} />
+      return <JoinLobbyMessage key={msg.id} time={msg.time} name={msg.name} />
     case LobbyMessageType.LeaveLobby:
-      return <LeaveLobbyMessage key={msg.id} record={msg} />
+      return <LeaveLobbyMessage key={msg.id} time={msg.time} name={msg.name} />
     case LobbyMessageType.KickLobbyPlayer:
-      return <KickLobbyPlayerMessage key={msg.id} record={msg} />
+      return <KickLobbyPlayerMessage key={msg.id} time={msg.time} name={msg.name} />
     case LobbyMessageType.BanLobbyPlayer:
-      return <BanLobbyPlayerMessage key={msg.id} record={msg} />
+      return <BanLobbyPlayerMessage key={msg.id} time={msg.time} name={msg.name} />
     case LobbyMessageType.SelfJoinLobby:
-      return <SelfJoinLobbyMessage key={msg.id} record={msg} />
+      return <SelfJoinLobbyMessage key={msg.id} time={msg.time} lobby={msg.lobby} host={msg.host} />
     case LobbyMessageType.LobbyHostChange:
-      return <LobbyHostChangeMessage key={msg.id} record={msg} />
+      return <LobbyHostChangeMessage key={msg.id} time={msg.time} name={msg.name} />
     case LobbyMessageType.LobbyCountdownStarted:
-      return <LobbyCountdownStartedMessage key={msg.id} record={msg} />
+      return <LobbyCountdownStartedMessage key={msg.id} time={msg.time} />
     case LobbyMessageType.LobbyCountdownTick:
-      return <LobbyCountdownTickMessage key={msg.id} record={msg} />
+      return <LobbyCountdownTickMessage key={msg.id} time={msg.time} timeLeft={msg.timeLeft} />
     case LobbyMessageType.LobbyCountdownCanceled:
-      return <LobbyCountdownCanceledMessage key={msg.id} record={msg} />
+      return <LobbyCountdownCanceledMessage key={msg.id} time={msg.time} />
     case LobbyMessageType.LobbyLoadingCanceled:
-      return <LobbyLoadingCanceledMessage key={msg.id} record={msg} />
+      return <LobbyLoadingCanceledMessage key={msg.id} time={msg.time} />
     default:
       return null
   }
@@ -185,7 +185,7 @@ function renderChatMessages(msg: Message) {
 interface LobbyProps {
   lobby: typeof LobbyInfo
   chat: List<Message>
-  user: typeof User
+  user: SelfUserRecord
   isFavoritingMap: boolean
   onLeaveLobbyClick: () => void
   onSetRace: (slotId: string, race: RaceChar) => void
@@ -400,7 +400,7 @@ export default class Lobby extends React.Component<LobbyProps> {
             <RegularSlots>{slots}</RegularSlots>
             <ObserverSlots>{obsSlots}</ObserverSlots>
           </SlotsCard>
-          <StyledMessageList messages={this.props.chat} renderMessages={renderChatMessages} />
+          <StyledMessageList messages={this.props.chat} renderMessage={renderChatMessages} />
           <StyledMessageInput onSend={onSendChatMessage} />
         </Left>
         <Info>

--- a/client/messaging/message-layout.jsx
+++ b/client/messaging/message-layout.jsx
@@ -59,14 +59,14 @@ const Timestamp = styled.span`
   text-align: right;
 `
 
-export const ChatTimestamp = props => (
+export const MessageTimestamp = props => (
   <Timestamp title={longTimestamp.format(props.time)}>
     <Separator aria-hidden={true}>[</Separator>
     {getLocalTime(new Date(props.time))}
     <Separator aria-hidden={true}>] </Separator>
   </Timestamp>
 )
-ChatTimestamp.propTypes = {
+MessageTimestamp.propTypes = {
   time: PropTypes.number.isRequired,
 }
 
@@ -91,15 +91,15 @@ const MessageContainer = styled.div`
   text-indent: -72px;
 `
 
-export const ChatMessageLayout = props => {
+export const TimestampMessageLayout = props => {
   return (
     <MessageContainer className={props.className} role='document'>
-      <ChatTimestamp time={props.time} />
+      <MessageTimestamp time={props.time} />
       {props.children}
     </MessageContainer>
   )
 }
-ChatMessageLayout.propTypes = {
+TimestampMessageLayout.propTypes = {
   time: PropTypes.number.isRequired,
   className: PropTypes.string,
 }
@@ -139,11 +139,11 @@ export class TextMessageDisplay extends React.Component {
     const { user, time, text } = this.props
 
     return (
-      <ChatMessageLayout time={time}>
+      <TimestampMessageLayout time={time}>
         <Username>{user}</Username>
         <Separator aria-hidden={true}>{': '}</Separator>
         <Text>{text}</Text>
-      </ChatMessageLayout>
+      </TimestampMessageLayout>
     )
   }
 }

--- a/client/messaging/message-list.tsx
+++ b/client/messaging/message-list.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components'
 import { animationFrameHandler } from '../material/animation-frame-handler'
 import LoadingIndicator from '../progress/dots'
 import { TextMessageDisplay } from './message-layout'
-import { CommonMessage, CommonMessageType, Message } from './message-records'
+import { CommonMessageType, Message } from './message-records'
 
 /**
  * How many pixels a user can be away from the bottom of the scrollable area and still be
@@ -178,10 +178,7 @@ export default class MessageList extends React.Component<
         {needsLoadingArea ? (
           <LoadingArea>{this.props.loading ? <LoadingIndicator /> : null}</LoadingArea>
         ) : null}
-        <PureMessageList
-          messages={this.props.messages}
-          renderMessage={this.props.renderMessage}
-        />
+        <PureMessageList messages={this.props.messages} renderMessage={this.props.renderMessage} />
       </Scrollable>
     )
   }

--- a/client/messaging/message-list.tsx
+++ b/client/messaging/message-list.tsx
@@ -49,7 +49,7 @@ function renderCommonMessage(msg: Message) {
 }
 
 const handleUnknown = (msg: Message) => {
-  throw new Error('Trying to render unknown message type: ' + msg.type)
+  return null
 }
 
 // This contains just the messages, to avoid needing to re-render them all if e.g. loading state

--- a/client/messaging/message-records.ts
+++ b/client/messaging/message-records.ts
@@ -1,19 +1,21 @@
 import { Record } from 'immutable'
+import { ChatMessage } from '../chat/chat-message-records'
+import { LobbyMessage } from '../lobbies/lobby-message-records'
 
-export enum ChatMessageType {
+/**
+ * NOTE(2Pac): A common message type that's used in all messaging-related services (e.g. chat,
+ * whispers, lobbies, parties, etc.). For now that's only a default text message, but there might be
+ * more in the future. All other message types that are specific to a particular service are defined
+ * in their respective folders.
+ */
+export enum CommonMessageType {
   TextMessage = 'message',
-  JoinChannel = 'joinChannel',
-  LeaveChannel = 'leaveChannel',
-  NewChannelOwner = 'newOwner',
-  SelfJoinChannel = 'selfJoinChannel',
-  UserOnline = 'userOnline',
-  UserOffline = 'userOffline',
 }
 
 /**
- * The base fields for all chat messages. Any added messages should implement this.
+ * The base fields for all messages. Any added messages should implement this.
  */
-interface BaseChatMessage {
+export interface BaseMessage {
   readonly id: string
   readonly type: string
   readonly time: number
@@ -21,55 +23,15 @@ interface BaseChatMessage {
 
 // TODO(tec27): Write a function or something to declare just the extra parts + do the correct
 // typing of the type field automatically.
-export class TextMessage
+export class TextMessageRecord
   extends Record({
     id: '',
-    type: ChatMessageType.TextMessage as typeof ChatMessageType.TextMessage,
+    type: CommonMessageType.TextMessage,
     time: 0,
     from: '',
     text: '',
   })
-  implements BaseChatMessage {}
+  implements BaseMessage {}
 
-export class JoinChannelMessage
-  extends Record({
-    id: '',
-    type: ChatMessageType.JoinChannel as typeof ChatMessageType.JoinChannel,
-    time: 0,
-    user: '',
-  })
-  implements BaseChatMessage {}
-
-export class LeaveChannelMessage
-  extends Record({
-    id: '',
-    type: ChatMessageType.LeaveChannel as typeof ChatMessageType.LeaveChannel,
-    time: 0,
-    user: '',
-  })
-  implements BaseChatMessage {}
-
-export class NewChannelOwnerMessage
-  extends Record({
-    id: '',
-    type: ChatMessageType.NewChannelOwner as typeof ChatMessageType.NewChannelOwner,
-    time: 0,
-    newOwner: '',
-  })
-  implements BaseChatMessage {}
-
-export class SelfJoinChannelMessage
-  extends Record({
-    id: '',
-    type: ChatMessageType.SelfJoinChannel as typeof ChatMessageType.SelfJoinChannel,
-    time: 0,
-    channel: '',
-  })
-  implements BaseChatMessage {}
-
-export type ChatMessage =
-  | TextMessage
-  | JoinChannelMessage
-  | LeaveChannelMessage
-  | NewChannelOwnerMessage
-  | SelfJoinChannelMessage
+export type CommonMessage = TextMessageRecord
+export type Message = CommonMessage | ChatMessage | LobbyMessage

--- a/client/messaging/message-records.ts
+++ b/client/messaging/message-records.ts
@@ -3,10 +3,9 @@ import { ChatMessage } from '../chat/chat-message-records'
 import { LobbyMessage } from '../lobbies/lobby-message-records'
 
 /**
- * NOTE(2Pac): A common message type that's used in all messaging-related services (e.g. chat,
- * whispers, lobbies, parties, etc.). For now that's only a default text message, but there might be
- * more in the future. All other message types that are specific to a particular service are defined
- * in their respective folders.
+ * A common message type that's used in all messaging-related services (e.g. chat, whispers,
+ * lobbies, parties, etc.). All other message types that are specific to a particular service are
+ * defined in their respective folders.
  */
 export enum CommonMessageType {
   TextMessage = 'message',
@@ -26,7 +25,7 @@ export interface BaseMessage {
 export class TextMessageRecord
   extends Record({
     id: '',
-    type: CommonMessageType.TextMessage,
+    type: CommonMessageType.TextMessage as typeof CommonMessageType.TextMessage,
     time: 0,
     from: '',
     text: '',

--- a/client/react-extra-hooks.ts
+++ b/client/react-extra-hooks.ts
@@ -1,0 +1,24 @@
+import { useEffect, useRef } from 'react'
+
+// This file contains hooks that should really be a part of the react itself, but for some reason
+// aren't. At least not yet.
+
+/**
+ * A hook to access the previous value of some variable inside a functional component. Can be used
+ * for both props and state.
+ *
+ * @example
+ *
+ * export const CounterComponent = () => {
+ *   const [count, setCount] = useState(0)
+ *   const prevCount = usePrevious(count)
+ *   return <div>Now: {count}, before: {prevCount}</div>
+ * }
+ */
+export const usePrevious = <T>(value: T): T | undefined => {
+  const ref = useRef<T>()
+  useEffect(() => {
+    ref.current = value
+  })
+  return ref.current
+}

--- a/client/state-hooks.ts
+++ b/client/state-hooks.ts
@@ -1,8 +1,5 @@
 import { useEffect, useRef } from 'react'
 
-// This file contains hooks that should really be a part of the react itself, but for some reason
-// aren't. At least not yet.
-
 /**
  * A hook to access the previous value of some variable inside a functional component. Can be used
  * for both props and state.
@@ -15,7 +12,7 @@ import { useEffect, useRef } from 'react'
  *   return <div>Now: {count}, before: {prevCount}</div>
  * }
  */
-export const usePrevious = <T>(value: T): T | undefined => {
+export function usePrevious<T>(value: T): T | undefined {
   const ref = useRef<T>()
   useEffect(() => {
     ref.current = value

--- a/client/whispers/whisper-reducer.js
+++ b/client/whispers/whisper-reducer.js
@@ -15,7 +15,7 @@ import {
   WHISPERS_UPDATE_USER_OFFLINE,
   NETWORK_SITE_CONNECTED,
 } from '../actions'
-import { TextMessage } from '../messaging/message-records'
+import { TextMessageRecord } from '../messaging/message-records'
 
 // How many messages should be kept for inactive channels
 const INACTIVE_CHANNEL_MAX_HISTORY = 150
@@ -106,7 +106,7 @@ export default keyedReducer(new WhisperState(), {
   [WHISPERS_UPDATE_MESSAGE](state, action) {
     const { id, time, from, to, message } = action.payload
     const target = state.sessions.has(from) ? from : to
-    const newMessage = new TextMessage({
+    const newMessage = new TextMessageRecord({
       id,
       time,
       from,
@@ -158,7 +158,7 @@ export default keyedReducer(new WhisperState(), {
     const newMessages = new List(
       action.payload.map(
         msg =>
-          new TextMessage({
+          new TextMessageRecord({
             id: msg.id,
             time: msg.sent,
             from: msg.from,


### PR DESCRIPTION
This is the first (out of many I'm sure) steps that refactors the chat
stuff to make it more organized and with less repetitions. This PR
organizes and refactors a bunch of stuff related to message types.

The idea was simple:
  - Everything that is common to all messaging-related services (chat,
    whispers, lobbies, parties) should go in the "messaging" folder
  - Everything else that's specific to a particular message service goes
    in their respective folders

So related to the message types, in the messaging folder there's only
basic text message type defined that's used in all the services, while
chat and lobbies (whispers don't have any yet) specific message types
are defined in their own folder.

Besides definition of message types, this PR applies the same principle
for messages layout as well. Now each messaging-related service is in
charge of rendering its own messages. `MessageList` component has been
extended with an additional property which allows its users to define
how to render their message, with `MessageList` only rendering the
common message types (e.g. text message).

Lobby has been refactored to take advantage of this new setup.