### PR TITLE
Fix a bug when selecting a random race while `useAlternateRace` was set

### DIFF
--- a/client/matchmaking/find-match.jsx
+++ b/client/matchmaking/find-match.jsx
@@ -288,10 +288,13 @@ export default class FindMatch extends React.Component {
     // TODO(2Pac): Remove this once we add support for other tabs that we currently display
     if (activeTab !== TAB_1V1) return
 
+    const { race, useAlternateRace, alternateRace } = this._form.current.getModel()
     this.props.dispatch(
       updateMatchmakingPreferences({
         matchmakingType: tabToType(activeTab),
-        ...this._form.current.getModel(),
+        race,
+        useAlternateRace: race !== 'r' ? useAlternateRace : false,
+        alternateRace,
         preferredMaps: this._getPreferredMaps().map(m => m.id),
       }),
     )
@@ -449,7 +452,13 @@ export default class FindMatch extends React.Component {
     const preferredMaps = this._getPreferredMaps().map(m => m.id)
 
     this.props.dispatch(
-      findMatch(matchmakingType, race, useAlternateRace, alternateRace, preferredMaps),
+      findMatch(
+        matchmakingType,
+        race,
+        race !== 'r' ? useAlternateRace : false,
+        alternateRace,
+        preferredMaps,
+      ),
     )
     this.props.dispatch(closeOverlay())
   }


### PR DESCRIPTION
to true.

Previously we would send `useAlteranteRace` to server, whatever it was
previously set. And with a main race set to random, this would case an
error when saving matchmaking preferences. Now we're forcing
`useAlternateRace` to `false` whenever main race is set to random.