### PR TITLE
Removing bad request error for empty map description

### DIFF
--- a/server/lib/maps/map-api.ts
+++ b/server/lib/maps/map-api.ts
@@ -243,8 +243,6 @@ export class MapsApi {
 
     if (!name) {
       throw new httpErrors.BadRequest("Map name can't be empty")
-    } else if (!description) {
-      throw new httpErrors.BadRequest("Map description can't be empty")
     }
 
     let map = (await getMapInfo([mapId], ctx.session!.userId))[0]


### PR DESCRIPTION
For #786 

Just removed the offending if statement. 

Test suite runs successfully and I've been able to edit / update a map without description without issue.  

Was able to create a game with that map and play with no issues.