### PR TITLE
Refactor the menu component to not render the popover part.

### DIFF
--- a/client/admin/map-pools.jsx
+++ b/client/admin/map-pools.jsx
@@ -16,8 +16,8 @@ import Carousel from '../lists/carousel'
 import { MapThumbnail } from '../maps/map-thumbnail'
 import { IconButton, RaisedButton, TextButton } from '../material/button'
 import { MenuItem } from '../material/menu/item'
-import { Menu } from '../material/menu/menu'
-import { useAnchorPosition } from '../material/popover'
+import { MenuList } from '../material/menu/menu'
+import { Popover, useAnchorPosition } from '../material/popover'
 import { TabItem, Tabs } from '../material/tabs'
 import { TextField } from '../material/text-field'
 import LoadingIndicator from '../progress/dots'
@@ -400,17 +400,15 @@ const MapPoolHistoryRow = React.memo(props => {
           ref={anchorRef}
           onClick={onActionsOverlayOpen}
         />
-        <Menu
-          popoverProps={{
-            open: actionsOverlayOpen,
-            onDismiss: onActionsOverlayClose,
-            anchorX: anchorX ?? 0,
-            anchorY: anchorY ?? 0,
-            originX: 'left',
-            originY: 'top',
-          }}>
-          {actions}
-        </Menu>
+        <Popover
+          open={actionsOverlayOpen}
+          onDismiss={onActionsOverlayClose}
+          anchorX={anchorX ?? 0}
+          anchorY={anchorY ?? 0}
+          originX='left'
+          originY='top'>
+          <MenuList>{actions}</MenuList>
+        </Popover>
       </>
     )
   }

--- a/client/admin/map-pools.jsx
+++ b/client/admin/map-pools.jsx
@@ -401,12 +401,14 @@ const MapPoolHistoryRow = React.memo(props => {
           onClick={onActionsOverlayOpen}
         />
         <Menu
-          open={actionsOverlayOpen}
-          onDismiss={onActionsOverlayClose}
-          anchorX={anchorX ?? 0}
-          anchorY={anchorY ?? 0}
-          originX='left'
-          originY='top'>
+          popoverProps={{
+            open: actionsOverlayOpen,
+            onDismiss: onActionsOverlayClose,
+            anchorX: anchorX ?? 0,
+            anchorY: anchorY ?? 0,
+            originX: 'left',
+            originY: 'top',
+          }}>
           {actions}
         </Menu>
       </>

--- a/client/lobbies/slot-actions.tsx
+++ b/client/lobbies/slot-actions.tsx
@@ -2,8 +2,8 @@ import React, { useCallback, useMemo, useState } from 'react'
 import SlotActionsIcon from '../icons/material/ic_more_vert_black_24px.svg'
 import { IconButton } from '../material/button'
 import { MenuItem } from '../material/menu/item'
-import { Menu } from '../material/menu/menu'
-import { useAnchorPosition } from '../material/popover'
+import { MenuList } from '../material/menu/menu'
+import { Popover, useAnchorPosition } from '../material/popover'
 
 interface SlotActionsProps {
   slotActions: Array<[text: string, handler: () => void]>
@@ -43,17 +43,15 @@ export function SlotActions({ slotActions }: SlotActionsProps) {
         ref={anchorRef}
         onClick={onOpenOverlay}
       />
-      <Menu
-        popoverProps={{
-          open: overlayOpen,
-          onDismiss: onCloseOverlay,
-          originX: 'right',
-          originY: 'top',
-          anchorX: anchorX ?? 0,
-          anchorY: anchorY ?? 0,
-        }}>
-        {actions}
-      </Menu>
+      <Popover
+        open={overlayOpen}
+        onDismiss={onCloseOverlay}
+        anchorX={anchorX ?? 0}
+        anchorY={anchorY ?? 0}
+        originX='right'
+        originY='top'>
+        <MenuList>{actions}</MenuList>
+      </Popover>
     </div>
   )
 }

--- a/client/lobbies/slot-actions.tsx
+++ b/client/lobbies/slot-actions.tsx
@@ -44,12 +44,14 @@ export function SlotActions({ slotActions }: SlotActionsProps) {
         onClick={onOpenOverlay}
       />
       <Menu
-        open={overlayOpen}
-        onDismiss={onCloseOverlay}
-        originX='right'
-        originY='top'
-        anchorX={anchorX ?? 0}
-        anchorY={anchorY ?? 0}>
+        popoverProps={{
+          open: overlayOpen,
+          onDismiss: onCloseOverlay,
+          originX: 'right',
+          originY: 'top',
+          anchorX: anchorX ?? 0,
+          anchorY: anchorY ?? 0,
+        }}>
         {actions}
       </Menu>
     </div>

--- a/client/maps/browser-footer.tsx
+++ b/client/maps/browser-footer.tsx
@@ -14,9 +14,9 @@ import CheckBox from '../material/check-box'
 import { fastOutSlowInShort } from '../material/curves'
 import { FloatingActionButton } from '../material/floating-action-button'
 import { LegacyPopover } from '../material/legacy-popover'
-import { Menu } from '../material/menu/menu'
-import { SelectedItem as SelectedMenuItem } from '../material/menu/selected-item'
-import { useAnchorPosition } from '../material/popover'
+import { MenuList } from '../material/menu/menu'
+import { SelectableMenuItem } from '../material/menu/selectable-item'
+import { Popover, useAnchorPosition } from '../material/popover'
 import { SearchInput } from '../search/search-input'
 import { usePrevious, useValueAsRef } from '../state-hooks'
 import { colorTextSecondary } from '../styles/colors'
@@ -361,25 +361,25 @@ export const BrowserFooter = React.memo((props: BrowserFooterProps) => {
 
       <StyledSearchInput searchQuery={searchQuery} onSearchChange={onSearchChange} />
 
-      <Menu
-        dense={true}
-        popoverProps={{
-          open: open === 'sizeMenu',
-          onDismiss,
-          anchorX: sizeAnchorX ?? 0,
-          anchorY: sizeAnchorY ?? 0,
-          originX: 'right',
-          originY: 'bottom',
-        }}>
-        {SIZE_MENU_OPTIONS.map((text, index) => (
-          <SelectedMenuItem
-            key={index}
-            text={text}
-            selected={props.thumbnailSize === index}
-            onClick={() => onSizeSelected(index)}
-          />
-        ))}
-      </Menu>
+      <Popover
+        open={open === 'sizeMenu'}
+        onDismiss={onDismiss}
+        anchorX={sizeAnchorX ?? 0}
+        anchorY={sizeAnchorY ?? 0}
+        originX='right'
+        originY='bottom'>
+        <MenuList dense={true}>
+          {SIZE_MENU_OPTIONS.map((text, index) => (
+            <SelectableMenuItem
+              key={index}
+              text={text}
+              selected={props.thumbnailSize === index}
+              onClick={() => onSizeSelected(index)}
+            />
+          ))}
+        </MenuList>
+      </Popover>
+
       <FilterOverlay
         open={open === 'filterOverlay'}
         onDismiss={onDismiss}
@@ -399,25 +399,25 @@ export const BrowserFooter = React.memo((props: BrowserFooterProps) => {
           />
         </FilterActions>
       </FilterOverlay>
-      <Menu
-        dense={true}
-        popoverProps={{
-          open: open === 'sortMenu',
-          onDismiss,
-          anchorX: sortAnchorX ?? 0,
-          anchorY: sortAnchorY ?? 0,
-          originX: 'right',
-          originY: 'bottom',
-        }}>
-        {SORT_MENU_OPTIONS.map((text, index) => (
-          <SelectedMenuItem
-            key={index}
-            text={text}
-            selected={props.sortOption === index}
-            onClick={() => onSortSelected(index)}
-          />
-        ))}
-      </Menu>
+
+      <Popover
+        open={open === 'sortMenu'}
+        onDismiss={onDismiss}
+        anchorX={sortAnchorX ?? 0}
+        anchorY={sortAnchorY ?? 0}
+        originX='right'
+        originY='bottom'>
+        <MenuList dense={true}>
+          {SORT_MENU_OPTIONS.map((text, index) => (
+            <SelectableMenuItem
+              key={index}
+              text={text}
+              selected={props.sortOption === index}
+              onClick={() => onSortSelected(index)}
+            />
+          ))}
+        </MenuList>
+      </Popover>
     </Container>
   )
 })

--- a/client/maps/browser-footer.tsx
+++ b/client/maps/browser-footer.tsx
@@ -225,6 +225,8 @@ export interface BrowserFooterProps {
 }
 
 type FooterView = 'filterOverlay' | 'sizeMenu' | 'sortMenu'
+const SIZE_MENU_OPTIONS = ['Small', 'Medium', 'Large']
+const SORT_MENU_OPTIONS = ['Name', 'Number of players', 'Date uploaded']
 
 export const BrowserFooter = React.memo((props: BrowserFooterProps) => {
   const [open, setOpen] = useState<FooterView>()
@@ -360,18 +362,23 @@ export const BrowserFooter = React.memo((props: BrowserFooterProps) => {
       <StyledSearchInput searchQuery={searchQuery} onSearchChange={onSearchChange} />
 
       <Menu
-        open={open === 'sizeMenu'}
-        onDismiss={onDismiss}
-        anchorX={sizeAnchorX ?? 0}
-        anchorY={sizeAnchorY ?? 0}
-        originX='right'
-        originY='bottom'
         dense={true}
-        selectedIndex={props.thumbnailSize}
-        onItemSelected={onSizeSelected}>
-        <SelectedMenuItem text='Small' />
-        <SelectedMenuItem text='Medium' />
-        <SelectedMenuItem text='Large' />
+        popoverProps={{
+          open: open === 'sizeMenu',
+          onDismiss,
+          anchorX: sizeAnchorX ?? 0,
+          anchorY: sizeAnchorY ?? 0,
+          originX: 'right',
+          originY: 'bottom',
+        }}>
+        {SIZE_MENU_OPTIONS.map((text, index) => (
+          <SelectedMenuItem
+            key={index}
+            text={text}
+            selected={props.thumbnailSize === index}
+            onClick={() => onSizeSelected(index)}
+          />
+        ))}
       </Menu>
       <FilterOverlay
         open={open === 'filterOverlay'}
@@ -393,18 +400,23 @@ export const BrowserFooter = React.memo((props: BrowserFooterProps) => {
         </FilterActions>
       </FilterOverlay>
       <Menu
-        open={open === 'sortMenu'}
-        onDismiss={onDismiss}
-        anchorX={sortAnchorX ?? 0}
-        anchorY={sortAnchorY ?? 0}
-        originX='right'
-        originY='bottom'
         dense={true}
-        selectedIndex={props.sortOption}
-        onItemSelected={onSortSelected}>
-        <SelectedMenuItem text='Name' />
-        <SelectedMenuItem text='Number of players' />
-        <SelectedMenuItem text='Date uploaded' />
+        popoverProps={{
+          open: open === 'sortMenu',
+          onDismiss,
+          anchorX: sortAnchorX ?? 0,
+          anchorY: sortAnchorY ?? 0,
+          originX: 'right',
+          originY: 'bottom',
+        }}>
+        {SORT_MENU_OPTIONS.map((text, index) => (
+          <SelectedMenuItem
+            key={index}
+            text={text}
+            selected={props.sortOption === index}
+            onClick={() => onSortSelected(index)}
+          />
+        ))}
       </Menu>
     </Container>
   )

--- a/client/maps/map-thumbnail.tsx
+++ b/client/maps/map-thumbnail.tsx
@@ -270,12 +270,14 @@ export function MapThumbnail({
                 onClick={onOpenMenu}
               />
               <Menu
-                open={menuOpen}
-                onDismiss={onCloseMenu}
-                anchorX={anchorX ?? 0}
-                anchorY={anchorY ?? 0}
-                originX='right'
-                originY='top'>
+                popoverProps={{
+                  open: menuOpen,
+                  onDismiss: onCloseMenu,
+                  anchorX: anchorX ?? 0,
+                  anchorY: anchorY ?? 0,
+                  originX: 'right',
+                  originY: 'top',
+                }}>
                 {actions}
               </Menu>
             </>

--- a/client/maps/map-thumbnail.tsx
+++ b/client/maps/map-thumbnail.tsx
@@ -10,8 +10,8 @@ import MapActionsIcon from '../icons/material/ic_more_vert_black_24px.svg'
 import ZoomInIcon from '../icons/material/zoom_in-24px.svg'
 import { IconButton } from '../material/button'
 import { MenuItem } from '../material/menu/item'
-import { Menu } from '../material/menu/menu'
-import { useAnchorPosition } from '../material/popover'
+import { MenuList } from '../material/menu/menu'
+import { Popover, useAnchorPosition } from '../material/popover'
 import { amberA100, background700, background900, colorTextPrimary } from '../styles/colors'
 import { singleLine, subtitle2 } from '../styles/typography'
 import MapImage from './map-image'
@@ -269,17 +269,15 @@ export function MapThumbnail({
                 title='Map actions'
                 onClick={onOpenMenu}
               />
-              <Menu
-                popoverProps={{
-                  open: menuOpen,
-                  onDismiss: onCloseMenu,
-                  anchorX: anchorX ?? 0,
-                  anchorY: anchorY ?? 0,
-                  originX: 'right',
-                  originY: 'top',
-                }}>
-                {actions}
-              </Menu>
+              <Popover
+                open={menuOpen}
+                onDismiss={onCloseMenu}
+                anchorX={anchorX ?? 0}
+                anchorY={anchorY ?? 0}
+                originX='right'
+                originY='top'>
+                <MenuList>{actions}</MenuList>
+              </Popover>
             </>
           ) : null}
         </TextProtection>

--- a/client/material/devonly/menu-test.tsx
+++ b/client/material/devonly/menu-test.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react'
+import React, { useCallback, useMemo, useState } from 'react'
 import styled from 'styled-components'
 import { colorTextSecondary } from '../../styles/colors'
 import { subtitle1 } from '../../styles/typography'
@@ -6,9 +6,9 @@ import { RaisedButton } from '../button'
 import Card from '../card'
 import { Divider } from '../menu/divider'
 import { MenuItem } from '../menu/item'
-import { Menu } from '../menu/menu'
-import { SelectedItem as SelectedMenuItem } from '../menu/selected-item'
-import { useAnchorPosition } from '../popover'
+import { MenuList } from '../menu/menu'
+import { SelectableMenuItem } from '../menu/selectable-item'
+import { OriginX, OriginY, Popover, useAnchorPosition } from '../popover'
 
 const Container = styled.div`
   display: flex;
@@ -25,7 +25,7 @@ const StyledCard = styled(Card)`
   max-width: 640px;
 `
 
-const StyledMenu = styled(Menu)`
+const StyledMenuList = styled(MenuList)`
   min-width: 256px;
 `
 
@@ -66,6 +66,17 @@ export function MenuTest() {
     }
   }
 
+  const popoverProps = useMemo(
+    () => ({
+      onDismiss,
+      originX: 'center' as OriginX,
+      originY: 'top' as OriginY,
+      anchorX: anchorX ?? 0,
+      anchorY: (anchorY ?? 0) + 36,
+    }),
+    [anchorX, anchorY, onDismiss],
+  )
+
   return (
     <Container>
       <StyledCard>
@@ -76,123 +87,88 @@ export function MenuTest() {
         <RaisedButton label='Selection menu' onClick={makeClickHandler('selection-menu')} />
         <RaisedButton label='Mixed' onClick={makeClickHandler('mixed')} />
 
-        <Menu
-          popoverProps={{
-            open: activeMenu === 'normal',
-            onDismiss,
-            originX: 'center',
-            originY: 'top',
-            anchorX: anchorX ?? 0,
-            anchorY: (anchorY ?? 0) + 36,
-          }}>
-          <MenuItem text='Menu item 1' onClick={onDismiss} />
-          <MenuItem text='Menu item 2' onClick={onDismiss} />
-          <MenuItem text='Menu item 3' onClick={onDismiss} />
-        </Menu>
-        <StyledMenu
-          popoverProps={{
-            open: activeMenu === 'scrollable',
-            onDismiss,
-            originX: 'center',
-            originY: 'top',
-            anchorX: anchorX ?? 0,
-            anchorY: (anchorY ?? 0) + 36,
-          }}>
-          <MenuItem text='Menu item 1' onClick={onDismiss} />
-          <MenuItem text='Menu item 2' onClick={onDismiss} />
-          <MenuItem text='Menu item 3' onClick={onDismiss} />
-          <MenuItem text='Menu item 4' onClick={onDismiss} />
-          <MenuItem text='Menu item 5' onClick={onDismiss} />
-          <MenuItem text='Menu item 6' onClick={onDismiss} />
-          <MenuItem text='Menu item 7' onClick={onDismiss} />
-          <MenuItem text='Menu item 8' onClick={onDismiss} />
-          <MenuItem text='Menu item 9' onClick={onDismiss} />
-          <MenuItem text='Menu item 10' onClick={onDismiss} />
-        </StyledMenu>
-        <Menu
-          dense={true}
-          popoverProps={{
-            open: activeMenu === 'dense',
-            onDismiss,
-            originX: 'center',
-            originY: 'top',
-            anchorX: anchorX ?? 0,
-            anchorY: (anchorY ?? 0) + 36,
-          }}>
-          <MenuItem text='Menu item 1' onClick={onDismiss} />
-          <MenuItem text='Menu item 2' onClick={onDismiss} />
-          <MenuItem text='Menu item 3' onClick={onDismiss} />
-          <MenuItem text='Menu item 4' onClick={onDismiss} />
-          <MenuItem text='Menu item 5' onClick={onDismiss} />
-        </Menu>
-        <StyledMenu
-          dense={true}
-          popoverProps={{
-            open: activeMenu === 'scrollable-dense',
-            onDismiss,
-            originX: 'center',
-            originY: 'top',
-            anchorX: anchorX ?? 0,
-            anchorY: (anchorY ?? 0) + 36,
-          }}>
-          <MenuItem text='Menu item 1' onClick={onDismiss} />
-          <MenuItem text='Menu item 2' onClick={onDismiss} />
-          <MenuItem text='Menu item 3' onClick={onDismiss} />
-          <MenuItem text='Menu item 4' onClick={onDismiss} />
-          <MenuItem text='Menu item 5' onClick={onDismiss} />
-          <MenuItem text='Menu item 6' onClick={onDismiss} />
-          <MenuItem text='Menu item 7' onClick={onDismiss} />
-          <MenuItem text='Menu item 8' onClick={onDismiss} />
-          <MenuItem text='Menu item 9' onClick={onDismiss} />
-          <MenuItem text='Menu item 10' onClick={onDismiss} />
-          <MenuItem text='Menu item 11' onClick={onDismiss} />
-          <MenuItem text='Menu item 12' onClick={onDismiss} />
-          <MenuItem text='Menu item 13' onClick={onDismiss} />
-          <MenuItem text='Menu item 14' onClick={onDismiss} />
-          <MenuItem text='Menu item 15' onClick={onDismiss} />
-        </StyledMenu>
-        <Menu
-          dense={true}
-          popoverProps={{
-            open: activeMenu === 'selection-menu',
-            onDismiss,
-            originX: 'center',
-            originY: 'top',
-            anchorX: anchorX ?? 0,
-            anchorY: (anchorY ?? 0) + 36,
-          }}>
-          {makeArrayRange(5).map(i => (
-            <SelectedMenuItem
-              key={i}
-              text={`Menu item ${i + 1}`}
-              selected={selectedIndex === i}
-              onClick={() => onSelected(i)}
-            />
-          ))}
-        </Menu>
-        <StyledMenu
-          dense={true}
-          popoverProps={{
-            open: activeMenu === 'mixed',
-            onDismiss,
-            originX: 'center',
-            originY: 'top',
-            anchorX: anchorX ?? 0,
-            anchorY: (anchorY ?? 0) + 36,
-          }}>
-          <Overline>Subheading</Overline>
-          {makeArrayRange(3).map(i => (
-            <SelectedMenuItem
-              key={i}
-              text={`Menu item ${i + 1}`}
-              selected={selectedIndex === i}
-              onClick={() => onSelected(i)}
-            />
-          ))}
-          <Divider />
-          <MenuItem text='Menu item 4' onClick={onDismiss} />
-          <MenuItem text='Menu item 5' onClick={onDismiss} />
-        </StyledMenu>
+        <Popover open={activeMenu === 'normal'} {...popoverProps}>
+          <MenuList>
+            <MenuItem text='Menu item 1' onClick={onDismiss} />
+            <MenuItem text='Menu item 2' onClick={onDismiss} />
+            <MenuItem text='Menu item 3' onClick={onDismiss} />
+          </MenuList>
+        </Popover>
+
+        <Popover open={activeMenu === 'scrollable'} {...popoverProps}>
+          <StyledMenuList>
+            <MenuItem text='Menu item 1' onClick={onDismiss} />
+            <MenuItem text='Menu item 2' onClick={onDismiss} />
+            <MenuItem text='Menu item 3' onClick={onDismiss} />
+            <MenuItem text='Menu item 4' onClick={onDismiss} />
+            <MenuItem text='Menu item 5' onClick={onDismiss} />
+            <MenuItem text='Menu item 6' onClick={onDismiss} />
+            <MenuItem text='Menu item 7' onClick={onDismiss} />
+            <MenuItem text='Menu item 8' onClick={onDismiss} />
+            <MenuItem text='Menu item 9' onClick={onDismiss} />
+            <MenuItem text='Menu item 10' onClick={onDismiss} />
+          </StyledMenuList>
+        </Popover>
+
+        <Popover open={activeMenu === 'dense'} {...popoverProps}>
+          <MenuList dense={true}>
+            <MenuItem text='Menu item 1' onClick={onDismiss} />
+            <MenuItem text='Menu item 2' onClick={onDismiss} />
+            <MenuItem text='Menu item 3' onClick={onDismiss} />
+            <MenuItem text='Menu item 4' onClick={onDismiss} />
+            <MenuItem text='Menu item 5' onClick={onDismiss} />
+          </MenuList>
+        </Popover>
+
+        <Popover open={activeMenu === 'scrollable-dense'} {...popoverProps}>
+          <StyledMenuList dense={true}>
+            <MenuItem text='Menu item 1' onClick={onDismiss} />
+            <MenuItem text='Menu item 2' onClick={onDismiss} />
+            <MenuItem text='Menu item 3' onClick={onDismiss} />
+            <MenuItem text='Menu item 4' onClick={onDismiss} />
+            <MenuItem text='Menu item 5' onClick={onDismiss} />
+            <MenuItem text='Menu item 6' onClick={onDismiss} />
+            <MenuItem text='Menu item 7' onClick={onDismiss} />
+            <MenuItem text='Menu item 8' onClick={onDismiss} />
+            <MenuItem text='Menu item 9' onClick={onDismiss} />
+            <MenuItem text='Menu item 10' onClick={onDismiss} />
+            <MenuItem text='Menu item 11' onClick={onDismiss} />
+            <MenuItem text='Menu item 12' onClick={onDismiss} />
+            <MenuItem text='Menu item 13' onClick={onDismiss} />
+            <MenuItem text='Menu item 14' onClick={onDismiss} />
+            <MenuItem text='Menu item 15' onClick={onDismiss} />
+          </StyledMenuList>
+        </Popover>
+
+        <Popover open={activeMenu === 'selection-menu'} {...popoverProps}>
+          <MenuList dense={true}>
+            {makeArrayRange(5).map(i => (
+              <SelectableMenuItem
+                key={i}
+                text={`Menu item ${i + 1}`}
+                selected={selectedIndex === i}
+                onClick={() => onSelected(i)}
+              />
+            ))}
+          </MenuList>
+        </Popover>
+
+        <Popover open={activeMenu === 'mixed'} {...popoverProps}>
+          <StyledMenuList dense={true}>
+            <Overline>Subheading</Overline>
+            {makeArrayRange(3).map(i => (
+              <SelectableMenuItem
+                key={i}
+                text={`Menu item ${i + 1}`}
+                selected={selectedIndex === i}
+                onClick={() => onSelected(i)}
+              />
+            ))}
+            <Divider />
+            <MenuItem text='Menu item 4' onClick={onDismiss} />
+            <MenuItem text='Menu item 5' onClick={onDismiss} />
+          </StyledMenuList>
+        </Popover>
       </StyledCard>
     </Container>
   )

--- a/client/material/devonly/menu-test.tsx
+++ b/client/material/devonly/menu-test.tsx
@@ -36,6 +36,8 @@ const Overline = styled.div`
   color: ${colorTextSecondary};
 `
 
+const makeArrayRange = (size: number) => Array.from(Array(size).keys())
+
 export function MenuTest() {
   const [activeMenu, setActiveMenu] = useState<string>()
   const [anchorElem, setAnchorElem] = useState<HTMLElement>()
@@ -75,23 +77,27 @@ export function MenuTest() {
         <RaisedButton label='Mixed' onClick={makeClickHandler('mixed')} />
 
         <Menu
-          open={activeMenu === 'normal'}
-          onDismiss={onDismiss}
-          originX='center'
-          originY='top'
-          anchorX={anchorX ?? 0}
-          anchorY={(anchorY ?? 0) + 36}>
+          popoverProps={{
+            open: activeMenu === 'normal',
+            onDismiss,
+            originX: 'center',
+            originY: 'top',
+            anchorX: anchorX ?? 0,
+            anchorY: (anchorY ?? 0) + 36,
+          }}>
           <MenuItem text='Menu item 1' onClick={onDismiss} />
           <MenuItem text='Menu item 2' onClick={onDismiss} />
           <MenuItem text='Menu item 3' onClick={onDismiss} />
         </Menu>
         <StyledMenu
-          open={activeMenu === 'scrollable'}
-          onDismiss={onDismiss}
-          originX='center'
-          originY='top'
-          anchorX={anchorX ?? 0}
-          anchorY={(anchorY ?? 0) + 36}>
+          popoverProps={{
+            open: activeMenu === 'scrollable',
+            onDismiss,
+            originX: 'center',
+            originY: 'top',
+            anchorX: anchorX ?? 0,
+            anchorY: (anchorY ?? 0) + 36,
+          }}>
           <MenuItem text='Menu item 1' onClick={onDismiss} />
           <MenuItem text='Menu item 2' onClick={onDismiss} />
           <MenuItem text='Menu item 3' onClick={onDismiss} />
@@ -104,13 +110,15 @@ export function MenuTest() {
           <MenuItem text='Menu item 10' onClick={onDismiss} />
         </StyledMenu>
         <Menu
-          open={activeMenu === 'dense'}
-          onDismiss={onDismiss}
-          originX='center'
-          originY='top'
-          anchorX={anchorX ?? 0}
-          anchorY={(anchorY ?? 0) + 36}
-          dense={true}>
+          dense={true}
+          popoverProps={{
+            open: activeMenu === 'dense',
+            onDismiss,
+            originX: 'center',
+            originY: 'top',
+            anchorX: anchorX ?? 0,
+            anchorY: (anchorY ?? 0) + 36,
+          }}>
           <MenuItem text='Menu item 1' onClick={onDismiss} />
           <MenuItem text='Menu item 2' onClick={onDismiss} />
           <MenuItem text='Menu item 3' onClick={onDismiss} />
@@ -118,13 +126,15 @@ export function MenuTest() {
           <MenuItem text='Menu item 5' onClick={onDismiss} />
         </Menu>
         <StyledMenu
-          open={activeMenu === 'scrollable-dense'}
-          onDismiss={onDismiss}
-          originX='center'
-          originY='top'
-          anchorX={anchorX ?? 0}
-          anchorY={(anchorY ?? 0) + 36}
-          dense={true}>
+          dense={true}
+          popoverProps={{
+            open: activeMenu === 'scrollable-dense',
+            onDismiss,
+            originX: 'center',
+            originY: 'top',
+            anchorX: anchorX ?? 0,
+            anchorY: (anchorY ?? 0) + 36,
+          }}>
           <MenuItem text='Menu item 1' onClick={onDismiss} />
           <MenuItem text='Menu item 2' onClick={onDismiss} />
           <MenuItem text='Menu item 3' onClick={onDismiss} />
@@ -142,35 +152,43 @@ export function MenuTest() {
           <MenuItem text='Menu item 15' onClick={onDismiss} />
         </StyledMenu>
         <Menu
-          open={activeMenu === 'selection-menu'}
-          onDismiss={onDismiss}
-          originX='center'
-          originY='top'
-          anchorX={anchorX ?? 0}
-          anchorY={(anchorY ?? 0) + 36}
           dense={true}
-          selectedIndex={selectedIndex}
-          onItemSelected={onSelected}>
-          <SelectedMenuItem text='Menu item 1' />
-          <SelectedMenuItem text='Menu item 2' />
-          <SelectedMenuItem text='Menu item 3' />
-          <SelectedMenuItem text='Menu item 4' />
-          <SelectedMenuItem text='Menu item 5' />
+          popoverProps={{
+            open: activeMenu === 'selection-menu',
+            onDismiss,
+            originX: 'center',
+            originY: 'top',
+            anchorX: anchorX ?? 0,
+            anchorY: (anchorY ?? 0) + 36,
+          }}>
+          {makeArrayRange(5).map(i => (
+            <SelectedMenuItem
+              key={i}
+              text={`Menu item ${i + 1}`}
+              selected={selectedIndex === i}
+              onClick={() => onSelected(i)}
+            />
+          ))}
         </Menu>
         <StyledMenu
-          open={activeMenu === 'mixed'}
-          onDismiss={onDismiss}
-          originX='center'
-          originY='top'
-          anchorX={anchorX ?? 0}
-          anchorY={(anchorY ?? 0) + 36}
           dense={true}
-          selectedIndex={selectedIndex}
-          onItemSelected={onSelected}>
+          popoverProps={{
+            open: activeMenu === 'mixed',
+            onDismiss,
+            originX: 'center',
+            originY: 'top',
+            anchorX: anchorX ?? 0,
+            anchorY: (anchorY ?? 0) + 36,
+          }}>
           <Overline>Subheading</Overline>
-          <SelectedMenuItem text='Menu item 1' />
-          <SelectedMenuItem text='Menu item 2' />
-          <SelectedMenuItem text='Menu item 3' />
+          {makeArrayRange(3).map(i => (
+            <SelectedMenuItem
+              key={i}
+              text={`Menu item ${i + 1}`}
+              selected={selectedIndex === i}
+              onClick={() => onSelected(i)}
+            />
+          ))}
           <Divider />
           <MenuItem text='Menu item 4' onClick={onDismiss} />
           <MenuItem text='Menu item 5' onClick={onDismiss} />

--- a/client/material/menu/item.tsx
+++ b/client/material/menu/item.tsx
@@ -1,11 +1,11 @@
-import React from 'react'
+import React, { useEffect, useRef } from 'react'
 import styled from 'styled-components'
 import { singleLine } from '../../styles/typography'
 import { useButtonState } from '../button'
 import { buttonReset } from '../button-reset'
 import { Ripple } from '../ripple'
 import { ITEM_HEIGHT, ITEM_HEIGHT_DENSE } from './menu'
-import { MenuItemSymbol } from './menu-item-symbol'
+import { MenuItemSymbol, MenuItemType } from './menu-item-symbol'
 
 const Item = styled.button<{ $dense?: boolean; $focused?: boolean }>`
   ${buttonReset};
@@ -17,6 +17,7 @@ const Item = styled.button<{ $dense?: boolean; $focused?: boolean }>`
 
   display: flex;
   align-items: center;
+  flex-shrink: 0;
 
   border-radius: 2px;
   text-align: left;
@@ -45,12 +46,20 @@ export interface MenuItemProps {
   onClick?: (event: React.MouseEvent) => void
 }
 
-export function MenuItem({ text, icon, dense, onClick, className }: MenuItemProps) {
-  // TODO(tec27): Should probably use the `onFocus` here instead of faking focus from the menu?
+export function MenuItem({ text, icon, dense, focused, onClick, className }: MenuItemProps) {
   const [buttonProps, rippleRef] = useButtonState({ onClick })
+  const buttonRef = useRef<HTMLButtonElement>(null)
+
+  useEffect(() => {
+    if (focused) {
+      buttonRef.current?.focus()
+    } else {
+      buttonRef.current?.blur()
+    }
+  }, [focused])
 
   return (
-    <Item className={className} $dense={dense} {...buttonProps}>
+    <Item ref={buttonRef} className={className} $dense={dense} {...buttonProps}>
       {icon ? <ItemIcon>{icon}</ItemIcon> : null}
       <ItemText>{text}</ItemText>
       <Ripple ref={rippleRef} />
@@ -58,4 +67,4 @@ export function MenuItem({ text, icon, dense, onClick, className }: MenuItemProp
   )
 }
 
-MenuItem[MenuItemSymbol] = true
+MenuItem[MenuItemSymbol] = MenuItemType.Default

--- a/client/material/menu/menu-item-symbol.ts
+++ b/client/material/menu/menu-item-symbol.ts
@@ -1,16 +1,37 @@
 import { ReactElement } from 'react'
 
+export enum MenuItemType {
+  Default = 'Default',
+  Selected = 'Selected',
+}
+
+export const ALL_MENU_ITEM_TYPES: ReadonlyArray<MenuItemType> = Object.values(MenuItemType)
+
 /**
- * A Symbol which all `MenuItem` components should set to true as a static property, so that
- * menu implementations can distinguish between menu items and decorative elements (e.g. dividers,
- * overlines, etc.).
+ * A Symbol which all `MenuItem` components should set to `MenuItemType` as a static property, so
+ * that menu implementations can distinguish between menu items and decorative elements (e.g.
+ * dividers, overlines, etc.).
  */
 export const MenuItemSymbol = Symbol('MenuItem')
 
 /**
- * Returns true of the specified child has a typed marked as a MenuItem (rather than static or
+ * Returns true if the specified child has a type marked as a MenuItem (rather than static or
  * decorative content).
  */
 export function isMenuItem(child: unknown): child is ReactElement {
-  return child && (child as any).type && (child as any).type[MenuItemSymbol]
+  return (
+    child &&
+    (child as any).type &&
+    ALL_MENU_ITEM_TYPES.includes((child as any).type[MenuItemSymbol])
+  )
+}
+
+/**
+ * Returns true if the specified child has a type marked as a selected MenuItem (rather than any
+ * other type of menu item or static or decorative content).
+ */
+export function isSelectedMenuItem(child: unknown): child is ReactElement {
+  return (
+    child && (child as any).type && (child as any).type[MenuItemSymbol] === MenuItemType.Selected
+  )
 }

--- a/client/material/menu/menu-item-symbol.ts
+++ b/client/material/menu/menu-item-symbol.ts
@@ -2,7 +2,7 @@ import { ReactElement } from 'react'
 
 export enum MenuItemType {
   Default = 'Default',
-  Selected = 'Selected',
+  Selectable = 'Selectable',
 }
 
 export const ALL_MENU_ITEM_TYPES: ReadonlyArray<MenuItemType> = Object.values(MenuItemType)
@@ -27,11 +27,11 @@ export function isMenuItem(child: unknown): child is ReactElement {
 }
 
 /**
- * Returns true if the specified child has a type marked as a selected MenuItem (rather than any
+ * Returns true if the specified child has a type marked as a selectable MenuItem (rather than any
  * other type of menu item or static or decorative content).
  */
-export function isSelectedMenuItem(child: unknown): child is ReactElement {
+export function isSelectableMenuItem(child: unknown): child is ReactElement {
   return (
-    child && (child as any).type && (child as any).type[MenuItemSymbol] === MenuItemType.Selected
+    child && (child as any).type && (child as any).type[MenuItemSymbol] === MenuItemType.Selectable
   )
 }

--- a/client/material/menu/menu.tsx
+++ b/client/material/menu/menu.tsx
@@ -1,7 +1,7 @@
-import PropTypes from 'prop-types'
-import React from 'react'
+import React, { useMemo, useRef, useState } from 'react'
 import styled from 'styled-components'
-import KeyListener from '../../keyboard/key-listener'
+import { useKeyListener } from '../../keyboard/key-listener'
+import { useStableCallback } from '../../state-hooks'
 import { CardLayer } from '../../styles/colors'
 import { body1, subtitle1 } from '../../styles/typography'
 import { Popover, PopoverProps } from '../popover'
@@ -10,8 +10,7 @@ import { isMenuItem } from './menu-item-symbol'
 
 const ENTER = 'Enter'
 const ENTER_NUMPAD = 'NumpadEnter'
-const TAB = 'Tab'
-const ESCAPE = 'Escape'
+const SPACE = 'Space'
 const UP = 'ArrowUp'
 const DOWN = 'ArrowDown'
 
@@ -53,133 +52,46 @@ export const Overlay = styled(CardLayer)<{ $dense?: boolean }>`
 const Padding = styled.div`
   width: auto;
   height: 8px;
+  flex-shrink: 0;
 `
 
-export interface MenuProps extends PopoverProps {
-  selectedIndex?: number
+export interface MenuListProps {
+  children: React.ReactNode
+  className?: string
   dense?: boolean
-  onItemSelected?: (index: number) => void
 }
 
-interface MenuState {
-  activeIndex: number
-}
+export function MenuList({ children, className, dense }: MenuListProps) {
+  const [activeIndex, setActiveIndex] = useState(-1)
+  const overlayRef = useRef<HTMLDivElement>(null)
 
-// A wrapper component around Popover that can be used to quickly write Menus
-// TODO(2Pac): Menus should probably have some default positioning instead of exposing the
-// lower-level API of the Popovers.
-export class Menu extends React.Component<MenuProps, MenuState> {
-  static propTypes = {
-    dense: PropTypes.bool,
-    selectedIndex: PropTypes.number,
-    // Use this function to implement a custom CSS transitions for opening/closing the menu. Will be
-    // called with the menu content.
-    renderTransition: PropTypes.func,
-    onItemSelected: PropTypes.func,
-  }
+  const menuItems = useMemo(() => {
+    return React.Children.toArray(children).filter(child => isMenuItem(child))
+  }, [children])
 
-  static defaultProps = {
-    selectedIndex: -1,
-  }
-
-  override state = {
-    activeIndex: this.props.selectedIndex!,
-  }
-
-  private overlay = React.createRef<HTMLDivElement>()
-
-  override componentDidUpdate(prevProps: MenuProps) {
-    if (prevProps.open && !this.props.open) {
-      this.setState({ activeIndex: this.props.selectedIndex! })
-    }
-    if (!prevProps.open && this.overlay.current) {
-      // update the scroll position to the selected value
-      const firstDisplayed = this.getFirstDisplayedItemIndex()
-      this.overlay.current.scrollTop = firstDisplayed * ITEM_HEIGHT
-    }
-  }
-
-  private getMenuItems() {
-    return React.Children.toArray(this.props.children).filter(child => isMenuItem(child))
-  }
-
-  private getFirstDisplayedItemIndex() {
-    const { dense, selectedIndex } = this.props
-    const numItems = this.getMenuItems().length
-    const itemsShown = dense ? ITEMS_SHOWN_DENSE : ITEMS_SHOWN
-    const lastVisibleIndex = itemsShown - 1
-    if (selectedIndex! <= lastVisibleIndex || numItems < itemsShown) {
-      return 0
-    }
-    return Math.min(numItems - itemsShown, selectedIndex! - lastVisibleIndex)
-  }
-
-  override render() {
-    const {
-      children,
-      dense,
-      selectedIndex,
-      onItemSelected, // eslint-disable-line @typescript-eslint/no-unused-vars
-      ...popoverProps
-    } = this.props
-
-    let i = 0
-    const items = React.Children.map(children, child => {
-      // Leave the non-selectable elements (e.g. dividers, overlines, etc.) as they are
-      if (!isMenuItem(child)) return child
-
-      // Define a block-scoped variable which will bind to the `onItemSelected` closure below
-      const index = i
-      const elem = React.cloneElement(child, {
-        dense,
-        focused: index === this.state.activeIndex,
-        selected: index === selectedIndex,
-        onItemSelected: () => this.onItemSelected(index),
-      })
-      i++
-
-      return elem
-    })
-
-    return (
-      <Popover {...popoverProps}>
-        <KeyListener onKeyDown={this.onKeyDown} />
-        <Overlay key='menu' ref={this.overlay} className={this.props.className} $dense={dense}>
-          <Padding />
-          {items}
-          <Padding />
-        </Overlay>
-      </Popover>
-    )
-  }
-
-  private moveActiveIndexBy(delta: number) {
-    const { dense } = this.props
-
-    let newIndex = this.state.activeIndex
-    if (newIndex === -1) {
-      newIndex = this.props.selectedIndex!
+  const moveActiveIndexBy = useStableCallback((delta: number) => {
+    if (!overlayRef.current || menuItems.length < 1) {
+      return
     }
 
-    const numItems = this.getMenuItems().length
-    newIndex += delta
-    while (newIndex < 0) {
-      newIndex += numItems
+    let newIndex = activeIndex + delta
+    if (newIndex < 0) {
+      newIndex = menuItems.length - 1
     }
-    newIndex = newIndex % numItems
+    newIndex = newIndex % menuItems.length
 
-    if (newIndex !== this.state.activeIndex) {
-      this.setState({
-        activeIndex: newIndex,
-      })
+    if (newIndex !== activeIndex) {
+      setActiveIndex(newIndex)
     }
 
     const itemHeight = dense ? ITEM_HEIGHT_DENSE : ITEM_HEIGHT
     const itemsShown = dense ? ITEMS_SHOWN_DENSE : ITEMS_SHOWN
 
     // Adjust scroll position to keep the item in view
+    // TODO(2Pac): This doesn't really work correctly if the Menu has non-menu-items in it (e.g.
+    // overlines, dividers, etc.)
     const curTopIndex = Math.ceil(
-      Math.max(0, this.overlay.current!.scrollTop - VERT_PADDING) / itemHeight,
+      Math.max(0, overlayRef.current.scrollTop - VERT_PADDING) / itemHeight,
     )
     const curBottomIndex = curTopIndex + itemsShown - 1 // accounts for partially shown options
     if (newIndex >= curTopIndex && newIndex <= curBottomIndex) {
@@ -187,41 +99,75 @@ export class Menu extends React.Component<MenuProps, MenuState> {
       return
     } else if (newIndex < curTopIndex) {
       // Make the new index the top item
-      this.overlay.current!.scrollTop = itemHeight * newIndex
+      overlayRef.current.scrollTop = itemHeight * newIndex
     } else {
       // Make the new index the bottom item
-      this.overlay.current!.scrollTop = itemHeight * (newIndex + 1 - itemsShown)
+      overlayRef.current.scrollTop = itemHeight * (newIndex + 1 - itemsShown)
     }
-  }
+  })
 
-  onKeyDown = (event: KeyboardEvent) => {
-    if (event.code === ESCAPE) {
-      this.props.onDismiss()
-      return true
-    } else if (event.code === UP) {
-      this.moveActiveIndexBy(-1)
-      return true
-    } else if (event.code === DOWN) {
-      this.moveActiveIndexBy(1)
-      return true
-    } else if (event.code === TAB) {
-      if (this.state.activeIndex >= 0) {
-        this.onItemSelected(this.state.activeIndex)
+  useKeyListener({
+    // TODO(2Pac): Call the click handler of the currently active menu item by pressing Enter (and
+    // Space?)
+    onKeyDown: useStableCallback(event => {
+      if (event.code === UP) {
+        moveActiveIndexBy(-1)
         return true
-      }
-    } else if (event.code === ENTER || event.code === ENTER_NUMPAD) {
-      if (this.state.activeIndex >= 0) {
-        this.onItemSelected(this.state.activeIndex)
+      } else if (event.code === DOWN) {
+        moveActiveIndexBy(1)
         return true
+      } else if (event.code === ENTER || event.code === ENTER_NUMPAD || event.code === SPACE) {
+        const activeItem = menuItems[activeIndex]
+        if (isMenuItem(activeItem)) {
+          activeItem.props.onClick()
+        }
       }
-    }
 
-    return false
-  }
+      return false
+    }),
+  })
 
-  onItemSelected = (index: number) => {
-    if (this.props.onItemSelected) {
-      this.props.onItemSelected(index)
-    }
-  }
+  // We're using this variable as an index for only the menu items, so we don't try focusing a
+  // non-menu-item (e.g. overline, divider, etc.)
+  let i = 0
+  const items = React.Children.map(children, child => {
+    // Leave the non-selectable elements (e.g. dividers, overlines, etc.) as they are
+    if (!isMenuItem(child)) return child
+
+    const index = i
+    const elem = React.cloneElement(child, {
+      dense,
+      focused: index === activeIndex,
+    })
+    i++
+
+    return elem
+  })
+
+  return (
+    <Overlay key='menu' ref={overlayRef} className={className} $dense={dense}>
+      <Padding />
+      {items}
+      <Padding />
+    </Overlay>
+  )
+}
+
+export interface MenuProps extends MenuListProps {
+  popoverProps: Omit<PopoverProps, 'children'>
+}
+
+/**
+ * A wrapper component around Popover that can be used to quickly write menus.
+ *
+ * This component just renders the `Popover` and expects it to only render the `MenuList` when the
+ * menu is actually open. This makes sure that all the logic of the menu (e.g. keyboard handlers) is
+ * only run when the menu is open.
+ */
+export function Menu({ popoverProps, ...menuListProps }: MenuProps) {
+  return (
+    <Popover {...popoverProps}>
+      <MenuList {...menuListProps} />
+    </Popover>
+  )
 }

--- a/client/material/menu/menu.tsx
+++ b/client/material/menu/menu.tsx
@@ -4,7 +4,6 @@ import { useKeyListener } from '../../keyboard/key-listener'
 import { useStableCallback } from '../../state-hooks'
 import { CardLayer } from '../../styles/colors'
 import { body1, subtitle1 } from '../../styles/typography'
-import { Popover, PopoverProps } from '../popover'
 import { zIndexMenu } from '../zindex'
 import { isMenuItem } from './menu-item-symbol'
 
@@ -61,6 +60,13 @@ export interface MenuListProps {
   dense?: boolean
 }
 
+/**
+ * A material design menu component with support for dense menu items and keyboard handling.
+ *
+ * Note that this component just renders the menu content, it doesn't render the popover part. The
+ * reason for this separation is so we can create menus that run certain hooks (e.g. connect to the
+ * store) which will be rendered only when the popover is open.
+ */
 export function MenuList({ children, className, dense }: MenuListProps) {
   const [activeIndex, setActiveIndex] = useState(-1)
   const overlayRef = useRef<HTMLDivElement>(null)
@@ -107,8 +113,6 @@ export function MenuList({ children, className, dense }: MenuListProps) {
   })
 
   useKeyListener({
-    // TODO(2Pac): Call the click handler of the currently active menu item by pressing Enter (and
-    // Space?)
     onKeyDown: useStableCallback(event => {
       if (event.code === UP) {
         moveActiveIndexBy(-1)
@@ -150,24 +154,5 @@ export function MenuList({ children, className, dense }: MenuListProps) {
       {items}
       <Padding />
     </Overlay>
-  )
-}
-
-export interface MenuProps extends MenuListProps {
-  popoverProps: Omit<PopoverProps, 'children'>
-}
-
-/**
- * A wrapper component around Popover that can be used to quickly write menus.
- *
- * This component just renders the `Popover` and expects it to only render the `MenuList` when the
- * menu is actually open. This makes sure that all the logic of the menu (e.g. keyboard handlers) is
- * only run when the menu is open.
- */
-export function Menu({ popoverProps, ...menuListProps }: MenuProps) {
-  return (
-    <Popover {...popoverProps}>
-      <MenuList {...menuListProps} />
-    </Popover>
   )
 }

--- a/client/material/menu/selectable-item.tsx
+++ b/client/material/menu/selectable-item.tsx
@@ -9,14 +9,14 @@ const StyledMenuItem = styled(MenuItem)<{ $selected?: boolean }>`
   padding-left: ${props => (props.$selected ? '10px' : '46px')};
 `
 
-export interface SelectedItemProps extends Omit<MenuItemProps, 'icon'> {
+export interface SelectableMenuItemProps extends Omit<MenuItemProps, 'icon'> {
   selected?: boolean
 }
 
-export function SelectedItem({ selected, ...otherProps }: SelectedItemProps) {
+export function SelectableMenuItem({ selected, ...otherProps }: SelectableMenuItemProps) {
   const icon = selected ? <SelectedIcon /> : undefined
 
   return <StyledMenuItem {...otherProps} $selected={selected} icon={icon} />
 }
 
-SelectedItem[MenuItemSymbol] = MenuItemType.Selected
+SelectableMenuItem[MenuItemSymbol] = MenuItemType.Selectable

--- a/client/material/menu/selected-item.tsx
+++ b/client/material/menu/selected-item.tsx
@@ -2,24 +2,21 @@ import React from 'react'
 import styled from 'styled-components'
 import SelectedIcon from '../../icons/material/check-24px.svg'
 import { MenuItem, MenuItemProps } from './item'
-import { MenuItemSymbol } from './menu-item-symbol'
+import { MenuItemSymbol, MenuItemType } from './menu-item-symbol'
 
 // 10px is (12px - 2px of built-in padding in the icon)
 const StyledMenuItem = styled(MenuItem)<{ $selected?: boolean }>`
   padding-left: ${props => (props.$selected ? '10px' : '46px')};
 `
 
-export interface SelectedItemProps extends Omit<MenuItemProps, 'onClick' | 'icon'> {
+export interface SelectedItemProps extends Omit<MenuItemProps, 'icon'> {
   selected?: boolean
-  onItemSelected?: () => void
 }
 
-export function SelectedItem({ selected, onItemSelected, ...otherProps }: SelectedItemProps) {
+export function SelectedItem({ selected, ...otherProps }: SelectedItemProps) {
   const icon = selected ? <SelectedIcon /> : undefined
 
-  return (
-    <StyledMenuItem {...otherProps} $selected={selected} icon={icon} onClick={onItemSelected} />
-  )
+  return <StyledMenuItem {...otherProps} $selected={selected} icon={icon} />
 }
 
-SelectedItem[MenuItemSymbol] = true
+SelectedItem[MenuItemSymbol] = MenuItemType.Selected

--- a/client/material/select/option.tsx
+++ b/client/material/select/option.tsx
@@ -53,4 +53,4 @@ export function SelectOption({ text, focused, selected, onClick }: SelectOptionP
   )
 }
 
-SelectOption[MenuItemSymbol] = MenuItemType.Selected
+SelectOption[MenuItemSymbol] = MenuItemType.Selectable

--- a/client/material/select/option.tsx
+++ b/client/material/select/option.tsx
@@ -1,10 +1,9 @@
 import { rgba } from 'polished'
-import PropTypes from 'prop-types'
 import React, { useCallback } from 'react'
 import styled from 'styled-components'
 import { amberA400 } from '../../styles/colors'
 import { MenuItem } from '../menu/item'
-import { MenuItemSymbol } from '../menu/menu-item-symbol'
+import { MenuItemSymbol, MenuItemType } from '../menu/menu-item-symbol'
 
 const StyledMenuItem = styled(MenuItem)<{ $selected?: boolean; $focused?: boolean }>`
   &:hover {
@@ -41,25 +40,17 @@ export interface SelectOptionProps {
   value: unknown
   focused?: boolean
   selected?: boolean
-  onItemSelected?: () => void
+  onClick?: () => void
 }
 
-export function SelectOption({ text, focused, selected, onItemSelected }: SelectOptionProps) {
-  const onClick = useCallback(() => {
-    if (onItemSelected) {
-      onItemSelected()
-    }
-  }, [onItemSelected])
+export function SelectOption({ text, focused, selected, onClick }: SelectOptionProps) {
+  const onOptionClick = useCallback(() => {
+    onClick?.()
+  }, [onClick])
 
-  return <StyledMenuItem onClick={onClick} text={text} $focused={focused} $selected={selected} />
+  return (
+    <StyledMenuItem text={text} $focused={focused} $selected={selected} onClick={onOptionClick} />
+  )
 }
 
-SelectOption.propTypes = {
-  text: PropTypes.string.isRequired,
-  value: PropTypes.any.isRequired,
-  focused: PropTypes.bool,
-  selected: PropTypes.bool,
-  onItemSelected: PropTypes.func,
-}
-
-SelectOption[MenuItemSymbol] = true
+SelectOption[MenuItemSymbol] = MenuItemType.Selected

--- a/client/material/select/select.tsx
+++ b/client/material/select/select.tsx
@@ -11,9 +11,9 @@ import { InputBase } from '../input-base'
 import { InputError } from '../input-error'
 import { FloatingLabel } from '../input-floating-label'
 import { InputUnderline } from '../input-underline'
-import { Menu } from '../menu/menu'
-import { isSelectedMenuItem } from '../menu/menu-item-symbol'
-import { useAnchorPosition } from '../popover'
+import { MenuList } from '../menu/menu'
+import { isSelectableMenuItem } from '../menu/menu-item-symbol'
+import { Popover, useAnchorPosition } from '../popover'
 import { defaultSpring } from '../springs'
 
 const SPACE = 'Space'
@@ -94,7 +94,7 @@ const Icon = styled.span<{ $disabled?: boolean; $focused?: boolean; $opened?: bo
   }
 `
 
-const StyledMenu = styled(Menu)<{ $overlayWidth: number }>`
+const StyledMenuList = styled(MenuList)<{ $overlayWidth: number }>`
   width: ${props => props.$overlayWidth}px;
   background-color: ${background300};
 `
@@ -248,7 +248,7 @@ export const Select = React.forwardRef<SelectRef, SelectProps>(
     const [displayValue, options] = useMemo(() => {
       let displayText: string | undefined
       const options = React.Children.map(children, (child, index) => {
-        if (!isSelectedMenuItem(child)) return child
+        if (!isSelectableMenuItem(child)) return child
 
         let selected = false
         if (value !== undefined && child.props.value !== undefined) {
@@ -301,19 +301,16 @@ export const Select = React.forwardRef<SelectRef, SelectProps>(
           <InputUnderline focused={focused} error={!!errorText} disabled={disabled} />
         </SelectContainer>
         {allowErrors ? <InputError error={errorText} /> : null}
-        <StyledMenu
-          $overlayWidth={overlayWidth}
-          popoverProps={{
-            open: opened,
-            onDismiss: onClose,
-            anchorX: anchorX ?? 0,
-            anchorY: anchorY ?? 0,
-            originX: 'center',
-            originY: 'top',
-            transitionProps: MENU_TRANSITION,
-          }}>
-          {options}
-        </StyledMenu>
+        <Popover
+          open={opened}
+          onDismiss={onClose}
+          anchorX={anchorX ?? 0}
+          anchorY={anchorY ?? 0}
+          originX='center'
+          originY='top'
+          transitionProps={MENU_TRANSITION}>
+          <StyledMenuList $overlayWidth={overlayWidth}>{options}</StyledMenuList>
+        </Popover>
       </div>
     )
   },

--- a/client/navigation/connected-left-nav.tsx
+++ b/client/navigation/connected-left-nav.tsx
@@ -35,8 +35,8 @@ import Subheader from '../material/left-nav/subheader'
 import { SubheaderButton } from '../material/left-nav/subheader-button'
 import { Divider as MenuDivider } from '../material/menu/divider'
 import { MenuItem } from '../material/menu/item'
-import { Menu } from '../material/menu/menu'
-import { useAnchorPosition } from '../material/popover'
+import { MenuList } from '../material/menu/menu'
+import { Popover, useAnchorPosition } from '../material/popover'
 import { defaultSpring } from '../material/springs'
 import { Tooltip } from '../material/tooltip'
 import { leaveParty } from '../parties/action-creators'
@@ -65,7 +65,7 @@ const LockupContainer = styled.div`
   width: 100%;
 `
 
-const AppMenu = styled(Menu)`
+const AppMenu = styled(MenuList)`
   width: 256px;
   max-height: 420px;
 `
@@ -146,18 +146,16 @@ function LockupAndMenu() {
   return (
     <LockupContainer>
       <Lockup onClick={onLockupClick} menuOpened={!!appMenuAnchor} />
-      <AppMenu
-        popoverProps={{
-          open: !!appMenuAnchor,
-          onDismiss: onAppMenuDismiss,
-          originX: 'center',
-          originY: 'top',
-          anchorX: (anchorX ?? 0) - 8,
-          anchorY: (anchorY ?? 0) + 8,
-          transitionProps: MENU_TRANSITION,
-        }}>
-        {appMenuItems}
-      </AppMenu>
+      <Popover
+        open={!!appMenuAnchor}
+        onDismiss={onAppMenuDismiss}
+        anchorX={(anchorX ?? 0) - 8}
+        anchorY={(anchorY ?? 0) + 8}
+        originX='center'
+        originY='top'
+        transitionProps={MENU_TRANSITION}>
+        <AppMenu>{appMenuItems}</AppMenu>
+      </Popover>
     </LockupContainer>
   )
 }

--- a/client/navigation/connected-left-nav.tsx
+++ b/client/navigation/connected-left-nav.tsx
@@ -147,13 +147,15 @@ function LockupAndMenu() {
     <LockupContainer>
       <Lockup onClick={onLockupClick} menuOpened={!!appMenuAnchor} />
       <AppMenu
-        open={!!appMenuAnchor}
-        onDismiss={onAppMenuDismiss}
-        originX='center'
-        originY='top'
-        anchorX={(anchorX ?? 0) - 8}
-        anchorY={(anchorY ?? 0) + 8}
-        transitionProps={MENU_TRANSITION}>
+        popoverProps={{
+          open: !!appMenuAnchor,
+          onDismiss: onAppMenuDismiss,
+          originX: 'center',
+          originY: 'top',
+          anchorX: (anchorX ?? 0) - 8,
+          anchorY: (anchorY ?? 0) + 8,
+          transitionProps: MENU_TRANSITION,
+        }}>
         {appMenuItems}
       </AppMenu>
     </LockupContainer>

--- a/client/users/user-context-menu.tsx
+++ b/client/users/user-context-menu.tsx
@@ -91,7 +91,7 @@ export function ConnectedUserContextMenu({ userId, popoverProps }: ConnectedUser
   }
 
   return (
-    <Menu dense={true} {...popoverProps}>
+    <Menu dense={true} popoverProps={popoverProps}>
       {actions}
     </Menu>
   )

--- a/client/users/user-context-menu.tsx
+++ b/client/users/user-context-menu.tsx
@@ -2,8 +2,8 @@ import React, { useCallback } from 'react'
 import styled from 'styled-components'
 import { SbUserId } from '../../common/users/sb-user'
 import { MenuItem } from '../material/menu/item'
-import { Menu } from '../material/menu/menu'
-import { PopoverProps } from '../material/popover'
+import { MenuList } from '../material/menu/menu'
+import { Popover, PopoverProps } from '../material/popover'
 import { inviteToParty, kickPlayer, removePartyInvite } from '../parties/action-creators'
 import { useAppDispatch, useAppSelector } from '../redux-hooks'
 import { colorTextFaint } from '../styles/colors'
@@ -14,12 +14,16 @@ const LoadingItem = styled(MenuItem)`
   color: ${colorTextFaint};
 `
 
-export interface ConnectedUserContextMenuProps {
+/**
+ * Helper component for user context menu to make sure the hooks are only run when the menu is open.
+ */
+function ConnectedUserContextMenuContents({
+  userId,
+  onDismiss,
+}: {
   userId: SbUserId
-  popoverProps: Omit<PopoverProps, 'children'>
-}
-
-export function ConnectedUserContextMenu({ userId, popoverProps }: ConnectedUserContextMenuProps) {
+  onDismiss: () => void
+}) {
   const dispatch = useAppDispatch()
   const selfUser = useAppSelector(s => s.auth.user)
   const user = useAppSelector(s => s.users.byId.get(userId))
@@ -28,8 +32,6 @@ export function ConnectedUserContextMenu({ userId, popoverProps }: ConnectedUser
   const partyMembers = useAppSelector(s => s.party.current?.members)
   const partyInvites = useAppSelector(s => s.party.current?.invites)
   const partyLeader = useAppSelector(s => s.party.current?.leader)
-
-  const onPopoverDismiss = popoverProps.onDismiss
 
   const onViewProfileClick = useCallback(() => {
     navigateToUserProfile(user!.id, user!.name)
@@ -41,18 +43,18 @@ export function ConnectedUserContextMenu({ userId, popoverProps }: ConnectedUser
 
   const onInviteToPartyClick = useCallback(() => {
     dispatch(inviteToParty({ targetId: userId }))
-    onPopoverDismiss()
-  }, [userId, dispatch, onPopoverDismiss])
+    onDismiss()
+  }, [userId, dispatch, onDismiss])
 
   const onRemovePartyInvite = useCallback(() => {
     dispatch(removePartyInvite(partyId!, userId))
-    onPopoverDismiss()
-  }, [partyId, userId, dispatch, onPopoverDismiss])
+    onDismiss()
+  }, [partyId, userId, dispatch, onDismiss])
 
   const onKickPlayerClick = useCallback(() => {
     dispatch(kickPlayer(partyId!, userId))
-    onPopoverDismiss()
-  }, [partyId, userId, dispatch, onPopoverDismiss])
+    onDismiss()
+  }, [partyId, userId, dispatch, onDismiss])
 
   const actions: React.ReactNode[] = []
   if (!user) {
@@ -90,9 +92,18 @@ export function ConnectedUserContextMenu({ userId, popoverProps }: ConnectedUser
     }
   }
 
+  return <MenuList dense={true}>{actions}</MenuList>
+}
+
+export interface ConnectedUserContextMenuProps {
+  userId: SbUserId
+  popoverProps: Omit<PopoverProps, 'children'>
+}
+
+export function ConnectedUserContextMenu({ userId, popoverProps }: ConnectedUserContextMenuProps) {
   return (
-    <Menu dense={true} popoverProps={popoverProps}>
-      {actions}
-    </Menu>
+    <Popover {...popoverProps}>
+      <ConnectedUserContextMenuContents userId={userId} onDismiss={popoverProps.onDismiss} />
+    </Popover>
   )
 }


### PR DESCRIPTION
Now the menu component only renders its contents and it's left to the
users of this component to render it inside a popover, if they wish so.
The reason for this separation is so we can have menus that need to
run certain hooks (e.g. connect to a store) to only do so if they're open.

This commit also does the following:
  - change the handling of the selectable menu items
  - fix the scrollable menu (the menu items would shrink and not show
    the scrollbar)
  - fix the focused state of the menu items by using the button's
    native focus state instead of faking it
  - remove the TAB hotkey (not sure what this hotkey should be doing in
    the first place)
  - add the SPACE hotkey to click the menu item (along with ENTER)
  - stop scrolling the menu to the selected item when first opened; i'm
    not sure if this was ever a desired behaviour and feels like it
    would be hard to make work if we ever allow multiple selections
  - a few other changes (like moving to a functional component for
    menus, etc.)