### PR TITLE
Support EUD maps

### DIFF
--- a/client/maps/devonly/maps-for-testing.ts
+++ b/client/maps/devonly/maps-for-testing.ts
@@ -36,6 +36,7 @@ export const FightingSpirit: MapInfoJson = {
     ],
     width: 128,
     height: 128,
+    isEud: false,
   },
   isFavorited: false,
   mapUrl: 'https://example.org/map.scx',

--- a/common/maps.ts
+++ b/common/maps.ts
@@ -102,6 +102,7 @@ export interface MapData {
   umsForces: MapForce[]
   width: number
   height: number
+  isEud: boolean
 }
 
 export interface MapInfo {

--- a/game/src/app_messages.rs
+++ b/game/src/app_messages.rs
@@ -128,6 +128,7 @@ pub struct MapData {
     pub slots: u8,
     pub tileset: u16,
     pub ums_forces: Vec<MapForce>,
+    pub is_eud: bool,
 }
 
 #[derive(Deserialize)]

--- a/game/src/bw.rs
+++ b/game/src/bw.rs
@@ -11,7 +11,7 @@ use winapi::shared::ntdef::HANDLE;
 
 use bw_dat::UnitId;
 
-use crate::app_messages::Settings;
+use crate::app_messages::{MapInfo, Settings};
 
 pub use bw_dat::structs::*;
 
@@ -52,6 +52,7 @@ pub trait Bw: Sync + Send {
     unsafe fn create_lobby(
         &self,
         map_path: &Path,
+        map_info: &MapInfo,
         lobby_name: &str,
         game_type: GameType,
     ) -> Result<(), LobbyCreateError>;
@@ -60,6 +61,7 @@ pub trait Bw: Sync + Send {
     unsafe fn join_lobby(
         &self,
         game_info: &mut JoinableGameInfo,
+        is_eud_map: bool,
         map_path: &[u8],
         address: std::net::Ipv4Addr,
     ) -> Result<(), u32>;

--- a/game/src/bw_1161.rs
+++ b/game/src/bw_1161.rs
@@ -14,7 +14,7 @@ use winapi::um::winnt::HANDLE;
 
 use bw_dat::UnitId;
 
-use crate::app_messages::Settings;
+use crate::app_messages::{MapInfo, Settings};
 use crate::bw::{self, FowSpriteIterator, StormPlayerId};
 use crate::bw::unit::{Unit, UnitIterator};
 use crate::chat;
@@ -104,6 +104,7 @@ impl bw::Bw for Bw1161 {
     unsafe fn create_lobby(
         &self,
         map_path: &Path,
+        _map_info: &MapInfo,
         lobby_name: &str,
         game_type: bw::GameType,
     ) -> Result<(), bw::LobbyCreateError> {
@@ -113,6 +114,7 @@ impl bw::Bw for Bw1161 {
     unsafe fn join_lobby(
         &self,
         game_info: &mut bw::JoinableGameInfo,
+        _is_eud: bool,
         map_path: &[u8],
         _address: std::net::Ipv4Addr,
     ) -> Result<(), u32> {

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "babel-plugin-transform-typescript-metadata": "^0.3.1",
     "bcrypt": "^5.0.0",
     "bl": "^5.0.0",
-    "bw-chk": "^1.2.1",
+    "bw-chk": "^1.3.0",
     "canonical-host": "^0.0.5",
     "core-js": "^3.6.1",
     "cross-env": "^7.0.2",

--- a/server/lib/lobbies/lobby.test.ts
+++ b/server/lib/lobbies/lobby.test.ts
@@ -46,6 +46,7 @@ const BigGameHunters: MapInfo = {
     umsForces: [{ name: 'team', teamId: 0, players: [] }],
     width: 256,
     height: 256,
+    isEud: false,
   },
   isFavorited: false,
 }
@@ -885,6 +886,7 @@ const UMS_MAP_1: MapInfo = {
     ],
     width: 256,
     height: 256,
+    isEud: false,
   },
   isFavorited: false,
 }
@@ -929,6 +931,7 @@ const UMS_MAP_2: MapInfo = {
     ],
     width: 128,
     height: 128,
+    isEud: false,
   },
   isFavorited: false,
 }
@@ -967,6 +970,7 @@ const UMS_MAP_3: MapInfo = {
     ],
     width: 128,
     height: 128,
+    isEud: false,
   },
   isFavorited: false,
 }
@@ -1017,6 +1021,7 @@ const UMS_MAP_4: MapInfo = {
     ],
     width: 256,
     height: 256,
+    isEud: false,
   },
   isFavorited: false,
 }

--- a/server/lib/maps/map-models.ts
+++ b/server/lib/maps/map-models.ts
@@ -32,6 +32,7 @@ type DbMapInfo = Dbify<{
   originalDescription: string
   playersMelee: number
   playersUms: number
+  isEud: boolean
   lobbyInitData: {
     forces: MapForce[]
   }
@@ -70,6 +71,7 @@ function convertFromDb(props: DbMapInfo, urls: MapUrlProps): MapInfo {
       umsForces: props.lobby_init_data.forces,
       width: props.width,
       height: props.height,
+      isEud: props.is_eud,
     },
     isFavorited: !!props.favorited,
     ...urls,
@@ -126,6 +128,7 @@ export async function addMap(
       tileset,
       meleePlayers,
       umsPlayers,
+      isEud,
       lobbyInitData,
     } = mapData
 
@@ -134,9 +137,10 @@ export async function addMap(
     if (!exists) {
       const query = sql`
         INSERT INTO maps (hash, extension, title, description,
-          width, height, tileset, players_melee, players_ums, lobby_init_data)
+          width, height, tileset, players_melee, players_ums, lobby_init_data, is_eud)
         VALUES (${hashBuffer}, ${extension}, ${title}, ${description},
-          ${width}, ${height}, ${tileset}, ${meleePlayers}, ${umsPlayers}, ${lobbyInitData});
+          ${width}, ${height}, ${tileset}, ${meleePlayers}, ${umsPlayers}, ${lobbyInitData},
+          ${isEud});
       `
       await client.query(query)
       // Run the `transactionFn` only if a new map is added
@@ -173,6 +177,7 @@ export async function addMap(
         m.tileset,
         m.players_melee,
         m.players_ums,
+        m.is_eud,
         m.lobby_init_data,
         u.name AS uploaded_by_name
       FROM ins
@@ -240,6 +245,7 @@ export async function getMapInfo(mapIds: string[], favoritedBy?: SbUserId): Prom
         m.tileset,
         m.players_melee,
         m.players_ums,
+        m.is_eud,
         m.lobby_init_data,
         u.name AS uploaded_by_name
       FROM uploaded_maps AS um
@@ -351,6 +357,7 @@ export async function getMaps(
         m.tileset,
         m.players_melee,
         m.players_ums,
+        m.is_eud,
         m.lobby_init_data,
         u.name AS uploaded_by_name
       FROM uploaded_maps AS um
@@ -421,6 +428,7 @@ export async function getFavoritedMaps(
       m.tileset,
       m.players_melee,
       m.players_ums,
+      m.is_eud,
       m.lobby_init_data,
       u.name AS uploaded_by_name,
       true AS favorited
@@ -489,6 +497,7 @@ export async function updateMap(
       m.tileset,
       m.players_melee,
       m.players_ums,
+      m.is_eud,
       m.lobby_init_data,
       u.name AS uploaded_by_name,
       fav.map_id AS favorited

--- a/server/lib/maps/map-parse-worker.js
+++ b/server/lib/maps/map-parse-worker.js
@@ -144,6 +144,7 @@ process.once('message', async msg => {
           tileset: map.tileset,
           meleePlayers: map.maxPlayers(false),
           umsPlayers: map.maxPlayers(true),
+          isEud: map.isEudMap(),
           lobbyInitData: createLobbyInitData(map),
         },
         resolve,

--- a/server/lib/maps/parse-data.ts
+++ b/server/lib/maps/parse-data.ts
@@ -9,6 +9,7 @@ export interface MapParseData {
   tileset: number
   meleePlayers: number
   umsPlayers: number
+  isEud: boolean
   lobbyInitData: {
     forces: MapForce[]
   }

--- a/server/migrations/20211109203236-add-eud-map-column.js
+++ b/server/migrations/20211109203236-add-eud-map-column.js
@@ -1,0 +1,15 @@
+exports.up = async function (db) {
+  await db.runSql(`
+    ALTER TABLE maps ADD COLUMN is_eud BOOLEAN NOT NULL DEFAULT false;
+  `)
+}
+
+exports.down = async function (db) {
+  await db.runSql(`
+    ALTER TABLE maps DROP COLUMN is_eud;
+  `)
+}
+
+exports._meta = {
+  version: 1,
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3386,7 +3386,7 @@ bl@^1.0.1:
     readable-stream "^2.3.5"
     safe-buffer "^5.1.1"
 
-bl@^4.0.0, bl@^4.0.3:
+bl@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/bl/-/bl-4.1.0.tgz#451535264182bec2fbbc83a62ab98cf11d9f7b3a"
   integrity sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==
@@ -3597,12 +3597,12 @@ builder-util@22.13.1:
     stat-mode "^1.0.0"
     temp-file "^3.4.0"
 
-bw-chk@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/bw-chk/-/bw-chk-1.2.1.tgz#80c5ef96d017bb80ec093117629ba1d42f6101f1"
-  integrity sha512-FL9y8i7TTfu72vkK2qG/RS4grJNFs1WpNddiuI95ck3KP43sJiHZSxnCSrRVvf7itlFhd31Fp3gtyokpR4HjYQ==
+bw-chk@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/bw-chk/-/bw-chk-1.3.0.tgz#d167a6e119b696dd931935f1cfb1c0e163d3d4f7"
+  integrity sha512-SrADgyvtLWWHbzrlXZ3ib+q9DBYOKDk6mBUAmUBT6R9owyLvwaReLjyXd7SpfuWLvJe9ZAVyxUQyHQXn0EExCA==
   dependencies:
-    bl "^4.0.3"
+    bl "^5.0.0"
     iconv-lite "^0.6.2"
 
 bytes@3.1.0, bytes@^3.0.0:


### PR DESCRIPTION
Does not include anything to parse existing maps again, so this won't fix
EUD maps that were already uploaded.

The bw-chk update also adds support for UTF-8 map encodings; this also
would benefit from being able to reparse all maps in the database.