### PR TITLE
Allow SB client to be registered for *.rep files

### DIFF
--- a/app/app.ts
+++ b/app/app.ts
@@ -578,6 +578,14 @@ app.on('ready', async () => {
     await createWindow()
     systemTray = new SystemTray(mainWindow, () => app.quit())
 
+    // looking to start replay file
+    if (process.argv.length > 0) {
+      const file = process.argv[1]
+      if (file.endsWith('.rep')) {
+        TypedIpcSender.from(mainWindow?.webContents).send('openReplay', file)
+      }
+    }
+
     mainWindow?.webContents.on('did-finish-load', () => {
       TypedIpcSender.from(mainWindow?.webContents).send(
         'windowMaximizedState',

--- a/app/single-instance.js
+++ b/app/single-instance.js
@@ -23,19 +23,15 @@ export default function () {
       // successfully connect to the running server). Just send some data to the server, which is
       // running on the first instance, so the main window can be focused there and quit this
       // instance.
-      const event = {
-        type: 'focus first instance',
-      }
+
+      let event = 'focus first instance'
+
       if (process.argv.length > 1) {
-        const replayFile = process.argv[1]
+        const file = process.argv[1]
 
-        if (replayFile.endsWith('.rep')) {
-          event.type = 'openReplay'
-          event.replay = replayFile
-        }
+        if (file.endsWith('.rep')) event = file
       }
-
-      client.write(JSON.stringify(event), () => app.quit())
+      client.write(event, () => app.quit())
     })
     .on('error', err => {
       if (err.code !== 'ENOENT') throw err
@@ -57,12 +53,10 @@ export default function () {
           connection.on('data', data => {
             const mainWindow = getMainWindow()
             if (mainWindow) {
-              try {
-                const event = JSON.parse(data)
-                if (event.type === 'openReplay') {
-                  mainWindow.webContents.send('openReplay', event.replay)
-                }
-              } catch (e) {}
+              const file = data.toString()
+              if (file.endsWith('.rep')) {
+                mainWindow.webContents.send('openReplay', file)
+              }
 
               if (!mainWindow.isVisible()) {
                 mainWindow.show()

--- a/client/app.jsx
+++ b/client/app.jsx
@@ -30,6 +30,8 @@ import ResetStyle from './styles/reset'
 
 const IS_PRODUCTION = __WEBPACK_ENV.NODE_ENV === 'production'
 
+const ReplayDrop = IS_ELECTRON ? require('./replays/replay-drop').default : () => null
+
 const LoadableDev = IS_PRODUCTION
   ? () => null
   : loadable(() => import('./dev'), {
@@ -75,6 +77,7 @@ function App() {
         <GlobalStyle />
         <WindowControlsStyle />
         <WindowControls />
+        <ReplayDrop />
         <Switch>
           <Route path='/splash' component={Splash} />
           <Route path='/faq' component={Faq} />

--- a/client/network/socket-handlers.ts
+++ b/client/network/socket-handlers.ts
@@ -91,6 +91,7 @@ const envSpecificHandlers = IS_ELECTRON
       require('../lobbies/socket-handlers').default,
       require('../matchmaking/socket-handlers').default,
       require('../parties/socket-handlers').default,
+      require('../replays/ipc-handlers').default,
       require('../settings/ipc-handlers').default,
     ]
   : []

--- a/client/replays/ipc-handlers.ts
+++ b/client/replays/ipc-handlers.ts
@@ -1,0 +1,7 @@
+import { TypedIpcRenderer } from '../../common/ipc'
+import { dispatch } from '../dispatch-registry'
+import { openReplay } from './action-creators'
+
+export default function registerModule({ ipcRenderer }: { ipcRenderer: TypedIpcRenderer }) {
+  ipcRenderer.on('openReplay', (_, replay) => dispatch(openReplay(replay)))
+}

--- a/client/replays/replay-drop.tsx
+++ b/client/replays/replay-drop.tsx
@@ -1,0 +1,44 @@
+import { useCallback, useEffect } from 'react'
+import { useAppDispatch } from '../redux-hooks'
+import { openReplay } from './action-creators'
+
+export default function ReplayDrop() {
+  const dispatch = useAppDispatch()
+
+  const onDrop = useCallback(
+    (e: DragEvent) => {
+      e.preventDefault()
+      e.stopPropagation()
+
+      const [file] = e.dataTransfer?.files || []
+      if (file?.path.slice(-4) === '.rep') {
+        dispatch(openReplay(file.path))
+      }
+    },
+    [dispatch],
+  )
+
+  const onDragOver = useCallback((e: DragEvent) => {
+    e.preventDefault()
+    e.stopPropagation()
+
+    // NOTE: it is not possible to access files during `dragover` now,
+    // see this electron issue:
+    // https://github.com/electron/electron/issues/9840
+    // Thus, just allow any files here and deal with the garbage
+    // in `drop` handler
+    if (e.dataTransfer) e.dataTransfer.dropEffect = 'link'
+  }, [])
+
+  useEffect(() => {
+    document.addEventListener('drop', onDrop)
+    document.addEventListener('dragover', onDragOver)
+
+    return () => {
+      document.removeEventListener('drop', onDrop)
+      document.removeEventListener('dragover', onDragOver)
+    }
+  }, [onDrop, onDragOver])
+
+  return null
+}

--- a/client/replays/replay-drop.tsx
+++ b/client/replays/replay-drop.tsx
@@ -11,7 +11,7 @@ export default function ReplayDrop() {
       e.stopPropagation()
 
       const [file] = e.dataTransfer?.files || []
-      if (file?.path.slice(-4) === '.rep') {
+      if (file?.path.endsWith('.rep')) {
         dispatch(openReplay(file.path))
       }
     },

--- a/common/ipc.ts
+++ b/common/ipc.ts
@@ -71,6 +71,8 @@ interface IpcMainSendables {
   }) => void
   activeGameStatus: (status: { id: string; state: string; extra?: any; isReplay: boolean }) => void
 
+  openReplay: (path: string) => void
+
   rallyPointPingResult: (server: ResolvedRallyPointServer, ping: number) => void
 
   settingsLocalChanged: (settings: Readonly<Partial<LocalSettingsData>>) => void

--- a/prod.yml
+++ b/prod.yml
@@ -21,6 +21,11 @@ files:
     filter:
       - '**/*.js'
       - '**/*.node'
+fileAssociations:
+  ext: 'rep'
+  name: 'Starcraft Broodwar Replay'
+  description: 'Starcraft (Broodwar and Remastered) replay file'
+  role: 'Viewer'
 nsis:
   artifactName: '${productName}-setup-${version}.${ext}'
 win:


### PR DESCRIPTION
closes #769

1. launch shb and start a replay when a user opens the replay file
2. start a replay when a user opens the replay file if shb is already launched
3. start a replay if the replay file was dropped into shb window (works only in desktop version)
4. register file association for `.rep` files so they can be opened with shb app with double click

File association registers during installation without asking a user. Also no settings in shb app to change it (my guess it will be needed to play with windows registry to do so).

About testing: pack entire prod app and associate `.rep` files manually with compiled `.exe`. The building takes noticeable amount of time (at least 1.5 minutes for me). Maybe there is an easier way to build and test it. Though at this time it probably does not matter since core functional is here.