### PR TITLE
Move the channel owners state to the channel table itself.

### DIFF
--- a/client/chat/socket-handlers.ts
+++ b/client/chat/socket-handlers.ts
@@ -16,7 +16,7 @@ type EventToChatActionMap = {
 }
 
 const eventToChatAction: EventToChatActionMap = {
-  init2(channel, event) {
+  init3(channel, event) {
     return {
       type: '@chat/initChannel',
       payload: event,

--- a/common/chat.ts
+++ b/common/chat.ts
@@ -99,17 +99,55 @@ export type ClientChatMessage =
 
 export type ChatMessage = ServerChatMessage | ClientChatMessage
 
+export interface ChannelInfo {
+  /** The name of the chat channel. */
+  name: string
+  /**
+   * The ID of the user that is considered a channel owner. Usually the person who joined the chat
+   * channel the earliest.
+   */
+  ownerId: SbUserId
+  /**
+   * A flag indicating whether the chat channel is private or not. Private chat channels can only be
+   * joined through an invite.
+   */
+  private: boolean
+  /**
+   * A flag indicating whether the chat channel is declared as having high traffic or not. High
+   * traffic channels can have certain rules (e.g. owners are not automatically transferred in them)
+   * that distinguish them from smaller channels.
+   */
+  highTraffic: boolean
+  /** A short message used to display the channel's current topic. */
+  topic: string
+  // TODO(2Pac): Can probably remove this, if we go with invitation system for private channels.
+  /** A channel's password */
+  password: string
+}
+
 export interface ChannelPermissions {
+  /**
+   * A flag indicating whether the user has a permission to kick someone from the channel. Kicking a
+   * user allows them to rejoin the channel immediately after they've been kicked.
+   */
   kick: boolean
+  /**
+   * A flag indicating whether the user has a permission to ban someone from the channel. Banning a
+   * user forbids them from rejoining the channel until they've been unbanned.
+   */
   ban: boolean
+  /** A flag indicating whether the user has a permission to change the channel's topic. */
   changeTopic: boolean
+  /** A flag indicating whether the user has a permission to change the channel's private status. */
   togglePrivate: boolean
+  /** A flag indicating whether the user has a permission to edit other user's permissions. */
   editPermissions: boolean
-  owner: boolean
 }
 
 export interface ChatInitEvent {
-  action: 'init2'
+  action: 'init3'
+  /** The information about the channel that the current user is initializing. */
+  channelInfo: ChannelInfo
   /** A list of IDs of active users that are in the chat channel. */
   activeUserIds: SbUserId[]
   /** The channel permissions for the current user that is initializing the channel. */
@@ -129,7 +167,7 @@ export interface ChatLeaveEvent {
   /** The ID of a user that has left the chat channel. */
   userId: SbUserId
   /** The ID of a user that was selected as a new owner of the channel, if any. */
-  newOwnerId: SbUserId | null
+  newOwnerId?: SbUserId
 }
 
 export interface ChatKickEvent {
@@ -137,7 +175,7 @@ export interface ChatKickEvent {
   /** The ID of a user that was kicked from the chat channel. */
   targetId: SbUserId
   /** The ID of a user that was selected as a new owner of the channel, if any. */
-  newOwnerId: SbUserId | null
+  newOwnerId?: SbUserId
 }
 
 export interface ChatBanEvent {
@@ -145,7 +183,7 @@ export interface ChatBanEvent {
   /** The ID of a user that was banned from the chat channel. */
   targetId: SbUserId
   /** The ID of a user that was selected as a new owner of the channel, if any. */
-  newOwnerId: SbUserId | null
+  newOwnerId?: SbUserId
 }
 
 export interface ChatMessageEvent {
@@ -252,8 +290,8 @@ export interface ChatUserProfile {
   channelName: string
   joinDate: Date
   /**
-   * User is considered a channel moderator if they have one of the following permissions:
-   *  - owner
+   * User is considered a channel moderator if they are an owner of the channel, or have one of the
+   * following permissions:
    *  - editPermissions
    *  - ban
    *  - kick

--- a/server/lib/chat/chat-models.ts
+++ b/server/lib/chat/chat-models.ts
@@ -262,7 +262,7 @@ export async function removeUserFromChannel(
     if (deleteChannelResult.rowCount > 0) {
       // Channel was deleted; meaning there is no one left in it so there is no one to transfer the
       // ownership to
-      return { newOwnerId: undefined } as LeaveChannelResult
+      return {}
     }
 
     const currentOwnerResult = await client.query<{ owner_id: SbUserId }>(sql`
@@ -273,7 +273,7 @@ export async function removeUserFromChannel(
 
     if (currentOwnerResult.rows[0].owner_id !== userId) {
       // The leaving user was not the owner, so there's no reason to transfer ownership to anyone
-      return { newOwnerId: undefined } as LeaveChannelResult
+      return {}
     }
 
     const highTrafficChannelResult = await client.query(sql`
@@ -282,7 +282,7 @@ export async function removeUserFromChannel(
     `)
     if (highTrafficChannelResult.rowCount > 0) {
       // Don't transfer ownership in "high traffic" channels
-      return { newOwnerId: undefined } as LeaveChannelResult
+      return {}
     }
 
     const earliestPermissionUserResult = await client.query<DbUserChannelEntry>(sql`
@@ -305,7 +305,7 @@ export async function removeUserFromChannel(
         SET owner_id = ${newOwner.user_id}
         WHERE name = ${channelName};
       `)
-      return { newOwnerId: newOwner.user_id } as LeaveChannelResult
+      return { newOwnerId: newOwner.user_id }
     }
 
     // Transfer ownership to the user who has joined the channel earliest
@@ -326,7 +326,7 @@ export async function removeUserFromChannel(
       SET owner_id = ${earliestUserResult.rows[0].user_id}
       WHERE name = ${channelName};
     `)
-    return { newOwnerId: earliestUserResult.rows[0].user_id } as LeaveChannelResult
+    return { newOwnerId: earliestUserResult.rows[0].user_id }
   })
 }
 

--- a/server/lib/chat/chat-models.ts
+++ b/server/lib/chat/chat-models.ts
@@ -1,5 +1,5 @@
-import sql, { SQLStatement } from 'sql-template-strings'
-import { ChannelPermissions, ServerChatMessageType } from '../../../common/chat'
+import sql from 'sql-template-strings'
+import { ChannelInfo, ChannelPermissions, ServerChatMessageType } from '../../../common/chat'
 import { SbUser, SbUserId } from '../../../common/users/sb-user'
 import db, { DbClient } from '../db'
 import transact from '../db/transaction'
@@ -25,7 +25,6 @@ function convertUserChannelEntryFromDb(props: DbUserChannelEntry): UserChannelEn
       changeTopic: props.change_topic,
       togglePrivate: props.toggle_private,
       editPermissions: props.edit_permissions,
-      owner: props.owner,
     },
   }
 }
@@ -90,33 +89,24 @@ export async function getUserChannelEntryForUser(
 export async function addUserToChannel(
   userId: SbUserId,
   channelName: string,
-  client?: DbClient,
+  withClient?: DbClient,
 ): Promise<UserChannelEntry> {
   const doIt = async (client: DbClient) => {
-    const channelExists = await findChannel(channelName)
     await client.query(sql`
-      INSERT INTO channels (name) SELECT ${channelName} WHERE NOT EXISTS (
-        SELECT 1 FROM channels WHERE name=${channelName}
-      );
+      INSERT INTO channels (name, owner_id)
+      VALUES (${channelName}, ${userId})
+      ON CONFLICT (name)
+      DO NOTHING;
     `)
 
-    let query: SQLStatement
-    if (channelExists) {
-      query = sql`
-        INSERT INTO channel_users (user_id, channel_name, join_date)
-        VALUES (${userId}, ${channelName}, CURRENT_TIMESTAMP AT TIME ZONE 'UTC')
-        RETURNING *;`
-    } else {
-      // Users joining a new channel get full permissions
-      query = sql`
-        INSERT INTO channel_users (user_id, channel_name, join_date, kick, ban, change_topic,
-          toggle_private, edit_permissions, owner)
-        VALUES (${userId}, ${channelName}, CURRENT_TIMESTAMP AT TIME ZONE 'UTC', true, true, true,
-          true, true, true)
-        RETURNING *;`
-    }
-
-    const result = await client.query<DbUserChannelEntry>(query)
+    // We don't bother with giving users in newly created channels full permissions since they're
+    // already marked as an owner of the channel, which trumps all other permissions and allows them
+    // to do everything in the channel.
+    const result = await client.query<DbUserChannelEntry>(sql`
+      INSERT INTO channel_users (user_id, channel_name, join_date)
+      VALUES (${userId}, ${channelName}, CURRENT_TIMESTAMP AT TIME ZONE 'UTC')
+      RETURNING *;
+    `)
 
     if (result.rowCount < 1) {
       throw new Error('No rows returned')
@@ -125,8 +115,8 @@ export async function addUserToChannel(
     return convertUserChannelEntryFromDb(result.rows[0])
   }
 
-  if (client) {
-    return doIt(client)
+  if (withClient) {
+    return doIt(withClient)
   } else {
     return transact(doIt)
   }
@@ -247,9 +237,10 @@ export async function getMessagesForChannel(
 
 export interface LeaveChannelResult {
   /**
-   * The ID of a new owner of the channel, or null if the channel ownership has been left unchanged.
+   * The ID of a user that was selected as a new owner of the channel, or `undefined` if the channel
+   * ownership has been left unchanged.
    */
-  newOwnerId: SbUserId | null
+  newOwnerId?: SbUserId
 }
 
 export async function removeUserFromChannel(
@@ -257,70 +248,88 @@ export async function removeUserFromChannel(
   channelName: string,
 ): Promise<LeaveChannelResult> {
   return transact(async function (client) {
-    const channelUserResult = await client.query<DbUserChannelEntry>(sql`
+    await client.query(sql`
       DELETE FROM channel_users
-      WHERE user_id = ${userId} AND channel_name = ${channelName}
-      RETURNING *`)
-    if (channelUserResult.rowCount < 1) {
-      throw new Error('No rows returned')
-    }
+      WHERE user_id = ${userId} AND channel_name = ${channelName};
+    `)
 
-    let result = await client.query(sql`
+    const deleteChannelResult = await client.query(sql`
       DELETE FROM channels
       WHERE name = ${channelName} AND
         NOT EXISTS (SELECT 1 FROM channel_users WHERE channel_name = ${channelName})
-      RETURNING name`)
-    if (result.rowCount > 0) {
+      RETURNING name;
+    `)
+    if (deleteChannelResult.rowCount > 0) {
       // Channel was deleted; meaning there is no one left in it so there is no one to transfer the
       // ownership to
-      return { newOwnerId: null }
+      return { newOwnerId: undefined } as LeaveChannelResult
     }
 
-    if (!channelUserResult.rows[0].owner) {
+    const currentOwnerResult = await client.query<{ owner_id: SbUserId }>(sql`
+      SELECT owner_id
+      FROM channels
+      WHERE name = ${channelName};
+    `)
+
+    if (currentOwnerResult.rows[0].owner_id !== userId) {
       // The leaving user was not the owner, so there's no reason to transfer ownership to anyone
-      return { newOwnerId: null }
+      return { newOwnerId: undefined } as LeaveChannelResult
     }
 
-    result = await client.query(sql`
+    // TODO(2Pac): Re-think this. This means that a channel might have an owner who is not in it
+    // anymore. Although, they would keep their ownership status if they rejoin later, so maybe
+    // that's fine?
+    const highTrafficChannelResult = await client.query(sql`
       SELECT name FROM channels
-      WHERE name = ${channelName} AND high_traffic = true`)
-    if (result.rowCount > 0) {
+      WHERE name = ${channelName} AND high_traffic = true;
+    `)
+    if (highTrafficChannelResult.rowCount > 0) {
       // Don't transfer ownership in "high traffic" channels
-      return { newOwnerId: null }
+      return { newOwnerId: undefined } as LeaveChannelResult
     }
 
-    result = await client.query<DbUserChannelEntry>(sql`
+    const earliestPermissionUserResult = await client.query<DbUserChannelEntry>(sql`
       SELECT *
       FROM channel_users
       WHERE channel_name = ${channelName} AND (kick = true OR ban = true OR
         change_topic = true OR toggle_private = true OR edit_permissions = true)
-      ORDER BY join_date`)
-    if (result.rowCount > 0) {
+      ORDER BY join_date;
+    `)
+    if (earliestPermissionUserResult.rowCount > 0) {
       // Transfer ownership to the user who has joined the channel earliest and has an
       // `edit_permissions` permission, or if there's no such user, then choose the first user with
       // any kind of permission
-      const newOwner = result.rows.find(u => u.edit_permissions) || result.rows[0]
+      const newOwner =
+        earliestPermissionUserResult.rows.find(u => u.edit_permissions) ||
+        earliestPermissionUserResult.rows[0]
+
       await client.query(sql`
-        UPDATE channel_users
-        SET kick = true, ban = true, change_topic = true, toggle_private = true,
-          edit_permissions = true, owner = true
-        WHERE user_id = ${newOwner.user_id} AND channel_name = ${channelName}`)
-      return { newOwnerId: newOwner.user_id }
+        UPDATE channels
+        SET owner_id = ${newOwner.user_id}
+        WHERE name = ${channelName};
+      `)
+      return { newOwnerId: newOwner.user_id } as LeaveChannelResult
     }
 
     // Transfer ownership to the user who has joined the channel earliest
-    result = await client.query(sql`
-      SELECT user_id, join_date
+    const earliestUserResult = await client.query<{ user_id: SbUserId }>(sql`
+      SELECT user_id
       FROM channel_users
       WHERE channel_name = ${channelName}
-      ORDER BY join_date`)
+      ORDER BY join_date;
+    `)
+
+    // This would mean that the channel has no users left at all which would be very odd indeed
+    if (earliestUserResult.rowCount < 1) {
+      throw new Error('No rows returned')
+    }
 
     await client.query(sql`
-      UPDATE channel_users
-      SET kick = true, ban = true, change_topic = true, toggle_private = true,
-        edit_permissions = true, owner = true
-      WHERE user_id = ${result.rows[0].user_id} AND channel_name = ${channelName}`)
-    return { newOwnerId: result.rows[0].user_id }
+      UPDATE channels
+      SET owner_id = ${earliestUserResult.rows[0].user_id}
+      WHERE name = ${channelName};
+    `)
+    return { newOwnerId: earliestUserResult.rows[0].user_id } as LeaveChannelResult
   })
 }
 
@@ -358,19 +367,12 @@ export async function isUserBannedFromChannel(
   }
 }
 
-export interface Channel {
-  name: string
-  private: boolean
-  highTraffic: boolean
-  topic: string
-  password: string
-}
+type DbChannel = Dbify<ChannelInfo>
 
-type DbChannel = Dbify<Channel>
-
-function convertChannelFromDb(props: DbChannel): Channel {
+function convertChannelFromDb(props: DbChannel): ChannelInfo {
   return {
     name: props.name,
+    ownerId: props.owner_id,
     private: props.private,
     highTraffic: props.high_traffic,
     topic: props.topic,
@@ -378,13 +380,42 @@ function convertChannelFromDb(props: DbChannel): Channel {
   }
 }
 
-export async function findChannel(channelName: string): Promise<Channel | null> {
-  const { client, done } = await db()
+/**
+ * Retrieves information for the specified chat channels. The channels are returned in the same
+ * order they were passed in. If one of the channels could not be found, it will not be included in
+ * the result.
+ */
+export async function getChannelInfo(
+  channelNames: string[],
+  withClient?: DbClient,
+): Promise<ChannelInfo[]> {
+  const { client, done } = await db(withClient)
   try {
     const result = await client.query<DbChannel>(sql`
-      SELECT * FROM channels WHERE name = ${channelName};
+      SELECT *
+      FROM channels
+      WHERE name = ANY(${channelNames});
     `)
-    return result.rowCount < 1 ? null : convertChannelFromDb(result.rows[0])
+
+    if (result.rowCount < 1) {
+      return []
+    }
+
+    const channelInfos = await Promise.all(result.rows.map(c => convertChannelFromDb(c)))
+    const nameToChannelInfo = new Map<string, ChannelInfo>()
+    for (const channelInfo of channelInfos) {
+      nameToChannelInfo.set(channelInfo.name.toLowerCase(), channelInfo)
+    }
+
+    const orderedChannelInfos = []
+    for (const channelName of channelNames) {
+      const info = nameToChannelInfo.get(channelName.toLowerCase())
+      if (info) {
+        orderedChannelInfos.push(info)
+      }
+    }
+
+    return orderedChannelInfos
   } finally {
     done()
   }

--- a/server/lib/chat/chat-models.ts
+++ b/server/lib/chat/chat-models.ts
@@ -276,9 +276,6 @@ export async function removeUserFromChannel(
       return { newOwnerId: undefined } as LeaveChannelResult
     }
 
-    // TODO(2Pac): Re-think this. This means that a channel might have an owner who is not in it
-    // anymore. Although, they would keep their ownership status if they rejoin later, so maybe
-    // that's fine?
     const highTrafficChannelResult = await client.query(sql`
       SELECT name FROM channels
       WHERE name = ${channelName} AND high_traffic = true;

--- a/server/migrations/20220228141557-move-channel-owners-to-channels-table.js
+++ b/server/migrations/20220228141557-move-channel-owners-to-channels-table.js
@@ -1,0 +1,71 @@
+exports.up = async function (db) {
+  // We don't use `ON DELETE CASCADE` here which means that a user can't be deleted if they're still
+  // an owner of a channel. This shouldn't really matter since we'll probably never delete user rows
+  // outright, but it also serves as a safety check so we don't lose a whole channel by deleting a
+  // single user in that channel, even if that user is the owner. Although we probably *should*
+  // delete a channel if they're were the only user in it, but not sure if that's even possible to
+  // write in SQL, so yeah... just make sure to transfer the channel ownership before deleting a
+  // user and everything should be fine :d
+  await db.runSql(`
+    ALTER TABLE channels
+    ADD COLUMN owner_id integer;
+  `)
+
+  await db.runSql(`
+    ALTER TABLE channels
+    ADD CONSTRAINT channels_owner_id_fkey FOREIGN KEY (owner_id) REFERENCES users (id);
+  `)
+
+  // This should be safe to do because in previous migration we updated all channels to have an
+  // owner.
+  await db.runSql(`
+    UPDATE channels AS c
+    SET owner_id = cu.user_id
+    FROM channel_users AS cu
+    WHERE c.name = cu.channel_name AND cu.owner = true;
+  `)
+
+  await db.runSql(`
+    ALTER TABLE channels
+    ALTER COLUMN owner_id SET NOT NULL;
+  `)
+
+  await db.runSql(`
+    DROP INDEX joined_channels_owner;
+  `)
+
+  await db.runSql(`
+    ALTER TABLE channel_users
+    DROP COLUMN owner;
+  `)
+}
+
+exports.down = async function (db) {
+  await db.runSql(`
+    ALTER TABLE channel_users
+    ADD COLUMN owner
+    BOOLEAN NOT NULL DEFAULT false;
+  `)
+
+  await db.runSql(`
+    CREATE UNIQUE INDEX joined_channels_owner
+    ON channel_users (channel_name, owner)
+    WHERE owner = true;
+  `)
+
+  await db.runSql(`
+    UPDATE channel_users AS cu
+    SET owner = true
+    FROM channels AS c
+    WHERE c.name = cu.channel_name AND c.owner_id = cu.user_id;
+  `)
+
+  await db.runSql(`
+    ALTER TABLE channels
+    DROP COLUMN owner_id;
+  `)
+}
+
+exports._meta = {
+  version: 1,
+}


### PR DESCRIPTION
Even though it makes retrieving some information a bit harder, having
the owner state in the channels table itself just makes a lot more sense
than having it in channel_users table. Also, this ensures that there is
only one owner per channel, and makes changing user permissions a bit
safer.