### PR TITLE
Detect links in text messages and make them clickable.

### DIFF
--- a/client/messaging/common-message-layout.tsx
+++ b/client/messaging/common-message-layout.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo } from 'react'
 import styled from 'styled-components'
+import { matchLinks } from '../../common/text/links'
 import { amberA100 } from '../styles/colors'
 import { body2 } from '../styles/typography'
 import { ConnectedUsername } from './connected-username'
@@ -9,8 +10,6 @@ import {
   Separator,
   TimestampMessageLayout,
 } from './message-layout'
-
-const URL_REGEX = /(?<g1>https?:\/\/)(?:[^\s)"\].]|(?:\.(?=\S))|(?<=\k<g1>.*\([^)]*)\)){2,}/gi
 
 const newDayFormat = new Intl.DateTimeFormat(navigator.language, {
   year: 'numeric',
@@ -36,7 +35,7 @@ const Text = styled.span`
 
 export function ParsedText({ text }: { text: string }) {
   const parsedText = useMemo(() => {
-    const matches = text.matchAll(URL_REGEX)
+    const matches = matchLinks(text)
     const elements = []
     let lastIndex = 0
 

--- a/client/messaging/common-message-layout.tsx
+++ b/client/messaging/common-message-layout.tsx
@@ -46,8 +46,10 @@ export function ParsedText({ text }: { text: string }) {
       }
 
       elements.push(
+        // TODO(tec27): Handle links to our own host specially, redirecting to the correct route
+        // in-client instead
         // TODO(2Pac): Show a warning message about opening untrusted links
-        <a key={match.index} href={match[0]} target='_blank' rel='noopener'>
+        <a key={match.index} href={match[0]} target='_blank' rel='noopener nofollow'>
           {match[0]}
         </a>,
       )

--- a/common/text/links.test.ts
+++ b/common/text/links.test.ts
@@ -1,0 +1,223 @@
+import { matchLinks } from './links'
+
+function doMatch(text: string): string[] {
+  return Array.from(matchLinks(text), match => match[0])
+}
+
+describe('common/text/links/matchLinks', () => {
+  test('link as entire text', () => {
+    expect(doMatch('http://example.org/')).toMatchInlineSnapshot(`
+      Array [
+        "http://example.org/",
+      ]
+    `)
+  })
+
+  test('link as beginning text', () => {
+    expect(doMatch('http://example.org/ is a link')).toMatchInlineSnapshot(`
+      Array [
+        "http://example.org/",
+      ]
+    `)
+  })
+
+  test('link as ending text', () => {
+    expect(doMatch('here is a link http://example.org/')).toMatchInlineSnapshot(`
+      Array [
+        "http://example.org/",
+      ]
+    `)
+  })
+
+  test('link as middle text', () => {
+    expect(doMatch('here is a link http://example.org/ okay')).toMatchInlineSnapshot(`
+      Array [
+        "http://example.org/",
+      ]
+    `)
+  })
+
+  test('link without path', () => {
+    expect(doMatch('http://example.org')).toMatchInlineSnapshot(`
+      Array [
+        "http://example.org",
+      ]
+    `)
+  })
+
+  test('link with hex escaping', () => {
+    expect(doMatch('http://www.google.com/#file%20one%26two')).toMatchInlineSnapshot(`
+      Array [
+        "http://www.google.com/#file%20one%26two",
+      ]
+    `)
+  })
+
+  test('link with https', () => {
+    expect(doMatch('https://www.google.com/test')).toMatchInlineSnapshot(`
+      Array [
+        "https://www.google.com/test",
+      ]
+    `)
+  })
+
+  test('link with empty query', () => {
+    expect(doMatch('https://www.google.com/?')).toMatchInlineSnapshot(`
+      Array [
+        "https://www.google.com/?",
+      ]
+    `)
+  })
+
+  test('link with query values', () => {
+    expect(doMatch('https://www.google.com/?test=true&array%5B%5D=15&array%5B%5D=23'))
+      .toMatchInlineSnapshot(`
+      Array [
+        "https://www.google.com/?test=true&array%5B%5D=15&array%5B%5D=23",
+      ]
+    `)
+  })
+
+  test('link ending in question mark', () => {
+    expect(doMatch('http://www.google.com/?foo=bar?')).toMatchInlineSnapshot(`
+      Array [
+        "http://www.google.com/?foo=bar?",
+      ]
+    `)
+  })
+
+  test('link with query with a +', () => {
+    expect(doMatch('http://www.google.com/?foo+bar')).toMatchInlineSnapshot(`
+      Array [
+        "http://www.google.com/?foo+bar",
+      ]
+    `)
+  })
+
+  test('link with hex escaping in path', () => {
+    expect(doMatch('http://www.google.com/test%20path?query')).toMatchInlineSnapshot(`
+      Array [
+        "http://www.google.com/test%20path?query",
+      ]
+    `)
+  })
+
+  test('link with hash and query', () => {
+    expect(doMatch('http://www.google.com/path?query#hash%20escaped')).toMatchInlineSnapshot(`
+      Array [
+        "http://www.google.com/path?query#hash%20escaped",
+      ]
+    `)
+  })
+
+  test('link with mixed case', () => {
+    expect(doMatch('htTpS://WWW.example.ORG/path')).toMatchInlineSnapshot(`
+      Array [
+        "htTpS://WWW.example.ORG/path",
+      ]
+    `)
+  })
+
+  test('link with ipv4 address', () => {
+    expect(doMatch('http://192.168.0.1')).toMatchInlineSnapshot(`
+      Array [
+        "http://192.168.0.1",
+      ]
+    `)
+  })
+
+  test('link with ip address and port', () => {
+    expect(doMatch('http://192.168.0.1:9999')).toMatchInlineSnapshot(`
+      Array [
+        "http://192.168.0.1:9999",
+      ]
+    `)
+  })
+
+  test('link with host and port', () => {
+    expect(doMatch('https://example.org:9999')).toMatchInlineSnapshot(`
+      Array [
+        "https://example.org:9999",
+      ]
+    `)
+  })
+
+  test('link with percent encoded host', () => {
+    expect(doMatch('http://hello.%e4%b8%96%e7%95%8c.com/foo')).toMatchInlineSnapshot(`
+      Array [
+        "http://hello.%e4%b8%96%e7%95%8c.com/foo",
+      ]
+    `)
+  })
+
+  test('link with path beginning with /', () => {
+    expect(doMatch('http://example.org//foo')).toMatchInlineSnapshot(`
+      Array [
+        "http://example.org//foo",
+      ]
+    `)
+  })
+
+  test('multiple links in text', () => {
+    expect(doMatch('hello http://example.org/ world https://shieldbattery.net foo'))
+      .toMatchInlineSnapshot(`
+      Array [
+        "http://example.org/",
+        "https://shieldbattery.net",
+      ]
+    `)
+  })
+
+  test('link in parentheses', () => {
+    expect(doMatch('hello (http://example.org/) world')).toMatchInlineSnapshot(`
+      Array [
+        "http://example.org/",
+      ]
+    `)
+  })
+
+  /* eslint-disable-next-line jest/no-commented-out-tests */
+  /* TODO(tec27): Fix these, they're broken
+
+  test('link with host subcomponent, ipv6 RFC 3986', () => {
+    expect(doMatch('https://[fe80::1]')).toMatchInlineSnapshot(`
+      Array [
+        "https://[fe80::1]",
+      ]
+    `)
+  })
+
+  test('link with host subcomponent and port, ipv6 RFC 3986', () => {
+    expect(doMatch('https://[fe80::1]:9999')).toMatchInlineSnapshot(`
+      Array [
+        "https://[fe80::1]:9999",
+      ]
+    `)
+  })
+
+  test('link with host subcomponent, zone identifier, ipv6 RFC 6874', () => {
+    expect(doMatch('http://[fe80::1%25en0]')).toMatchInlineSnapshot(`
+      Array [
+        "http://[fe80::1%25en0]",
+      ]
+    `)
+  })
+
+  test('link with host subcomponent, zone identifier, port ipv6 RFC 6874', () => {
+    expect(doMatch('http://[fe80::1%25en0]:9999')).toMatchInlineSnapshot(`
+      Array [
+        "http://[fe80::1%25en0]:9999",
+      ]
+    `)
+  })
+
+  test('link with host subcomponent, unreserved zone identifier, port ipv6 RFC 6874', () => {
+    expect(doMatch('http://[fe80::1%25%65%6e%301-._~]:9999/')).toMatchInlineSnapshot(`
+      Array [
+        "http://[fe80::1%25%65%6e%301-._~]:9999/",
+      ]
+    `)
+  })
+
+  */
+})

--- a/common/text/links.ts
+++ b/common/text/links.ts
@@ -1,0 +1,6 @@
+const URL_REGEX = /(?<g1>https?:\/\/)(?:[^\s)"\].]|(?:\.(?=\S))|(?<=\k<g1>.*\([^)]*)\)){2,}/gi
+
+/** Returns an iterator of matches for links within the specified `text`. */
+export function matchLinks(text: string): IterableIterator<RegExpMatchArray> {
+  return text.matchAll(URL_REGEX)
+}


### PR DESCRIPTION
This does some basic link detection in text messages, similar to what
Discord does. One thing that should probably be added as soon as
possible as well is some kind of a warning message that we show to users
about opening untrusted links.

But then we should also probably remember their choices for each
specific domain, and that's a whole thing now ^^.

Additionally, the component that is implemented here to parse the text
messages could be extended to parse other types of content (e.g.
mentions, links to lobbies, maps, etc.). Regex for each of those should
be written separately, which should be easier since we can create custom
schemes for each one, and then combined into a single regex so the text
is parsed only once. I don't know yet if this is possible or how it will
work, but we'll see when we get there :).