### PR TITLE
Make the user context menu, well... contextual.

### DIFF
--- a/client/app.jsx
+++ b/client/app.jsx
@@ -22,6 +22,7 @@ import {
   PrivacyPolicyPage,
   TermsOfServicePage,
 } from './policies/policy-displays'
+import { UserContextMenuProvider } from './profile/user-context-menu'
 import LoadingIndicator from './progress/dots'
 import { useAppSelector } from './redux-hooks'
 import { RootErrorBoundary } from './root-error-boundary'
@@ -69,7 +70,9 @@ function MainContent() {
     <LoggedInFilter>
       <SiteConnectedFilter>
         <LoadingFilter>
-          <MainLayout />
+          <UserContextMenuProvider>
+            <MainLayout />
+          </UserContextMenuProvider>
         </LoadingFilter>
       </SiteConnectedFilter>
     </LoggedInFilter>

--- a/client/profile/user-context-menu.tsx
+++ b/client/profile/user-context-menu.tsx
@@ -1,14 +1,120 @@
-import React, { useCallback } from 'react'
+import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react'
 import styled from 'styled-components'
 import { SbUserId } from '../../common/users/sb-user'
+import { Divider } from '../material/menu/divider'
 import { MenuItem } from '../material/menu/item'
 import { Menu } from '../material/menu/menu'
 import { PopoverProps } from '../material/popover'
 import { inviteToParty, kickPlayer, removePartyInvite } from '../parties/action-creators'
 import { useAppDispatch, useAppSelector } from '../redux-hooks'
+import { useStableCallback } from '../state-hooks'
 import { colorTextFaint } from '../styles/colors'
 import { navigateToWhisper } from '../whispers/action-creators'
 import { navigateToUserProfile } from './action-creators'
+
+type MenuItemCategory = string
+type MenuItems = Map<MenuItemCategory, React.ReactNode[]>
+
+interface MenuStatus {
+  isOpen: boolean
+  onDismiss: (event?: MouseEvent) => void
+}
+
+export interface UserMenuContextValue {
+  userMenuItems: Map<SbUserId, MenuItems>
+  userMenuStatuses: Map<SbUserId, MenuStatus>
+  updateContextMenuStatus: (
+    userId: SbUserId,
+    isOpen: boolean,
+    onDismiss: (event?: MouseEvent) => void,
+  ) => void
+  replaceUserMenuItems: (userId: SbUserId, menuItems: MenuItems) => void
+  appendUserMenuItems: (userId: SbUserId, menuItems: MenuItems) => void
+  prependUserMenuItems: (userId: SbUserId, menuItems: MenuItems) => void
+}
+
+export const UserMenuContext = React.createContext<UserMenuContextValue>({
+  userMenuItems: new Map(),
+  userMenuStatuses: new Map(),
+  updateContextMenuStatus: () => {},
+  replaceUserMenuItems: () => {},
+  appendUserMenuItems: () => {},
+  prependUserMenuItems: () => {},
+})
+
+export function UserContextMenuProvider(props: { children: React.ReactNode }) {
+  const [userMenuItems, setUserMenuItems] = useState<Map<SbUserId, MenuItems>>(new Map())
+  const [userMenuStatuses, setUserMenuStatuses] = useState<Map<SbUserId, MenuStatus>>(new Map())
+
+  const updateContextMenuStatus = useStableCallback(
+    (userId: SbUserId, isOpen: boolean, onDismiss: () => void) => {
+      console.log('updateContextMenuStatus')
+      setUserMenuStatuses(new Map(userMenuStatuses).set(userId, { isOpen, onDismiss }))
+    },
+  )
+
+  const replaceUserMenuItems = useStableCallback((userId: SbUserId, menuItems: MenuItems) => {
+    console.log(userMenuStatuses.get(userId)?.isOpen)
+    if (!userMenuStatuses.get(userId)?.isOpen) {
+      return
+    }
+
+    console.log('replaceUserMenuItems')
+    setUserMenuItems(userMenuItems => new Map(userMenuItems).set(userId, menuItems))
+  })
+
+  const appendUserMenuItems = useStableCallback((userId: SbUserId, menuItems: MenuItems) => {
+    console.log(userMenuStatuses.get(userId)?.isOpen)
+    if (!userMenuStatuses.get(userId)?.isOpen) {
+      return
+    }
+
+    console.log('appendUserMenuItems')
+    setUserMenuItems(userMenuItems => {
+      const newMenuItems: MenuItems = userMenuItems.get(userId) ?? new Map()
+      for (const [itemCategory, items] of menuItems) {
+        newMenuItems.set(itemCategory, (newMenuItems.get(itemCategory) ?? []).concat(items))
+      }
+
+      return new Map(userMenuItems).set(userId, newMenuItems)
+    })
+  })
+
+  const prependUserMenuItems = useStableCallback((userId: SbUserId, menuItems: MenuItems) => {
+    if (!userMenuStatuses.get(userId)?.isOpen) {
+      return
+    }
+
+    console.log('appendUserMenuItems')
+    setUserMenuItems(userMenuItems => {
+      const existingMenuItems: MenuItems = userMenuItems.get(userId) ?? new Map()
+      const newMenuItems: MenuItems = new Map(menuItems)
+      for (const [itemCategory, items] of existingMenuItems) {
+        newMenuItems.set(itemCategory, (newMenuItems.get(itemCategory) ?? []).concat(items))
+      }
+
+      return new Map(userMenuItems).set(userId, newMenuItems)
+    })
+  })
+
+  return (
+    <UserMenuContext.Provider
+      value={{
+        userMenuItems,
+        userMenuStatuses,
+        updateContextMenuStatus,
+        replaceUserMenuItems,
+        appendUserMenuItems,
+        prependUserMenuItems,
+      }}>
+      {props.children}
+    </UserMenuContext.Provider>
+  )
+}
+
+export function useUserMenuContext(): UserMenuContextValue {
+  return useContext(UserMenuContext)
+}
 
 const LoadingItem = styled(MenuItem)`
   color: ${colorTextFaint};
@@ -23,6 +129,7 @@ export function ConnectedUserContextMenu({ userId, popoverProps }: ConnectedUser
   const dispatch = useAppDispatch()
   const selfUser = useAppSelector(s => s.auth.user)
   const user = useAppSelector(s => s.users.byId.get(userId))
+  const { userMenuItems, updateContextMenuStatus, replaceUserMenuItems } = useUserMenuContext()
 
   const partyId = useAppSelector(s => s.party.current?.id)
   const partyMembers = useAppSelector(s => s.party.current?.members)
@@ -54,41 +161,81 @@ export function ConnectedUserContextMenu({ userId, popoverProps }: ConnectedUser
     onPopoverDismiss()
   }, [partyId, userId, dispatch, onPopoverDismiss])
 
-  const actions: React.ReactNode[] = []
-  if (!user) {
-    // TODO(tec27): Ideally this wouldn't have hover/focus state
-    actions.push(<LoadingItem key='loading' text='Loading user…' />)
-  } else {
-    actions.push(<MenuItem key='profile' text='View profile' onClick={onViewProfileClick} />)
+  const commonActions = useMemo(() => {
+    const actions: React.ReactNode[] = []
+    if (!user) {
+      // TODO(tec27): Ideally this wouldn't have hover/focus state
+      actions.push(<LoadingItem key='loading' text='Loading user…' />)
+    } else {
+      actions.push(<MenuItem key='profile' text='View profile' onClick={onViewProfileClick} />)
 
-    if (user.id !== selfUser.id) {
-      actions.push(<MenuItem key='whisper' text='Whisper' onClick={onWhisperClick} />)
+      if (user.id !== selfUser.id) {
+        actions.push(<MenuItem key='whisper' text='Whisper' onClick={onWhisperClick} />)
 
-      if (IS_ELECTRON) {
-        if (!partyId) {
-          actions.push(
-            <MenuItem key='invite' text='Invite to party' onClick={onInviteToPartyClick} />,
-          )
-        } else if (partyLeader === selfUser.id) {
-          const isAlreadyInParty = !!partyMembers?.includes(user.id)
-          const hasInvite = !!partyInvites?.includes(user.id)
-          if (isAlreadyInParty) {
-            actions.push(
-              <MenuItem key='kick-party' text='Kick from party' onClick={onKickPlayerClick} />,
-            )
-          } else if (hasInvite) {
-            actions.push(
-              <MenuItem key='invite' text='Uninvite from party' onClick={onRemovePartyInvite} />,
-            )
-          } else {
+        if (IS_ELECTRON) {
+          if (!partyId) {
             actions.push(
               <MenuItem key='invite' text='Invite to party' onClick={onInviteToPartyClick} />,
             )
+          } else if (partyLeader === selfUser.id) {
+            const isAlreadyInParty = !!partyMembers?.includes(user.id)
+            const hasInvite = !!partyInvites?.includes(user.id)
+            if (isAlreadyInParty) {
+              actions.push(
+                <MenuItem key='kick-party' text='Kick from party' onClick={onKickPlayerClick} />,
+              )
+            } else if (hasInvite) {
+              actions.push(
+                <MenuItem key='invite' text='Uninvite from party' onClick={onRemovePartyInvite} />,
+              )
+            } else {
+              actions.push(
+                <MenuItem key='invite' text='Invite to party' onClick={onInviteToPartyClick} />,
+              )
+            }
           }
         }
       }
     }
-  }
+
+    return new Map([['common', actions]])
+  }, [
+    onInviteToPartyClick,
+    onKickPlayerClick,
+    onRemovePartyInvite,
+    onViewProfileClick,
+    onWhisperClick,
+    partyId,
+    partyInvites,
+    partyLeader,
+    partyMembers,
+    selfUser.id,
+    user,
+  ])
+
+  useEffect(() => {
+    console.log('effect1')
+    updateContextMenuStatus(userId, popoverProps.open, popoverProps.onDismiss)
+  }, [popoverProps.onDismiss, popoverProps.open, updateContextMenuStatus, userId])
+
+  useEffect(() => {
+    console.log('effect2')
+    replaceUserMenuItems(userId, commonActions)
+  }, [commonActions, replaceUserMenuItems, userId])
+
+  const actions = useMemo(
+    () =>
+      Array.from(userMenuItems.get(userId)?.values() ?? []).reduce((acc, items, index, array) => {
+        acc.push(items)
+
+        if (array.length - 1 !== index) {
+          acc.push(<Divider key={`divider-${index}`} />)
+        }
+
+        return acc
+      }, []),
+    [userId, userMenuItems],
+  )
 
   return (
     <Menu dense={true} {...popoverProps}>

--- a/client/state-hooks.ts
+++ b/client/state-hooks.ts
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react'
+import React, { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
 
 /**
  * A hook to access the previous value of some variable inside a functional component.
@@ -51,6 +51,21 @@ export function useValueAsRef<T>(value: T): React.MutableRefObject<T> {
   ref.current = value
 
   return ref
+}
+
+type CallbackFn<A extends any[], R> = (...args: A) => R
+export function useStableCallback<A extends any[], R>(
+  callbackFn: CallbackFn<A, R>,
+): CallbackFn<A, R> {
+  const callbackRef = useRef<CallbackFn<A, R>>(callbackFn)
+
+  useLayoutEffect(() => {
+    callbackRef.current = callbackFn
+  })
+
+  return useCallback((...args: A): R => {
+    return callbackRef.current(...args)
+  }, [])
 }
 
 /**


### PR DESCRIPTION
So this is probably like my third attempt at achieving this. My thinking
in this PR was to make the following:
- Make a `UserContextMenuProvider` component which wraps the whole main
  application (basically everywhere we might want to display a user
  context menu), and holds all the state needed to handle and display
  user context menu.
- This means that the `UserContextMenu` component holds the menu items
  for each user, and exposes methods to modify them; for now, 3 methods
  are exposed, one to replace all of the menu items (useful for
  initializing the context menu), one to append menu items, and one to
  prepend).
- Additionally, `UserContextMenuProvider` holds the status of the menu
  itself (whether it's open, and a method to close it). This allows us
  to use it in places that might not have this information readily
  available, e.g. text messages.

The way I imagined this working is by using our current
`ConnectedUserContextMenu` component to "initialize" the provider with
common menu items, as well as keep the menu status updated. And then, in
all the other places, we should have all the information to use this
context to dynamically append and/or prepend menu items to the common
ones.

However, I'm having trouble with the timings of the effects that are
run, mainly the first two; one that updates the menu status, and one
that sets the common menu items that runs right after. The menu is still
technically closed when we attempt to add common items, so they're never
added.