### PR TITLE
Improve the party handling on non-electron clients.

### DIFF
--- a/client/notifications/socket-handlers.ts
+++ b/client/notifications/socket-handlers.ts
@@ -1,8 +1,11 @@
+import { Set } from 'immutable'
 import type { NydusClient, RouteHandler, RouteInfo } from 'nydus-client'
 import { NotificationEvent, NotificationType } from '../../common/notifications'
 import { dispatch, Dispatchable } from '../dispatch-registry'
 
-const ELECTRON_ONLY_NOTIFICATION_TYPES = [NotificationType.PartyInvite]
+const ELECTRON_ONLY_NOTIFICATION_TYPES = Set<Readonly<NotificationType>>([
+  NotificationType.PartyInvite,
+])
 
 type EventToActionMap = {
   [E in NotificationEvent['type']]?: (
@@ -14,7 +17,7 @@ const eventToAction: EventToActionMap = {
   serverInit: event => {
     const notifications = IS_ELECTRON
       ? event.notifications
-      : event.notifications.filter(n => !ELECTRON_ONLY_NOTIFICATION_TYPES.includes(n.type))
+      : event.notifications.filter(n => !ELECTRON_ONLY_NOTIFICATION_TYPES.has(n.type))
 
     return {
       type: '@notifications/serverInit',
@@ -25,7 +28,7 @@ const eventToAction: EventToActionMap = {
   add: event => dispatch => {
     const { notification } = event
 
-    if (!IS_ELECTRON && ELECTRON_ONLY_NOTIFICATION_TYPES.includes(notification.type)) {
+    if (!IS_ELECTRON && ELECTRON_ONLY_NOTIFICATION_TYPES.has(notification.type)) {
       return
     }
 

--- a/server/lib/parties/party-service.test.ts
+++ b/server/lib/parties/party-service.test.ts
@@ -26,6 +26,7 @@ describe('parties/party-service', () => {
   const user8: PartyUser = { id: 8, name: 'riptide' }
   const user9: PartyUser = { id: 9, name: 'manifesto7' }
   const offlineUser: PartyUser = { id: 10, name: 'tt1' }
+  const webUser: PartyUser = { id: 11, name: 'nyoken' }
 
   const USER1_CLIENT_ID = 'USER1_CLIENT_ID'
   const USER2_CLIENT_ID = 'USER2_CLIENT_ID'
@@ -36,6 +37,7 @@ describe('parties/party-service', () => {
   const USER7_CLIENT_ID = 'USER7_CLIENT_ID'
   const USER8_CLIENT_ID = 'USER8_CLIENT_ID'
   const USER9_CLIENT_ID = 'USER9_CLIENT_ID'
+  const WEB_USER_CLIENT_ID = 'WEB_USER_CLIENT_ID'
 
   let client1: InspectableNydusClient
   let client2: InspectableNydusClient
@@ -46,6 +48,7 @@ describe('parties/party-service', () => {
   let client7: InspectableNydusClient
   let client8: InspectableNydusClient
   let client9: InspectableNydusClient
+  let webClient: InspectableNydusClient
 
   let nydus: NydusServer
   let partyService: PartyService
@@ -83,6 +86,8 @@ describe('parties/party-service', () => {
     client8 = connector.connectClient(user8, USER8_CLIENT_ID)
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     client9 = connector.connectClient(user9, USER9_CLIENT_ID)
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    webClient = connector.connectClient(webUser, WEB_USER_CLIENT_ID, 'web')
 
     clearTestLogs(nydus)
   })
@@ -404,6 +409,14 @@ describe('parties/party-service', () => {
       expect(() =>
         partyService.acceptInvite(party.id, user9, USER9_CLIENT_ID),
       ).toThrowErrorMatchingInlineSnapshot(`"Party is full"`)
+    })
+
+    test('should throw if accepting on web client', async () => {
+      party = await partyService.invite(leader, USER1_CLIENT_ID, webUser)
+
+      expect(() =>
+        partyService.acceptInvite(party.id, webUser, WEB_USER_CLIENT_ID),
+      ).toThrowErrorMatchingInlineSnapshot(`"Invalid client"`)
     })
 
     test('should update the party record', () => {

--- a/server/lib/parties/party-service.ts
+++ b/server/lib/parties/party-service.ts
@@ -219,9 +219,11 @@ export default class PartyService {
       throw new PartyServiceError(PartyServiceErrorCode.PartyFull, 'Party is full')
     }
 
-    // TODO(2Pac): Only allow accepting an invite for electron clients?
-
     const clientSockets = this.getClientSockets(user.id, clientId)
+    if (clientSockets.clientType !== 'electron') {
+      throw new PartyServiceError(PartyServiceErrorCode.InvalidAction, 'Invalid client')
+    }
+
     const oldParty = this.getClientParty(clientSockets)
 
     // TODO(2Pac): Maybe display a confirmation dialog first to the user if they were already in an

--- a/server/lib/websockets/testing/websockets.ts
+++ b/server/lib/websockets/testing/websockets.ts
@@ -114,7 +114,11 @@ export class NydusConnector {
     this.fakeNydus = nydus
   }
 
-  connectClient(user: { id: number; name: string }, clientId: string): InspectableNydusClient {
+  connectClient(
+    user: { id: number; name: string },
+    clientId: string,
+    clientType: 'web' | 'electron' = 'electron',
+  ): InspectableNydusClient {
     const id = String(clientIdCounter++)
     const fakeRequest = {
       headers: [],
@@ -128,7 +132,7 @@ export class NydusConnector {
       userName: user.name,
       clientId,
       address: '127.0.0.1',
-      clientType: 'electron',
+      clientType,
     }
     this.sessionLookup.set(fakeRequest, fakeSession)
     const client = new InspectableNydusClient(


### PR DESCRIPTION
This PR does two things:
- doesn't display party invite notifications on web clients
- throws an error if user tries to accept a party invitation on a
  non-electron client