### PR TITLE
Fix the mention regex not matching multiple mentions separated by space.

### DIFF
--- a/client/messaging/common-message-layout.test.tsx
+++ b/client/messaging/common-message-layout.test.tsx
@@ -89,7 +89,6 @@ describe('client/messaging/common-message-layout/TextMessage', () => {
             isMention={true}
             userId={123}
           />
-          
         </common-message-layout__Text>
       </TimestampMessageLayout>
     `)
@@ -125,7 +124,6 @@ describe('client/messaging/common-message-layout/TextMessage', () => {
             isMention={true}
             userId={123}
           />
-          
         </common-message-layout__Text>
       </TimestampMessageLayout>
     `)
@@ -154,8 +152,7 @@ describe('client/messaging/common-message-layout/TextMessage', () => {
             isMention={true}
             userId={123}
           />
-           
-          see 
+           see 
           <a
             href="http://www.example.com"
             rel="noopener nofollow"
@@ -169,7 +166,6 @@ describe('client/messaging/common-message-layout/TextMessage', () => {
             isMention={true}
             userId={123}
           />
-          
         </common-message-layout__Text>
       </TimestampMessageLayout>
     `)
@@ -197,8 +193,7 @@ describe('client/messaging/common-message-layout/TextMessage', () => {
             isMention={true}
             userId={123}
           />
-           
-          go to 
+           go to 
           <a
             href="http://www.example.com"
             rel="noopener nofollow"
@@ -242,8 +237,7 @@ describe('client/messaging/common-message-layout/TextMessage', () => {
             isMention={true}
             userId={123}
           />
-           
-          or here 
+           or here 
           <a
             href="http://www.example.com"
             rel="noopener nofollow"
@@ -279,7 +273,6 @@ describe('client/messaging/common-message-layout/TextMessage', () => {
             isMention={true}
             userId={1}
           />
-          
         </common-message-layout__Text>
       </TimestampMessageLayout>
     `)

--- a/client/messaging/common-message-layout.tsx
+++ b/client/messaging/common-message-layout.tsx
@@ -81,7 +81,6 @@ export const TextMessage = React.memo<{
         elements.push(
           match.groups.prefix,
           <MentionedUsername key={match.index} userId={userId} isMention={true} />,
-          match.groups.postfix,
         )
       } else if (match.type === 'link') {
         // TODO(tec27): Handle links to our own host specially, redirecting to the correct route

--- a/common/text/mentions.test.ts
+++ b/common/text/mentions.test.ts
@@ -46,6 +46,16 @@ describe('common/text/mentions/matchUserMentions', () => {
     `)
   })
 
+  test('user with multiple mentions separated by space', () => {
+    expect(doMatch('Hi @test @test @test')).toMatchInlineSnapshot(`
+      Array [
+        "test",
+        "test",
+        "test",
+      ]
+    `)
+  })
+
   test('user with comma after it', () => {
     expect(doMatch('Hi @test, and everyone else.')).toMatchInlineSnapshot(`
       Array [
@@ -118,7 +128,7 @@ describe('common/text/mentions/matchUserMentions', () => {
     `)
   })
 
-  test('user with varios other special characters in name', () => {
+  test('user with various other special characters in name', () => {
     expect(doMatch('Hi @test`$^&*+=_-')).toMatchInlineSnapshot(`
       Array [
         "test\`$^&*+=_-",

--- a/common/text/mentions.ts
+++ b/common/text/mentions.ts
@@ -2,7 +2,7 @@ import { USERNAME_ALLOWED_CHARACTERS } from '../constants'
 import { TypedGroupRegExpMatchArray } from '../regex'
 
 const MENTION_PREFIX = String.raw`(?<prefix>\s|^)`
-const MENTION_POSTFIX = String.raw`(?<postfix>\s|$|[,;:?])`
+const MENTION_POSTFIX = String.raw`(?=\s|$|[,;:?])`
 
 /**
  * Regex for detecting and parsing user mentions. User mentions are a piece of text that start with
@@ -10,9 +10,11 @@ const MENTION_POSTFIX = String.raw`(?<postfix>\s|$|[,;:?])`
  * missing from the allowed punctuation list are . and ! since they are allowed username characters
  * as well.
  *
- * The matched user's name is available in the "user" capture group. There's also two additional
- * capture groups, namely "prefix" and "postfix", that contain all the matched characters
- * before/after the username.
+ * The matched user's name is available in the "user" capture group. There's also one additional
+ * named capture group, namely "prefix", that contains all the matched characters before the
+ * username. For characters that are allowed to come after the username, a positive lookahead group
+ * is used. Those character won't end up in a matched string, which could potentially interfer with
+ * prefix characters of the next match.
  */
 export const MENTION_REGEX = new RegExp(
   String.raw`${MENTION_PREFIX}@(?<username>${USERNAME_ALLOWED_CHARACTERS})${MENTION_POSTFIX}`,
@@ -32,7 +34,6 @@ export const MENTION_MARKUP_REGEX = new RegExp(
 export interface UserMentionGroups {
   prefix: string
   username: string
-  postfix: string
 }
 
 export interface UserMentionMatch {
@@ -67,7 +68,6 @@ export function* matchUserMentions(text: string): Generator<UserMentionMatch> {
 export interface MentionMarkupGroups {
   prefix: string
   userId: string
-  postfix: string
 }
 
 export interface MentionMarkupMatch {

--- a/common/text/mentions.ts
+++ b/common/text/mentions.ts
@@ -13,7 +13,7 @@ const MENTION_POSTFIX = String.raw`(?=\s|$|[,;:?])`
  * The matched user's name is available in the "user" capture group. There's also one additional
  * named capture group, namely "prefix", that contains all the matched characters before the
  * username. For characters that are allowed to come after the username, a positive lookahead group
- * is used. Those character won't end up in a matched string, which could potentially interfer with
+ * is used. Those character won't end up in a matched string, which could potentially interfere with
  * prefix characters of the next match.
  */
 export const MENTION_REGEX = new RegExp(

--- a/server/lib/messaging/process-chat-message.ts
+++ b/server/lib/messaging/process-chat-message.ts
@@ -20,12 +20,12 @@ export async function processMessageContents(
   const usernamesLowercase = new Map(
     Array.from(mentionedUsers.entries(), ([k, v]) => [k.toLowerCase(), v]),
   )
-  const processedText = text.replaceAll(MENTION_REGEX, (_, prefix, username, postfix) => {
+  const processedText = text.replaceAll(MENTION_REGEX, (_, prefix, username) => {
     const lowerCaseUser = username.toLowerCase()
 
     return usernamesLowercase.has(lowerCaseUser)
-      ? `${prefix}<@${usernamesLowercase.get(lowerCaseUser)!.id}>${postfix}`
-      : `${prefix}@${username}${postfix}`
+      ? `${prefix}<@${usernamesLowercase.get(lowerCaseUser)!.id}>`
+      : `${prefix}@${username}`
   })
 
   return [processedText, mentionedUsers]


### PR DESCRIPTION
When having two mentions separated by a space, the "postfix" character
of the first mention would interfer with the "prefix" of the second
mention, resulting in second mention not being mentioned.

This was fixed by making the "postfix" group use the positive lookahead
instead of a named capture group, so it doesn't end up in matched
string.

Also added a regression test for this behaviour.