### PR TITLE
Display the actual reason why accepting a party invite failed.

### DIFF
--- a/client/parties/action-creators.ts
+++ b/client/parties/action-creators.ts
@@ -27,11 +27,17 @@ export function inviteToParty(targetId: number): ThunkAction {
         method: 'POST',
         body: JSON.stringify(requestBody),
       }).catch(err => {
-        dispatch(
-          openSnackbar({
-            message: 'An error occurred while sending an invite',
-          }),
-        )
+        let message = 'An error occurred while sending an invite'
+        if (err.body.code === PartyServiceErrorCode.NotificationFailure) {
+          message = 'Failed to send an invite. Please try again'
+        } else if (err.body.code === PartyServiceErrorCode.AlreadyMember) {
+          const user = err.body.user?.name ?? 'The user'
+          message = `${user} is already in your party`
+        } else if (err.body.code === PartyServiceErrorCode.InvalidSelfAction) {
+          message = "Can't invite yourself to the party"
+        }
+
+        dispatch(openSnackbar({ message, time: TIMING_LONG }))
         throw err
       }),
       meta: params,

--- a/client/parties/action-creators.ts
+++ b/client/parties/action-creators.ts
@@ -1,6 +1,7 @@
 import {
   AcceptPartyInviteServerBody,
   InviteToPartyServerBody,
+  PartyServiceErrorCode,
   SendChatMessageServerBody,
 } from '../../common/parties'
 import { ThunkAction } from '../dispatch-registry'
@@ -8,7 +9,7 @@ import { push } from '../navigation/routing'
 import { clientId } from '../network/client-id'
 import fetch from '../network/fetch'
 import { apiUrl, urlPath } from '../network/urls'
-import { openSnackbar } from '../snackbars/action-creators'
+import { openSnackbar, TIMING_LONG } from '../snackbars/action-creators'
 import { ActivateParty, DeactivateParty } from './actions'
 
 export function inviteToParty(targetId: number): ThunkAction {
@@ -103,12 +104,14 @@ export function acceptPartyInvite(partyId: string): ThunkAction {
         method: 'POST',
         body: JSON.stringify(requestBody),
       }).catch(err => {
-        // TODO(2Pac): Show an actual reason why the this failed (e.g. party doesn't exist anymore)
-        dispatch(
-          openSnackbar({
-            message: 'An error occurred while accepting an invite',
-          }),
-        )
+        let message = 'An error occurred while accepting an invite'
+        if (err.body.code === PartyServiceErrorCode.NotFoundOrNotInvited) {
+          message = "Party doesn't exist anymore"
+        } else if (err.body.code === PartyServiceErrorCode.PartyFull) {
+          message = 'Party is full'
+        }
+
+        dispatch(openSnackbar({ message, time: TIMING_LONG }))
         throw err
       }),
       meta: params,

--- a/common/parties.ts
+++ b/common/parties.ts
@@ -7,6 +7,16 @@ import { User } from './users/user-info'
  */
 export const MAX_PARTY_SIZE = 8
 
+export enum PartyServiceErrorCode {
+  NotFoundOrNotInvited = 'NotFoundOrNotInvited',
+  NotFoundOrNotInParty = 'NotFoundOrNotInParty',
+  InsufficientPermissions = 'InsufficientPermissions',
+  PartyFull = 'PartyFull',
+  UserOffline = 'UserOffline',
+  InvalidAction = 'InvalidAction',
+  NotificationFailure = 'NotificationFailure',
+}
+
 export interface PartyUser {
   id: number
   name: string

--- a/common/parties.ts
+++ b/common/parties.ts
@@ -15,6 +15,8 @@ export enum PartyServiceErrorCode {
   UserOffline = 'UserOffline',
   InvalidAction = 'InvalidAction',
   NotificationFailure = 'NotificationFailure',
+  AlreadyMember = 'AlreadyMember',
+  InvalidSelfAction = 'InvalidSelfAction',
 }
 
 export interface PartyUser {

--- a/server/lib/errors/error-with-payload.ts
+++ b/server/lib/errors/error-with-payload.ts
@@ -25,9 +25,9 @@ export class HttpErrorWithPayload<T = unknown> extends Error {
 /**
  * A helper function which makes throwing HTTP errors with error code a bit easier to use.
  *
- * @param {number} statusCode HTTP error code
- * @param {string }} error The error to be thrown with a custom `code` that will be included in the
- *  payload
+ * @param statusCode HTTP error code
+ * @param error The error to be thrown with a custom `code`, and optionally any additional data,
+ *  that will be included in the payload
  */
 export function asHttpError(statusCode: number, error: Error & { code: string; data?: any }) {
   return new HttpErrorWithPayload(statusCode, error.message, { code: error.code, ...error.data })

--- a/server/lib/errors/error-with-payload.ts
+++ b/server/lib/errors/error-with-payload.ts
@@ -21,3 +21,14 @@ export class HttpErrorWithPayload<T = unknown> extends Error {
     })
   }
 }
+
+/**
+ * A helper function which makes throwing HTTP errors with error code a bit easier to use.
+ *
+ * @param {number} statusCode HTTP error code
+ * @param {string }} error The error to be thrown with a custom `code` that will be included in the
+ *  payload
+ */
+export function asHttpError(statusCode: number, error: Error & { code: string; data?: any }) {
+  return new HttpErrorWithPayload(statusCode, error.message, { code: error.code, ...error.data })
+}

--- a/server/lib/parties/party-api.ts
+++ b/server/lib/parties/party-api.ts
@@ -13,7 +13,7 @@ import {
   PartyUser,
   SendChatMessageServerBody,
 } from '../../../common/parties'
-import { HttpErrorWithPayload } from '../errors/error-with-payload'
+import { asHttpError } from '../errors/error-with-payload'
 import { featureEnabled } from '../flags/feature-enabled'
 import { httpApi, HttpApi } from '../http/http-api'
 import ensureLoggedIn from '../session/ensure-logged-in'
@@ -54,15 +54,17 @@ function convertPartyServiceError(err: Error) {
     case PartyServiceErrorCode.NotFoundOrNotInvited:
     case PartyServiceErrorCode.NotFoundOrNotInParty:
     case PartyServiceErrorCode.InvalidAction:
-      throw new HttpErrorWithPayload(400, err.message, { code: err.code })
+    case PartyServiceErrorCode.AlreadyMember:
+    case PartyServiceErrorCode.InvalidSelfAction:
+      throw asHttpError(400, err)
     case PartyServiceErrorCode.InsufficientPermissions:
-      throw new HttpErrorWithPayload(403, err.message, { code: err.code })
+      throw asHttpError(403, err)
     case PartyServiceErrorCode.PartyFull:
-      throw new HttpErrorWithPayload(409, err.message, { code: err.code })
+      throw asHttpError(409, err)
     case PartyServiceErrorCode.UserOffline:
-      throw new HttpErrorWithPayload(404, err.message, { code: err.code })
+      throw asHttpError(404, err)
     case PartyServiceErrorCode.NotificationFailure:
-      throw new HttpErrorWithPayload(500, err.message, { code: err.code })
+      throw asHttpError(500, err)
     default:
       assertUnreachable(err.code)
   }

--- a/server/lib/parties/party-service.ts
+++ b/server/lib/parties/party-service.ts
@@ -6,6 +6,7 @@ import {
   PartyEvent,
   PartyInitEvent,
   PartyPayload,
+  PartyServiceErrorCode,
   PartyUser,
 } from '../../../common/parties'
 import logger from '../logging/logger'
@@ -20,16 +21,6 @@ export interface PartyRecord {
   invites: Map<number, PartyUser>
   members: Map<number, PartyUser>
   leader: PartyUser
-}
-
-export enum PartyServiceErrorCode {
-  NotFoundOrNotInvited,
-  NotFoundOrNotInParty,
-  InsufficientPermissions,
-  PartyFull,
-  UserOffline,
-  InvalidAction,
-  NotificationFailure,
 }
 
 export class PartyServiceError extends Error {

--- a/server/lib/parties/party-service.ts
+++ b/server/lib/parties/party-service.ts
@@ -24,7 +24,7 @@ export interface PartyRecord {
 }
 
 export class PartyServiceError extends Error {
-  constructor(readonly code: PartyServiceErrorCode, message: string) {
+  constructor(readonly code: PartyServiceErrorCode, message: string, readonly data?: any) {
     super(message)
   }
 }
@@ -78,7 +78,7 @@ export default class PartyService {
 
     if (invitedUser.id === leader.id) {
       throw new PartyServiceError(
-        PartyServiceErrorCode.InvalidAction,
+        PartyServiceErrorCode.InvalidSelfAction,
         "Can't invite yourself to the party",
       )
     }
@@ -94,8 +94,9 @@ export default class PartyService {
 
       if (party.members.has(invitedUser.id)) {
         throw new PartyServiceError(
-          PartyServiceErrorCode.InvalidAction,
+          PartyServiceErrorCode.AlreadyMember,
           'This user is already a member of this party',
+          { user: invitedUser },
         )
       }
 
@@ -301,7 +302,7 @@ export default class PartyService {
     }
 
     if (kickingUser.id === target.id) {
-      throw new PartyServiceError(PartyServiceErrorCode.InvalidAction, "Can't kick yourself")
+      throw new PartyServiceError(PartyServiceErrorCode.InvalidSelfAction, "Can't kick yourself")
     }
 
     this.publisher.publish(getPartyPath(party.id), {


### PR DESCRIPTION
These are more or less the only errors that are likely to happen to
users in their normal usage of the party system. Now we display the
actual reason to them if they try to accept an invite to a party that
doesn't exist anymore, or if the party is currently full.