### PR TITLE
Handle user changing a party.

### DIFF
--- a/client/parties/actions.ts
+++ b/client/parties/actions.ts
@@ -262,6 +262,7 @@ export interface UpdateLeave {
 export interface UpdateLeaveSelf {
   type: '@parties/updateLeaveSelf'
   payload: {
+    partyId: string
     time: number
   }
 }

--- a/client/parties/party-reducer.ts
+++ b/client/parties/party-reducer.ts
@@ -157,6 +157,12 @@ export default keyedReducer(new PartyRecord(), {
   },
 
   ['@parties/updateLeaveSelf'](state, action) {
+    const { partyId } = action.payload
+
+    if (partyId !== state.id) {
+      return state
+    }
+
     return new PartyRecord()
   },
 

--- a/client/parties/party-view.tsx
+++ b/client/parties/party-view.tsx
@@ -12,10 +12,9 @@ import { SlotActions } from '../lobbies/slot-actions'
 import { TextButton } from '../material/button'
 import Chat from '../messaging/chat'
 import { Message } from '../messaging/message-records'
-import { push } from '../navigation/routing'
+import { replace } from '../navigation/routing'
 import { urlPath } from '../network/urls'
 import { useAppDispatch, useAppSelector } from '../redux-hooks'
-import { usePrevious } from '../state-hooks'
 import { background700, background800 } from '../styles/colors'
 import { activateParty, deactivateParty, leaveParty, sendChatMessage } from './action-creators'
 import {
@@ -130,25 +129,29 @@ function renderPartyMessage(msg: Message) {
   }
 }
 
-export function PartyView() {
+interface PartyViewProps {
+  params: { partyId: string }
+}
+
+export function PartyView(props: PartyViewProps) {
   const dispatch = useAppDispatch()
   const party = useAppSelector(s => s.party)
   const partyId = party.id
-  const prevPartyId = usePrevious(partyId)
+  const routePartyId = decodeURIComponent(props.params.partyId)
   // Party can change when a user accepts an invite to a new party while already being a member of a
   // different party that is currently being rendered.
-  const partyChanged = !!prevPartyId && prevPartyId !== partyId
+  const partyChanged = routePartyId !== partyId
 
   useEffect(() => {
     const isInParty = !!partyId
 
     if (isInParty) {
       if (partyChanged) {
-        push(urlPath`/parties/${partyId}`)
+        replace(urlPath`/parties/${partyId}`)
       }
       dispatch(activateParty(partyId))
     } else {
-      push('/')
+      replace('/')
     }
 
     return () => dispatch(deactivateParty(partyId))

--- a/client/parties/party-view.tsx
+++ b/client/parties/party-view.tsx
@@ -149,8 +149,9 @@ export function PartyView(props: PartyViewProps) {
       // party view while you're in a different party.
       if (routePartyId !== partyId) {
         replace(urlPath`/parties/${partyId}`)
+      } else {
+        dispatch(activateParty(partyId))
       }
-      dispatch(activateParty(partyId))
     } else {
       replace('/')
     }

--- a/client/parties/party-view.tsx
+++ b/client/parties/party-view.tsx
@@ -138,15 +138,16 @@ export function PartyView(props: PartyViewProps) {
   const party = useAppSelector(s => s.party)
   const partyId = party.id
   const routePartyId = decodeURIComponent(props.params.partyId)
-  // Party can change when a user accepts an invite to a new party while already being a member of a
-  // different party that is currently being rendered.
-  const partyChanged = routePartyId !== partyId
 
   useEffect(() => {
     const isInParty = !!partyId
 
     if (isInParty) {
-      if (partyChanged) {
+      // The mismatch between the current URL and the party state can occur in a couple of ways. One
+      // is when a user accepts an invite to a new party while already being a member of a different
+      // party that is currently being rendered. Another way is that someone links to their own
+      // party view while you're in a different party.
+      if (routePartyId !== partyId) {
         replace(urlPath`/parties/${partyId}`)
       }
       dispatch(activateParty(partyId))
@@ -155,7 +156,7 @@ export function PartyView(props: PartyViewProps) {
     }
 
     return () => dispatch(deactivateParty(partyId))
-  }, [partyId, partyChanged, dispatch])
+  }, [partyId, routePartyId, dispatch])
 
   const onSendChatMessage = useCallback(
     (msg: string) => dispatch(sendChatMessage(partyId, msg)),

--- a/client/parties/socket-handlers.ts
+++ b/client/parties/socket-handlers.ts
@@ -82,6 +82,7 @@ const eventToAction: EventToActionMap = {
       dispatch({
         type: '@parties/updateLeaveSelf',
         payload: {
+          partyId,
           time,
         },
       })

--- a/server/lib/parties/party-service.test.ts
+++ b/server/lib/parties/party-service.test.ts
@@ -467,11 +467,12 @@ describe('parties/party-service', () => {
       })
 
       test('should publish "leave" message to the old party path', async () => {
-        await partyService.acceptInvite(newParty.id, user6, USER6_CLIENT_ID)
+        await partyService.acceptInvite(newParty.id, user6, USER6_CLIENT_ID, currentTime)
 
         expect(nydus.publish).toHaveBeenCalledWith(getPartyPath(oldParty.id), {
           type: 'leave',
           user: user6,
+          time: currentTime,
         })
       })
     })

--- a/server/lib/parties/party-service.test.ts
+++ b/server/lib/parties/party-service.test.ts
@@ -444,6 +444,37 @@ describe('parties/party-service', () => {
         ],
       })
     })
+
+    describe('when user was already in a party', () => {
+      let oldLeader: PartyUser
+      let oldParty: PartyRecord
+      let newLeader: PartyUser
+      let newParty: PartyRecord
+
+      beforeEach(async () => {
+        oldLeader = user4
+        oldParty = await partyService.invite(oldLeader, USER4_CLIENT_ID, user6)
+        await partyService.acceptInvite(oldParty.id, user6, USER6_CLIENT_ID)
+
+        newLeader = user5
+        newParty = await partyService.invite(newLeader, USER5_CLIENT_ID, user6)
+      })
+
+      test('should remove the user from the old party', async () => {
+        await partyService.acceptInvite(newParty.id, user6, USER6_CLIENT_ID)
+
+        expect(oldParty.members).toMatchObject(new Map([[oldLeader.id, oldLeader]]))
+      })
+
+      test('should publish "leave" message to the old party path', async () => {
+        await partyService.acceptInvite(newParty.id, user6, USER6_CLIENT_ID)
+
+        expect(nydus.publish).toHaveBeenCalledWith(getPartyPath(oldParty.id), {
+          type: 'leave',
+          user: user6,
+        })
+      })
+    })
   })
 
   describe('leaveParty', () => {

--- a/server/lib/parties/party-service.test.ts
+++ b/server/lib/parties/party-service.test.ts
@@ -466,8 +466,15 @@ describe('parties/party-service', () => {
         expect(oldParty.members).toMatchObject(new Map([[oldLeader.id, oldLeader]]))
       })
 
+      test('should remove the user from the new party on disconnect', async () => {
+        await partyService.acceptInvite(newParty.id, user6, USER6_CLIENT_ID)
+        client6.disconnect()
+
+        expect(newParty.members).toMatchObject(new Map([[newLeader.id, newLeader]]))
+      })
+
       test('should publish "leave" message to the old party path', async () => {
-        await partyService.acceptInvite(newParty.id, user6, USER6_CLIENT_ID, currentTime)
+        await partyService.acceptInvite(newParty.id, user6, USER6_CLIENT_ID)
 
         expect(nydus.publish).toHaveBeenCalledWith(getPartyPath(oldParty.id), {
           type: 'leave',

--- a/server/lib/parties/party-service.ts
+++ b/server/lib/parties/party-service.ts
@@ -242,7 +242,7 @@ export default class PartyService {
       // NOTE(2Pac): We're removing the user from an old party *after* we subscribe them to a new
       // one, to better represent a party change. This way the client won't have a brief period of
       // being in no party, which can change the UI in unexpected ways.
-      this.removeClientFromParty(clientSockets, oldParty, time)
+      this.removeClientFromParty(clientSockets, oldParty)
     }
   }
 

--- a/server/lib/parties/party-service.ts
+++ b/server/lib/parties/party-service.ts
@@ -242,7 +242,7 @@ export default class PartyService {
       // NOTE(2Pac): We're removing the user from an old party *after* we subscribe them to a new
       // one, to better represent a party change. This way the client won't have a brief period of
       // being in no party, which can change the UI in unexpected ways.
-      this.removeClientFromParty(clientSockets, oldParty)
+      this.removeClientFromParty(clientSockets, oldParty, time)
     }
   }
 

--- a/server/lib/parties/party-service.ts
+++ b/server/lib/parties/party-service.ts
@@ -222,10 +222,10 @@ export default class PartyService {
     // TODO(2Pac): Only allow accepting an invite for electron clients?
 
     const clientSockets = this.getClientSockets(user.id, clientId)
-    const userParty = this.getClientParty(clientSockets)
-    if (userParty) {
-      // TODO(2Pac): Handle switching parties
-    }
+    const oldParty = this.getClientParty(clientSockets)
+
+    // TODO(2Pac): Maybe display a confirmation dialog first to the user if they were already in an
+    // existing party, instead of uncoditionally moving them to a new party?
 
     party.invites.delete(user.id)
     party.members.set(user.id, user)
@@ -237,6 +237,13 @@ export default class PartyService {
       time: this.clock.now(),
     })
     this.subscribeToParty(clientSockets, party)
+
+    if (oldParty) {
+      // NOTE(2Pac): We're removing the user from an old party *after* we subscribe them to a new
+      // one, to better represent a party change. This way the client won't have a brief period of
+      // being in no party, which can change the UI in unexpected ways.
+      this.removeClientFromParty(clientSockets, oldParty)
+    }
   }
 
   leaveParty(partyId: string, userId: number, clientId: string) {

--- a/server/lib/parties/party-service.ts
+++ b/server/lib/parties/party-service.ts
@@ -332,7 +332,13 @@ export default class PartyService {
       })
     }
 
-    this.clientSocketsToPartyId.delete(clientSockets)
+    const clientPartyId = this.clientSocketsToPartyId.get(clientSockets)!
+    // Client's party can change when switching parties, so we must check if they're actually
+    // leaving the party, or have simply switched to a new one.
+    if (clientPartyId === party.id) {
+      this.clientSocketsToPartyId.delete(clientSockets)
+    }
+
     clientSockets.unsubscribe(getPartyPath(party.id))
 
     // TODO(2Pac): Handle party leader leaving

--- a/server/lib/websockets/testing/websockets.ts
+++ b/server/lib/websockets/testing/websockets.ts
@@ -87,6 +87,7 @@ export class InspectableNydusClient extends NydusClient {
   // documentation (the arguments are named, vs the arg_0, arg_1 stuff from Jest)
   publish: (path: string, data: any) => void = jest.fn()
   unsubscribe: (path: string) => boolean = jest.fn()
+  disconnect = jest.fn(() => this.emit('close', 'CLIENT_DISCONNECT'))
 }
 
 export function clearTestLogs(nydus: NydusServer) {


### PR DESCRIPTION
This can happen when a user gets invited to a party while they were
already in a different party. By accepting the invite to a new party,
they will immediately leave the old party and be put in a new party.

TODO: The transition from one party to another might be a bit jarring,
so maybe eventually we want to display some kind of a confirmation
dialog before doing it?