### PR TITLE
Use a restore icon when the window is maximized.

### DIFF
--- a/client/icons/codicons/chrome-restore.svg
+++ b/client/icons/codicons/chrome-restore.svg
@@ -1,0 +1,1 @@
+<svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" fill="currentColor"><path d="M3 5v9h9V5H3zm8 8H4V6h7v7z"/><path fill-rule="evenodd" clip-rule="evenodd" d="M5 5h1V4h7v7h-1v1h2V3H5v2z"/></svg>

--- a/client/system-bar/window-controls.tsx
+++ b/client/system-bar/window-controls.tsx
@@ -6,6 +6,7 @@ import { useExternalElementRef } from '../dom/use-external-element-ref'
 import CloseIcon from '../icons/codicons/chrome-close.svg'
 import MaximizeIcon from '../icons/codicons/chrome-maximize.svg'
 import MinimizeIcon from '../icons/codicons/chrome-minimize.svg'
+import RestoreIcon from '../icons/codicons/chrome-restore.svg'
 import { buttonReset } from '../material/button-reset'
 import { zIndexWindowControls } from '../material/zindex'
 
@@ -57,7 +58,23 @@ const CloseButton = styled.button`
   }
 `
 
-const MaximizeButton = styled.button`
+const StyledMaximizeIcon = styled(MaximizeIcon)`
+  display: inline;
+
+  .maximized & {
+    display: none;
+  }
+`
+
+const StyledRestoreIcon = styled(RestoreIcon)`
+  display: none;
+
+  .maximized & {
+    display: inline;
+  }
+`
+
+const MaximizeRestoreButton = styled.button`
   ${button};
 `
 
@@ -131,9 +148,10 @@ export function WindowControls() {
       <CloseButton title={'Close'} onClick={onCloseClick}>
         <CloseIcon />
       </CloseButton>
-      <MaximizeButton title={'Maximize/Restore'} onClick={onMaximizeClick}>
-        <MaximizeIcon />
-      </MaximizeButton>
+      <MaximizeRestoreButton title={'Maximize/Restore'} onClick={onMaximizeClick}>
+        <StyledMaximizeIcon />
+        <StyledRestoreIcon />
+      </MaximizeRestoreButton>
       <MinimizeButton title={'Minimize'} onClick={onMinimizeClick}>
         <MinimizeIcon />
       </MinimizeButton>


### PR DESCRIPTION
I must be the only person who uses the app in maximized state and get
ticked off by icon being the same in both maximized and non-maximized
states ^^.

This might've been a bit cleaner to implement if we saved the maximized
state in the store, but hopefully this is good enough for now.