### PR TITLE
Implement dialog stacking.

### DIFF
--- a/client/auth/edit-account.jsx
+++ b/client/auth/edit-account.jsx
@@ -10,6 +10,7 @@ import {
 } from '../../common/constants'
 import { Avatar } from '../avatars/avatar'
 import { closeDialog } from '../dialogs/action-creators'
+import { DialogType } from '../dialogs/dialog-type'
 import form from '../forms/form'
 import SubmitOnEnter from '../forms/submit-on-enter'
 import {
@@ -171,7 +172,7 @@ export default class EditAccount extends React.Component {
     const hasError = !!this.props.auth.lastFailure
 
     if (isPrevRequesting && !isRequesting && !hasError) {
-      this.props.dispatch(closeDialog())
+      this.props.dispatch(closeDialog(DialogType.Account))
     }
   }
 
@@ -261,7 +262,7 @@ export default class EditAccount extends React.Component {
 
     if (oldValues.email === values.email && !values.newPassword) {
       // Nothing changed, just close the dialog.
-      this.props.dispatch(closeDialog())
+      this.props.dispatch(closeDialog(DialogType.Account))
       return
     }
     if (oldValues.email !== values.email) {

--- a/client/auth/signup.jsx
+++ b/client/auth/signup.jsx
@@ -113,7 +113,7 @@ function DialogLink({ dialogType, text }) {
   const onClick = event => {
     event.preventDefault()
     event.stopPropagation()
-    dispatch(openDialog(dialogType))
+    dispatch(openDialog({ type: dialogType }))
   }
 
   return (

--- a/client/changelog/action-creators.js
+++ b/client/changelog/action-creators.js
@@ -11,5 +11,5 @@ export function openChangelogIfNecessary() {
 }
 
 export function openChangelog() {
-  return openDialog(DialogType.Changelog)
+  return openDialog({ type: DialogType.Changelog })
 }

--- a/client/chat/channel-ban-user-dialog.tsx
+++ b/client/chat/channel-ban-user-dialog.tsx
@@ -4,6 +4,7 @@ import { ChannelModerationAction, ChatServiceErrorCode } from '../../common/chat
 import { SbUser } from '../../common/users/sb-user'
 import { closeDialog } from '../dialogs/action-creators'
 import { CommonDialogProps } from '../dialogs/common-dialog-props'
+import { DialogType } from '../dialogs/dialog-type'
 import { useForm } from '../forms/form-hook'
 import { useAutoFocusRef } from '../material/auto-focus'
 import { TextButton } from '../material/button'
@@ -92,7 +93,7 @@ export function ChannelBanUserDialog({
           {
             onSuccess: () => {
               dispatch(openSnackbar({ message: `${user.name} was banned` }))
-              dispatch(closeDialog())
+              dispatch(closeDialog(DialogType.ChannelBanUser))
             },
             onError: err => setBanUserError(err),
           },

--- a/client/chat/join-channel.jsx
+++ b/client/chat/join-channel.jsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { connect } from 'react-redux'
 import { CHANNEL_MAXLENGTH, CHANNEL_PATTERN } from '../../common/constants'
 import { closeDialog } from '../dialogs/action-creators'
+import { DialogType } from '../dialogs/dialog-type'
 import form from '../forms/form'
 import { composeValidators, maxLength, regex, required } from '../forms/validators'
 import { TextButton } from '../material/button'
@@ -96,7 +97,7 @@ export default class JoinChannel extends React.Component {
 
   onSubmit = () => {
     const channel = this._form.getModel().channel
-    this.props.dispatch(closeDialog())
+    this.props.dispatch(closeDialog(DialogType.ChannelJoin))
     navigateToChannel(channel)
   }
 }

--- a/client/dialogs/action-creators.ts
+++ b/client/dialogs/action-creators.ts
@@ -20,8 +20,11 @@ export function openSimpleDialog(
   })
 }
 
-export function closeDialog(): CloseDialog {
+export function closeDialog(dialogType: DialogType | 'all'): CloseDialog {
   return {
     type: '@dialogs/close',
+    payload: {
+      dialogType,
+    },
   }
 }

--- a/client/dialogs/action-creators.ts
+++ b/client/dialogs/action-creators.ts
@@ -1,14 +1,11 @@
 import React from 'react'
 import { CloseDialog, OpenDialog } from './actions'
-import { DialogType } from './dialog-type'
+import { DialogPayload, DialogType } from './dialog-type'
 
-export function openDialog(dialogType: DialogType, initData = {}): OpenDialog {
+export function openDialog(payload: DialogPayload): OpenDialog {
   return {
     type: '@dialogs/open',
-    payload: {
-      dialogType,
-      initData,
-    },
+    payload,
   }
 }
 
@@ -17,7 +14,10 @@ export function openSimpleDialog(
   simpleContent: React.ReactNode,
   hasButton = true,
 ): OpenDialog {
-  return openDialog(DialogType.Simple, { simpleTitle, simpleContent, hasButton })
+  return openDialog({
+    type: DialogType.Simple,
+    initData: { simpleTitle, simpleContent, hasButton },
+  })
 }
 
 export function closeDialog(): CloseDialog {

--- a/client/dialogs/actions.ts
+++ b/client/dialogs/actions.ts
@@ -1,13 +1,10 @@
-import { DialogType } from './dialog-type'
+import { DialogPayload } from './dialog-type'
 
 export type DialogActions = OpenDialog | CloseDialog
 
 export interface OpenDialog {
   type: '@dialogs/open'
-  payload: {
-    dialogType: DialogType
-    initData: any // TODO(tec27): Type this based on dialog type
-  }
+  payload: DialogPayload
 }
 
 export interface CloseDialog {

--- a/client/dialogs/actions.ts
+++ b/client/dialogs/actions.ts
@@ -1,4 +1,4 @@
-import { DialogPayload } from './dialog-type'
+import { DialogPayload, DialogType } from './dialog-type'
 
 export type DialogActions = OpenDialog | CloseDialog
 
@@ -9,4 +9,7 @@ export interface OpenDialog {
 
 export interface CloseDialog {
   type: '@dialogs/close'
+  payload: {
+    dialogType: DialogType | 'all'
+  }
 }

--- a/client/dialogs/connected-dialog-overlay.tsx
+++ b/client/dialogs/connected-dialog-overlay.tsx
@@ -52,6 +52,8 @@ const Scrim = styled(animated.div)`
 const INVISIBLE_SCRIM_COLOR = rgba(dialogScrim, 0)
 const VISIBLE_SCRIM_COLOR = rgba(dialogScrim, 0.42)
 
+const noop = () => {}
+
 export interface DialogContextValue {
   styles: SpringValues
 }
@@ -124,9 +126,9 @@ export function ConnectedDialogOverlay() {
 
   const isTopDialogModal = topDialog ? getDialog(topDialog.type, starcraft).modal : false
   const onCancel = useCallback(
-    (modal: boolean, event?: React.MouseEvent) => {
-      if (!modal && (!event || !isHandledDismissalEvent(event.nativeEvent))) {
-        dispatch(closeDialog())
+    (dialogType: DialogType | 'all', event?: React.MouseEvent) => {
+      if (!event || !isHandledDismissalEvent(event.nativeEvent)) {
+        dispatch(closeDialog(dialogType))
       }
     },
     [dispatch],
@@ -165,7 +167,14 @@ export function ConnectedDialogOverlay() {
     <>
       {scrimTransition(
         (styles, open) =>
-          open && <Scrim style={styles} onClick={event => onCancel(isTopDialogModal, event)} />,
+          open && (
+            <Scrim
+              style={styles}
+              onClick={event =>
+                isTopDialogModal ? noop() : onCancel(topDialog?.type ?? 'all', event)
+              }
+            />
+          ),
       )}
       {dialogTransition((styles, dialogState) => {
         const { component: DialogComponent, modal } = getDialog(dialogState.type, starcraft)
@@ -179,7 +188,9 @@ export function ConnectedDialogOverlay() {
               <DialogContext.Provider value={{ styles }}>
                 <DialogComponent
                   dialogRef={dialogRef}
-                  onCancel={(event: React.MouseEvent) => onCancel(modal, event)}
+                  onCancel={(event: React.MouseEvent) =>
+                    modal ? noop() : onCancel(dialogState.type, event)
+                  }
                   {...dialogState.initData}
                 />
               </DialogContext.Provider>

--- a/client/dialogs/connected-dialog-overlay.tsx
+++ b/client/dialogs/connected-dialog-overlay.tsx
@@ -1,8 +1,7 @@
 import { rgba } from 'polished'
 import React, { useCallback, useRef } from 'react'
 import ReactDOM from 'react-dom'
-import { animated, useTransition } from 'react-spring'
-import { CSSTransition, TransitionGroup } from 'react-transition-group'
+import { animated, SpringValues, useTransition, UseTransitionProps } from 'react-spring'
 import styled from 'styled-components'
 import { assertUnreachable } from '../../common/assert-unreachable'
 import EditAccount from '../auth/edit-account'
@@ -34,6 +33,7 @@ import StarcraftHealthCheckupDialog from '../starcraft/starcraft-health'
 import { dialogScrim } from '../styles/colors'
 import CreateWhisperSessionDialog from '../whispers/create-whisper'
 import { closeDialog } from './action-creators'
+import { DialogState } from './dialog-reducer'
 import { DialogType } from './dialog-type'
 import { SimpleDialog } from './simple-dialog'
 
@@ -52,14 +52,12 @@ const Scrim = styled(animated.div)`
 const INVISIBLE_SCRIM_COLOR = rgba(dialogScrim, 0)
 const VISIBLE_SCRIM_COLOR = rgba(dialogScrim, 0.42)
 
-const transitionNames = {
-  appear: 'enter',
-  appearActive: 'enterActive',
-  enter: 'enter',
-  enterActive: 'enterActive',
-  exit: 'exit',
-  exitActive: 'exitActive',
+export interface DialogContextValue {
+  styles: SpringValues
 }
+export const DialogContext = React.createContext<DialogContextValue>({
+  styles: {},
+})
 
 function getDialog(
   dialogType: DialogType,
@@ -115,32 +113,30 @@ function getDialog(
 
 export function ConnectedDialogOverlay() {
   const dispatch = useAppDispatch()
-  const dialogState = useAppSelector(s => s.dialog)
+  const dialogHistory = useAppSelector(s => s.dialog.history)
+  const isDialogOpen = dialogHistory.length > 0
+  const topDialog = isDialogOpen ? dialogHistory[dialogHistory.length - 1] : undefined
   const starcraft = useAppSelector(s => s.starcraft)
 
   const focusableRef = useRef<HTMLSpanElement>(null)
   const dialogRef = useRef<HTMLElement>(null)
   const portalRef = useExternalElementRef()
 
-  const { dialogType } = dialogState
-  const { component: DialogComponent, modal } = dialogType
-    ? getDialog(dialogType, starcraft)
-    : { component: null, modal: false }
-
+  const isTopDialogModal = topDialog ? getDialog(topDialog.type, starcraft).modal : false
   const onCancel = useCallback(
-    (event?: React.MouseEvent) => {
-      if (dialogType && !modal && (!event || !isHandledDismissalEvent(event.nativeEvent))) {
+    (modal: boolean, event?: React.MouseEvent) => {
+      if (!modal && (!event || !isHandledDismissalEvent(event.nativeEvent))) {
         dispatch(closeDialog())
       }
     },
-    [dialogType, modal, dispatch],
+    [dispatch],
   )
   const onFocusTrap = useCallback(() => {
     // Focus was about to leave the dialog area, redirect it back to the dialog
     focusableRef.current?.focus()
   }, [])
 
-  const scrimTransition = useTransition(dialogState.isDialogOpened, {
+  const scrimTransition = useTransition(isDialogOpen, {
     from: {
       background: INVISIBLE_SCRIM_COLOR,
     },
@@ -152,33 +148,46 @@ export function ConnectedDialogOverlay() {
     },
   })
 
-  // Dialog content implementations should focus *something* when mounted, so that our focus traps
-  // have the proper effect of keeping focus in the dialog
-  let renderedDialog
-  if (dialogState.isDialogOpened && DialogComponent) {
-    renderedDialog = (
-      <CSSTransition
-        classNames={transitionNames}
-        timeout={{ enter: 350, exit: 250 }}
-        nodeRef={dialogRef}>
-        <DialogComponent
-          key='dialog'
-          dialogRef={dialogRef}
-          onCancel={onCancel}
-          {...dialogState.initData.toJS()}
-        />
-      </CSSTransition>
-    )
-  }
+  const dialogTransition = useTransition<DialogState, UseTransitionProps<DialogState>>(
+    dialogHistory,
+    {
+      from: { opacity: 0, transform: 'translate3d(0, -100%, 0) scale(0.6, 0.2)' },
+      enter: { opacity: 1, transform: 'translate3d(0, 0%, 0) scale(1, 1)' },
+      leave: { opacity: 0, transform: 'translate3d(0, -100%, 0) scale(0.6, 0.2)' },
+      config: {
+        ...defaultSpring,
+        clamp: true,
+      },
+    },
+  )
 
   return ReactDOM.createPortal(
     <>
-      {scrimTransition((styles, open) => open && <Scrim style={styles} onClick={onCancel} />)}
-      <span tabIndex={0} onFocus={onFocusTrap} />
-      <span ref={focusableRef} tabIndex={-1}>
-        <TransitionGroup>{renderedDialog}</TransitionGroup>
-      </span>
-      <span tabIndex={0} onFocus={onFocusTrap} />
+      {scrimTransition(
+        (styles, open) =>
+          open && <Scrim style={styles} onClick={event => onCancel(isTopDialogModal, event)} />,
+      )}
+      {dialogTransition((styles, dialogState) => {
+        const { component: DialogComponent, modal } = getDialog(dialogState.type, starcraft)
+
+        // Dialog content implementations should focus *something* when mounted, so that our focus
+        // traps have the proper effect of keeping focus in the dialog
+        return (
+          <>
+            <span tabIndex={0} onFocus={onFocusTrap} />
+            <span ref={focusableRef} tabIndex={-1}>
+              <DialogContext.Provider value={{ styles }}>
+                <DialogComponent
+                  dialogRef={dialogRef}
+                  onCancel={(event: React.MouseEvent) => onCancel(modal, event)}
+                  {...dialogState.initData}
+                />
+              </DialogContext.Provider>
+            </span>
+            <span tabIndex={0} onFocus={onFocusTrap} />
+          </>
+        )
+      })}
     </>,
     portalRef.current,
   )

--- a/client/dialogs/dialog-reducer.ts
+++ b/client/dialogs/dialog-reducer.ts
@@ -1,4 +1,5 @@
 import { Immutable } from 'immer'
+import { findLastIndex } from '../../common/arrays'
 import { immerKeyedReducer } from '../reducers/keyed-reducer'
 import { DialogType } from './dialog-type'
 
@@ -30,11 +31,11 @@ export default immerKeyedReducer(DEFAULT_DIALOG_HISTORY_STATE, {
       return
     }
 
-    const dialogIndex = state.history.findIndex(h => h.type === dialogType)
+    const dialogIndex = findLastIndex(state.history, h => h.type === dialogType)
     if (dialogIndex < 0) {
       return
     }
 
-    state.history.splice(dialogIndex)
+    state.history = state.history.slice(0, dialogIndex)
   },
 })

--- a/client/dialogs/dialog-reducer.ts
+++ b/client/dialogs/dialog-reducer.ts
@@ -23,6 +23,18 @@ export default immerKeyedReducer(DEFAULT_DIALOG_HISTORY_STATE, {
   },
 
   ['@dialogs/close'](state, action) {
-    state.history.pop()
+    const { dialogType } = action.payload
+
+    if (dialogType === 'all') {
+      state.history = []
+      return
+    }
+
+    const dialogIndex = state.history.findIndex(h => h.type === dialogType)
+    if (dialogIndex < 0) {
+      return
+    }
+
+    state.history.splice(dialogIndex)
   },
 })

--- a/client/dialogs/dialog-reducer.ts
+++ b/client/dialogs/dialog-reducer.ts
@@ -1,23 +1,28 @@
-import { Map, Record } from 'immutable'
-import { keyedReducer } from '../reducers/keyed-reducer'
+import { Immutable } from 'immer'
+import { immerKeyedReducer } from '../reducers/keyed-reducer'
 import { DialogType } from './dialog-type'
 
-export class DialogState extends Record({
-  isDialogOpened: false,
-  dialogType: null as DialogType | null,
-  initData: Map(),
-}) {}
+export interface DialogState {
+  type: DialogType
+  initData?: Record<string, unknown>
+}
 
-export default keyedReducer(new DialogState(), {
+export interface DialogHistoryState {
+  history: DialogState[]
+}
+
+const DEFAULT_DIALOG_HISTORY_STATE: Immutable<DialogHistoryState> = {
+  history: [],
+}
+
+export default immerKeyedReducer(DEFAULT_DIALOG_HISTORY_STATE, {
   ['@dialogs/open'](state, action) {
-    return new DialogState({
-      isDialogOpened: true,
-      dialogType: action.payload.dialogType,
-      initData: Map(Object.entries(action.payload.initData)),
-    })
+    const { type, initData } = action.payload
+
+    state.history.push({ type, initData })
   },
 
   ['@dialogs/close'](state, action) {
-    return new DialogState()
+    state.history.pop()
   },
 })

--- a/client/dialogs/dialog-type.ts
+++ b/client/dialogs/dialog-type.ts
@@ -20,3 +20,125 @@ export enum DialogType {
   TermsOfService = 'termsOfService',
   Whispers = 'whispers',
 }
+
+export interface BaseDialogPayload {
+  type: DialogType
+  initData?: Record<string, unknown>
+}
+
+export interface AcceptableUseDialogPayload extends BaseDialogPayload {
+  type: typeof DialogType.AcceptableUse
+}
+
+export interface AcceptMatchDialogPayload extends BaseDialogPayload {
+  type: typeof DialogType.AcceptMatch
+}
+
+export interface AccountDialogPayload extends BaseDialogPayload {
+  type: typeof DialogType.Account
+}
+
+export interface ChangelogDialogPayload extends BaseDialogPayload {
+  type: typeof DialogType.Changelog
+}
+
+export interface ChannelJoinDialogPayload extends BaseDialogPayload {
+  type: typeof DialogType.ChannelJoin
+}
+
+export interface ChannelBanUserDialogPayload extends BaseDialogPayload {
+  type: typeof DialogType.ChannelBanUser
+}
+
+export interface DownloadDialogPayload extends BaseDialogPayload {
+  type: typeof DialogType.Download
+}
+
+export interface ExternalLinkDialogPayload extends BaseDialogPayload {
+  type: typeof DialogType.ExternalLink
+  initData: {
+    href: string
+    domain: string
+  }
+}
+
+export interface MapDetailsDialogPayload extends BaseDialogPayload {
+  type: typeof DialogType.MapDetails
+  initData: {
+    mapId: string
+  }
+}
+
+export interface MapPreviewDialogPayload extends BaseDialogPayload {
+  type: typeof DialogType.MapPreview
+  initData: {
+    mapId: string
+  }
+}
+
+export interface PartyQueueAcceptDialogPayload extends BaseDialogPayload {
+  type: typeof DialogType.PartyQueueAccept
+}
+
+export interface PartyInviteDialogPayload extends BaseDialogPayload {
+  type: typeof DialogType.PartyInvite
+}
+
+export interface PrivacyPolicyDialogPayload extends BaseDialogPayload {
+  type: typeof DialogType.PrivacyPolicy
+}
+
+export interface SettingsDialogPayload extends BaseDialogPayload {
+  type: typeof DialogType.Settings
+}
+
+export interface SimpleDialogPayload extends BaseDialogPayload {
+  type: typeof DialogType.Simple
+  initData: {
+    simpleTitle: string
+    simpleContent: React.ReactNode
+    hasButton: boolean
+  }
+}
+
+export interface ShieldBatteryHealthDialogPayload extends BaseDialogPayload {
+  type: typeof DialogType.ShieldBatteryHealth
+}
+
+export interface StarcraftHealthDialogPayload extends BaseDialogPayload {
+  type: typeof DialogType.StarcraftHealth
+}
+
+export interface StarcraftPathDialogPayload extends BaseDialogPayload {
+  type: typeof DialogType.StarcraftPath
+}
+
+export interface TermsOfServiceDialogPayload extends BaseDialogPayload {
+  type: typeof DialogType.TermsOfService
+}
+
+export interface WhispersDialogPayload extends BaseDialogPayload {
+  type: typeof DialogType.Whispers
+}
+
+export type DialogPayload =
+  | AcceptableUseDialogPayload
+  | AcceptMatchDialogPayload
+  | AccountDialogPayload
+  | ChangelogDialogPayload
+  | ChannelJoinDialogPayload
+  | ChannelBanUserDialogPayload
+  | DownloadDialogPayload
+  | ExternalLinkDialogPayload
+  | MapDetailsDialogPayload
+  | MapPreviewDialogPayload
+  | PartyQueueAcceptDialogPayload
+  | PartyInviteDialogPayload
+  | PrivacyPolicyDialogPayload
+  | SettingsDialogPayload
+  | SimpleDialogPayload
+  | ShieldBatteryHealthDialogPayload
+  | StarcraftHealthDialogPayload
+  | StarcraftPathDialogPayload
+  | TermsOfServiceDialogPayload
+  | WhispersDialogPayload

--- a/client/dialogs/dialog-type.ts
+++ b/client/dialogs/dialog-type.ts
@@ -21,105 +21,54 @@ export enum DialogType {
   Whispers = 'whispers',
 }
 
-export interface BaseDialogPayload {
-  type: DialogType
-  initData?: Record<string, unknown>
+type BaseDialogPayload<D, DataType = Record<string, never>> = {
+  type: D
+  initData?: DataType
 }
 
-export interface AcceptableUseDialogPayload extends BaseDialogPayload {
-  type: typeof DialogType.AcceptableUse
-}
-
-export interface AcceptMatchDialogPayload extends BaseDialogPayload {
-  type: typeof DialogType.AcceptMatch
-}
-
-export interface AccountDialogPayload extends BaseDialogPayload {
-  type: typeof DialogType.Account
-}
-
-export interface ChangelogDialogPayload extends BaseDialogPayload {
-  type: typeof DialogType.Changelog
-}
-
-export interface ChannelJoinDialogPayload extends BaseDialogPayload {
-  type: typeof DialogType.ChannelJoin
-}
-
-export interface ChannelBanUserDialogPayload extends BaseDialogPayload {
-  type: typeof DialogType.ChannelBanUser
-}
-
-export interface DownloadDialogPayload extends BaseDialogPayload {
-  type: typeof DialogType.Download
-}
-
-export interface ExternalLinkDialogPayload extends BaseDialogPayload {
-  type: typeof DialogType.ExternalLink
-  initData: {
+type AcceptableUseDialogPayload = BaseDialogPayload<typeof DialogType.AcceptableUse>
+type AcceptMatchDialogPayload = BaseDialogPayload<typeof DialogType.AcceptMatch>
+type AccountDialogPayload = BaseDialogPayload<typeof DialogType.Account>
+type ChangelogDialogPayload = BaseDialogPayload<typeof DialogType.Changelog>
+type ChannelJoinDialogPayload = BaseDialogPayload<typeof DialogType.ChannelJoin>
+type ChannelBanUserDialogPayload = BaseDialogPayload<typeof DialogType.ChannelBanUser>
+type DownloadDialogPayload = BaseDialogPayload<typeof DialogType.Download>
+type ExternalLinkDialogPayload = BaseDialogPayload<
+  typeof DialogType.ExternalLink,
+  {
     href: string
     domain: string
   }
-}
-
-export interface MapDetailsDialogPayload extends BaseDialogPayload {
-  type: typeof DialogType.MapDetails
-  initData: {
+>
+type MapDetailsDialogPayload = BaseDialogPayload<
+  typeof DialogType.MapDetails,
+  {
     mapId: string
   }
-}
-
-export interface MapPreviewDialogPayload extends BaseDialogPayload {
-  type: typeof DialogType.MapPreview
-  initData: {
+>
+type MapPreviewDialogPayload = BaseDialogPayload<
+  typeof DialogType.MapPreview,
+  {
     mapId: string
   }
-}
-
-export interface PartyQueueAcceptDialogPayload extends BaseDialogPayload {
-  type: typeof DialogType.PartyQueueAccept
-}
-
-export interface PartyInviteDialogPayload extends BaseDialogPayload {
-  type: typeof DialogType.PartyInvite
-}
-
-export interface PrivacyPolicyDialogPayload extends BaseDialogPayload {
-  type: typeof DialogType.PrivacyPolicy
-}
-
-export interface SettingsDialogPayload extends BaseDialogPayload {
-  type: typeof DialogType.Settings
-}
-
-export interface SimpleDialogPayload extends BaseDialogPayload {
-  type: typeof DialogType.Simple
-  initData: {
+>
+type PartyQueueAcceptDialogPayload = BaseDialogPayload<typeof DialogType.PartyQueueAccept>
+type PartyInviteDialogPayload = BaseDialogPayload<typeof DialogType.PartyInvite>
+type PrivacyPolicyDialogPayload = BaseDialogPayload<typeof DialogType.PrivacyPolicy>
+type SettingsDialogPayload = BaseDialogPayload<typeof DialogType.Settings>
+type SimpleDialogPayload = BaseDialogPayload<
+  typeof DialogType.Simple,
+  {
     simpleTitle: string
     simpleContent: React.ReactNode
     hasButton: boolean
   }
-}
-
-export interface ShieldBatteryHealthDialogPayload extends BaseDialogPayload {
-  type: typeof DialogType.ShieldBatteryHealth
-}
-
-export interface StarcraftHealthDialogPayload extends BaseDialogPayload {
-  type: typeof DialogType.StarcraftHealth
-}
-
-export interface StarcraftPathDialogPayload extends BaseDialogPayload {
-  type: typeof DialogType.StarcraftPath
-}
-
-export interface TermsOfServiceDialogPayload extends BaseDialogPayload {
-  type: typeof DialogType.TermsOfService
-}
-
-export interface WhispersDialogPayload extends BaseDialogPayload {
-  type: typeof DialogType.Whispers
-}
+>
+type ShieldBatteryHealthDialogPayload = BaseDialogPayload<typeof DialogType.ShieldBatteryHealth>
+type StarcraftHealthDialogPayload = BaseDialogPayload<typeof DialogType.StarcraftHealth>
+type StarcraftPathDialogPayload = BaseDialogPayload<typeof DialogType.StarcraftPath>
+type TermsOfServiceDialogPayload = BaseDialogPayload<typeof DialogType.TermsOfService>
+type WhispersDialogPayload = BaseDialogPayload<typeof DialogType.Whispers>
 
 export type DialogPayload =
   | AcceptableUseDialogPayload

--- a/client/landing/splash.tsx
+++ b/client/landing/splash.tsx
@@ -483,7 +483,7 @@ export default function Splash() {
           <SplashButton
             label='Download'
             color='primary'
-            onClick={() => dispatch(openDialog(DialogType.Download))}
+            onClick={() => dispatch(openDialog({ type: DialogType.Download }))}
           />
         </ButtonsContainer>
       ) : (

--- a/client/main-layout.tsx
+++ b/client/main-layout.tsx
@@ -137,9 +137,9 @@ function useHealthyStarcraftCallback<T extends (...args: any[]) => any>(
   return useCallback(
     (...args) => {
       if (!isShieldBatteryHealthy({ starcraft })) {
-        dispatch(openDialog(DialogType.ShieldBatteryHealth))
+        dispatch(openDialog({ type: DialogType.ShieldBatteryHealth }))
       } else if (!isStarcraftHealthy({ starcraft })) {
-        dispatch(openDialog(DialogType.StarcraftHealth))
+        dispatch(openDialog({ type: DialogType.StarcraftHealth }))
       } else {
         callback(...args)
       }
@@ -204,7 +204,7 @@ export function MainLayout() {
 
   const onMapDetails = useCallback(
     (map: MapInfoJson) => {
-      dispatch(openDialog(DialogType.MapDetails, { mapId: map.id }))
+      dispatch(openDialog({ type: DialogType.MapDetails, initData: { mapId: map.id } }))
     },
     [dispatch],
   )
@@ -264,9 +264,9 @@ export function MainLayout() {
 
   const onReplaysClick = useCallback(() => {
     if (!isShieldBatteryHealthy({ starcraft })) {
-      dispatch(openDialog(DialogType.ShieldBatteryHealth))
+      dispatch(openDialog({ type: DialogType.ShieldBatteryHealth }))
     } else if (!isStarcraftHealthy({ starcraft })) {
-      dispatch(openDialog(DialogType.StarcraftHealth))
+      dispatch(openDialog({ type: DialogType.StarcraftHealth }))
     } else {
       // TODO(2Pac): Remove `any` once the `openOverlay` is TS-ified
       dispatch(openOverlay('watchReplay') as any)
@@ -340,7 +340,7 @@ export function MainLayout() {
           key='download'
           icon={<DownloadIcon />}
           label='Download'
-          onClick={() => dispatch(openDialog(DialogType.Download))}
+          onClick={() => dispatch(openDialog({ type: DialogType.Download }))}
           hotkey={ALT_O}
         />,
         <ActivityButton
@@ -407,7 +407,7 @@ export function MainLayout() {
               key='settings'
               ref={settingsButtonRef}
               icon={<FadedSettingsIcon />}
-              onClick={() => dispatch(openDialog(DialogType.Settings))}
+              onClick={() => dispatch(openDialog({ type: DialogType.Settings }))}
             />
           </Tooltip>
         </MiniActivityButtonsContainer>

--- a/client/maps/action-creators.ts
+++ b/client/maps/action-creators.ts
@@ -295,5 +295,5 @@ export function batchGetMapInfo(mapId: string, maxCacheAgeMillis = 60000): Thunk
 }
 
 export function openMapPreviewDialog(mapId: string) {
-  return openDialog(DialogType.MapPreview, { mapId })
+  return openDialog({ type: DialogType.MapPreview, initData: { mapId } })
 }

--- a/client/maps/map-preview.tsx
+++ b/client/maps/map-preview.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo } from 'react'
+import React, { useEffect } from 'react'
 import styled from 'styled-components'
 import { CommonDialogProps } from '../dialogs/common-dialog-props'
 import { Dialog } from '../material/dialog'
@@ -7,7 +7,9 @@ import { background400 } from '../styles/colors'
 import { batchGetMapInfo } from './action-creators'
 import MapImage from './map-image'
 
-const StyledDialog = styled(Dialog)`
+const StyledDialog = styled(Dialog)<{ $mapWidth?: number; $mapHeight?: number }>`
+  --sb-map-width: ${props => props.$mapWidth};
+  --sb-map-height: ${props => props.$mapHeight};
   --sb-map-preview-aspect-ratio: calc(var(--sb-map-width, 1) / var(--sb-map-height, 1));
 
   --sb-map-preview-height-restricted: calc((100vh - 160px) * var(--sb-map-preview-aspect-ratio));
@@ -38,17 +40,10 @@ export function MapPreviewDialog({ mapId, onCancel, dialogRef }: MapPreviewDialo
     dispatch(batchGetMapInfo(mapId))
   }, [dispatch, mapId])
 
-  const style = useMemo(
-    () => ({
-      '--sb-map-width': map?.mapData.width,
-      '--sb-map-height': map?.mapData.height,
-    }),
-    [map],
-  )
-
   return (
     <StyledDialog
-      style={style as any}
+      $mapWidth={map?.mapData.width}
+      $mapHeight={map?.mapData.height}
       onCancel={onCancel}
       dialogRef={dialogRef}
       fullBleed={true}

--- a/client/maps/map-preview.tsx
+++ b/client/maps/map-preview.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react'
+import React, { useEffect, useMemo } from 'react'
 import styled from 'styled-components'
 import { CommonDialogProps } from '../dialogs/common-dialog-props'
 import { Dialog } from '../material/dialog'
@@ -7,9 +7,7 @@ import { background400 } from '../styles/colors'
 import { batchGetMapInfo } from './action-creators'
 import MapImage from './map-image'
 
-const StyledDialog = styled(Dialog)<{ $mapWidth?: number; $mapHeight?: number }>`
-  --sb-map-width: ${props => props.$mapWidth};
-  --sb-map-height: ${props => props.$mapHeight};
+const StyledDialog = styled(Dialog)`
   --sb-map-preview-aspect-ratio: calc(var(--sb-map-width, 1) / var(--sb-map-height, 1));
 
   --sb-map-preview-height-restricted: calc((100vh - 160px) * var(--sb-map-preview-aspect-ratio));
@@ -40,10 +38,17 @@ export function MapPreviewDialog({ mapId, onCancel, dialogRef }: MapPreviewDialo
     dispatch(batchGetMapInfo(mapId))
   }, [dispatch, mapId])
 
+  const style = useMemo(
+    () => ({
+      '--sb-map-width': map?.mapData.width,
+      '--sb-map-height': map?.mapData.height,
+    }),
+    [map],
+  )
+
   return (
     <StyledDialog
-      $mapWidth={map?.mapData.width}
-      $mapHeight={map?.mapData.height}
+      style={style as any}
       onCancel={onCancel}
       dialogRef={dialogRef}
       fullBleed={true}

--- a/client/matchmaking/accept-match.jsx
+++ b/client/matchmaking/accept-match.jsx
@@ -5,6 +5,7 @@ import styled from 'styled-components'
 import { MATCHMAKING_ACCEPT_MATCH_TIME_MS } from '../../common/matchmaking'
 import { Avatar } from '../avatars/avatar'
 import { closeDialog } from '../dialogs/action-creators'
+import { DialogType } from '../dialogs/dialog-type'
 import KeyListener from '../keyboard/key-listener'
 import { RaisedButton } from '../material/button'
 import { Dialog } from '../material/dialog'
@@ -72,7 +73,7 @@ export default class AcceptMatch extends React.Component {
       matchmaking: { searchInfo, failedToAccept, match },
     } = this.props
     if (!searchInfo && !failedToAccept && !match) {
-      this.props.dispatch(closeDialog())
+      this.props.dispatch(closeDialog(DialogType.AcceptMatch))
     }
   }
 
@@ -152,7 +153,7 @@ export default class AcceptMatch extends React.Component {
   }
 
   onFailedClick = () => {
-    this.props.dispatch(closeDialog())
+    this.props.dispatch(closeDialog(DialogType.AcceptMatch))
   }
 
   onAcceptKeyDown = event => {

--- a/client/matchmaking/socket-handlers.ts
+++ b/client/matchmaking/socket-handlers.ts
@@ -105,7 +105,7 @@ const eventToAction: EventToActionMap = {
       type: '@matchmaking/acceptMatchTime',
       payload: tick,
     })
-    dispatch(openDialog(DialogType.AcceptMatch))
+    dispatch(openDialog({ type: DialogType.AcceptMatch }))
 
     acceptMatchState.timer = setInterval(() => {
       tick -= 1

--- a/client/matchmaking/socket-handlers.ts
+++ b/client/matchmaking/socket-handlers.ts
@@ -158,12 +158,12 @@ const eventToAction: EventToActionMap = {
     requeueState.timer = setTimeout(() => {
       // TODO(tec27): we should allow people to close this dialog themselves, and if/when they do,
       // clear this timer
-      dispatch(closeDialog())
+      dispatch(closeDialog(DialogType.AcceptMatch))
     }, 5000)
   },
 
   matchReady: (matchmakingType, event) => (dispatch, getState) => {
-    dispatch(closeDialog())
+    dispatch(closeDialog(DialogType.AcceptMatch))
     clearAcceptMatchTimer()
 
     // All players are ready; feel free to move to the loading screen and start the game

--- a/client/material/dialog.tsx
+++ b/client/material/dialog.tsx
@@ -160,6 +160,7 @@ export interface DialogProps {
    */
   fullBleed?: boolean
   showCloseButton?: boolean
+  style?: React.CSSProperties
   tabs?: React.ReactNode
   title: string
   titleAction?: React.ReactNode
@@ -174,6 +175,7 @@ export function Dialog({
   dialogRef,
   fullBleed = false,
   showCloseButton = false,
+  style,
   tabs,
   title,
   titleAction,
@@ -200,7 +202,7 @@ export function Dialog({
 
   return (
     <Container role='dialog'>
-      <Surface className={className} style={dialogContext.styles} ref={dialogRef}>
+      <Surface className={className} style={{ ...style, ...dialogContext.styles }} ref={dialogRef}>
         <KeyListener onKeyDown={onKeyDown} exclusive={true} />
         <TitleBar $fullBleed={fullBleed} $showDivider={!isAtTop && !tabs}>
           <Title>{title}</Title>

--- a/client/material/dialog.tsx
+++ b/client/material/dialog.tsx
@@ -1,13 +1,14 @@
 import keycode from 'keycode'
 import { rgba } from 'polished'
-import React, { useCallback } from 'react'
+import React, { useCallback, useContext } from 'react'
+import { animated } from 'react-spring'
 import styled, { css } from 'styled-components'
+import { DialogContext } from '../dialogs/connected-dialog-overlay'
 import CloseDialogIcon from '../icons/material/ic_close_black_24px.svg'
 import KeyListener from '../keyboard/key-listener'
 import { background900, CardLayer, colorDividers } from '../styles/colors'
 import { headline5 } from '../styles/typography'
 import { IconButton } from './button'
-import { fastOutLinearIn, fastOutSlowIn, linearOutSlowIn } from './curve-constants'
 import { useScrollIndicatorState } from './scroll-indicator'
 import { shadowDef8dp } from './shadow-constants'
 import { zIndexDialog } from './zindex'
@@ -28,7 +29,7 @@ const Container = styled.div`
   z-index: ${zIndexDialog};
 `
 
-const Surface = styled(CardLayer)`
+const Surface = styled(animated(CardLayer))`
   width: calc(100% - 160px);
   max-width: 768px;
   max-height: calc(100% - 160px);
@@ -44,29 +45,6 @@ const Surface = styled(CardLayer)`
   contain: paint;
   overscroll-behavior: contain;
   pointer-events: auto;
-
-  &.enter {
-    transform: translate3d(0, -100%, 0) scale(0.6, 0.2);
-    opacity: 0;
-  }
-
-  &.enterActive {
-    opacity: 1;
-    transform: translate3d(0, 0, 0) scale(1);
-    transition: transform 350ms ${linearOutSlowIn}, opacity 250ms ${fastOutSlowIn};
-  }
-
-  &.exit {
-    pointer-events: none;
-    transform: translate3d(0, 0, 0) scale(1);
-    opacity: 1;
-  }
-
-  &.exitActive {
-    transform: translate3d(0, -100%, 0) scale(0.6, 0.2);
-    opacity: 0;
-    transition: transform 250ms ${fastOutLinearIn}, opacity 200ms ${fastOutSlowIn} 50ms;
-  }
 `
 
 const TitleBar = styled.div<{ $fullBleed?: boolean; $showDivider?: boolean }>`
@@ -182,7 +160,6 @@ export interface DialogProps {
    */
   fullBleed?: boolean
   showCloseButton?: boolean
-  style?: React.CSSProperties
   tabs?: React.ReactNode
   title: string
   titleAction?: React.ReactNode
@@ -197,13 +174,13 @@ export function Dialog({
   dialogRef,
   fullBleed = false,
   showCloseButton = false,
-  style,
   tabs,
   title,
   titleAction,
   onCancel,
   alwaysHasTopDivider = false,
 }: DialogProps) {
+  const dialogContext = useContext(DialogContext)
   const onKeyDown = useCallback(
     (event: KeyboardEvent) => {
       if (onCancel && event.keyCode === ESCAPE) {
@@ -223,7 +200,7 @@ export function Dialog({
 
   return (
     <Container role='dialog'>
-      <Surface className={className} style={style} ref={dialogRef}>
+      <Surface className={className} style={dialogContext.styles} ref={dialogRef}>
         <KeyListener onKeyDown={onKeyDown} exclusive={true} />
         <TitleBar $fullBleed={fullBleed} $showDivider={!isAtTop && !tabs}>
           <Title>{title}</Title>

--- a/client/messaging/action-creators.ts
+++ b/client/messaging/action-creators.ts
@@ -20,7 +20,7 @@ export function maybeOpenExternalLinkDialog(e: MouseEvent<HTMLAnchorElement>): T
 
     if (!isHostTrusted) {
       e.preventDefault()
-      dispatch(openDialog(DialogType.ExternalLink, { href, domain }))
+      dispatch(openDialog({ type: DialogType.ExternalLink, initData: { href, domain } }))
     }
   }
 }

--- a/client/messaging/external-link-dialog.tsx
+++ b/client/messaging/external-link-dialog.tsx
@@ -2,6 +2,7 @@ import React, { useCallback } from 'react'
 import styled from 'styled-components'
 import { closeDialog } from '../dialogs/action-creators'
 import { CommonDialogProps } from '../dialogs/common-dialog-props'
+import { DialogType } from '../dialogs/dialog-type'
 import { TextButton } from '../material/button'
 import { Dialog } from '../material/dialog'
 import { useAppDispatch } from '../redux-hooks'
@@ -49,7 +50,7 @@ export function ExternalLinkDialog({ href, domain, onCancel, dialogRef }: Extern
   const dispatch = useAppDispatch()
 
   const onOpenLinkClick = useCallback(() => {
-    dispatch(closeDialog())
+    dispatch(closeDialog(DialogType.ExternalLink))
     window.open(href, '_blank', 'noopener,noreferrer')
   }, [dispatch, href])
 

--- a/client/navigation/connected-left-nav.tsx
+++ b/client/navigation/connected-left-nav.tsx
@@ -315,7 +315,7 @@ function PartySection() {
   const currentParty = useAppSelector(s => s.party.current)
 
   const onInviteClick = useCallback(() => {
-    dispatch(openDialog(DialogType.PartyInvite))
+    dispatch(openDialog({ type: DialogType.PartyInvite }))
   }, [dispatch])
   const onLeaveClick = useCallback(
     (partyId: string) => {
@@ -419,7 +419,7 @@ export function ConnectedLeftNav() {
   }, [dispatch, onProfileOverlayClose])
   const onEditAccountClick = useCallback(() => {
     onProfileOverlayClose()
-    dispatch(openDialog(DialogType.Account))
+    dispatch(openDialog({ type: DialogType.Account }))
   }, [dispatch, onProfileOverlayClose])
   const onViewProfileClick = useCallback(() => {
     onProfileOverlayClose()
@@ -439,7 +439,7 @@ export function ConnectedLeftNav() {
   )
 
   const onJoinChannelClick = useCallback(() => {
-    dispatch(openDialog(DialogType.ChannelJoin))
+    dispatch(openDialog({ type: DialogType.ChannelJoin }))
   }, [dispatch])
   const onChannelLeave = useCallback(
     (channel: string) => {
@@ -448,7 +448,7 @@ export function ConnectedLeftNav() {
     [dispatch],
   )
   const onAddWhisperClick = useCallback(() => {
-    dispatch(openDialog(DialogType.Whispers))
+    dispatch(openDialog({ type: DialogType.Whispers }))
   }, [dispatch])
   const onWhisperClose = useCallback(
     (username: string) => {

--- a/client/parties/party-invite-dialog.tsx
+++ b/client/parties/party-invite-dialog.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useRef } from 'react'
 import { USERNAME_MAXLENGTH, USERNAME_MINLENGTH, USERNAME_PATTERN } from '../../common/constants'
 import { closeDialog } from '../dialogs/action-creators'
+import { DialogType } from '../dialogs/dialog-type'
 import { useForm } from '../forms/form-hook'
 import { composeValidators, maxLength, minLength, regex, required } from '../forms/validators'
 import { TextButton } from '../material/button'
@@ -38,7 +39,7 @@ export function PartyInviteDialog({
   const onFormSubmit = useCallback(
     (model: InviteUsersModel) => {
       dispatch(inviteToParty({ targetName: model.user }))
-      dispatch(closeDialog())
+      dispatch(closeDialog(DialogType.PartyInvite))
     },
     [dispatch],
   )

--- a/client/parties/party-queue-accept-dialog.tsx
+++ b/client/parties/party-queue-accept-dialog.tsx
@@ -4,6 +4,7 @@ import { MatchmakingType, matchmakingTypeToLabel } from '../../common/matchmakin
 import { useSelfUser } from '../auth/state-hooks'
 import { closeDialog } from '../dialogs/action-creators'
 import { CommonDialogProps } from '../dialogs/common-dialog-props'
+import { DialogType } from '../dialogs/dialog-type'
 import { RacePickerSize } from '../lobbies/race-picker'
 import { RaceSelect } from '../matchmaking/race-select'
 import { TextButton } from '../material/button'
@@ -88,7 +89,7 @@ export function PartyQueueAcceptDialog({ dialogRef }: CommonDialogProps) {
 
   useEffect(() => {
     if (!queueState || queueState.accepted.has(selfId)) {
-      dispatch(closeDialog())
+      dispatch(closeDialog(DialogType.PartyQueueAccept))
     }
   }, [selfId, queueState, dispatch])
   useEffect(() => {

--- a/client/parties/party-view.tsx
+++ b/client/parties/party-view.tsx
@@ -257,7 +257,10 @@ export function PartyView(props: PartyViewProps) {
       )
     }
   }, [partyId, queueId, dispatch])
-  const onInviteClick = useCallback(() => dispatch(openDialog(DialogType.PartyInvite)), [dispatch])
+  const onInviteClick = useCallback(
+    () => dispatch(openDialog({ type: DialogType.PartyInvite })),
+    [dispatch],
+  )
   const onLeaveClick = useCallback(() => dispatch(leaveParty(partyId!)), [partyId, dispatch])
   const onKickPlayerClick = useCallback(
     userId => dispatch(kickPlayer(partyId!, userId)),

--- a/client/parties/socket-handlers.ts
+++ b/client/parties/socket-handlers.ts
@@ -187,7 +187,7 @@ const eventToAction: EventToActionMap = {
 
     if (showRaceDialog) {
       audioManager.playSound(AvailableSound.PartyQueue)
-      dispatch(openDialog(DialogType.PartyQueueAccept))
+      dispatch(openDialog({ type: DialogType.PartyQueueAccept }))
     }
   },
 

--- a/client/policies/policy-update-notification-ui.tsx
+++ b/client/policies/policy-update-notification-ui.tsx
@@ -44,7 +44,7 @@ export const PolicyUpdateNotificationUi = React.forwardRef<
             href='#'
             onClick={e => {
               e.preventDefault()
-              dispatch(openDialog(dialogType))
+              dispatch(openDialog({ type: dialogType }))
             }}>
             {label}
           </a>{' '}
@@ -55,7 +55,9 @@ export const PolicyUpdateNotificationUi = React.forwardRef<
   )
 })
 
-function policyTypeToDialogType(policyType: SbPolicyType): DialogType {
+function policyTypeToDialogType(
+  policyType: SbPolicyType,
+): DialogType.AcceptableUse | DialogType.PrivacyPolicy | DialogType.TermsOfService {
   switch (policyType) {
     case SbPolicyType.AcceptableUse:
       return DialogType.AcceptableUse

--- a/client/settings/settings.tsx
+++ b/client/settings/settings.tsx
@@ -88,7 +88,7 @@ export default function SettingsDialog({ dialogRef, onCancel }: CommonDialogProp
     formRef.current?.submit()
   }, [])
   const onSettingsCancel = useCallback(() => {
-    dispatch(closeDialog())
+    dispatch(closeDialog(DialogType.Settings))
   }, [dispatch])
   const onSettingsChange = useCallback((settings: Partial<LocalSettings & ScrSettings>) => {
     setTempLocalSettings(prev => prev.merge(settings))
@@ -109,7 +109,7 @@ export default function SettingsDialog({ dialogRef, onCancel }: CommonDialogProp
     // those would happen async-ly. Should probably have a form of this that doesn't bother with
     // dispatching and just returns a promise we can await
     if (!lastError) {
-      dispatch(closeDialog())
+      dispatch(closeDialog(DialogType.Settings))
     }
   }, [dispatch, tempLocalSettings, tempScrSettings, lastError])
 

--- a/client/settings/settings.tsx
+++ b/client/settings/settings.tsx
@@ -82,7 +82,7 @@ export default function SettingsDialog({ dialogRef, onCancel }: CommonDialogProp
     savedSettingsTab.setValue(value)
   }, [])
   const onSetPathClick = useCallback(() => {
-    dispatch(openDialog(DialogType.StarcraftPath))
+    dispatch(openDialog({ type: DialogType.StarcraftPath }))
   }, [dispatch])
   const onSettingsSave = useCallback(() => {
     formRef.current?.submit()

--- a/client/settings/starcraft-path-dialog.jsx
+++ b/client/settings/starcraft-path-dialog.jsx
@@ -139,7 +139,7 @@ export default class StarcraftPath extends React.Component {
 
   onSettingsCancel = () => {
     if (isStarcraftHealthy(this.props)) {
-      this.props.dispatch(openDialog(DialogType.Settings))
+      this.props.dispatch(openDialog({ type: DialogType.Settings }))
     } else {
       this.props.dispatch(closeDialog())
     }
@@ -153,7 +153,7 @@ export default class StarcraftPath extends React.Component {
     this.props.dispatch(mergeLocalSettings(newSettings))
 
     if (!this.props.settings.lastError) {
-      this.props.dispatch(openDialog(DialogType.Settings))
+      this.props.dispatch(openDialog({ type: DialogType.Settings }))
     }
   }
 }

--- a/client/settings/starcraft-path-dialog.jsx
+++ b/client/settings/starcraft-path-dialog.jsx
@@ -141,7 +141,7 @@ export default class StarcraftPath extends React.Component {
     if (isStarcraftHealthy(this.props)) {
       this.props.dispatch(openDialog({ type: DialogType.Settings }))
     } else {
-      this.props.dispatch(closeDialog())
+      this.props.dispatch(closeDialog(DialogType.StarcraftPath))
     }
   }
 

--- a/client/starcraft/shieldbattery-health.jsx
+++ b/client/starcraft/shieldbattery-health.jsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { connect } from 'react-redux'
 import styled from 'styled-components'
 import { closeDialog } from '../dialogs/action-creators'
+import { DialogType } from '../dialogs/dialog-type'
 import { RaisedButton } from '../material/button'
 import { Dialog } from '../material/dialog'
 import { openSnackbar } from '../snackbars/action-creators'
@@ -35,7 +36,7 @@ export class ShieldBatteryHealthDialog extends React.Component {
           message: 'Your local installation is now free of problems.',
         }),
       )
-      this.props.dispatch(closeDialog())
+      this.props.dispatch(closeDialog(DialogType.ShieldBatteryHealth))
     }
   }
 

--- a/client/starcraft/starcraft-health.jsx
+++ b/client/starcraft/starcraft-health.jsx
@@ -92,6 +92,6 @@ export default class StarcraftHealthCheckupDialog extends React.Component {
 
   onSettingsClicked(e) {
     e.preventDefault()
-    this.props.dispatch(openDialog(DialogType.Settings))
+    this.props.dispatch(openDialog({ type: DialogType.Settings }))
   }
 }

--- a/client/starcraft/starcraft-health.jsx
+++ b/client/starcraft/starcraft-health.jsx
@@ -26,7 +26,7 @@ export default class StarcraftHealthCheckupDialog extends React.Component {
           message: 'Your local installation is now free of problems.',
         }),
       )
-      this.props.dispatch(closeDialog())
+      this.props.dispatch(closeDialog(DialogType.StarcraftHealth))
     }
   }
 

--- a/client/whispers/create-whisper.jsx
+++ b/client/whispers/create-whisper.jsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { connect } from 'react-redux'
 import { USERNAME_MAXLENGTH, USERNAME_MINLENGTH, USERNAME_PATTERN } from '../../common/constants'
 import { closeDialog } from '../dialogs/action-creators'
+import { DialogType } from '../dialogs/dialog-type'
 import form from '../forms/form'
 import { composeValidators, maxLength, minLength, regex, required } from '../forms/validators'
 import { TextButton } from '../material/button'
@@ -97,7 +98,7 @@ export default class CreateWhisper extends React.Component {
 
   onSubmit = () => {
     const target = this._form.getModel().target
-    this.props.dispatch(closeDialog())
+    this.props.dispatch(closeDialog(DialogType.Whispers))
     navigateToWhisper(target)
   }
 }

--- a/common/arrays.test.ts
+++ b/common/arrays.test.ts
@@ -1,0 +1,14 @@
+import { findLastIndex } from './arrays'
+
+const makeCallbackFn = (searchValue: number) => (value: number) => value === searchValue
+
+describe('common/arrays', () => {
+  test('findLastIndex', () => {
+    expect(findLastIndex([], makeCallbackFn(1))).toBe(-1)
+    expect(findLastIndex([1], makeCallbackFn(1))).toBe(0)
+    expect(findLastIndex([1, 2, 3], makeCallbackFn(1))).toBe(0)
+    expect(findLastIndex([1, 2, 3], makeCallbackFn(2))).toBe(1)
+    expect(findLastIndex([1, 2, 3], makeCallbackFn(3))).toBe(2)
+    expect(findLastIndex([1, 2, 3], makeCallbackFn(4))).toBe(-1)
+  })
+})

--- a/common/arrays.test.ts
+++ b/common/arrays.test.ts
@@ -10,5 +10,7 @@ describe('common/arrays', () => {
     expect(findLastIndex([1, 2, 3], makeCallbackFn(2))).toBe(1)
     expect(findLastIndex([1, 2, 3], makeCallbackFn(3))).toBe(2)
     expect(findLastIndex([1, 2, 3], makeCallbackFn(4))).toBe(-1)
+    expect(findLastIndex([1, 1, 1], makeCallbackFn(1))).toBe(2)
+    expect(findLastIndex([1, 2, 1, 2], makeCallbackFn(1))).toBe(2)
   })
 })

--- a/common/arrays.ts
+++ b/common/arrays.ts
@@ -1,0 +1,18 @@
+// Utility functions for use on Arrays
+
+/**
+ * Returns the index of the last element in the array where `callbackFn` returns `true`, and -1
+ * otherwise.
+ */
+export function findLastIndex<T>(
+  array: ReadonlyArray<T>,
+  callbackFn: (element: T, index: number, arr: ReadonlyArray<T>) => boolean,
+): number {
+  for (let i = array.length - 1; i >= 0; i--) {
+    if (callbackFn(array[i], i, array)) {
+      return i
+    }
+  }
+
+  return -1
+}


### PR DESCRIPTION
This makes it possible to open one dialog from another, without losing
the context of first dialog. This should be used very sparingly, since
opening dialogs from dialogs can make for a very confusing user
experience.

This PR also does the following:
- Moves dialogs reducer to immer
- Types the payload of opening dialogs, along with its `initData`
- Moves dialog opening/closing animation to react-spring