### PR TITLE
Add a Tooltip component and use it to display full dates in user profile

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -217,7 +217,7 @@
     "no-this-before-super": 2,
     "no-throw-literal": 2,
     "no-trailing-spaces": 2,
-    "no-undef": 2,
+    "no-undef": 0,
     "no-undef-init": 2,
     "no-undefined": 0,
     "no-underscore-dangle": 0,

--- a/.eslintrc
+++ b/.eslintrc
@@ -59,6 +59,7 @@
 
   "globals": {
     "document": "readonly",
+    "JSX": "readonly",
     "navigator": "readonly",
     "window": "readonly",
     "IS_ELECTRON": "readonly",

--- a/.eslintrc
+++ b/.eslintrc
@@ -59,7 +59,6 @@
 
   "globals": {
     "document": "readonly",
-    "JSX": "readonly",
     "navigator": "readonly",
     "window": "readonly",
     "IS_ELECTRON": "readonly",

--- a/client/dom/unique-id.ts
+++ b/client/dom/unique-id.ts
@@ -1,4 +1,4 @@
-import { useRef } from 'react'
+import { useState } from 'react'
 
 let id = 0
 
@@ -16,10 +16,6 @@ export default function genId(): string {
  * referenced by a label element).
  */
 export function useId(): string {
-  const idRef = useRef<string>()
-  if (!idRef.current) {
-    idRef.current = genId()
-  }
-
-  return idRef.current!
+  const [id] = useState(() => genId())
+  return id
 }

--- a/client/material/button.tsx
+++ b/client/material/button.tsx
@@ -511,6 +511,8 @@ export interface IconButtonProps {
   onClick?: React.MouseEventHandler
   onDoubleClick?: React.MouseEventHandler
   onMouseDown?: React.MouseEventHandler
+  onMouseEnter?: React.MouseEventHandler
+  onMouseLeave?: React.MouseEventHandler
   tabIndex?: number
   type?: 'button' | 'reset' | 'submit'
   name?: string
@@ -530,6 +532,8 @@ export const IconButton = React.forwardRef(
       onClick,
       onDoubleClick,
       onMouseDown,
+      onMouseEnter,
+      onMouseLeave,
       tabIndex,
       type,
       name,
@@ -544,6 +548,8 @@ export const IconButton = React.forwardRef(
       onClick,
       onDoubleClick,
       onMouseDown,
+      onMouseEnter,
+      onMouseLeave,
     })
 
     return (

--- a/client/material/button.tsx
+++ b/client/material/button.tsx
@@ -511,8 +511,6 @@ export interface IconButtonProps {
   onClick?: React.MouseEventHandler
   onDoubleClick?: React.MouseEventHandler
   onMouseDown?: React.MouseEventHandler
-  onMouseEnter?: React.MouseEventHandler
-  onMouseLeave?: React.MouseEventHandler
   tabIndex?: number
   type?: 'button' | 'reset' | 'submit'
   name?: string
@@ -532,8 +530,6 @@ export const IconButton = React.forwardRef(
       onClick,
       onDoubleClick,
       onMouseDown,
-      onMouseEnter,
-      onMouseLeave,
       tabIndex,
       type,
       name,
@@ -548,8 +544,6 @@ export const IconButton = React.forwardRef(
       onClick,
       onDoubleClick,
       onMouseDown,
-      onMouseEnter,
-      onMouseLeave,
     })
 
     return (

--- a/client/material/devonly/routes.tsx
+++ b/client/material/devonly/routes.tsx
@@ -8,6 +8,7 @@ import DevSliders from './slider-test'
 import DevSteppers from './stepper-test'
 import { TabsTest } from './tabs-test'
 import DevTextFields from './text-field-test'
+import { TooltipTest } from './tooltip-test'
 
 const BASE_URL = '/dev/material'
 
@@ -38,6 +39,9 @@ function DevMaterialDashboard() {
       <li>
         <Link href={`${BASE_URL}/textfield`}>Textfield component</Link>
       </li>
+      <li>
+        <Link href={`${BASE_URL}/tooltip`}>Tooltip component</Link>
+      </li>
     </ul>
   )
 }
@@ -53,6 +57,7 @@ export default function DevMaterialRoutes() {
       <Route path={`${BASE_URL}/stepper`} component={DevSteppers as any} />
       <Route path={`${BASE_URL}/tabs`} component={TabsTest} />
       <Route path={`${BASE_URL}/textfield`} component={DevTextFields as any} />
+      <Route path={`${BASE_URL}/tooltip`} component={TooltipTest} />
       <Route>
         <DevMaterialDashboard />
       </Route>

--- a/client/material/devonly/tooltip-test.tsx
+++ b/client/material/devonly/tooltip-test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
-import { Tooltip } from '../tooltip'
+import { Tooltip, TooltipPosition } from '../tooltip'
 
 const Container = styled.div`
   width: 100%;
@@ -23,6 +23,11 @@ const StyledTooltipTarget = styled(Tooltip)`
   margin: 0 16px;
 `
 
+const ContentComponent = styled.div<{ $position?: TooltipPosition }>`
+  background-color: red;
+  border-radius: 50%;
+`
+
 export function TooltipTest() {
   return (
     <Container>
@@ -38,6 +43,9 @@ export function TooltipTest() {
         </StyledTooltipTarget>
         <StyledTooltipTarget text="Hi. I'm a tooltip!" position='right'>
           <span>Tooltip at right side</span>
+        </StyledTooltipTarget>
+        <StyledTooltipTarget text="Hi. I'm a tooltip!" contentComponent={<ContentComponent />}>
+          <span>Tooltip with custom content component</span>
         </StyledTooltipTarget>
       </Content>
     </Container>

--- a/client/material/devonly/tooltip-test.tsx
+++ b/client/material/devonly/tooltip-test.tsx
@@ -1,0 +1,44 @@
+import React from 'react'
+import styled from 'styled-components'
+import { Tooltip } from '../tooltip'
+
+const Container = styled.div`
+  width: 100%;
+  height: 100%;
+  padding: 16px !important;
+  padding-top: 64px !important;
+`
+
+const Content = styled.div`
+  position: relative;
+  height: 80%;
+  max-width: 960px;
+  min-height: 512px;
+  margin: 0px auto;
+  border-left: var(--pixel-shove-x, 0) solid transparent;
+`
+
+const TooltipTarget = styled.span`
+  margin: 16px;
+`
+
+export function TooltipTest() {
+  return (
+    <Container>
+      <Content>
+        <Tooltip text="Hi. I'm a tooltip!" position='bottom'>
+          <TooltipTarget>Tooltip at bottom</TooltipTarget>
+        </Tooltip>
+        <Tooltip text="Hi. I'm a tooltip!" position='top'>
+          <TooltipTarget>Tooltip at top</TooltipTarget>
+        </Tooltip>
+        <Tooltip text="Hi. I'm a tooltip!" position='left'>
+          <TooltipTarget>Tooltip at left side</TooltipTarget>
+        </Tooltip>
+        <Tooltip text="Hi. I'm a tooltip!" position='right'>
+          <TooltipTarget>Tooltip at right side</TooltipTarget>
+        </Tooltip>
+      </Content>
+    </Container>
+  )
+}

--- a/client/material/devonly/tooltip-test.tsx
+++ b/client/material/devonly/tooltip-test.tsx
@@ -18,26 +18,27 @@ const Content = styled.div`
   border-left: var(--pixel-shove-x, 0) solid transparent;
 `
 
-const TooltipTarget = styled.span`
-  margin: 16px;
+const StyledTooltipTarget = styled(Tooltip)`
+  display: inline-block;
+  margin: 0 16px;
 `
 
 export function TooltipTest() {
   return (
     <Container>
       <Content>
-        <Tooltip text="Hi. I'm a tooltip!" position='bottom'>
-          <TooltipTarget>Tooltip at bottom</TooltipTarget>
-        </Tooltip>
-        <Tooltip text="Hi. I'm a tooltip!" position='top'>
-          <TooltipTarget>Tooltip at top</TooltipTarget>
-        </Tooltip>
-        <Tooltip text="Hi. I'm a tooltip!" position='left'>
-          <TooltipTarget>Tooltip at left side</TooltipTarget>
-        </Tooltip>
-        <Tooltip text="Hi. I'm a tooltip!" position='right'>
-          <TooltipTarget>Tooltip at right side</TooltipTarget>
-        </Tooltip>
+        <StyledTooltipTarget text="Hi. I'm a tooltip!" position='bottom'>
+          <span>Tooltip at bottom</span>
+        </StyledTooltipTarget>
+        <StyledTooltipTarget text="Hi. I'm a tooltip!" position='top'>
+          <span>Tooltip at top</span>
+        </StyledTooltipTarget>
+        <StyledTooltipTarget text="Hi. I'm a tooltip!" position='left'>
+          <span>Tooltip at left side</span>
+        </StyledTooltipTarget>
+        <StyledTooltipTarget text="Hi. I'm a tooltip!" position='right'>
+          <span>Tooltip at right side</span>
+        </StyledTooltipTarget>
       </Content>
     </Container>
   )

--- a/client/material/devonly/tooltip-test.tsx
+++ b/client/material/devonly/tooltip-test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
-import { Tooltip, TooltipPosition } from '../tooltip'
+import { Tooltip } from '../tooltip'
 
 const Container = styled.div`
   width: 100%;
@@ -23,7 +23,7 @@ const StyledTooltipTarget = styled(Tooltip)`
   margin: 0 16px;
 `
 
-const ContentComponent = styled.div<{ $position?: TooltipPosition }>`
+const ContentComponent = styled.div`
   background-color: red;
   border-radius: 50%;
 `
@@ -44,7 +44,7 @@ export function TooltipTest() {
         <StyledTooltipTarget text="Hi. I'm a tooltip!" position='right'>
           <span>Tooltip at right side</span>
         </StyledTooltipTarget>
-        <StyledTooltipTarget text="Hi. I'm a tooltip!" contentComponent={<ContentComponent />}>
+        <StyledTooltipTarget text="Hi. I'm a tooltip!" ContentComponent={ContentComponent}>
           <span>Tooltip with custom content component</span>
         </StyledTooltipTarget>
       </Content>

--- a/client/material/popover.tsx
+++ b/client/material/popover.tsx
@@ -121,17 +121,26 @@ export function Popover(props: PopoverProps) {
     (styles, open) =>
       open && (
         <Portal onDismiss={props.onDismiss} open={open}>
-          <PopoverContent {...props} styles={styles} />
+          <PopoverContent {...props} styles={styles}>
+            <Card>{props.children}</Card>
+          </PopoverContent>
         </Portal>
       ),
   )
 }
 
+export interface PopoverContentProps extends Omit<PopoverProps, 'open' | 'onDismiss'> {
+  open?: boolean
+  onDismiss?: (event?: MouseEvent) => void
+  styles: React.CSSProperties
+}
+
 /**
  * Helper component for Popovers to minimize the amount of work being done/hooks being kept for
- * popovers that are not open.
+ * popovers that are not open. Also used by components similar to Popovers, but with slightly
+ * different API/styling, e.g. Tooltips.
  */
-function PopoverContent({
+export function PopoverContent({
   anchorX,
   anchorY,
   children,
@@ -140,7 +149,7 @@ function PopoverContent({
   originX,
   originY,
   styles,
-}: PopoverProps & { styles: React.CSSProperties }) {
+}: PopoverContentProps) {
   const [maxSizeRectRef, maxSizeRect] = useElementRect()
   // NOTE(tec27): We need this so that the component re-renders if the window is resized
   const [maxSizeObserverRef] = useObservedDimensions()
@@ -253,7 +262,7 @@ function PopoverContent({
         ref={containerRef}
         className={className}
         style={{ ...styles, ...(containerStyle as any) }}>
-        <Card>{children}</Card>
+        {children}
       </Container>
     </PositioningArea>
   )

--- a/client/material/popover.tsx
+++ b/client/material/popover.tsx
@@ -132,6 +132,9 @@ export function Popover(props: PopoverProps) {
 export interface PopoverContentProps extends Omit<PopoverProps, 'open' | 'onDismiss'> {
   open?: boolean
   onDismiss?: (event?: MouseEvent) => void
+  id?: string
+  /** The ARIA role to use for the content container. */
+  role?: React.AriaRole
   styles: React.CSSProperties
 }
 
@@ -145,6 +148,8 @@ export function PopoverContent({
   anchorY,
   children,
   className,
+  id,
+  role,
   onDismiss,
   originX,
   originY,
@@ -261,6 +266,8 @@ export function PopoverContent({
       <Container
         ref={containerRef}
         className={className}
+        id={id}
+        role={role}
         style={{ ...styles, ...(containerStyle as any) }}>
         {children}
       </Container>

--- a/client/material/portal.tsx
+++ b/client/material/portal.tsx
@@ -61,6 +61,7 @@ function useDismissalClickHandler(
 }
 
 export interface PortalProps {
+  className?: string
   /** Children rendered inside the Portal. */
   children: React.ReactNode
   /** Whether or not the portal contents should be shown/rendered */
@@ -83,6 +84,8 @@ export function Portal(props: PortalProps) {
   const portalRef = useExternalElementRef()
   const [onCaptureClick, onBubbleClick] = useDismissalClickHandler(portalRef, onDismiss)
   const [onCaptureContextMenu, onBubbleContextMenu] = useDismissalClickHandler(portalRef, onDismiss)
+
+  portalRef.current.className = props.className ?? ''
 
   useEffect(() => {
     if (open) {

--- a/client/material/tooltip.tsx
+++ b/client/material/tooltip.tsx
@@ -49,7 +49,7 @@ const arrowStyle: Record<TooltipPosition, FlattenSimpleInterpolation> = {
   `,
 }
 
-const TooltipContent = styled.div<{ $position?: TooltipPosition }>`
+const TooltipContent = styled.div<{ $position: TooltipPosition }>`
   ${caption};
   ${shadow2dp};
 
@@ -75,7 +75,7 @@ const TooltipContent = styled.div<{ $position?: TooltipPosition }>`
     background-color: inherit;
     border: 1px solid rgba(255, 255, 255, 0.36);
 
-    ${props => arrowStyle[props.$position!]};
+    ${props => arrowStyle[props.$position]};
   }
 `
 
@@ -101,10 +101,10 @@ interface TooltipProps {
   /**
    * A custom component that will be used instead of the default Tooltip content element. Can be
    * used if you wish to customize the Tooltip style. Will get injected with the following props:
-   *  - $position: TooltipPosition
-   *  - children: string (the Tooltip's text)
+   *  - $position: the `TooltipPosition` of the content
+   *  - children: the Tooltip's text
    * */
-  contentComponent?: React.ReactNode
+  ContentComponent?: React.ComponentType<{ $position: TooltipPosition; children: React.ReactNode }>
 }
 
 /**
@@ -119,7 +119,7 @@ export function Tooltip({
   className,
   ariaLabel = text,
   position = 'bottom',
-  contentComponent = <TooltipContent />,
+  ContentComponent = TooltipContent,
 }: TooltipProps) {
   const [open, setOpen] = useState(false)
   const [anchorElem, setAnchorElem] = useState<HTMLElement>()
@@ -186,11 +186,6 @@ export function Tooltip({
     originY = 'center'
   }
 
-  const tooltipContent = React.cloneElement(contentComponent as JSX.Element, {
-    $position: position,
-    children: text,
-  })
-
   return (
     <>
       <div
@@ -210,7 +205,7 @@ export function Tooltip({
                 originX={originX}
                 originY={originY}
                 styles={styles}>
-                {tooltipContent}
+                <ContentComponent $position={position}>{text}</ContentComponent>
               </NoPointerPopoverContent>
             </NoPointerPortal>
           ),

--- a/client/material/tooltip.tsx
+++ b/client/material/tooltip.tsx
@@ -1,0 +1,121 @@
+import React, { useState } from 'react'
+import { useTransition, UseTransitionProps } from 'react-spring'
+import styled from 'styled-components'
+import { background100 } from '../styles/colors'
+import { caption } from '../styles/typography'
+import { OriginX, OriginY, PopoverContent, useAnchorPosition } from './popover'
+import { Portal } from './portal'
+import { defaultSpring } from './springs'
+
+const isDev = __WEBPACK_ENV.NODE_ENV !== 'production'
+
+const Container = styled.div`
+  ${caption};
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  min-height: 24px;
+  padding: 4px 8px;
+  border-radius: 4px;
+  background-color: ${background100};
+`
+
+export type TooltipPosition = 'left' | 'right' | 'top' | 'bottom'
+
+interface TooltipProps {
+  /** The text that should be displayed in the Tooltip. */
+  text: string
+  /** The child element that the Tooltip should be linked to. Should only be a single element. */
+  children: React.ReactNode
+  /** One of the four sides that can be used to position the Tooltip. Defaults to 'bottom'. */
+  position?: TooltipPosition
+  /** Class name applied to the root container of the Tooltip (that has the background, etc.). */
+  className?: string
+}
+
+/**
+ * A component that displays some content in a floated UI element when a user hovers over a target
+ * element. Should generally be used over native `title` attribute on elements.
+ *
+ * Utilizes popovers to deal with positioning, but with a much simpler API than that of a Popover.
+ */
+export function Tooltip({ text, children, position = 'bottom', className }: TooltipProps) {
+  const [anchorElem, setAnchorElem] = useState<HTMLElement>()
+  const transition = useTransition<boolean, UseTransitionProps<boolean>>(!!anchorElem, {
+    from: { opacity: 0, scale: 0.667 },
+    enter: { opacity: 1, scale: 1 },
+    leave: { opacity: 0, scale: 0.333 },
+    delay: 800,
+    config: (item, index, phase) => key =>
+      phase === 'leave' || key === 'opacity' ? { ...defaultSpring, clamp: true } : defaultSpring,
+  })
+
+  const anchorOriginX = position === 'top' || position === 'bottom' ? 'center' : position
+  const anchorOriginY = position === 'left' || position === 'right' ? 'center' : position
+  let [, anchorX = 0, anchorY = 0] = useAnchorPosition(
+    anchorOriginX,
+    anchorOriginY,
+    anchorElem ?? null,
+  )
+
+  const onMouseEnter = (event: React.MouseEvent) => {
+    setAnchorElem(event.currentTarget as HTMLElement)
+  }
+  const onMouseLeave = (event: React.MouseEvent) => {
+    setAnchorElem(undefined)
+  }
+
+  const childrenCount = React.Children.count(children)
+  if (isDev && childrenCount !== 1) {
+    throw new Error('Tooltip should wrap exactly one element')
+  }
+
+  const childNode = React.cloneElement(children as JSX.Element, {
+    onMouseEnter,
+    onMouseLeave,
+  })
+
+  let originX: OriginX
+  if (anchorOriginX === 'left') {
+    originX = 'right'
+    anchorX = anchorX - 16
+  } else if (anchorOriginX === 'right') {
+    originX = 'left'
+    anchorX = anchorX + 16
+  } else {
+    originX = 'center'
+  }
+
+  let originY: OriginY
+  if (anchorOriginY === 'top') {
+    originY = 'bottom'
+    anchorY = anchorY - 16
+  } else if (anchorOriginY === 'bottom') {
+    originY = 'top'
+    anchorY = anchorY + 16
+  } else {
+    originY = 'center'
+  }
+
+  return (
+    <>
+      {childNode}
+      {transition(
+        (styles, open) =>
+          open && (
+            <Portal open={open}>
+              <PopoverContent
+                anchorX={anchorX}
+                anchorY={anchorY}
+                originX={originX}
+                originY={originY}
+                styles={styles}>
+                <Container className={className}>{text}</Container>
+              </PopoverContent>
+            </Portal>
+          ),
+      )}
+    </>
+  )
+}

--- a/client/material/tooltip.tsx
+++ b/client/material/tooltip.tsx
@@ -1,10 +1,11 @@
 import React, { useCallback, useEffect, useState } from 'react'
 import { useTransition, UseTransitionProps } from 'react-spring'
 import styled from 'styled-components'
-import { background100 } from '../styles/colors'
+import { background900 } from '../styles/colors'
 import { caption } from '../styles/typography'
 import { OriginX, OriginY, PopoverContent, useAnchorPosition } from './popover'
 import { Portal } from './portal'
+import { shadow2dp } from './shadows'
 import { defaultSpring } from './springs'
 
 const isDev = __WEBPACK_ENV.NODE_ENV !== 'production'
@@ -15,6 +16,7 @@ const NoPointerPortal = styled(Portal)`
 
 const Container = styled.div`
   ${caption};
+  ${shadow2dp};
 
   min-height: 24px;
   padding: 4px 8px;
@@ -23,8 +25,9 @@ const Container = styled.div`
   align-items: center;
   justify-content: center;
 
+  border: 1px solid rgba(255, 255, 255, 0.36);
   border-radius: 4px;
-  background-color: ${background100};
+  background-color: ${background900};
   pointer-events: none;
 `
 

--- a/client/material/tooltip.tsx
+++ b/client/material/tooltip.tsx
@@ -9,6 +9,10 @@ import { defaultSpring } from './springs'
 
 const isDev = __WEBPACK_ENV.NODE_ENV !== 'production'
 
+const NoPointerPortal = styled(Portal)`
+  pointer-events: none;
+`
+
 const Container = styled.div`
   ${caption};
 
@@ -21,6 +25,10 @@ const Container = styled.div`
 
   border-radius: 4px;
   background-color: ${background100};
+  pointer-events: none;
+`
+
+const NoPointerPopoverContent = styled(PopoverContent)`
   pointer-events: none;
 `
 
@@ -125,16 +133,16 @@ export function Tooltip({ text, children, position = 'bottom', className }: Tool
       {transition(
         (styles, open) =>
           open && (
-            <Portal open={open}>
-              <PopoverContent
+            <NoPointerPortal open={open}>
+              <NoPointerPopoverContent
                 anchorX={anchorX}
                 anchorY={anchorY}
                 originX={originX}
                 originY={originY}
                 styles={styles}>
                 <Container className={className}>{text}</Container>
-              </PopoverContent>
-            </Portal>
+              </NoPointerPopoverContent>
+            </NoPointerPortal>
           ),
       )}
     </>

--- a/client/material/tooltip.tsx
+++ b/client/material/tooltip.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useState } from 'react'
 import { useTransition, UseTransitionProps } from 'react-spring'
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 import { background900 } from '../styles/colors'
 import { caption } from '../styles/typography'
 import { OriginX, OriginY, PopoverContent, useAnchorPosition } from './popover'
@@ -14,10 +14,11 @@ const NoPointerPortal = styled(Portal)`
   pointer-events: none;
 `
 
-const Container = styled.div`
+const Container = styled.div<{ $position: TooltipPosition }>`
   ${caption};
   ${shadow2dp};
 
+  position: relative;
   min-height: 24px;
   padding: 4px 8px;
 
@@ -29,6 +30,58 @@ const Container = styled.div`
   border-radius: 4px;
   background-color: ${background900};
   pointer-events: none;
+
+  &::before {
+    content: '';
+    position: absolute;
+    width: 8px;
+    height: 8px;
+
+    background-color: inherit;
+    border: 1px solid rgba(255, 255, 255, 0.36);
+
+    ${props => {
+      if (props.$position === 'left') {
+        return css`
+          top: 50%;
+          right: 0px;
+
+          transform: translate(50%, -50%) rotate(45deg);
+          border-bottom: none;
+          border-left: none;
+        `
+      } else if (props.$position === 'right') {
+        return css`
+          top: 50%;
+          left: 0px;
+
+          transform: translate(-50%, -50%) rotate(45deg);
+          border-top: none;
+          border-right: none;
+        `
+      } else if (props.$position === 'top') {
+        return css`
+          bottom: 0px;
+          left: 50%;
+
+          transform: translate(-50%, 50%) rotate(45deg);
+          border-top: none;
+          border-left: none;
+        `
+      } else if (props.$position === 'bottom') {
+        return css`
+          top: 0px;
+          left: 50%;
+
+          transform: translate(-50%, -50%) rotate(45deg);
+          border-bottom: none;
+          border-right: none;
+        `
+      } else {
+        return ''
+      }
+    }}
+  }
 `
 
 const NoPointerPopoverContent = styled(PopoverContent)`
@@ -111,10 +164,10 @@ export function Tooltip({ text, children, position = 'bottom', className }: Tool
   let originX: OriginX
   if (anchorOriginX === 'left') {
     originX = 'right'
-    anchorX = anchorX - 16
+    anchorX = anchorX - 8
   } else if (anchorOriginX === 'right') {
     originX = 'left'
-    anchorX = anchorX + 16
+    anchorX = anchorX + 8
   } else {
     originX = 'center'
   }
@@ -122,10 +175,10 @@ export function Tooltip({ text, children, position = 'bottom', className }: Tool
   let originY: OriginY
   if (anchorOriginY === 'top') {
     originY = 'bottom'
-    anchorY = anchorY - 16
+    anchorY = anchorY - 8
   } else if (anchorOriginY === 'bottom') {
     originY = 'top'
-    anchorY = anchorY + 16
+    anchorY = anchorY + 8
   } else {
     originY = 'center'
   }
@@ -143,7 +196,9 @@ export function Tooltip({ text, children, position = 'bottom', className }: Tool
                 originX={originX}
                 originY={originY}
                 styles={styles}>
-                <Container className={className}>{text}</Container>
+                <Container className={className} $position={position}>
+                  {text}
+                </Container>
               </NoPointerPopoverContent>
             </NoPointerPortal>
           ),

--- a/client/messaging/message-layout.tsx
+++ b/client/messaging/message-layout.tsx
@@ -24,6 +24,10 @@ export const Separator = styled.i.attrs({ 'aria-hidden': true })`
   pointer-events: none;
 `
 
+const StyledTooltip = styled(Tooltip)`
+  display: inline;
+`
+
 // NOTE(tec27): These styles are done a bit oddly to ensure that message contents wraps in a
 // pleasing way. We effectively pad everything and then push the timestamps into the padding. By
 // doing this we also ensure copy+paste looks decent (instead of on separate lines)
@@ -43,13 +47,13 @@ interface MessageTimestampProps {
 }
 
 export const MessageTimestamp = (props: MessageTimestampProps) => (
-  <Tooltip text={longTimestamp.format(props.time)} position='top'>
+  <StyledTooltip text={longTimestamp.format(props.time)} position='top'>
     <Timestamp>
       <Separator>[</Separator>
       {shortTimestamp.format(props.time)}
       <Separator>] </Separator>
     </Timestamp>
-  </Tooltip>
+  </StyledTooltip>
 )
 
 const messageContainerBase = css`

--- a/client/messaging/message-layout.tsx
+++ b/client/messaging/message-layout.tsx
@@ -21,6 +21,7 @@ export const Separator = styled.i.attrs({ 'aria-hidden': true })`
   line-height: inherit;
   opacity: 0;
   white-space: pre;
+  pointer-events: none;
 `
 
 // NOTE(tec27): These styles are done a bit oddly to ensure that message contents wraps in a

--- a/client/messaging/message-layout.tsx
+++ b/client/messaging/message-layout.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import styled, { css } from 'styled-components'
 import { longTimestamp, shortTimestamp } from '../i18n/date-formats'
+import { Tooltip } from '../material/tooltip'
 import {
   amberA100,
   blue100,
@@ -41,11 +42,13 @@ interface MessageTimestampProps {
 }
 
 export const MessageTimestamp = (props: MessageTimestampProps) => (
-  <Timestamp title={longTimestamp.format(props.time)}>
-    <Separator>[</Separator>
-    {shortTimestamp.format(props.time)}
-    <Separator>] </Separator>
-  </Timestamp>
+  <Tooltip text={longTimestamp.format(props.time)} position='top'>
+    <Timestamp>
+      <Separator>[</Separator>
+      {shortTimestamp.format(props.time)}
+      <Separator>] </Separator>
+    </Timestamp>
+  </Tooltip>
 )
 
 const messageContainerBase = css`

--- a/client/profile/user-profile-overlay.tsx
+++ b/client/profile/user-profile-overlay.tsx
@@ -12,6 +12,7 @@ import { ConnectedAvatar } from '../avatars/avatar'
 import { longTimestamp } from '../i18n/date-formats'
 import { Popover, PopoverProps } from '../material/popover'
 import { shadow2dp } from '../material/shadows'
+import { Tooltip } from '../material/tooltip'
 import { LoadingDotsArea } from '../progress/dots'
 import { useAppDispatch, useAppSelector } from '../redux-hooks'
 import {
@@ -236,9 +237,9 @@ function OverlayContents({ userId, onDismiss }: { userId: SbUserId; onDismiss: (
         <>
           <div>
             <SectionHeader>Info</SectionHeader>
-            <Body1 title={longTimestamp.format(profile.created)}>
-              Joined {joinDateFormat.format(profile.created)}
-            </Body1>
+            <Tooltip text={longTimestamp.format(profile.created)}>
+              <Body1>Joined {joinDateFormat.format(profile.created)}</Body1>
+            </Tooltip>
           </div>
 
           <div>

--- a/client/profile/user-profile-overlay.tsx
+++ b/client/profile/user-profile-overlay.tsx
@@ -238,7 +238,7 @@ function OverlayContents({ userId, onDismiss }: { userId: SbUserId; onDismiss: (
         <>
           <div>
             <SectionHeader>Info</SectionHeader>
-            <Tooltip text={longFormattedDate} ariaLabel={`Joined ${longFormattedDate}`}>
+            <Tooltip text={longFormattedDate}>
               <Body1>Joined {joinDateFormat.format(profile.created)}</Body1>
             </Tooltip>
           </div>

--- a/client/profile/user-profile-overlay.tsx
+++ b/client/profile/user-profile-overlay.tsx
@@ -213,6 +213,7 @@ function OverlayContents({ userId, onDismiss }: { userId: SbUserId; onDismiss: (
   }, [dispatch, userId])
 
   const hasAnyRanks = !!Object.keys(profile?.ladder ?? {}).length
+  const longFormattedDate = longTimestamp.format(profile?.created)
 
   return (
     <PopoverContents>
@@ -237,7 +238,7 @@ function OverlayContents({ userId, onDismiss }: { userId: SbUserId; onDismiss: (
         <>
           <div>
             <SectionHeader>Info</SectionHeader>
-            <Tooltip text={longTimestamp.format(profile.created)}>
+            <Tooltip text={longFormattedDate} ariaLabel={`Joined ${longFormattedDate}`}>
               <Body1>Joined {joinDateFormat.format(profile.created)}</Body1>
             </Tooltip>
           </div>

--- a/client/styles/colors.ts
+++ b/client/styles/colors.ts
@@ -46,8 +46,8 @@ export const background900 = '#091320'
 export const backgroundSaturatedLight = '#02498C'
 export const backgroundSaturatedDark = '#034078'
 
-export const alphaDividers = '0.12'
-export const alphaDisabled = '0.5'
+export const alphaDividers = 0.12
+export const alphaDisabled = 0.5
 
 export const colorText = '#ffffff'
 


### PR DESCRIPTION
overlay join date and chat message timestamp.

There are a few issues remaining that I haven't figured out how best to
resolve yet:
- Tooltip open state tracking needs to be reworked. Using simple
  mouseenter/mouseleave events to track the Tooltip open state is not
  good enough. For example, it's possible for Tooltip to be displayed
  above its target element (in case of popover clamping at the edge of a
  screen for example), in which case the 'mouselave' event of the target
  element is triggered if the Tooltip is shown right below the mouse
  cursor.

  Also, there's some weirdness when Tooltip is opened above one element
  that also has a Tooltip and then moving the mouse over that element
  quickly can show/hide its Tooltip immediately. This is most easily
  reproducible on hovering over chat message timestamps by going from a
  below message to the one right above it.
- The transition used to open/close the Tooltip is copy-pasted from
  Popovers, with a delay of 800ms. This is probably not a correct thing
  for Tooltips, but then again, I'm not sure what is.
- I've used our lightest background color for Tooltips, since they can
  be shown over all other content, including Popovers which are fairly
  light themselves. However, I'm not sure if this was the best choice,
  but I wasn't sure what else to choose.