### PR TITLE
Make missing filepath error more clear

### DIFF
--- a/client/file-browser/get-files.js
+++ b/client/file-browser/get-files.js
@@ -2,7 +2,16 @@ import { promises as fsPromises } from 'fs'
 import path from 'path'
 
 export default async function readFolder(folderPath) {
-  const names = await fsPromises.readdir(folderPath)
+  let names
+  try {
+    names = await fsPromises.readdir(folderPath)
+  } catch (err) {
+    if (err.code === 'ENOENT') {
+      throw new Error('Filepath ' + folderPath + " doesn't exist")
+    }
+    throw err
+  }
+
   const stats = await Promise.all(
     names.map(async name => {
       const targetPath = path.join(folderPath, name)


### PR DESCRIPTION
Closes https://github.com/ShieldBattery/ShieldBattery/issues/239. I figured the improved logging route would be better since this would effect more than looking up replays (I think) and on a good broodwar install the folder should be there anyway. 
![missing-replays](https://user-images.githubusercontent.com/3045409/120090875-f7071100-c0d3-11eb-9a8c-548d93c6af3c.PNG)

