### PR TITLE
Handle pg syntax error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ app/styles/
 dist/
 node_modules/
 server/.env
+.idea/
 .env
 npm-debug.log
 yarn-error.log

--- a/server/lib/db/index.ts
+++ b/server/lib/db/index.ts
@@ -1,6 +1,7 @@
 import pg from 'pg'
 import { isTestRun } from '../../../common/is-test-run'
 import log from '../logging/logger'
+import handlePgError from './pg-error-handler'
 
 /**
  * The amount of time queries are allowed to run for before they are considered "slow" and logged
@@ -63,7 +64,9 @@ export class DbClient {
     const queryText = isQueryConfig(queryTextOrConfig) ? queryTextOrConfig.text : queryTextOrConfig
     const startTime = Date.now()
     try {
-      return this.wrappedClient.query(queryTextOrConfig, values)
+      return await this.wrappedClient.query(queryTextOrConfig, values)
+    } catch (error) {
+      throw handlePgError(queryText, error)
     } finally {
       const totalTime = Date.now() - startTime
       if (totalTime > SLOW_QUERY_TIME_MS) {

--- a/server/lib/db/pg-error-handler.ts
+++ b/server/lib/db/pg-error-handler.ts
@@ -1,0 +1,50 @@
+import { DatabaseError } from 'pg'
+import { SYNTAX_ERROR_OR_ACCESS_RULE_VIOLATION } from './pg-error-codes'
+
+export default function handlePgError(query: string, error: Error): Error {
+  if (
+    isDatabaseError(error) &&
+    error.code &&
+    getErrorClass(error.code) === getErrorClass(SYNTAX_ERROR_OR_ACCESS_RULE_VIOLATION)
+  ) {
+    return handlePgSyntaxError(query, error)
+  } else {
+    return error
+  }
+}
+
+function getErrorClass(code: string): string {
+  // By the standard, the first two character denote the class of error
+  // https://www.postgresql.org/docs/13/errcodes-appendix.html
+  return code.substring(0, 2)
+}
+
+function isDatabaseError(error: Error): error is DatabaseError {
+  return error.hasOwnProperty('code') && error.hasOwnProperty('position')
+}
+
+function handlePgSyntaxError(queryText: string, error: DatabaseError): Error {
+  const messageLines = queryText.split('\n')
+  const position = Number(error.position)
+
+  if (!isNaN(position)) {
+    let curLine = 0
+    let summedLength = 0
+    do {
+      summedLength += messageLines[curLine].length + 1 // 1 extra for the \n
+      curLine += 1
+    } while (curLine < messageLines.length && summedLength < position)
+
+    if (summedLength >= position) {
+      const foundLine = curLine - 1
+      const relativePosition = position - (summedLength - messageLines[foundLine].length)
+      const caretLine = '^'.padStart(relativePosition + 1)
+      messageLines.splice(curLine, 0, caretLine)
+    }
+  }
+
+  if (error.hint) {
+    messageLines.push(`hint: ${error.hint}`)
+  }
+  return new Error(`${error.message} in query: \n${messageLines.join('\n')}`)
+}


### PR DESCRIPTION
This is still a work in progress but wanted to share some work because I have some questions. 

1.) I've been googling everywhere and I can't find a way other than using something like https://www.npmjs.com/package/verror to get a full stack trace from where the query is made back to where it's parsed. I'm not sure if it's a super big deal though. 
2.) I kind of dislike relying on postgres' convention of using the first two values of the error code to show what class the error is. Would typing the errors by class, or building an enum of classes be overkill?  I don't think most error types will require a ton of customization 
3.) I was kind of thinking that hijacking the reject error of the Promise returned by the wrappedclient to do the parsing, and letting the caller handle it properly would be best, but I couldn't find a way to get to the error without the `.catch` on the promise in the db index file. I think I'm doing the correct thing but let me know since I'm still wrapping my head around nodes async model. 

Even on the off chance you all think everything is good, I still plan on incorporating the the `hint` value sometimes returned, and writing some unit tests for the error parsing. And I need to either pass long the rest of the pg error with my new error or be more opinionated to handle stuff like this https://github.com/ShieldBattery/ShieldBattery/blob/master/server/lib/api/users.js#L106-L110. 


p.s.. I can keep the .idea/ line in my personal git ignore if you like. I moved the pino config because that's what it said in the docs. 