### PR TITLE
Assign new leader in a party when the old one leaves.

### DIFF
--- a/client/parties/actions.ts
+++ b/client/parties/actions.ts
@@ -30,6 +30,7 @@ export type PartyActions =
   | UpdateJoin
   | UpdateLeave
   | UpdateLeaveSelf
+  | UpdateLeaderChange
   | UpdateChatMessage
 
 export interface InviteToPartyBegin {
@@ -263,6 +264,15 @@ export interface UpdateLeaveSelf {
   type: '@parties/updateLeaveSelf'
   payload: {
     partyId: string
+    time: number
+  }
+}
+
+export interface UpdateLeaderChange {
+  type: '@parties/updateLeaderChange'
+  payload: {
+    partyId: string
+    leader: PartyUser
     time: number
   }
 }

--- a/client/parties/party-message-layout.tsx
+++ b/client/parties/party-message-layout.tsx
@@ -61,3 +61,17 @@ export const LeavePartyMessage = React.memo<{ time: number; userId: number }>(pr
     </SystemMessage>
   )
 })
+
+export const PartyLeaderChangeMessage = React.memo<{ time: number; userId: number }>(props => {
+  const { time, userId } = props
+  return (
+    <SystemMessage time={time}>
+      <span>
+        <SystemImportant>
+          <ConnectedUsername userId={userId} />
+        </SystemImportant>{' '}
+        is now the leader
+      </span>
+    </SystemMessage>
+  )
+})

--- a/client/parties/party-message-records.ts
+++ b/client/parties/party-message-records.ts
@@ -6,6 +6,7 @@ export enum PartyMessageType {
   InviteToParty = 'inviteToParty',
   JoinParty = 'joinParty',
   LeaveParty = 'leaveParty',
+  LeaderChange = 'leaderChange',
 }
 
 export class SelfJoinPartyMessageRecord
@@ -44,8 +45,18 @@ export class LeavePartyMessageRecord
   })
   implements BaseMessage {}
 
+export class PartyLeaderChangeMessageRecord
+  extends Record({
+    id: '',
+    type: PartyMessageType.LeaderChange as typeof PartyMessageType.LeaderChange,
+    time: 0,
+    userId: 0,
+  })
+  implements BaseMessage {}
+
 export type PartyMessage =
   | SelfJoinPartyMessageRecord
   | InviteToPartyMessageRecord
   | JoinPartyMessageRecord
   | LeavePartyMessageRecord
+  | PartyLeaderChangeMessageRecord

--- a/client/parties/party-reducer.ts
+++ b/client/parties/party-reducer.ts
@@ -8,6 +8,7 @@ import {
   InviteToPartyMessageRecord,
   JoinPartyMessageRecord,
   LeavePartyMessageRecord,
+  PartyLeaderChangeMessageRecord,
   SelfJoinPartyMessageRecord,
 } from './party-message-records'
 
@@ -137,6 +138,37 @@ export default keyedReducer(new PartyRecord(), {
       )
   },
 
+  ['@parties/updateLeaveSelf'](state, action) {
+    const { partyId } = action.payload
+
+    if (partyId !== state.id) {
+      return state
+    }
+
+    return new PartyRecord()
+  },
+
+  ['@parties/updateLeaderChange'](state, action) {
+    const { partyId, leader, time } = action.payload
+
+    if (partyId !== state.id) {
+      return state
+    }
+
+    return state
+      .set('leader', new PartyUserRecord(leader))
+      .set('hasUnread', !state.activated)
+      .update('messages', messages =>
+        messages.push(
+          new PartyLeaderChangeMessageRecord({
+            id: cuid(),
+            time,
+            userId: leader.id,
+          }),
+        ),
+      )
+  },
+
   ['@parties/updateChatMessage'](state, action) {
     const { partyId, from, time, text } = action.payload
 
@@ -154,16 +186,6 @@ export default keyedReducer(new PartyRecord(), {
         }),
       ),
     )
-  },
-
-  ['@parties/updateLeaveSelf'](state, action) {
-    const { partyId } = action.payload
-
-    if (partyId !== state.id) {
-      return state
-    }
-
-    return new PartyRecord()
   },
 
   ['@parties/activateParty'](state, action) {

--- a/client/parties/party-view.tsx
+++ b/client/parties/party-view.tsx
@@ -21,6 +21,7 @@ import {
   InviteToPartyMessage,
   JoinPartyMessage,
   LeavePartyMessage,
+  PartyLeaderChangeMessage,
   SelfJoinPartyMessage,
 } from './party-message-layout'
 import { PartyMessageType } from './party-message-records'
@@ -127,6 +128,8 @@ function renderPartyMessage(msg: Message) {
       return <JoinPartyMessage key={msg.id} time={msg.time} userId={msg.userId} />
     case PartyMessageType.LeaveParty:
       return <LeavePartyMessage key={msg.id} time={msg.time} userId={msg.userId} />
+    case PartyMessageType.LeaderChange:
+      return <PartyLeaderChangeMessage key={msg.id} time={msg.time} userId={msg.userId} />
     default:
       return null
   }

--- a/client/parties/socket-handlers.ts
+++ b/client/parties/socket-handlers.ts
@@ -98,6 +98,18 @@ const eventToAction: EventToActionMap = {
     }
   },
 
+  leaderChange: (partyId, event) => {
+    const { leader, time } = event
+    return {
+      type: '@parties/updateLeaderChange',
+      payload: {
+        partyId,
+        leader,
+        time,
+      },
+    }
+  },
+
   chatMessage(partyId, event) {
     const { from, time, text } = event
 

--- a/common/parties.ts
+++ b/common/parties.ts
@@ -72,6 +72,12 @@ export interface PartyLeaveEvent {
   time: number
 }
 
+export interface PartyLeaderChangeEvent {
+  type: 'leaderChange'
+  leader: PartyUser
+  time: number
+}
+
 export interface PartyChatMessageEvent extends ChatMessage {
   type: 'chatMessage'
 }
@@ -83,6 +89,7 @@ export type PartyEvent =
   | PartyDeclineEvent
   | PartyJoinEvent
   | PartyLeaveEvent
+  | PartyLeaderChangeEvent
   | PartyChatMessageEvent
 
 export interface InviteToPartyServerBody {

--- a/server/lib/parties/party-service.test.ts
+++ b/server/lib/parties/party-service.test.ts
@@ -557,7 +557,7 @@ describe('parties/party-service', () => {
     })
 
     test('should publish "leaderChange" message to the party path when leader leaves', () => {
-      partyService.leaveParty(party.id, leader.id, USER1_CLIENT_ID, currentTime)
+      partyService.leaveParty(party.id, leader.id, USER1_CLIENT_ID)
 
       expect(nydus.publish).toHaveBeenCalledWith(getPartyPath(party.id), {
         type: 'leaderChange',

--- a/server/lib/parties/party-service.test.ts
+++ b/server/lib/parties/party-service.test.ts
@@ -549,6 +549,22 @@ describe('parties/party-service', () => {
 
       expect(client2.unsubscribe).toHaveBeenCalledWith(getPartyPath(party.id))
     })
+
+    test('should assign new leader when old leader leaves', () => {
+      partyService.leaveParty(party.id, leader.id, USER1_CLIENT_ID)
+
+      expect(party.leader).toMatchObject(user2)
+    })
+
+    test('should publish "leaderChange" message to the party path when leader leaves', () => {
+      partyService.leaveParty(party.id, leader.id, USER1_CLIENT_ID, currentTime)
+
+      expect(nydus.publish).toHaveBeenCalledWith(getPartyPath(party.id), {
+        type: 'leaderChange',
+        leader: user2,
+        time: currentTime,
+      })
+    })
   })
 
   describe('sendChatMessage', () => {

--- a/server/lib/parties/party-service.ts
+++ b/server/lib/parties/party-service.ts
@@ -357,7 +357,7 @@ export default class PartyService {
       this.publisher.publish(getPartyPath(party.id), {
         type: 'leaderChange',
         leader: newLeader,
-        time,
+        time: this.clock.now(),
       })
     }
   }


### PR DESCRIPTION
Generally the person who has joined the party the earliest will be
chosen as a new leader, but there's no robust solution implemented that
ensures this. My thinking was that since the multiple invites can be
sent at once, and the order in which those invites are accepted are
pretty arbitrary already, there's really no reason why someone
"deserves" to be a new leader more than someone else. Or well, no reason
big enough to spend time implementing a robust solution for this at
least :)