### PR TITLE
Improve the file expansion panel user experience and design.

### DIFF
--- a/client/file-browser/file-browser-entries.tsx
+++ b/client/file-browser/file-browser-entries.tsx
@@ -3,9 +3,8 @@ import styled, { css } from 'styled-components'
 import { longTimestamp } from '../i18n/date-formats'
 import Folder from '../icons/material/ic_folder_black_24px.svg'
 import UpDirectory from '../icons/material/ic_subdirectory_arrow_left_black_24px.svg'
-import { IconButton, TextButton } from '../material/button'
+import { TextButton } from '../material/button'
 import { useStableCallback } from '../state-hooks'
-import { AnimatedExpandIcon } from '../styles/animated-expand-icon'
 import { amberA400, blue700, colorTextPrimary, colorTextSecondary } from '../styles/colors'
 import { Caption, Subtitle1 } from '../styles/typography'
 import {
@@ -110,23 +109,7 @@ const SelectButton = styled(TextButton)<{ $focused: boolean }>`
       : ''}
 `
 
-const ExpandButton = styled(IconButton)<{ $focused: boolean }>`
-  ${props =>
-    !props.$focused
-      ? css`
-          display: none;
-        `
-      : ''}
-`
-
-const FileEntryContainer = styled(EntryContainer)<{ $clickable: boolean }>`
-  ${props =>
-    !props.$clickable
-      ? css`
-          cursor: auto !important;
-        `
-      : ''}
-
+const FileEntryContainer = styled(EntryContainer)`
   & ${EntryIcon} {
     background: ${blue700};
     color: ${colorTextPrimary};
@@ -134,9 +117,6 @@ const FileEntryContainer = styled(EntryContainer)<{ $clickable: boolean }>`
 
   &:hover ${SelectButton} {
     display: inline-table;
-  }
-  &:hover ${ExpandButton} {
-    display: flex;
   }
 `
 
@@ -151,46 +131,30 @@ export const FileEntry = React.memo(
     isFocused,
     isExpanded,
     onClick,
-    onExpandClick,
   }: FileBrowserEntryProps & {
     file: FileBrowserFileEntry
     fileEntryConfig: FileBrowserFileEntryConfig
     isFocused: boolean
     isExpanded?: boolean
     onClick: (entry: FileBrowserFileEntry) => void
-    onExpandClick?: (entry: FileBrowserFileEntry) => void
   }) => {
     const { icon, ExpansionPanelComponent, onSelect, onSelectTitle } = fileEntryConfig
 
-    const handleExpandClick = useStableCallback((event: React.MouseEvent) => {
+    const onSelectClick = useStableCallback((event: React.MouseEvent) => {
       event.stopPropagation()
-      onExpandClick?.(file)
+      onSelect(file)
     })
 
     return (
       <>
-        <FileEntryContainer
-          $clickable={!ExpansionPanelComponent}
-          $focused={isFocused}
-          onClick={() => onClick(file)}>
+        <FileEntryContainer $focused={isFocused} onClick={() => onClick(file)}>
           <EntryIcon>{icon}</EntryIcon>
           <InfoContainer>
             <Subtitle1>{file.name}</Subtitle1>
             <Caption>{longTimestamp.format(file.date)}</Caption>
           </InfoContainer>
           {ExpansionPanelComponent ? (
-            <>
-              <SelectButton
-                $focused={isFocused}
-                label={onSelectTitle}
-                onClick={() => onSelect(file)}
-              />
-              <ExpandButton
-                $focused={isFocused}
-                icon={<AnimatedExpandIcon $pointUp={isExpanded} />}
-                onClick={handleExpandClick}
-              />
-            </>
+            <SelectButton $focused={isFocused} label={onSelectTitle} onClick={onSelectClick} />
           ) : null}
         </FileEntryContainer>
         {isExpanded && !!ExpansionPanelComponent && <ExpansionPanelComponent file={file} />}

--- a/client/replays/browse-local-replays.tsx
+++ b/client/replays/browse-local-replays.tsx
@@ -24,12 +24,10 @@ import Replay from '../icons/material/ic_movie_black_24px.svg'
 import { RaceIcon } from '../lobbies/race-icon'
 import { MapNoImage } from '../maps/map-image'
 import { MapThumbnail } from '../maps/map-thumbnail'
-import { RaisedButton } from '../material/button'
 import { shadow2dp } from '../material/shadows'
 import { Tooltip } from '../material/tooltip'
 import { LoadingDotsArea } from '../progress/dots'
 import { useAppDispatch, useAppSelector } from '../redux-hooks'
-import { useStableCallback } from '../state-hooks'
 import { background400, colorError, colorTextSecondary } from '../styles/colors'
 import { headline6, overline, singleLine, subtitle1 } from '../styles/typography'
 import { startReplay } from './action-creators'
@@ -137,13 +135,7 @@ const StyledMapThumbnail = styled(MapThumbnail)`
 const MapName = styled.div`
   ${headline6};
   ${singleLine};
-  margin-top: 8px;
-`
-
-const StyledTooltip = styled(Tooltip)`
-  width: 100%;
-  display: flex;
-  justify-content: center;
+  margin: 8px 0;
 `
 
 const ReplayInfoText = styled.div`
@@ -160,14 +152,6 @@ const MapNoImageContainer = styled.div`
   height: auto;
   border-radius: 2px;
   contain: content;
-`
-
-const ReplayActionsContainer = styled.div`
-  display: flex;
-  justify-content: flex-end;
-  align-items: center;
-  width: 100%;
-  height: 56px;
 `
 
 export function ReplayExpansionPanel({ file }: ExpansionPanelProps) {
@@ -259,12 +243,6 @@ export function ReplayExpansionPanel({ file }: ExpansionPanelProps) {
     return [durationStr, gameTypeLabel, mapName, playerListItems]
   }, [mapInfo?.name, replayMetadata, replayUserIds, usersById])
 
-  const onStartReplay = useStableCallback(() => {
-    // TODO(2Pac): Remove `any` cast after overlays are TS-ified
-    dispatch(closeOverlay() as any)
-    dispatch(startReplay(file))
-  })
-
   let content
   if (parseError) {
     content = <ErrorText>There was an error parsing the replay</ErrorText>
@@ -282,26 +260,21 @@ export function ReplayExpansionPanel({ file }: ExpansionPanelProps) {
               <MapNoImage />
             </MapNoImageContainer>
           )}
-          <StyledTooltip text={mapName} position='bottom' disabled={!isMapNameOverflowing}>
-            <MapName ref={mapNameRef}>{mapName}</MapName>
-          </StyledTooltip>
-          <StyledTooltip text={gameTypeLabel} position='bottom' disabled={!isGameTypeOverflowing}>
-            <ReplayInfoText ref={gameTypeRef}>Game type: {gameTypeLabel}</ReplayInfoText>
-          </StyledTooltip>
-          <ReplayInfoText>Duration: {durationStr}</ReplayInfoText>
+          <div>
+            <Tooltip text={mapName} position='bottom' disabled={!isMapNameOverflowing}>
+              <MapName ref={mapNameRef}>{mapName}</MapName>
+            </Tooltip>
+            <Tooltip text={gameTypeLabel} position='bottom' disabled={!isGameTypeOverflowing}>
+              <ReplayInfoText ref={gameTypeRef}>Game type: {gameTypeLabel}</ReplayInfoText>
+            </Tooltip>
+            <ReplayInfoText>Duration: {durationStr}</ReplayInfoText>
+          </div>
         </ReplayInfoContainer>
       </InfoContainer>
     )
   }
 
-  return (
-    <ReplayPanelContainer>
-      {content}
-      <ReplayActionsContainer>
-        <RaisedButton label='Watch replay' onClick={onStartReplay} />
-      </ReplayActionsContainer>
-    </ReplayPanelContainer>
-  )
+  return <ReplayPanelContainer>{content}</ReplayPanelContainer>
 }
 
 export function BrowseLocalReplays() {

--- a/client/replays/browse-local-replays.tsx
+++ b/client/replays/browse-local-replays.tsx
@@ -154,6 +154,11 @@ const MapNoImageContainer = styled.div`
   contain: content;
 `
 
+const TextInfoContainer = styled.div`
+  max-width: 100%;
+  padding: 0 16px;
+`
+
 export function ReplayExpansionPanel({ file }: ExpansionPanelProps) {
   const dispatch = useAppDispatch()
   const [replayMetadata, setReplayMetadata] = useState<{
@@ -260,7 +265,7 @@ export function ReplayExpansionPanel({ file }: ExpansionPanelProps) {
               <MapNoImage />
             </MapNoImageContainer>
           )}
-          <div>
+          <TextInfoContainer>
             <Tooltip text={mapName} position='bottom' disabled={!isMapNameOverflowing}>
               <MapName ref={mapNameRef}>{mapName}</MapName>
             </Tooltip>
@@ -268,7 +273,7 @@ export function ReplayExpansionPanel({ file }: ExpansionPanelProps) {
               <ReplayInfoText ref={gameTypeRef}>Game type: {gameTypeLabel}</ReplayInfoText>
             </Tooltip>
             <ReplayInfoText>Duration: {durationStr}</ReplayInfoText>
-          </div>
+          </TextInfoContainer>
         </ReplayInfoContainer>
       </InfoContainer>
     )


### PR DESCRIPTION
- remove the dropdown button
- clicking the file entry open/closes the panel
- only one file entry allowed to be open at a time
- remove the redundant action button inside the panel itself
- left-align the replay info inside a centered container
- make the spacing between the replay info text consistent

Screenshot:
![image](https://user-images.githubusercontent.com/4757944/188020829-f8a4a672-e992-417a-88f4-fac80cf2f6f0.png)