### PR TITLE
Move the whispers stuff away from using usernames internally.

### DIFF
--- a/client/profile/user-reducer.ts
+++ b/client/profile/user-reducer.ts
@@ -93,4 +93,16 @@ export default immerKeyedReducer(DEFAULT_STATE, {
 
     updateUsers(state, action.payload.users)
   },
+
+  ['@whispers/loadMessageHistory'](state, action) {
+    if (action.error) {
+      return
+    }
+
+    updateUsers(state, action.payload.users)
+  },
+
+  ['@whispers/updateMessage'](state, action) {
+    updateUsers(state, action.payload.users)
+  },
 })

--- a/client/whispers/action-creators.ts
+++ b/client/whispers/action-creators.ts
@@ -1,4 +1,4 @@
-import { SendWhisperMessageServerBody, WhisperMessage } from '../../common/whispers'
+import { GetSessionHistoryServerPayload, SendWhisperMessageServerBody } from '../../common/whispers'
 import { ThunkAction } from '../dispatch-registry'
 import { push } from '../navigation/routing'
 import fetch from '../network/fetch'
@@ -75,7 +75,7 @@ export function getMessageHistory(target: string, limit: number): ThunkAction {
     })
     dispatch({
       type: '@whispers/loadMessageHistory',
-      payload: fetch<WhisperMessage[]>(
+      payload: fetch<GetSessionHistoryServerPayload>(
         apiUrl`whispers/${target}/messages?limit=${limit}&beforeTime=${earliestMessageTime}`,
         { method: 'GET' },
       ),

--- a/client/whispers/actions.ts
+++ b/client/whispers/actions.ts
@@ -1,4 +1,5 @@
-import { WhisperMessage, WhisperUser, WhisperUserStatus } from '../../common/whispers'
+import { User } from '../../common/users/user-info'
+import { GetSessionHistoryServerPayload, WhisperUserStatus } from '../../common/whispers'
 import { BaseFetchFailure } from '../network/fetch-action-types'
 
 export type WhisperActions =
@@ -124,7 +125,7 @@ export interface LoadMessageHistoryBegin {
  */
 export interface LoadMessageHistory {
   type: '@whispers/loadMessageHistory'
-  payload: WhisperMessage[]
+  payload: GetSessionHistoryServerPayload
   meta: {
     target: string
     limit: number
@@ -171,7 +172,7 @@ export interface DeactivateWhisperSession {
 export interface WhisperSessionInit {
   type: '@whispers/initSession'
   payload: {
-    target: WhisperUser
+    target: User
     targetStatus: WhisperUserStatus
   }
 }
@@ -182,7 +183,7 @@ export interface WhisperSessionInit {
 export interface WhisperSessionClose {
   type: '@whispers/closeSession'
   payload: {
-    target: WhisperUser
+    target: User
   }
 }
 
@@ -192,11 +193,14 @@ export interface WhisperSessionClose {
 export interface WhisperMessageUpdate {
   type: '@whispers/updateMessage'
   payload: {
-    id: string
-    time: number
-    from: WhisperUser
-    to: WhisperUser
-    message: string
+    message: {
+      id: string
+      time: number
+      from: User
+      to: User
+      text: string
+    }
+    users: User[]
   }
 }
 
@@ -206,7 +210,7 @@ export interface WhisperMessageUpdate {
 export interface WhisperUserActive {
   type: '@whispers/updateUserActive'
   payload: {
-    user: WhisperUser
+    user: User
   }
 }
 
@@ -216,7 +220,7 @@ export interface WhisperUserActive {
 export interface WhisperUserIdle {
   type: '@whispers/updateUserIdle'
   payload: {
-    user: WhisperUser
+    user: User
   }
 }
 
@@ -226,6 +230,6 @@ export interface WhisperUserIdle {
 export interface WhisperUserOffline {
   type: '@whispers/updateUserOffline'
   payload: {
-    user: WhisperUser
+    user: User
   }
 }

--- a/client/whispers/socket-handlers.ts
+++ b/client/whispers/socket-handlers.ts
@@ -31,16 +31,22 @@ const eventToAction: EventToActionMap = {
 
   message(event) {
     // Notify the main process of the new message, so it can display an appropriate notification
-    ipcRenderer.send('chatNewMessage', { user: event.from, message: event.data.text })
+    ipcRenderer.send('chatNewMessage', {
+      user: event.message.from.name,
+      message: event.message.data.text,
+    })
 
     return {
       type: '@whispers/updateMessage',
       payload: {
-        id: event.id,
-        time: event.sent,
-        from: event.from,
-        to: event.to,
-        message: event.data.text,
+        message: {
+          id: event.message.id,
+          time: event.message.sent,
+          from: event.message.from,
+          to: event.message.to,
+          text: event.message.data.text,
+        },
+        users: event.users,
       },
     }
   },

--- a/common/whispers.ts
+++ b/common/whispers.ts
@@ -1,3 +1,5 @@
+import { User } from './users/user-info'
+
 export enum WhisperMessageType {
   TextMessage = 'message',
 }
@@ -15,14 +17,11 @@ export type WhisperMessageData = WhisperTextMessageData
 
 export interface WhisperMessage {
   id: string
-  from: WhisperUser
-  to: WhisperUser
+  from: User
+  to: User
   sent: number
   data: WhisperMessageData
 }
-
-// TODO(2Pac): Make this into an interface and include more information here
-export type WhisperUser = string
 
 export enum WhisperUserStatus {
   Active = 'active',
@@ -32,32 +31,36 @@ export enum WhisperUserStatus {
 
 export interface WhisperSessionInitEvent {
   action: 'initSession'
-  target: WhisperUser
+  target: User
   targetStatus: WhisperUserStatus
 }
 
 export interface WhisperSessionCloseEvent {
   action: 'closeSession'
-  target: WhisperUser
+  target: User
 }
 
-export interface WhisperMessageUpdateEvent extends WhisperMessage {
+export interface WhisperMessageUpdateEvent {
   action: 'message'
+  /** A whisper message that was received. */
+  message: WhisperMessage
+  /** A list of user infos participating in the received message. */
+  users: User[]
 }
 
 export interface WhisperUserActiveEvent {
   action: 'userActive'
-  target: WhisperUser
+  target: User
 }
 
 export interface WhisperUserIdleEvent {
   action: 'userIdle'
-  target: WhisperUser
+  target: User
 }
 
 export interface WhisperUserOfflineEvent {
   action: 'userOffline'
-  target: WhisperUser
+  target: User
 }
 
 export type WhisperEvent =
@@ -70,4 +73,17 @@ export type WhisperEvent =
 
 export interface SendWhisperMessageServerBody {
   message: string
+}
+
+/**
+ * Payload returned for a request to retrieve the session history.
+ */
+export interface GetSessionHistoryServerPayload {
+  /**
+   * A list of messages for a particular whisper session. Note that this payload is paginated so not
+   * all of the messages are returned at once.
+   */
+  messages: WhisperMessage[]
+  /** A list of user infos participating in this whisper session. */
+  users: User[]
 }


### PR DESCRIPTION
Whispers are kind of in a weird place because we still want to use the
usernames in all the routing-related paths, which means it's still
preferable to use the usernames in various data structures (e.g. in the
reducer).

To be honest, we could probably get away with using usernames everywhere
(which makes this PR kinda useless huh), since we only need user IDs in
a couple of places, like in each whisper message.