### PR TITLE
Make channel owners be defined explicitly, instead of implicitly.

### DIFF
--- a/client/chat/actions.ts
+++ b/client/chat/actions.ts
@@ -5,7 +5,7 @@ import {
   GetChannelUsersServerPayload,
   JoinChannelMessage,
 } from '../../common/chat'
-import { SbUser } from '../../common/users/user-info'
+import { SbUser, SbUserId } from '../../common/users/user-info'
 import { BaseFetchFailure } from '../network/fetch-action-types'
 
 export type ChatActions =
@@ -225,7 +225,7 @@ export interface UpdateLeave {
   payload: {
     channel: string
     user: ChatUser
-    newOwner: ChatUser | null
+    newOwnerId: SbUserId | null
   }
 }
 

--- a/client/chat/chat-reducer.ts
+++ b/client/chat/chat-reducer.ts
@@ -122,7 +122,7 @@ export default immerKeyedReducer(DEFAULT_CHAT_STATE, {
   },
 
   ['@chat/updateLeave'](state, action) {
-    const { channel: channelName, user, newOwner } = action.payload
+    const { channel: channelName, user, newOwnerId } = action.payload
     const lowerCaseChannelName = channelName.toLowerCase()
 
     const channel = state.byName.get(lowerCaseChannelName)
@@ -144,14 +144,14 @@ export default immerKeyedReducer(DEFAULT_CHAT_STATE, {
       }),
     )
 
-    if (newOwner) {
+    if (newOwnerId) {
       updateMessages(state, lowerCaseChannelName, true, m =>
         m.concat({
           id: cuid(),
           type: ClientChatMessageType.NewChannelOwner,
           channel: lowerCaseChannelName,
           time: Date.now(),
-          newOwnerId: newOwner.id,
+          newOwnerId,
         }),
       )
     }

--- a/client/chat/socket-handlers.ts
+++ b/client/chat/socket-handlers.ts
@@ -51,7 +51,7 @@ const eventToAction: EventToActionMap = {
         payload: {
           channel,
           user: event.user,
-          newOwner: event.newOwner,
+          newOwnerId: event.newOwnerId,
         },
       })
     }

--- a/common/chat.ts
+++ b/common/chat.ts
@@ -93,24 +93,24 @@ export interface ChatLeaveEvent {
   action: 'leave'
   /** A user that has left the chat channel. */
   user: ChatUser
-  /** A user that was selected as a new owner of the channel, if any. */
-  newOwner: ChatUser | null
+  /** The ID of a user that was selected as a new owner of the channel, if any. */
+  newOwnerId: SbUserId | null
 }
 
 export interface ChatKickEvent {
   action: 'kick'
   /** A user that was kicked from the chat channel. */
   target: ChatUser
-  /** A user that was selected as a new owner of the channel, if any. */
-  newOwner: ChatUser | null
+  /** The ID of a user that was selected as a new owner of the channel, if any. */
+  newOwnerId: SbUserId | null
 }
 
 export interface ChatBanEvent {
   action: 'ban'
   /** A user that was banned from the chat channel. */
   target: ChatUser
-  /** A user that was selected as a new owner of the channel, if any. */
-  newOwner: ChatUser | null
+  /** The ID of a user that was selected as a new owner of the channel, if any. */
+  newOwnerId: SbUserId | null
 }
 
 export interface ChatMessageEvent {

--- a/server/migrations/20211110231126-add-channel-owners.js
+++ b/server/migrations/20211110231126-add-channel-owners.js
@@ -1,0 +1,26 @@
+exports.up = async function (db) {
+  await db.runSql(`
+    ALTER TABLE joined_channels
+    ADD COLUMN owner
+    BOOLEAN NOT NULL DEFAULT false;
+  `)
+
+  await db.runSql(`
+    CREATE UNIQUE INDEX joined_channels_owner
+    ON joined_channels (channel_name, owner)
+    WHERE owner = true;
+  `)
+}
+
+exports.down = async function (db) {
+  await db.runSql(`DROP INDEX joined_channels_owner`)
+
+  await db.runSql(`
+    ALTER TABLE joined_channels
+    DROP COLUMN owner;
+  `)
+}
+
+exports._meta = {
+  version: 1,
+}

--- a/server/migrations/20211110231126-add-channel-owners.js
+++ b/server/migrations/20211110231126-add-channel-owners.js
@@ -10,6 +10,20 @@ exports.up = async function (db) {
     ON joined_channels (channel_name, owner)
     WHERE owner = true;
   `)
+
+  // Give the channel ownership (and all the other permissions) to the earliest joined user.
+  await db.runSql(`
+    WITH o AS (
+      SELECT DISTINCT ON (channel_name) *
+      FROM joined_channels
+      ORDER BY channel_name, join_date
+    )
+    UPDATE joined_channels AS jc
+    SET kick = true, ban = true, change_topic = true, toggle_private = true,
+      edit_permissions = true, owner = true
+    FROM o
+    WHERE jc.user_id = o.user_id AND jc.channel_name = o.channel_name;
+  `)
 }
 
 exports.down = async function (db) {


### PR DESCRIPTION
Currently, we were using the "edit_permissions" flag as a makeshift
indicator of channel ownership. However, this is not ideal since more
than one person can have this permission set. Technically we could've
defined a channel owner at the model level, where the owner would be set
as a user with this permission and who joined the channel the earliest.

However, I feel like this would get a bit unwieldy and messy down the
line, especially if we start thinking about features like transferring
channel ownership.

This PR adds another column to the database, which ensures that there
can be only one owner per channel, at the database-level. I guess it is
a little bit weird to have a flag that trumps all other flags, no matter
their values, but I believe this is what Discord does too, so we should
be fine? :d