### PR TITLE
Kills server on bad redis connection

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -17,6 +17,7 @@ import logMiddleware from './lib/logging/log-middleware'
 import log from './lib/logging/logger'
 import userIpsMiddleware from './lib/network/user-ips-middleware'
 import { RallyPointService } from './lib/rally-point/rally-point-service'
+import redis from './lib/redis'
 import checkOrigin from './lib/security/check-origin'
 import { cors } from './lib/security/cors'
 import secureHeaders from './lib/security/headers'
@@ -154,6 +155,21 @@ const rallyPointInitPromise = rallyPointService.initialize(
     )
     app.use(koaConvert(koaWebpackHot(getWebpackCompiler())))
   }
+
+  log.info('Testing connection to redis.')
+  try {
+    await redis.ping()
+  } catch (err) {
+    log.error(
+      { err },
+      'Could not connect to Redis instance, redis host/port configuration may be incorrect',
+    )
+    process.exit(1)
+  }
+
+  redis.on('error', err => {
+    log.error({ err }, 'redis error')
+  })
 
   fileStoreMiddleware(app)
 


### PR DESCRIPTION
If you have a bad redis password or host, you'll see the log message without any other indication of failure. 

```
{"level":30,"time":1622497667609,"pid":18068,"hostname":"DESKTOP-8GER2KL","req":{"id":"ckpd57vxc0002xwuxcvya3agl","method":"GET","url":"/__webpack_hmr","headers":{"host":"localhost:5555","user-agent":"Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:88.0) Gecko/20100101 Firefox/88.0","accept":"text/event-stream","accept-language":"en-US,en;q=0.5","accept-e
ncoding":"gzip, deflate","connection":"keep-alive","referer":"http://localhost:5555/ladder","cookie":"s=ckpa49sxs001o1suxcaiz0h49; s.sig=4sSvYlKGhsYLrBQm-RfWH0zT4C8","pragma":"no-cache","cache-control":"no-cache"}},"res":{"statusCode":500},"err":{"type":"Error","message":"failed with status code 500","stack":"Error: failed with status code 500\n    at
ServerResponse.onResFinished (C:\\Users\\willi\\Code\\ShieldBattery\\node_modules\\pino-http\\logger.js:73:38)\n    at ServerResponse.emit (events.js:388:22)\n    at ServerResponse.emit (domain.js:470:12)\n    at onFinish (_http_outgoing.js:792:10)\n    at callback (internal/streams/writable.js:513:21)\n    at afterWrite (internal/streams/writable.js:4
66:5)\n    at afterWriteTick (internal/streams/writable.js:453:10)\n    at processTicksAndRejections (internal/process/task_queues.js:81:21)"},"responseTime":952,"msg":"request errored"}
{"level":30,"time":1622497667613,"pid":18068,"hostname":"DESKTOP-8GER2KL","reqId":"ckpd57wnx0003xwuxc1uy8xdt","req":{"method":"GET","url":"/engine.io/?clientId=ckpcqf19h00004f67peod6yp9&EIO=4&transport=polling&t=Nd4PQeQ","headers":{"host":"localhost:5555","connection":"keep-alive","accept":"*/*","x-shield-battery-client":"true","user-agent":"Mozilla/5.
0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) ShieldBattery-Local/7.0.12 Chrome/91.0.4472.69 Electron/13.0.1 Safari/537.36","origin":"shieldbattery://app","sec-fe
```

Some context on ioredis error handling https://github.com/luin/ioredis/issues/68. 

I'm worried this might be an over correction, since this will bomb out the server without retrying if there is a transient ENOTFOUND or ECONNREFUSED. Although i really don't know how common that is. 


A few other approaches i thought of are 

Just adding a log message like so, and then relying on external monitoring of redis health in production if that becomes necessary. 
```
redis.on('error', err => {
  console.log(err)
})
```

Or logging the error, building a slightly more comprehensive client that'll track if it's initial startup and fail hard then, and otherwise rely on logging. 

I've been staring at the ioredis docs and code a bit but i can't find a knob to turn that'll say something like throw and error after 30 seconds of failed requests or something like that. We could do that per client call, but we don't have full control over that in the case of the session-store and it'd be pretty annoying to have to remember to do that everywhere. 

