### PR TITLE
Move the user sockets to use primarily `userId` instead of `userName`.

### DIFF
--- a/server/lib/api/bans.js
+++ b/server/lib/api/bans.js
@@ -65,7 +65,7 @@ async function banUser(ctx, next, userSockets) {
   await Promise.all(deletions)
   const keyDeletion = redis.del(userSessionsKey)
 
-  const sockets = userSockets.getByName(user.name)
+  const sockets = userSockets.getById(userId)
   if (sockets) {
     sockets.closeAll()
   }

--- a/server/lib/chat/chat-api.ts
+++ b/server/lib/chat/chat-api.ts
@@ -127,7 +127,7 @@ function joinChannel(ctx: RouterContext) {
   const channelName = getValidatedChannelName(ctx)
 
   const chatService = container.resolve(ChatService)
-  chatService.joinChannel(channelName, ctx.session!.userName)
+  chatService.joinChannel(channelName, ctx.session!.userId)
 
   ctx.status = 204
 }
@@ -136,7 +136,7 @@ function leaveChannel(ctx: RouterContext) {
   const channelName = getValidatedChannelName(ctx)
 
   const chatService = container.resolve(ChatService)
-  chatService.leaveChannel(channelName, ctx.session!.userName)
+  chatService.leaveChannel(channelName, ctx.session!.userId)
 
   ctx.status = 204
 }
@@ -152,7 +152,7 @@ function sendChatMessage(ctx: RouterContext) {
   })
 
   const chatService = container.resolve(ChatService)
-  chatService.sendChatMessage(channelName, ctx.session!.userName, message)
+  chatService.sendChatMessage(channelName, ctx.session!.userId, message)
 
   ctx.status = 204
 }
@@ -171,7 +171,7 @@ async function getChannelHistory(ctx: RouterContext) {
   const chatService = container.resolve(ChatService)
   ctx.body = await chatService.getChannelHistory(
     channelName,
-    ctx.session!.userName,
+    ctx.session!.userId,
     limit,
     beforeTime,
   )
@@ -181,5 +181,5 @@ async function getChannelUsers(ctx: RouterContext) {
   const channelName = getValidatedChannelName(ctx)
 
   const chatService = container.resolve(ChatService)
-  ctx.body = await chatService.getChannelUsers(channelName, ctx.session!.userName)
+  ctx.body = await chatService.getChannelUsers(channelName, ctx.session!.userId)
 }

--- a/server/lib/chat/chat-service.ts
+++ b/server/lib/chat/chat-service.ts
@@ -51,8 +51,8 @@ export default class ChatService {
     private userSocketsManager: UserSocketsManager,
   ) {
     userSocketsManager
-      .on('newUser', (userSockets: UserSocketsGroup) => this.handleNewUser(userSockets))
-      .on('userQuit', (userId: number) => this.handleUserQuit(userId))
+      .on('newUser', userSockets => this.handleNewUser(userSockets))
+      .on('userQuit', userId => this.handleUserQuit(userId))
   }
 
   async joinChannel(channelName: string, userId: number) {

--- a/server/lib/chat/chat-service.ts
+++ b/server/lib/chat/chat-service.ts
@@ -1,8 +1,8 @@
 import { Map, Record, Set } from 'immutable'
-import { NydusServer } from 'nydus'
 import { singleton } from 'tsyringe'
 import { ChatEvent, ChatInitEvent, ChatMessage, ChatUser } from '../../../common/chat'
 import filterChatMessage from '../messaging/filter-chat-message'
+import users from '../models/users'
 import { UserSocketsGroup, UserSocketsManager } from '../websockets/socket-groups'
 import { TypedPublisher } from '../websockets/typed-publisher'
 import {
@@ -48,16 +48,15 @@ export default class ChatService {
 
   constructor(
     private publisher: TypedPublisher<ChatEvent>,
-    private nydus: NydusServer,
     private userSocketsManager: UserSocketsManager,
   ) {
     userSocketsManager
       .on('newUser', (userSockets: UserSocketsGroup) => this.handleNewUser(userSockets))
-      .on('userQuit', (userName: string) => this.handleUserQuit(userName))
+      .on('userQuit', (userId: number) => this.handleUserQuit(userId))
   }
 
-  async joinChannel(channelName: string, userName: string) {
-    const userSockets = this.getUserSockets(userName)
+  async joinChannel(channelName: string, userId: number) {
+    const userSockets = this.getUserSockets(userId)
     const originalChannelName = await this.getOriginalChannelName(channelName)
     if (
       this.state.users.has(userSockets.name) &&
@@ -69,18 +68,18 @@ export default class ChatService {
     await addUserToChannel(userSockets.session.userId, originalChannelName)
 
     this.state = this.state
-      .updateIn(['channels', originalChannelName], (s = Set()) => s.add(userName))
-      .updateIn(['users', userName], (s = Set()) => s.add(originalChannelName))
+      .updateIn(['channels', originalChannelName], (s = Set()) => s.add(userSockets.name))
+      .updateIn(['users', userSockets.name], (s = Set()) => s.add(originalChannelName))
 
     this.publisher.publish(getChannelPath(originalChannelName), {
       action: 'join',
-      user: userName,
+      user: userSockets.name,
     })
     this.subscribeUserToChannel(userSockets, originalChannelName)
   }
 
-  async leaveChannel(channelName: string, userName: string) {
-    const userSockets = this.getUserSockets(userName)
+  async leaveChannel(channelName: string, userId: number) {
+    const userSockets = this.getUserSockets(userId)
     const originalChannelName = await this.getOriginalChannelName(channelName)
     if (originalChannelName === 'ShieldBattery') {
       throw new ChatServiceError(
@@ -115,8 +114,8 @@ export default class ChatService {
     this.unsubscribeUserFromChannel(userSockets, originalChannelName)
   }
 
-  async sendChatMessage(channelName: string, userName: string, message: string) {
-    const userSockets = this.getUserSockets(userName)
+  async sendChatMessage(channelName: string, userId: number, message: string) {
+    const userSockets = this.getUserSockets(userId)
     const originalChannelName = await this.getOriginalChannelName(channelName)
     // TODO(tec27): lookup channel keys case insensitively?
     if (
@@ -146,11 +145,11 @@ export default class ChatService {
 
   async getChannelHistory(
     channelName: string,
-    userName: string,
+    userId: number,
     limit?: number,
     beforeTime?: number,
   ): Promise<ChatMessage[]> {
-    const userSockets = this.getUserSockets(userName)
+    const userSockets = this.getUserSockets(userId)
     const originalChannelName = await this.getOriginalChannelName(channelName)
     // TODO(tec27): lookup channel keys case insensitively?
     if (
@@ -177,8 +176,8 @@ export default class ChatService {
     }))
   }
 
-  async getChannelUsers(channelName: string, userName: string): Promise<ChatUser[]> {
-    const userSockets = this.getUserSockets(userName)
+  async getChannelUsers(channelName: string, userId: number): Promise<ChatUser[]> {
+    const userSockets = this.getUserSockets(userId)
     const originalChannelName = await this.getOriginalChannelName(channelName)
     if (
       !this.state.users.has(userSockets.name) ||
@@ -202,8 +201,8 @@ export default class ChatService {
     return foundChannel ? foundChannel.name : channelName
   }
 
-  private getUserSockets(userName: string): UserSocketsGroup {
-    const userSockets = this.userSocketsManager.getByName(userName)
+  private getUserSockets(userId: number): UserSocketsGroup {
+    const userSockets = this.userSocketsManager.getById(userId)
     if (!userSockets) {
       throw new ChatServiceError(ChatServiceErrorCode.UserOffline, 'User is offline')
     }
@@ -246,7 +245,14 @@ export default class ChatService {
     userSockets.subscribe(`${userSockets.getPath()}/chat`, () => ({ type: 'chatReady' }))
   }
 
-  private async handleUserQuit(userName: string) {
+  private async handleUserQuit(userId: number) {
+    // TODO(2Pac): Remove this once internal chat structures have been moved to use `userId`.
+    const foundUser = await users.find(userId)
+    if (!foundUser) {
+      return
+    }
+    const { name: userName } = foundUser
+
     if (!this.state.users.has(userName)) {
       // This can happen if a user disconnects before we get their channel list back from the DB
       return

--- a/server/lib/models/whispers.js
+++ b/server/lib/models/whispers.js
@@ -4,12 +4,15 @@ export async function getWhisperSessionsForUser(userId) {
   const { client, done } = await db()
   try {
     const result = await client.query(
-      `SELECT u.name AS target_user FROM whisper_sessions
+      `SELECT u.name AS target_name, u.id AS target_id FROM whisper_sessions
         INNER JOIN users AS u ON target_user_id = u.id
         WHERE user_id = $1 ORDER BY start_date`,
       [userId],
     )
-    return result.rows.map(row => row.target_user)
+    return result.rows.map(row => ({
+      targetUserId: row.target_id,
+      targetUserName: row.target_name,
+    }))
   } finally {
     done()
   }

--- a/server/lib/parties/party-service.ts
+++ b/server/lib/parties/party-service.ts
@@ -115,7 +115,7 @@ export default class PartyService {
     }
 
     // TODO(2Pac): Send the invite notification once the server-side notification system is in.
-    const userSockets = this.userSocketsManager.getByName(invitedUser.name)
+    const userSockets = this.userSocketsManager.getById(invitedUser.id)
     if (userSockets) {
       userSockets.subscribe(
         getInvitesPath(party!.id, userSockets.userId),
@@ -228,7 +228,7 @@ export default class PartyService {
   private unsubscribeFromInvites(party: PartyRecord, user: PartyUser) {
     this.nydus.publish(getInvitesPath(party.id, user.id), { type: 'removeInvite' })
     // TODO(2Pac): Remove the invite notification once the server-side notification system is in.
-    const userSockets = this.userSocketsManager.getByName(user.name)
+    const userSockets = this.userSocketsManager.getById(user.id)
     if (userSockets) {
       userSockets.unsubscribe(getInvitesPath(party.id, user.id))
     }

--- a/server/lib/wsapi/lobbies.js
+++ b/server/lib/wsapi/lobbies.js
@@ -653,7 +653,7 @@ export class LobbyApi {
     }
 
     try {
-      const user = this.getUserByName(client.name)
+      const user = this.getUserById(client.userId)
       user.unsubscribe(LobbyApi._getUserPath(lobby, client.name))
     } catch {
       // Getting the user can fail if they've gone offline, but we don't need to unsubscribe
@@ -807,7 +807,7 @@ export class LobbyApi {
     getHumanSlots(lobby)
       .map(p => activityRegistry.getClientForUser(p.userId))
       .forEach(client => {
-        const user = this.getUserByName(client.name)
+        const user = this.getUserById(client.userId)
         this._publishToUser(lobby, user.name, {
           type: 'status',
           lobby: null,
@@ -868,8 +868,8 @@ export class LobbyApi {
     return user
   }
 
-  getUserByName(name) {
-    const user = this.userSockets.getByName(name)
+  getUserById(id) {
+    const user = this.userSockets.getById(id)
     if (!user) throw new errors.BadRequest('user not online')
     return user
   }

--- a/server/lib/wsapi/matchmaking.ts
+++ b/server/lib/wsapi/matchmaking.ts
@@ -496,7 +496,7 @@ export class MatchmakingApi {
       matchmaking: null,
     })
 
-    const user = this.userSockets.getByName(client.name)
+    const user = this.userSockets.getById(client.userId)
     if (user) {
       user.unsubscribe(MatchmakingApi.getUserPath(client.name))
     }


### PR DESCRIPTION
All other services have only been updated by a bare minimum to make them
work again. Subsequent PR(s) should update them to use the `userId`s as
well, to make things more internally consistent and easier to work with.