### PR TITLE
Add underline to activity buttons

### DIFF
--- a/client/activities/activity-button.tsx
+++ b/client/activities/activity-button.tsx
@@ -169,24 +169,24 @@ export const ActivityButton = React.memo(
         },
         [disabled, hotkey, onClick],
       )
-      const getLabelJsx = useMemo(() => {
+      const labelElems = useMemo(() => {
         if (disabled || !hotkey) {
           return label
         }
 
         const hotkeyString = String.fromCharCode(hotkey.keyCode).toLowerCase()
-        const labelJsx = []
+        const result = []
         let hasFoundHotkeyChar = false
         for (const char of label) {
           if (!hasFoundHotkeyChar && char.toLowerCase() === hotkeyString) {
-            labelJsx.push(<u key={char}>{char}</u>)
+            result.push(<u key={char}>{char}</u>)
             hasFoundHotkeyChar = true
           } else {
-            labelJsx.push(char)
+            result.push(char)
           }
         }
 
-        return labelJsx
+        return result
       }, [disabled, hotkey, label])
 
       return (
@@ -197,7 +197,7 @@ export const ActivityButton = React.memo(
             {glowing ? icon : null}
             {icon}
           </IconContainer>
-          <Label>{getLabelJsx}</Label>
+          <Label>{labelElems}</Label>
           <Ripple ref={rippleRef} disabled={disabled} />
         </Container>
       )

--- a/client/activities/activity-button.tsx
+++ b/client/activities/activity-button.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef } from 'react'
+import React, { useCallback, useMemo, useRef } from 'react'
 import styled, { css, keyframes } from 'styled-components'
 import KeyListener from '../keyboard/key-listener'
 import { useButtonState } from '../material/button'
@@ -169,6 +169,25 @@ export const ActivityButton = React.memo(
         },
         [disabled, hotkey, onClick],
       )
+      const getLabelJsx = useMemo(() => {
+        if (disabled || !hotkey) {
+          return label
+        }
+
+        const hotkeyString = String.fromCharCode(hotkey.keyCode).toLowerCase()
+        const labelJsx = []
+        let hasFoundHotkeyChar = false
+        for (const char of label) {
+          if (!hasFoundHotkeyChar && char.toLowerCase() === hotkeyString) {
+            labelJsx.push(<u key={char}>{char}</u>)
+            hasFoundHotkeyChar = true
+          } else {
+            labelJsx.push(char)
+          }
+        }
+
+        return labelJsx
+      }, [disabled, hotkey, label])
 
       return (
         <Container ref={setRefs} {...buttonProps}>
@@ -178,7 +197,7 @@ export const ActivityButton = React.memo(
             {glowing ? icon : null}
             {icon}
           </IconContainer>
-          <Label>{label}</Label>
+          <Label>{getLabelJsx}</Label>
           <Ripple ref={rippleRef} disabled={disabled} />
         </Container>
       )


### PR DESCRIPTION
Fixes #532 

Underlines the first character of the label that matches its hotkey button.
Always shows, even if its modifier key is not pressed.

Preview: 
![activity-buttons-underlined](https://user-images.githubusercontent.com/43507279/119247941-5fde0e80-bb53-11eb-9953-d99bd17c07b0.png)
