### PR TITLE
Send user their channel permissions when they join a channel.

### DIFF
--- a/client/chat/action-creators.ts
+++ b/client/chat/action-creators.ts
@@ -107,7 +107,7 @@ export function retrieveUserList(channel: string): ThunkAction {
     })
     dispatch({
       type: '@chat/retrieveUserList',
-      payload: fetch<SbUser[]>(apiUrl`chat/${channel}/users2`, {
+      payload: fetchJson<SbUser[]>(apiUrl`chat/${channel}/users2`, {
         method: 'GET',
       }),
       meta: params,

--- a/client/chat/action-creators.ts
+++ b/client/chat/action-creators.ts
@@ -1,9 +1,6 @@
-import {
-  GetChannelHistoryServerPayload,
-  GetChannelUsersServerPayload,
-  SendChatMessageServerBody,
-} from '../../common/chat'
+import { GetChannelHistoryServerPayload, SendChatMessageServerBody } from '../../common/chat'
 import { apiUrl } from '../../common/urls'
+import { SbUser } from '../../common/users/user-info'
 import { ThunkAction } from '../dispatch-registry'
 import { push } from '../navigation/routing'
 import { fetchJson } from '../network/fetch'
@@ -110,7 +107,7 @@ export function retrieveUserList(channel: string): ThunkAction {
     })
     dispatch({
       type: '@chat/retrieveUserList',
-      payload: fetchJson<GetChannelUsersServerPayload>(apiUrl`chat/${channel}/users`, {
+      payload: fetch<SbUser[]>(apiUrl`chat/${channel}/users`, {
         method: 'GET',
       }),
       meta: params,

--- a/client/chat/action-creators.ts
+++ b/client/chat/action-creators.ts
@@ -107,7 +107,7 @@ export function retrieveUserList(channel: string): ThunkAction {
     })
     dispatch({
       type: '@chat/retrieveUserList',
-      payload: fetch<SbUser[]>(apiUrl`chat/${channel}/users`, {
+      payload: fetch<SbUser[]>(apiUrl`chat/${channel}/users2`, {
         method: 'GET',
       }),
       meta: params,

--- a/client/chat/actions.ts
+++ b/client/chat/actions.ts
@@ -1,5 +1,4 @@
 import {
-  ChatEvent,
   ChatInitEvent,
   ChatJoinEvent,
   ChatLeaveEvent,

--- a/client/chat/actions.ts
+++ b/client/chat/actions.ts
@@ -198,18 +198,12 @@ export interface DeactivateChannel {
 }
 
 /**
- * A type that allows using the socket events directly as payload for dispatch actions, by including
- * the channel in the payload, since the channel is not included in the event itself (it is part of
- * the websocket URL).
- */
-type PayloadWithChannel<T extends ChatEvent> = { channel: string } & Omit<T, 'action'>
-
-/**
  * We have joined a channel and the server has sent us some initial data.
  */
 export interface InitChannel {
   type: '@chat/initChannel'
-  payload: PayloadWithChannel<ChatInitEvent>
+  payload: ChatInitEvent
+  meta: { channel: string }
 }
 
 /**
@@ -217,7 +211,8 @@ export interface InitChannel {
  */
 export interface UpdateJoin {
   type: '@chat/updateJoin'
-  payload: PayloadWithChannel<ChatJoinEvent>
+  payload: ChatJoinEvent
+  meta: { channel: string }
 }
 
 /**
@@ -225,7 +220,8 @@ export interface UpdateJoin {
  */
 export interface UpdateLeave {
   type: '@chat/updateLeave'
-  payload: PayloadWithChannel<ChatLeaveEvent>
+  payload: ChatLeaveEvent
+  meta: { channel: string }
 }
 
 /**
@@ -233,7 +229,7 @@ export interface UpdateLeave {
  */
 export interface UpdateLeaveSelf {
   type: '@chat/updateLeaveSelf'
-  payload: { channel: string }
+  meta: { channel: string }
 }
 
 /**
@@ -241,7 +237,8 @@ export interface UpdateLeaveSelf {
  */
 export interface UpdateMessage {
   type: '@chat/updateMessage'
-  payload: PayloadWithChannel<ChatMessageEvent>
+  payload: ChatMessageEvent
+  meta: { channel: string }
 }
 
 /**
@@ -249,7 +246,8 @@ export interface UpdateMessage {
  */
 export interface UpdateUserActive {
   type: '@chat/updateUserActive'
-  payload: PayloadWithChannel<ChatUserActiveEvent>
+  payload: ChatUserActiveEvent
+  meta: { channel: string }
 }
 
 /**
@@ -257,7 +255,8 @@ export interface UpdateUserActive {
  */
 export interface UpdateUserIdle {
   type: '@chat/updateUserIdle'
-  payload: PayloadWithChannel<ChatUserIdleEvent>
+  payload: ChatUserIdleEvent
+  meta: { channel: string }
 }
 
 /**
@@ -265,5 +264,6 @@ export interface UpdateUserIdle {
  */
 export interface UpdateUserOffline {
   type: '@chat/updateUserOffline'
-  payload: PayloadWithChannel<ChatUserOfflineEvent>
+  payload: ChatUserOfflineEvent
+  meta: { channel: string }
 }

--- a/client/chat/actions.ts
+++ b/client/chat/actions.ts
@@ -1,4 +1,5 @@
 import {
+  ChatEvent,
   ChatInitEvent,
   ChatJoinEvent,
   ChatLeaveEvent,
@@ -7,8 +8,8 @@ import {
   ChatUserIdleEvent,
   ChatUserOfflineEvent,
   GetChannelHistoryServerPayload,
-  GetChannelUsersServerPayload,
 } from '../../common/chat'
+import { SbUser } from '../../common/users/user-info'
 import { BaseFetchFailure } from '../network/fetch-action-types'
 
 export type ChatActions =
@@ -161,7 +162,7 @@ export interface RetrieveUserListBegin {
  */
 export interface RetrieveUserList {
   type: '@chat/retrieveUserList'
-  payload: GetChannelUsersServerPayload
+  payload: SbUser[]
   meta: {
     channel: string
   }
@@ -201,7 +202,7 @@ export interface DeactivateChannel {
  * the channel in the payload, since the channel is not included in the event itself (it is part of
  * the websocket URL).
  */
-type PayloadWithChannel<T = void> = { channel: string } & Omit<T, 'action'>
+type PayloadWithChannel<T extends ChatEvent> = { channel: string } & Omit<T, 'action'>
 
 /**
  * We have joined a channel and the server has sent us some initial data.
@@ -232,7 +233,7 @@ export interface UpdateLeave {
  */
 export interface UpdateLeaveSelf {
   type: '@chat/updateLeaveSelf'
-  payload: PayloadWithChannel
+  payload: { channel: string }
 }
 
 /**

--- a/client/chat/actions.ts
+++ b/client/chat/actions.ts
@@ -1,11 +1,14 @@
 import {
+  ChatInitEvent,
+  ChatJoinEvent,
+  ChatLeaveEvent,
   ChatMessageEvent,
-  ChatUser,
+  ChatUserActiveEvent,
+  ChatUserIdleEvent,
+  ChatUserOfflineEvent,
   GetChannelHistoryServerPayload,
   GetChannelUsersServerPayload,
-  JoinChannelMessage,
 } from '../../common/chat'
-import { SbUser, SbUserId } from '../../common/users/user-info'
 import { BaseFetchFailure } from '../network/fetch-action-types'
 
 export type ChatActions =
@@ -194,14 +197,18 @@ export interface DeactivateChannel {
 }
 
 /**
+ * A type that allows using the socket events directly as payload for dispatch actions, by including
+ * the channel in the payload, since the channel is not included in the event itself (it is part of
+ * the websocket URL).
+ */
+type PayloadWithChannel<T = void> = { channel: string } & Omit<T, 'action'>
+
+/**
  * We have joined a channel and the server has sent us some initial data.
  */
 export interface InitChannel {
   type: '@chat/initChannel'
-  payload: {
-    channel: string
-    activeUsers: ChatUser[]
-  }
+  payload: PayloadWithChannel<ChatInitEvent>
 }
 
 /**
@@ -209,12 +216,7 @@ export interface InitChannel {
  */
 export interface UpdateJoin {
   type: '@chat/updateJoin'
-  payload: {
-    channel: string
-    channelUser: ChatUser
-    user: SbUser
-    message: JoinChannelMessage
-  }
+  payload: PayloadWithChannel<ChatJoinEvent>
 }
 
 /**
@@ -222,11 +224,7 @@ export interface UpdateJoin {
  */
 export interface UpdateLeave {
   type: '@chat/updateLeave'
-  payload: {
-    channel: string
-    user: ChatUser
-    newOwnerId: SbUserId | null
-  }
+  payload: PayloadWithChannel<ChatLeaveEvent>
 }
 
 /**
@@ -234,9 +232,7 @@ export interface UpdateLeave {
  */
 export interface UpdateLeaveSelf {
   type: '@chat/updateLeaveSelf'
-  payload: {
-    channel: string
-  }
+  payload: PayloadWithChannel
 }
 
 /**
@@ -244,7 +240,7 @@ export interface UpdateLeaveSelf {
  */
 export interface UpdateMessage {
   type: '@chat/updateMessage'
-  payload: ChatMessageEvent
+  payload: PayloadWithChannel<ChatMessageEvent>
 }
 
 /**
@@ -252,10 +248,7 @@ export interface UpdateMessage {
  */
 export interface UpdateUserActive {
   type: '@chat/updateUserActive'
-  payload: {
-    channel: string
-    user: ChatUser
-  }
+  payload: PayloadWithChannel<ChatUserActiveEvent>
 }
 
 /**
@@ -263,10 +256,7 @@ export interface UpdateUserActive {
  */
 export interface UpdateUserIdle {
   type: '@chat/updateUserIdle'
-  payload: {
-    channel: string
-    user: ChatUser
-  }
+  payload: PayloadWithChannel<ChatUserIdleEvent>
 }
 
 /**
@@ -274,8 +264,5 @@ export interface UpdateUserIdle {
  */
 export interface UpdateUserOffline {
   type: '@chat/updateUserOffline'
-  payload: {
-    channel: string
-    user: ChatUser
-  }
+  payload: PayloadWithChannel<ChatUserOfflineEvent>
 }

--- a/client/chat/channel.tsx
+++ b/client/chat/channel.tsx
@@ -371,7 +371,7 @@ export default function Channel(props: ChatChannelProps) {
   const prevChannelName = usePrevious(channelName)
   const prevChannel = usePrevious(channel)
   const isInChannel = !!channel
-  const isLeavingChannel = !isInChannel && prevChannel && prevChannelName === channelName
+  const isLeavingChannel = !isInChannel && !!prevChannel && prevChannelName === channelName
 
   // TODO(2Pac): Pull this out into some kind of "isLeaving" hook and share with whispers/lobby?
   useEffect(() => {

--- a/client/chat/channel.tsx
+++ b/client/chat/channel.tsx
@@ -369,7 +369,7 @@ function renderMessage(msg: Message) {
 
 type UserEntries = [userId: SbUserId, username: string | undefined][]
 
-function userEntriesSelector(userIds: ReadonlySet<SbUserId> | undefined) {
+function makeUserEntriesSelector(userIds: ReadonlySet<SbUserId> | undefined) {
   return (state: RootState) => {
     const userEntries: UserEntries = []
     if (!userIds) {
@@ -387,7 +387,7 @@ function userEntriesSelector(userIds: ReadonlySet<SbUserId> | undefined) {
   }
 }
 
-function didUserEntryChange(a: UserEntries, b: UserEntries) {
+function areUserEntriesEqual(a: UserEntries, b: UserEntries): boolean {
   if (a.length !== b.length) {
     return false
   }
@@ -433,9 +433,15 @@ export default function Channel(props: ChatChannelProps) {
   const offlineUserIds = channel?.users.offline
   // We map the user IDs to their usernames so we can sort them by their name without pulling all of
   // the users from the store and depending on any of their changes.
-  const activeUserEntries = useAppSelector(userEntriesSelector(activeUserIds), didUserEntryChange)
-  const idleUserEntries = useAppSelector(userEntriesSelector(idleUserIds), didUserEntryChange)
-  const offlineUserEntries = useAppSelector(userEntriesSelector(offlineUserIds), didUserEntryChange)
+  const activeUserEntries = useAppSelector(
+    makeUserEntriesSelector(activeUserIds),
+    areUserEntriesEqual,
+  )
+  const idleUserEntries = useAppSelector(makeUserEntriesSelector(idleUserIds), areUserEntriesEqual)
+  const offlineUserEntries = useAppSelector(
+    makeUserEntriesSelector(offlineUserIds),
+    areUserEntriesEqual,
+  )
 
   const prevChannelName = usePrevious(channelName)
   const prevChannel = usePrevious(channel)

--- a/client/chat/channel.tsx
+++ b/client/chat/channel.tsx
@@ -418,9 +418,12 @@ export default function Channel(props: ChatChannelProps) {
       const usernameA = userIdToUsername.get(a)
       const usernameB = userIdToUsername.get(b)
 
-      if (!usernameA || !usernameB) {
-        // We put any user that still hasn't loaded at the bottom of the list
+      // We put any user that still hasn't loaded at the bottom of the list
+      if (!usernameA) {
         return 1
+      }
+      if (!usernameB) {
+        return -1
       }
 
       return usernameA.localeCompare(usernameB)

--- a/client/chat/chat-reducer.ts
+++ b/client/chat/chat-reducer.ts
@@ -75,7 +75,8 @@ function updateMessages(
 
 export default immerKeyedReducer(DEFAULT_CHAT_STATE, {
   ['@chat/initChannel'](state, action) {
-    const { channel: channelName, activeUserIds, permissions } = action.payload
+    const { activeUserIds, permissions } = action.payload
+    const { channel: channelName } = action.meta
     const lowerCaseChannelName = channelName.toLowerCase()
 
     const channelUsers: UsersState = {
@@ -109,7 +110,8 @@ export default immerKeyedReducer(DEFAULT_CHAT_STATE, {
   },
 
   ['@chat/updateJoin'](state, action) {
-    const { channel: channelName, user, message } = action.payload
+    const { user, message } = action.payload
+    const { channel: channelName } = action.meta
     const lowerCaseChannelName = channelName.toLowerCase()
 
     const channel = state.byName.get(lowerCaseChannelName)
@@ -124,7 +126,8 @@ export default immerKeyedReducer(DEFAULT_CHAT_STATE, {
   },
 
   ['@chat/updateLeave'](state, action) {
-    const { channel: channelName, userId, newOwnerId } = action.payload
+    const { userId, newOwnerId } = action.payload
+    const { channel: channelName } = action.meta
     const lowerCaseChannelName = channelName.toLowerCase()
 
     const channel = state.byName.get(lowerCaseChannelName)
@@ -160,7 +163,7 @@ export default immerKeyedReducer(DEFAULT_CHAT_STATE, {
   },
 
   ['@chat/updateLeaveSelf'](state, action) {
-    const { channel: channelName } = action.payload
+    const { channel: channelName } = action.meta
     const lowerCaseChannelName = channelName.toLowerCase()
 
     state.channels.delete(channelName)
@@ -168,14 +171,16 @@ export default immerKeyedReducer(DEFAULT_CHAT_STATE, {
   },
 
   ['@chat/updateMessage'](state, action) {
-    const newMessage = action.payload.message
-    const lowerCaseChannelName = newMessage.channel.toLowerCase()
+    const { message: newMessage } = action.payload
+    const { channel: channelName } = action.meta
+    const lowerCaseChannelName = channelName.toLowerCase()
 
     updateMessages(state, lowerCaseChannelName, true, m => m.concat(newMessage))
   },
 
   ['@chat/updateUserActive'](state, action) {
-    const { channel: channelName, userId } = action.payload
+    const { userId } = action.payload
+    const { channel: channelName } = action.meta
     const lowerCaseChannelName = channelName.toLowerCase()
 
     const channel = state.byName.get(lowerCaseChannelName)
@@ -189,7 +194,8 @@ export default immerKeyedReducer(DEFAULT_CHAT_STATE, {
   },
 
   ['@chat/updateUserIdle'](state, action) {
-    const { channel: channelName, userId } = action.payload
+    const { userId } = action.payload
+    const { channel: channelName } = action.meta
     const lowerCaseChannelName = channelName.toLowerCase()
 
     const channel = state.byName.get(lowerCaseChannelName)
@@ -203,7 +209,8 @@ export default immerKeyedReducer(DEFAULT_CHAT_STATE, {
   },
 
   ['@chat/updateUserOffline'](state, action) {
-    const { channel: channelName, userId } = action.payload
+    const { userId } = action.payload
+    const { channel: channelName } = action.meta
     const lowerCaseChannelName = channelName.toLowerCase()
 
     const channel = state.byName.get(lowerCaseChannelName)

--- a/client/chat/chat-reducer.ts
+++ b/client/chat/chat-reducer.ts
@@ -18,7 +18,7 @@ export interface ChannelState {
   name: string
   messages: ChatMessage[]
   users: UsersState
-  permissions: ChannelPermissions
+  selfPermissions: ChannelPermissions
 
   loadingHistory: boolean
   hasHistory: boolean
@@ -75,7 +75,7 @@ function updateMessages(
 
 export default immerKeyedReducer(DEFAULT_CHAT_STATE, {
   ['@chat/initChannel'](state, action) {
-    const { activeUserIds, permissions } = action.payload
+    const { activeUserIds, selfPermissions } = action.payload
     const { channel: channelName } = action.meta
     const lowerCaseChannelName = channelName.toLowerCase()
 
@@ -88,7 +88,7 @@ export default immerKeyedReducer(DEFAULT_CHAT_STATE, {
       name: channelName,
       messages: [],
       users: channelUsers,
-      permissions,
+      selfPermissions,
       loadingHistory: false,
       hasHistory: true,
       hasLoadedUserList: false,

--- a/client/chat/socket-handlers.ts
+++ b/client/chat/socket-handlers.ts
@@ -18,7 +18,8 @@ const eventToAction: EventToActionMap = {
       type: '@chat/initChannel',
       payload: {
         channel,
-        activeUsers: event.activeUsers,
+        activeUserIds: event.activeUserIds,
+        permissions: event.permissions,
       },
     }
   },
@@ -28,7 +29,6 @@ const eventToAction: EventToActionMap = {
       type: '@chat/updateJoin',
       payload: {
         channel,
-        channelUser: event.channelUser,
         user: event.user,
         message: event.message,
       },

--- a/client/chat/socket-handlers.ts
+++ b/client/chat/socket-handlers.ts
@@ -37,7 +37,7 @@ const eventToAction: EventToActionMap = {
 
   leave: (channel, event) => (dispatch, getState) => {
     const { auth } = getState()
-    if (auth.user.id === event.user.id) {
+    if (auth.user.id === event.userId) {
       // It was us who left the channel
       dispatch({
         type: '@chat/updateLeaveSelf',
@@ -50,7 +50,7 @@ const eventToAction: EventToActionMap = {
         type: '@chat/updateLeave',
         payload: {
           channel,
-          user: event.user,
+          userId: event.userId,
           newOwnerId: event.newOwnerId,
         },
       })
@@ -70,7 +70,10 @@ const eventToAction: EventToActionMap = {
 
       dispatch({
         type: '@chat/updateMessage',
-        payload: event,
+        payload: {
+          channel,
+          ...event,
+        },
       })
     }
   },
@@ -80,7 +83,7 @@ const eventToAction: EventToActionMap = {
       type: '@chat/updateUserActive',
       payload: {
         channel,
-        user: event.user,
+        userId: event.userId,
       },
     }
   },
@@ -90,7 +93,7 @@ const eventToAction: EventToActionMap = {
       type: '@chat/updateUserIdle',
       payload: {
         channel,
-        user: event.user,
+        userId: event.userId,
       },
     }
   },
@@ -100,7 +103,7 @@ const eventToAction: EventToActionMap = {
       type: '@chat/updateUserOffline',
       payload: {
         channel,
-        user: event.user,
+        userId: event.userId,
       },
     }
   },

--- a/client/chat/socket-handlers.ts
+++ b/client/chat/socket-handlers.ts
@@ -13,7 +13,7 @@ type EventToActionMap = {
 }
 
 const eventToAction: EventToActionMap = {
-  init(channel, event) {
+  init2(channel, event) {
     return {
       type: '@chat/initChannel',
       payload: {
@@ -24,7 +24,7 @@ const eventToAction: EventToActionMap = {
     }
   },
 
-  join(channel, event) {
+  join2(channel, event) {
     return {
       type: '@chat/updateJoin',
       payload: {
@@ -35,7 +35,7 @@ const eventToAction: EventToActionMap = {
     }
   },
 
-  leave: (channel, event) => (dispatch, getState) => {
+  leave2: (channel, event) => (dispatch, getState) => {
     const { auth } = getState()
     if (auth.user.id === event.userId) {
       // It was us who left the channel
@@ -78,7 +78,7 @@ const eventToAction: EventToActionMap = {
     }
   },
 
-  userActive(channel, event) {
+  userActive2(channel, event) {
     return {
       type: '@chat/updateUserActive',
       payload: {
@@ -88,7 +88,7 @@ const eventToAction: EventToActionMap = {
     }
   },
 
-  userIdle(channel, event) {
+  userIdle2(channel, event) {
     return {
       type: '@chat/updateUserIdle',
       payload: {
@@ -98,7 +98,7 @@ const eventToAction: EventToActionMap = {
     }
   },
 
-  userOffline(channel, event) {
+  userOffline2(channel, event) {
     return {
       type: '@chat/updateUserOffline',
       payload: {

--- a/client/chat/socket-handlers.ts
+++ b/client/chat/socket-handlers.ts
@@ -16,22 +16,16 @@ const eventToAction: EventToActionMap = {
   init2(channel, event) {
     return {
       type: '@chat/initChannel',
-      payload: {
-        channel,
-        activeUserIds: event.activeUserIds,
-        permissions: event.permissions,
-      },
+      payload: event,
+      meta: { channel },
     }
   },
 
   join2(channel, event) {
     return {
       type: '@chat/updateJoin',
-      payload: {
-        channel,
-        user: event.user,
-        message: event.message,
-      },
+      payload: event,
+      meta: { channel },
     }
   },
 
@@ -41,18 +35,13 @@ const eventToAction: EventToActionMap = {
       // It was us who left the channel
       dispatch({
         type: '@chat/updateLeaveSelf',
-        payload: {
-          channel,
-        },
+        meta: { channel },
       })
     } else {
       dispatch({
         type: '@chat/updateLeave',
-        payload: {
-          channel,
-          userId: event.userId,
-          newOwnerId: event.newOwnerId,
-        },
+        payload: event,
+        meta: { channel },
       })
     }
   },
@@ -70,10 +59,8 @@ const eventToAction: EventToActionMap = {
 
       dispatch({
         type: '@chat/updateMessage',
-        payload: {
-          channel,
-          ...event,
-        },
+        payload: event,
+        meta: { channel },
       })
     }
   },
@@ -81,30 +68,24 @@ const eventToAction: EventToActionMap = {
   userActive2(channel, event) {
     return {
       type: '@chat/updateUserActive',
-      payload: {
-        channel,
-        userId: event.userId,
-      },
+      payload: event,
+      meta: { channel },
     }
   },
 
   userIdle2(channel, event) {
     return {
       type: '@chat/updateUserIdle',
-      payload: {
-        channel,
-        userId: event.userId,
-      },
+      payload: event,
+      meta: { channel },
     }
   },
 
   userOffline2(channel, event) {
     return {
       type: '@chat/updateUserOffline',
-      payload: {
-        channel,
-        userId: event.userId,
-      },
+      payload: event,
+      meta: { channel },
     }
   },
 }

--- a/client/profile/user-reducer.ts
+++ b/client/profile/user-reducer.ts
@@ -102,7 +102,7 @@ export default immerKeyedReducer(DEFAULT_STATE, {
       return
     }
 
-    updateUsers(state, action.payload.users)
+    updateUsers(state, action.payload)
   },
 
   ['@chat/updateJoin'](state, action) {

--- a/common/chat.ts
+++ b/common/chat.ts
@@ -77,7 +77,7 @@ export interface ChannelPermissions {
 }
 
 export interface ChatInitEvent {
-  action: 'init'
+  action: 'init2'
   /** A list of IDs of active user that are in the chat channel. */
   activeUserIds: SbUserId[]
   /** The channel permissions for the user that is initializing the channel. */
@@ -85,7 +85,7 @@ export interface ChatInitEvent {
 }
 
 export interface ChatJoinEvent {
-  action: 'join'
+  action: 'join2'
   /** A user info for the channel user that has joined the chat channel. */
   user: SbUser
   /** A message info for the user joining a channel that is saved in the DB. */
@@ -93,7 +93,7 @@ export interface ChatJoinEvent {
 }
 
 export interface ChatLeaveEvent {
-  action: 'leave'
+  action: 'leave2'
   /** The ID of a user that has left the chat channel. */
   userId: SbUserId
   /** The ID of a user that was selected as a new owner of the channel, if any. */
@@ -127,19 +127,19 @@ export interface ChatMessageEvent {
 }
 
 export interface ChatUserActiveEvent {
-  action: 'userActive'
+  action: 'userActive2'
   /** The ID of a user that has become active in a chat channel. */
   userId: SbUserId
 }
 
 export interface ChatUserIdleEvent {
-  action: 'userIdle'
+  action: 'userIdle2'
   /** The ID of a user that has become idle in a chat channel. */
   userId: SbUserId
 }
 
 export interface ChatUserOfflineEvent {
-  action: 'userOffline'
+  action: 'userOffline2'
   /** The ID of a user that went offline in a chat channel. */
   userId: SbUserId
 }

--- a/common/chat.ts
+++ b/common/chat.ts
@@ -15,22 +15,6 @@ export enum ClientChatMessageType {
 
 export type ChatMessageType = ServerChatMessageType | ClientChatMessageType
 
-export interface ChannelPermissions {
-  kick: boolean
-  ban: boolean
-  changeTopic: boolean
-  togglePrivate: boolean
-  editPermissions: boolean
-  owner: boolean
-}
-
-export interface ChatUser {
-  id: SbUserId
-  name: string
-  joinDate: number
-  permissions: ChannelPermissions
-}
-
 export interface BaseChatMessage {
   id: string
   type: ChatMessageType
@@ -83,17 +67,26 @@ export type ClientChatMessage =
 
 export type ChatMessage = ServerChatMessage | ClientChatMessage
 
+export interface ChannelPermissions {
+  kick: boolean
+  ban: boolean
+  changeTopic: boolean
+  togglePrivate: boolean
+  editPermissions: boolean
+  owner: boolean
+}
+
 export interface ChatInitEvent {
   action: 'init'
-  /** A list of active users that are in the chat channel. */
-  activeUsers: ChatUser[]
+  /** A list of IDs of active user that are in the chat channel. */
+  activeUserIds: SbUserId[]
+  /** The channel permissions for the user that is initializing the channel. */
+  permissions: ChannelPermissions
 }
 
 export interface ChatJoinEvent {
   action: 'join'
-  /** A user that has joined the chat channel. */
-  channelUser: ChatUser
-  /** A user info for the channel user that was returned in the `channelUser` property. */
+  /** A user info for the channel user that has joined the chat channel. */
   user: SbUser
   /** A message info for the user joining a channel that is saved in the DB. */
   message: JoinChannelMessage
@@ -135,16 +128,19 @@ export interface ChatMessageEvent {
 
 export interface ChatUserActiveEvent {
   action: 'userActive'
+  /** The ID of a user that has become active in a chat channel. */
   userId: SbUserId
 }
 
 export interface ChatUserIdleEvent {
   action: 'userIdle'
+  /** The ID of a user that has become idle in a chat channel. */
   userId: SbUserId
 }
 
 export interface ChatUserOfflineEvent {
   action: 'userOffline'
+  /** The ID of a user that went offline in a chat channel. */
   userId: SbUserId
 }
 
@@ -177,16 +173,6 @@ export interface GetChannelHistoryServerPayload {
   users: SbUser[]
   /** A list of user infos for all channel users that were mentioned in the messages, if any. */
   mentions: SbUser[]
-}
-
-/**
- * Payload returned for a request to retrieve the users in a chat channel.
- */
-export interface GetChannelUsersServerPayload {
-  /** A list of the users that are in the chat channel. */
-  channelUsers: ChatUser[]
-  /** A list of user infos for channel users that are in the returned `channelUsers` list. */
-  users: SbUser[]
 }
 
 /**

--- a/common/chat.ts
+++ b/common/chat.ts
@@ -80,7 +80,7 @@ export interface ChatInitEvent {
   action: 'init2'
   /** A list of IDs of active user that are in the chat channel. */
   activeUserIds: SbUserId[]
-  /** The channel permissions for the user that is initializing the channel. */
+  /** The channel permissions for the current user that is initializing the channel. */
   permissions: ChannelPermissions
 }
 

--- a/common/chat.ts
+++ b/common/chat.ts
@@ -15,10 +15,20 @@ export enum ClientChatMessageType {
 
 export type ChatMessageType = ServerChatMessageType | ClientChatMessageType
 
-// TODO(2Pac): Include more information here, e.g. channel permissions, join date, etc.
+export interface ChannelPermissions {
+  kick: boolean
+  ban: boolean
+  changeTopic: boolean
+  togglePrivate: boolean
+  editPermissions: boolean
+  owner: boolean
+}
+
 export interface ChatUser {
   id: SbUserId
   name: string
+  joinDate: number
+  permissions: ChannelPermissions
 }
 
 export interface BaseChatMessage {
@@ -91,24 +101,24 @@ export interface ChatJoinEvent {
 
 export interface ChatLeaveEvent {
   action: 'leave'
-  /** A user that has left the chat channel. */
-  user: ChatUser
+  /** The ID of a user that has left the chat channel. */
+  userId: SbUserId
   /** The ID of a user that was selected as a new owner of the channel, if any. */
   newOwnerId: SbUserId | null
 }
 
 export interface ChatKickEvent {
   action: 'kick'
-  /** A user that was kicked from the chat channel. */
-  target: ChatUser
+  /** The ID of a user that was kicked from the chat channel. */
+  targetId: SbUserId
   /** The ID of a user that was selected as a new owner of the channel, if any. */
   newOwnerId: SbUserId | null
 }
 
 export interface ChatBanEvent {
   action: 'ban'
-  /** A user that was banned from the chat channel. */
-  target: ChatUser
+  /** The ID of a user that was banned from the chat channel. */
+  targetId: SbUserId
   /** The ID of a user that was selected as a new owner of the channel, if any. */
   newOwnerId: SbUserId | null
 }
@@ -118,24 +128,24 @@ export interface ChatMessageEvent {
   /** A text message that was sent in a chat channel. */
   message: TextMessage
   /** User info for the channel user that sent the message. */
-  user: ChatUser
+  user: SbUser
   /** User infos for all channel users that were mentioned in the message, if any. */
   mentions: SbUser[]
 }
 
 export interface ChatUserActiveEvent {
   action: 'userActive'
-  user: ChatUser
+  userId: SbUserId
 }
 
 export interface ChatUserIdleEvent {
   action: 'userIdle'
-  user: ChatUser
+  userId: SbUserId
 }
 
 export interface ChatUserOfflineEvent {
   action: 'userOffline'
-  user: ChatUser
+  userId: SbUserId
 }
 
 export type ChatEvent =

--- a/common/chat.ts
+++ b/common/chat.ts
@@ -78,10 +78,10 @@ export interface ChannelPermissions {
 
 export interface ChatInitEvent {
   action: 'init2'
-  /** A list of IDs of active user that are in the chat channel. */
+  /** A list of IDs of active users that are in the chat channel. */
   activeUserIds: SbUserId[]
   /** The channel permissions for the current user that is initializing the channel. */
-  permissions: ChannelPermissions
+  selfPermissions: ChannelPermissions
 }
 
 export interface ChatJoinEvent {

--- a/server/lib/chat/chat-api.ts
+++ b/server/lib/chat/chat-api.ts
@@ -5,12 +5,12 @@ import Koa from 'koa'
 import { assertUnreachable } from '../../../common/assert-unreachable'
 import {
   GetChannelHistoryServerPayload,
-  GetChannelUsersServerPayload,
   ModerateChannelUserServerBody,
   SendChatMessageServerBody,
 } from '../../../common/chat'
 import { CHANNEL_MAXLENGTH, CHANNEL_PATTERN } from '../../../common/constants'
 import { MULTI_CHANNEL } from '../../../common/flags'
+import { SbUser } from '../../../common/users/user-info'
 import { featureEnabled } from '../flags/feature-enabled'
 import { httpApi, httpBeforeAll } from '../http/http-api'
 import { httpBefore, httpDelete, httpGet, httpPost } from '../http/route-decorators'
@@ -174,7 +174,7 @@ export class ChatApi {
 
   @httpGet('/:channelName/users')
   @httpBefore(throttleMiddleware(retrievalThrottle, ctx => String(ctx.session!.userId)))
-  async getChannelUsers(ctx: RouterContext): Promise<GetChannelUsersServerPayload> {
+  async getChannelUsers(ctx: RouterContext): Promise<SbUser[]> {
     const channelName = getValidatedChannelName(ctx)
     return await this.chatService.getChannelUsers(channelName, ctx.session!.userId)
   }

--- a/server/lib/chat/chat-api.ts
+++ b/server/lib/chat/chat-api.ts
@@ -172,7 +172,15 @@ export class ChatApi {
     )
   }
 
+  // Leaving the old API with a dummy payload in order to not break the auto-update functionality
+  // for old clients.
   @httpGet('/:channelName/users')
+  @httpBefore(throttleMiddleware(retrievalThrottle, ctx => String(ctx.session!.userId)))
+  async getChannelUsersOld(ctx: RouterContext) {
+    return []
+  }
+
+  @httpGet('/:channelName/users2')
   @httpBefore(throttleMiddleware(retrievalThrottle, ctx => String(ctx.session!.userId)))
   async getChannelUsers(ctx: RouterContext): Promise<SbUser[]> {
     const channelName = getValidatedChannelName(ctx)

--- a/server/lib/chat/chat-api.ts
+++ b/server/lib/chat/chat-api.ts
@@ -172,8 +172,9 @@ export class ChatApi {
     )
   }
 
-  // Leaving the old API with a dummy payload in order to not break the auto-update functionality
-  // for old clients.
+  /**
+   * @deprecated This API was last used in version 7.1.5. Use `/:channelName/users2` instead.
+   */
   @httpGet('/:channelName/users')
   @httpBefore(throttleMiddleware(retrievalThrottle, ctx => String(ctx.session!.userId)))
   async getChannelUsersOld(ctx: RouterContext) {

--- a/server/lib/chat/chat-api.ts
+++ b/server/lib/chat/chat-api.ts
@@ -57,6 +57,7 @@ function convertChatServiceError(err: unknown) {
 
   switch (err.code) {
     case ChatServiceErrorCode.UserOffline:
+    case ChatServiceErrorCode.UserNotFound:
       throw new httpErrors.NotFound(err.message)
     case ChatServiceErrorCode.InvalidJoinAction:
     case ChatServiceErrorCode.InvalidLeaveAction:
@@ -143,8 +144,9 @@ export class ChatApi {
     ctx.status = 204
   }
 
-  // Leaving the old API with a dummy payload in order to not break the auto-update functionality
-  // for old clients.
+  /**
+   * @deprecated This API was last used in version 7.1.4. Use `/:channelName/messages2` instead.
+   */
   @httpGet('/:channelName/messages')
   @httpBefore(throttleMiddleware(retrievalThrottle, ctx => String(ctx.session!.userId)))
   getChannelHistoryOld(ctx: RouterContext) {
@@ -173,7 +175,7 @@ export class ChatApi {
   }
 
   /**
-   * @deprecated This API was last used in version 7.1.5. Use `/:channelName/users2` instead.
+   * @deprecated This API was last used in version 7.1.7. Use `/:channelName/users2` instead.
    */
   @httpGet('/:channelName/users')
   @httpBefore(throttleMiddleware(retrievalThrottle, ctx => String(ctx.session!.userId)))

--- a/server/lib/chat/chat-models.ts
+++ b/server/lib/chat/chat-models.ts
@@ -265,7 +265,7 @@ export async function leaveChannel(
   channelName: string,
 ): Promise<LeaveChannelResult> {
   return transact(async function (client) {
-    const joinedChannelResult = await client.query<DbChannelUserEntry>(sql`
+    const joinedChannelResult = await client.query<DbUserChannelEntry>(sql`
       DELETE FROM channel_users
       WHERE user_id = ${userId} AND channel_name = ${channelName}
       RETURNING *`)
@@ -297,7 +297,7 @@ export async function leaveChannel(
       return { newOwnerId: null }
     }
 
-    result = await client.query<DbChannelUserEntry>(sql`
+    result = await client.query<DbUserChannelEntry>(sql`
       SELECT *
       FROM channel_users
       WHERE channel_name = ${channelName} AND (kick = true OR ban = true OR

--- a/server/lib/chat/chat-service.ts
+++ b/server/lib/chat/chat-service.ts
@@ -125,7 +125,7 @@ export default class ChatService {
         )
 
       this.publisher.publish(getChannelPath(originalChannelName), {
-        action: 'join',
+        action: 'join2',
         user: {
           id: result.userId,
           name: result.userName,
@@ -170,7 +170,7 @@ export default class ChatService {
     const newOwnerId = await this.removeUserFromChannel(originalChannelName, userId)
 
     this.publisher.publish(getChannelPath(originalChannelName), {
-      action: 'leave',
+      action: 'leave2',
       userId: userSockets.userId,
       newOwnerId,
     })
@@ -416,7 +416,7 @@ export default class ChatService {
 
   private subscribeUserToChannel(userSockets: UserSocketsGroup, userChannel: UserChannelEntry) {
     userSockets.subscribe<ChatInitEvent>(getChannelPath(userChannel.channelName), () => ({
-      action: 'init',
+      action: 'init2',
       activeUserIds: this.state.channels.get(userChannel.channelName)!.toArray(),
       permissions: userChannel.channelPermissions,
     }))
@@ -458,7 +458,7 @@ export default class ChatService {
       .setIn(['users', userSockets.userId], channelSet)
     for (const userChannel of userChannels) {
       this.publisher.publish(getChannelPath(userChannel.channelName), {
-        action: 'userActive',
+        action: 'userActive2',
         userId: userSockets.userId,
       })
       this.subscribeUserToChannel(userSockets, userChannel)
@@ -482,7 +482,7 @@ export default class ChatService {
 
     for (const c of channels.values()) {
       this.publisher.publish(getChannelPath(c), {
-        action: 'userOffline',
+        action: 'userOffline2',
         userId,
       })
     }

--- a/server/migrations/20211118224131-rename-joined-channels-table.js
+++ b/server/migrations/20211118224131-rename-joined-channels-table.js
@@ -1,0 +1,15 @@
+exports.up = async function (db) {
+  await db.runSql(`
+    ALTER TABLE joined_channels RENAME TO channel_users;
+  `)
+}
+
+exports.down = async function (db) {
+  await db.runSql(`
+    ALTER TABLE channel_users RENAME TO joined_channels;
+  `)
+}
+
+exports._meta = {
+  version: 1,
+}


### PR DESCRIPTION
This PR also does a couple of other things:
- cleans up most of the chat event types to only use `userId` instead
  of a whole channel user object if possible
- renames the `joined_channel` table in the DB to `channel_users`