### PR TITLE
Populate the user infos in lobbies.

### DIFF
--- a/client/lobbies/socket-handlers.ts
+++ b/client/lobbies/socket-handlers.ts
@@ -3,6 +3,7 @@ import { GameLaunchConfig, GameRoute } from '../../common/game-launch-config'
 import { TypedIpcRenderer } from '../../common/ipc'
 import { getIngameLobbySlotsWithIndexes } from '../../common/lobbies'
 import { urlPath } from '../../common/urls'
+import { SbUserId } from '../../common/users/user-info'
 import {
   ACTIVE_GAME_LAUNCH,
   LOBBIES_COUNT_UPDATE,
@@ -94,6 +95,11 @@ type LobbyEvent =
   | LobbyChatEvent
   | LobbyStatusEvent
 
+interface LobbyUser {
+  id: SbUserId
+  name: string
+}
+
 interface LobbyInitEvent {
   type: 'init'
   // TODO(tec27): actually type this
@@ -106,6 +112,8 @@ interface LobbyInitEvent {
       mapUrl: string
     }
   }
+  /** An array of infos for all users that were in the lobby at this point. */
+  userInfos: LobbyUser[]
 }
 
 interface LobbyDiffEvent {
@@ -119,6 +127,8 @@ interface LobbySlotCreateEvent {
   slot: {
     type: 'human' | 'computer'
   }
+  /** In case a human slot was created, this field will contain their properties, e.g. name. */
+  userInfo?: LobbyUser
 }
 
 interface LobbyRaceChangeEvent {

--- a/client/profile/user-reducer.ts
+++ b/client/profile/user-reducer.ts
@@ -1,6 +1,7 @@
 import { Immutable } from 'immer'
 import { GameRecordJson } from '../../common/games/games'
 import { SbUser, SbUserId, UserProfile } from '../../common/users/user-info'
+import { LOBBY_INIT_DATA, LOBBY_UPDATE_SLOT_CREATE } from '../actions'
 import { immerKeyedReducer } from '../reducers/keyed-reducer'
 
 export interface UserRequestInfo {
@@ -127,5 +128,15 @@ export default immerKeyedReducer(DEFAULT_STATE, {
 
   ['@parties/updateInvite'](state, action) {
     updateUsers(state, [action.payload.userInfo])
+  },
+
+  [LOBBY_INIT_DATA as any](state: any, action: any) {
+    updateUsers(state, action.payload.userInfos)
+  },
+
+  [LOBBY_UPDATE_SLOT_CREATE as any](state: any, action: any) {
+    if (action.payload.userInfo) {
+      updateUsers(state, [action.payload.userInfo])
+    }
   },
 })

--- a/server/lib/wsapi/lobbies.js
+++ b/server/lib/wsapi/lobbies.js
@@ -246,6 +246,10 @@ export class LobbyApi {
         return {
           type: 'init',
           lobby,
+          userInfos: getHumanSlots(lobby).map(s => ({
+            id: s.userId,
+            name: s.name,
+          })),
         }
       },
       client => this._removeClientFromLobby(this.lobbies.get(lobbyName), client),
@@ -1024,12 +1028,25 @@ export class LobbyApi {
       // includes the slots that were created as a result of players leaving the lobby, moving to a
       // different slot, open/closing a slot, etc.
       const [teamIndex, slotIndex, slot] = newIdSlots.get(id)
-      diffEvents.push({
+      const slotCreatedEvent = {
         type: 'slotCreate',
         teamIndex,
         slotIndex,
         slot,
-      })
+      }
+
+      if (slot.type === Slots.SlotType.Human || slot.type === Slots.SlotType.Observer) {
+        // At the moment, this seems unnecessary since this info already exists on the `slot` which
+        // we send to the client, but we might want to add additional data here in the future and
+        // also, this separation makes it a bit clearer that the purpose of this field is to just
+        // send user info.
+        slotCreatedEvent.userInfo = {
+          id: slot.userId,
+          name: slot.name,
+        }
+      }
+
+      diffEvents.push(slotCreatedEvent)
     }
 
     for (const id of same.values()) {


### PR DESCRIPTION
Previously, we were relying on user infos being already loaded inside
lobbies, which wasn't really a safe assumption. Creating a lobby from
any page other than the main chat channel could easily lead to someone
joining our lobby for whom we don't have user info loaded.

Now we're loading the user infos at 2 points. When we join the lobby, we
load the user infos for all users that are currently in the lobby, and
when someone new joins the lobby.

We don't clear the user infos when someone leaves the lobby, which might
be a problem for public lobbies? Probably not a big problem.