### PR TITLE
Add a hook which tracks the Popover open state.

### DIFF
--- a/client/admin/map-pools.jsx
+++ b/client/admin/map-pools.jsx
@@ -1,6 +1,6 @@
 import { List, OrderedMap } from 'immutable'
 import PropTypes from 'prop-types'
-import React, { useCallback, useState } from 'react'
+import React, { useCallback } from 'react'
 import { connect } from 'react-redux'
 import styled from 'styled-components'
 import { MapVisibility } from '../../common/maps'
@@ -17,7 +17,7 @@ import { MapThumbnail } from '../maps/map-thumbnail'
 import { IconButton, RaisedButton, TextButton } from '../material/button'
 import { MenuItem } from '../material/menu/item'
 import { MenuList } from '../material/menu/menu'
-import { Popover, useAnchorPosition } from '../material/popover'
+import { Popover, useAnchorPosition, usePopoverController } from '../material/popover'
 import { TabItem, Tabs } from '../material/tabs'
 import { TextField } from '../material/text-field'
 import LoadingIndicator from '../progress/dots'
@@ -354,21 +354,15 @@ export class MapPoolEditor extends React.Component {
 }
 
 const MapPoolHistoryRow = React.memo(props => {
-  const [actionsOverlayOpen, setActionsOverlayOpen] = useState(false)
+  const [actionsOverlayOpen, openActionsOverlay, closeActionsOverlay] = usePopoverController()
   const [anchorRef, anchorX, anchorY] = useAnchorPosition('left', 'top')
-  const onActionsOverlayOpen = useCallback(() => {
-    setActionsOverlayOpen(true)
-  }, [])
-  const onActionsOverlayClose = useCallback(() => {
-    setActionsOverlayOpen(false)
-  }, [])
 
   const onMapActionClick = useCallback(
     handler => {
       handler()
-      onActionsOverlayClose()
+      closeActionsOverlay()
     },
-    [onActionsOverlayClose],
+    [closeActionsOverlay],
   )
 
   const { id, startDate, maps } = props.mapPool
@@ -398,11 +392,11 @@ const MapPoolHistoryRow = React.memo(props => {
           icon={<MapPoolActionsIcon />}
           title='Map pool actions'
           ref={anchorRef}
-          onClick={onActionsOverlayOpen}
+          onClick={openActionsOverlay}
         />
         <Popover
           open={actionsOverlayOpen}
-          onDismiss={onActionsOverlayClose}
+          onDismiss={closeActionsOverlay}
           anchorX={anchorX ?? 0}
           anchorY={anchorY ?? 0}
           originX='left'

--- a/client/lobbies/slot-actions.tsx
+++ b/client/lobbies/slot-actions.tsx
@@ -1,30 +1,24 @@
-import React, { useCallback, useMemo, useState } from 'react'
+import React, { useCallback, useMemo } from 'react'
 import SlotActionsIcon from '../icons/material/more_vert-24px.svg'
 import { IconButton } from '../material/button'
 import { MenuItem } from '../material/menu/item'
 import { MenuList } from '../material/menu/menu'
-import { Popover, useAnchorPosition } from '../material/popover'
+import { Popover, useAnchorPosition, usePopoverController } from '../material/popover'
 
 interface SlotActionsProps {
   slotActions: Array<[text: string, handler: () => void]>
 }
 
 export function SlotActions({ slotActions }: SlotActionsProps) {
-  const [overlayOpen, setOverlayOpen] = useState(false)
+  const [overlayOpen, openOverlay, closeOverlay] = usePopoverController()
   const [anchorRef, anchorX, anchorY] = useAnchorPosition('right', 'top')
 
-  const onOpenOverlay = useCallback(() => {
-    setOverlayOpen(true)
-  }, [])
-  const onCloseOverlay = useCallback(() => {
-    setOverlayOpen(false)
-  }, [])
   const onActionClick = useCallback(
     (handler: () => void) => {
       handler()
-      onCloseOverlay()
+      closeOverlay()
     },
-    [onCloseOverlay],
+    [closeOverlay],
   )
 
   const actions = useMemo(
@@ -41,11 +35,11 @@ export function SlotActions({ slotActions }: SlotActionsProps) {
         icon={<SlotActionsIcon />}
         title='Slot actions'
         ref={anchorRef}
-        onClick={onOpenOverlay}
+        onClick={openOverlay}
       />
       <Popover
         open={overlayOpen}
-        onDismiss={onCloseOverlay}
+        onDismiss={closeOverlay}
         anchorX={anchorX ?? 0}
         anchorY={anchorY ?? 0}
         originX='right'

--- a/client/maps/map-thumbnail.tsx
+++ b/client/maps/map-thumbnail.tsx
@@ -1,6 +1,6 @@
 import { Immutable } from 'immer'
 import { rgba } from 'polished'
-import React, { useCallback, useMemo, useState } from 'react'
+import React, { useCallback, useMemo } from 'react'
 import styled from 'styled-components'
 import { MapInfoJson } from '../../common/maps'
 import ImageIcon from '../icons/material/image-24px.svg'
@@ -11,7 +11,7 @@ import ZoomInIcon from '../icons/material/zoom_in-24px.svg'
 import { IconButton } from '../material/button'
 import { MenuItem } from '../material/menu/item'
 import { MenuList } from '../material/menu/menu'
-import { Popover, useAnchorPosition } from '../material/popover'
+import { Popover, useAnchorPosition, usePopoverController } from '../material/popover'
 import { amberA100, background700, background900, colorTextPrimary } from '../styles/colors'
 import { singleLine, subtitle2 } from '../styles/typography'
 import MapImage from './map-image'
@@ -196,21 +196,15 @@ export function MapThumbnail({
   onRemove,
   onRegenMapImage,
 }: MapThumbnailProps) {
-  const [menuOpen, setMenuOpen] = useState(false)
+  const [menuOpen, openMenu, closeMenu] = usePopoverController()
   const [anchorRef, anchorX, anchorY] = useAnchorPosition('right', 'top')
 
-  const onOpenMenu = useCallback(() => {
-    setMenuOpen(true)
-  }, [])
-  const onCloseMenu = useCallback(() => {
-    setMenuOpen(false)
-  }, [])
   const onActionClick = useCallback(
     (handler: () => void) => {
       handler()
-      onCloseMenu()
+      closeMenu()
     },
-    [onCloseMenu],
+    [closeMenu],
   )
 
   const actions = useMemo(() => {
@@ -267,11 +261,11 @@ export function MapThumbnail({
                 ref={anchorRef}
                 icon={<MapActionsIcon />}
                 title='Map actions'
-                onClick={onOpenMenu}
+                onClick={openMenu}
               />
               <Popover
                 open={menuOpen}
-                onDismiss={onCloseMenu}
+                onDismiss={closeMenu}
                 anchorX={anchorX ?? 0}
                 anchorY={anchorY ?? 0}
                 originX='right'

--- a/client/material/devonly/menu-test.tsx
+++ b/client/material/devonly/menu-test.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useState } from 'react'
+import React, { useCallback, useState } from 'react'
 import styled from 'styled-components'
 import { colorTextSecondary } from '../../styles/colors'
 import { subtitle1 } from '../../styles/typography'
@@ -8,7 +8,7 @@ import { Divider } from '../menu/divider'
 import { MenuItem } from '../menu/item'
 import { MenuList } from '../menu/menu'
 import { SelectableMenuItem } from '../menu/selectable-item'
-import { OriginX, OriginY, Popover, useAnchorPosition } from '../popover'
+import { Popover, useAnchorPosition, usePopoverController } from '../popover'
 
 const Container = styled.div`
   display: flex;
@@ -39,108 +39,136 @@ const Overline = styled.div`
 const makeArrayRange = (size: number) => Array.from(Array(size).keys())
 
 export function MenuTest() {
-  const [activeMenu, setActiveMenu] = useState<string>()
-  const [anchorElem, setAnchorElem] = useState<HTMLElement>()
-  const [selectedIndex, setSelectedIndex] = useState(2)
-  const [, anchorX, anchorY] = useAnchorPosition('center', 'top', anchorElem ?? null)
+  const [normalMenuOpen, openNormalMenu, closeNormalMenu] = usePopoverController()
+  const [scrollableMenuOpen, openScrollableMenu, closeScrollableMenu] = usePopoverController()
+  const [denseMenuOpen, openDenseMenu, closeDenseMenu] = usePopoverController()
+  const [scrollableDenseMenuOpen, openScrollableDenseMenu, closeScrollableDenseMenu] =
+    usePopoverController()
+  const [selectionMenuOpen, openSelectionMenu, closeSelectionMenu] = usePopoverController()
+  const [mixedMenuOpen, openMixedMenu, closeMixedMenu] = usePopoverController()
 
-  const onButtonClick = useCallback((event: React.MouseEvent) => {
-    setAnchorElem(event.currentTarget as any)
-  }, [])
-  const onDismiss = useCallback(() => {
-    setAnchorElem(undefined)
-    setActiveMenu(undefined)
-  }, [])
+  const [normalAnchor, normalAnchorX, normalAnchorY] = useAnchorPosition('center', 'top')
+  const [scrollableAnchor, scrollableAnchorX, scrollableAnchorY] = useAnchorPosition(
+    'center',
+    'top',
+  )
+  const [denseAnchor, denseAnchorX, denseAnchorY] = useAnchorPosition('center', 'top')
+  const [scrollableDenseAnchor, scrollableDenseAnchorX, scrollableDenseAnchorY] = useAnchorPosition(
+    'center',
+    'top',
+  )
+  const [selectionAnchor, selectionAnchorX, selectionAnchorY] = useAnchorPosition('center', 'top')
+  const [mixedAnchor, mixedAnchorX, mixedAnchorY] = useAnchorPosition('center', 'top')
+
+  const [selectedIndex, setSelectedIndex] = useState(2)
+
   const onSelected = useCallback(
     (index: number) => {
       setSelectedIndex(index)
-      onDismiss()
+      closeSelectionMenu()
+      closeMixedMenu()
     },
-    [onDismiss],
-  )
-
-  const makeClickHandler = (name: string) => {
-    return (event: React.MouseEvent) => {
-      onButtonClick(event)
-      setActiveMenu(name)
-    }
-  }
-
-  const popoverProps = useMemo(
-    () => ({
-      onDismiss,
-      originX: 'center' as OriginX,
-      originY: 'top' as OriginY,
-      anchorX: anchorX ?? 0,
-      anchorY: (anchorY ?? 0) + 36,
-    }),
-    [anchorX, anchorY, onDismiss],
+    [closeMixedMenu, closeSelectionMenu],
   )
 
   return (
     <Container>
       <StyledCard>
-        <RaisedButton label='Open menu' onClick={makeClickHandler('normal')} />
-        <RaisedButton label='Scrollable' onClick={makeClickHandler('scrollable')} />
-        <RaisedButton label='Dense' onClick={makeClickHandler('dense')} />
-        <RaisedButton label='Scrollable dense' onClick={makeClickHandler('scrollable-dense')} />
-        <RaisedButton label='Selection menu' onClick={makeClickHandler('selection-menu')} />
-        <RaisedButton label='Mixed' onClick={makeClickHandler('mixed')} />
+        <RaisedButton ref={normalAnchor} label='Open menu' onClick={openNormalMenu} />
+        <RaisedButton ref={scrollableAnchor} label='Scrollable' onClick={openScrollableMenu} />
+        <RaisedButton ref={denseAnchor} label='Dense' onClick={openDenseMenu} />
+        <RaisedButton
+          ref={scrollableDenseAnchor}
+          label='Scrollable dense'
+          onClick={openScrollableDenseMenu}
+        />
+        <RaisedButton ref={selectionAnchor} label='Selection menu' onClick={openSelectionMenu} />
+        <RaisedButton ref={mixedAnchor} label='Mixed' onClick={openMixedMenu} />
 
-        <Popover open={activeMenu === 'normal'} {...popoverProps}>
+        <Popover
+          open={normalMenuOpen}
+          onDismiss={closeNormalMenu}
+          originX='center'
+          originY='top'
+          anchorX={normalAnchorX ?? 0}
+          anchorY={(normalAnchorY ?? 0) + 36}>
           <MenuList>
-            <MenuItem text='Menu item 1' onClick={onDismiss} />
-            <MenuItem text='Menu item 2' onClick={onDismiss} />
-            <MenuItem text='Menu item 3' onClick={onDismiss} />
+            <MenuItem text='Menu item 1' onClick={closeNormalMenu} />
+            <MenuItem text='Menu item 2' onClick={closeNormalMenu} />
+            <MenuItem text='Menu item 3' onClick={closeNormalMenu} />
           </MenuList>
         </Popover>
 
-        <Popover open={activeMenu === 'scrollable'} {...popoverProps}>
+        <Popover
+          open={scrollableMenuOpen}
+          onDismiss={closeScrollableMenu}
+          originX='center'
+          originY='top'
+          anchorX={scrollableAnchorX ?? 0}
+          anchorY={(scrollableAnchorY ?? 0) + 36}>
           <StyledMenuList>
-            <MenuItem text='Menu item 1' onClick={onDismiss} />
-            <MenuItem text='Menu item 2' onClick={onDismiss} />
-            <MenuItem text='Menu item 3' onClick={onDismiss} />
-            <MenuItem text='Menu item 4' onClick={onDismiss} />
-            <MenuItem text='Menu item 5' onClick={onDismiss} />
-            <MenuItem text='Menu item 6' onClick={onDismiss} />
-            <MenuItem text='Menu item 7' onClick={onDismiss} />
-            <MenuItem text='Menu item 8' onClick={onDismiss} />
-            <MenuItem text='Menu item 9' onClick={onDismiss} />
-            <MenuItem text='Menu item 10' onClick={onDismiss} />
+            <MenuItem text='Menu item 1' onClick={closeScrollableMenu} />
+            <MenuItem text='Menu item 2' onClick={closeScrollableMenu} />
+            <MenuItem text='Menu item 3' onClick={closeScrollableMenu} />
+            <MenuItem text='Menu item 4' onClick={closeScrollableMenu} />
+            <MenuItem text='Menu item 5' onClick={closeScrollableMenu} />
+            <MenuItem text='Menu item 6' onClick={closeScrollableMenu} />
+            <MenuItem text='Menu item 7' onClick={closeScrollableMenu} />
+            <MenuItem text='Menu item 8' onClick={closeScrollableMenu} />
+            <MenuItem text='Menu item 9' onClick={closeScrollableMenu} />
+            <MenuItem text='Menu item 10' onClick={closeScrollableMenu} />
           </StyledMenuList>
         </Popover>
 
-        <Popover open={activeMenu === 'dense'} {...popoverProps}>
+        <Popover
+          open={denseMenuOpen}
+          onDismiss={closeDenseMenu}
+          originX='center'
+          originY='top'
+          anchorX={denseAnchorX ?? 0}
+          anchorY={(denseAnchorY ?? 0) + 36}>
           <MenuList dense={true}>
-            <MenuItem text='Menu item 1' onClick={onDismiss} />
-            <MenuItem text='Menu item 2' onClick={onDismiss} />
-            <MenuItem text='Menu item 3' onClick={onDismiss} />
-            <MenuItem text='Menu item 4' onClick={onDismiss} />
-            <MenuItem text='Menu item 5' onClick={onDismiss} />
+            <MenuItem text='Menu item 1' onClick={closeDenseMenu} />
+            <MenuItem text='Menu item 2' onClick={closeDenseMenu} />
+            <MenuItem text='Menu item 3' onClick={closeDenseMenu} />
+            <MenuItem text='Menu item 4' onClick={closeDenseMenu} />
+            <MenuItem text='Menu item 5' onClick={closeDenseMenu} />
           </MenuList>
         </Popover>
 
-        <Popover open={activeMenu === 'scrollable-dense'} {...popoverProps}>
+        <Popover
+          open={scrollableDenseMenuOpen}
+          onDismiss={closeScrollableDenseMenu}
+          originX='center'
+          originY='top'
+          anchorX={scrollableDenseAnchorX ?? 0}
+          anchorY={(scrollableDenseAnchorY ?? 0) + 36}>
           <StyledMenuList dense={true}>
-            <MenuItem text='Menu item 1' onClick={onDismiss} />
-            <MenuItem text='Menu item 2' onClick={onDismiss} />
-            <MenuItem text='Menu item 3' onClick={onDismiss} />
-            <MenuItem text='Menu item 4' onClick={onDismiss} />
-            <MenuItem text='Menu item 5' onClick={onDismiss} />
-            <MenuItem text='Menu item 6' onClick={onDismiss} />
-            <MenuItem text='Menu item 7' onClick={onDismiss} />
-            <MenuItem text='Menu item 8' onClick={onDismiss} />
-            <MenuItem text='Menu item 9' onClick={onDismiss} />
-            <MenuItem text='Menu item 10' onClick={onDismiss} />
-            <MenuItem text='Menu item 11' onClick={onDismiss} />
-            <MenuItem text='Menu item 12' onClick={onDismiss} />
-            <MenuItem text='Menu item 13' onClick={onDismiss} />
-            <MenuItem text='Menu item 14' onClick={onDismiss} />
-            <MenuItem text='Menu item 15' onClick={onDismiss} />
+            <MenuItem text='Menu item 1' onClick={closeScrollableDenseMenu} />
+            <MenuItem text='Menu item 2' onClick={closeScrollableDenseMenu} />
+            <MenuItem text='Menu item 3' onClick={closeScrollableDenseMenu} />
+            <MenuItem text='Menu item 4' onClick={closeScrollableDenseMenu} />
+            <MenuItem text='Menu item 5' onClick={closeScrollableDenseMenu} />
+            <MenuItem text='Menu item 6' onClick={closeScrollableDenseMenu} />
+            <MenuItem text='Menu item 7' onClick={closeScrollableDenseMenu} />
+            <MenuItem text='Menu item 8' onClick={closeScrollableDenseMenu} />
+            <MenuItem text='Menu item 9' onClick={closeScrollableDenseMenu} />
+            <MenuItem text='Menu item 10' onClick={closeScrollableDenseMenu} />
+            <MenuItem text='Menu item 11' onClick={closeScrollableDenseMenu} />
+            <MenuItem text='Menu item 12' onClick={closeScrollableDenseMenu} />
+            <MenuItem text='Menu item 13' onClick={closeScrollableDenseMenu} />
+            <MenuItem text='Menu item 14' onClick={closeScrollableDenseMenu} />
+            <MenuItem text='Menu item 15' onClick={closeScrollableDenseMenu} />
           </StyledMenuList>
         </Popover>
 
-        <Popover open={activeMenu === 'selection-menu'} {...popoverProps}>
+        <Popover
+          open={selectionMenuOpen}
+          onDismiss={closeSelectionMenu}
+          originX='center'
+          originY='top'
+          anchorX={selectionAnchorX ?? 0}
+          anchorY={(selectionAnchorY ?? 0) + 36}>
           <MenuList dense={true}>
             {makeArrayRange(5).map(i => (
               <SelectableMenuItem
@@ -153,7 +181,13 @@ export function MenuTest() {
           </MenuList>
         </Popover>
 
-        <Popover open={activeMenu === 'mixed'} {...popoverProps}>
+        <Popover
+          open={mixedMenuOpen}
+          onDismiss={closeMixedMenu}
+          originX='center'
+          originY='top'
+          anchorX={mixedAnchorX ?? 0}
+          anchorY={(mixedAnchorY ?? 0) + 36}>
           <StyledMenuList dense={true}>
             <Overline>Subheading</Overline>
             {makeArrayRange(3).map(i => (
@@ -165,8 +199,8 @@ export function MenuTest() {
               />
             ))}
             <Divider />
-            <MenuItem text='Menu item 4' onClick={onDismiss} />
-            <MenuItem text='Menu item 5' onClick={onDismiss} />
+            <MenuItem text='Menu item 4' onClick={closeMixedMenu} />
+            <MenuItem text='Menu item 5' onClick={closeMixedMenu} />
           </StyledMenuList>
         </Popover>
       </StyledCard>

--- a/client/material/devonly/popover-test.tsx
+++ b/client/material/devonly/popover-test.tsx
@@ -1,7 +1,13 @@
-import React, { useCallback, useState } from 'react'
+import React, { useState } from 'react'
 import styled from 'styled-components'
 import VertMenuIcon from '../../icons/material/more_vert-24px.svg'
-import { OriginX, OriginY, Popover, useAnchorPosition } from '../../material/popover'
+import {
+  OriginX,
+  OriginY,
+  Popover,
+  useAnchorPosition,
+  usePopoverController,
+} from '../../material/popover'
 import { Headline4, Headline5, Subtitle1 } from '../../styles/typography'
 import { IconButton } from '../button'
 import { SelectOption } from '../select/option'
@@ -68,22 +74,97 @@ export default function PopoverTest() {
   const [popoverOriginX, setPopoverOriginX] = useState<OriginX>('left')
   const [popoverOriginY, setPopoverOriginY] = useState<OriginY>('top')
 
-  const [anchorElem, setAnchorElem] = useState<HTMLElement>()
-  const onButtonClick = useCallback((event: React.MouseEvent) => {
-    setAnchorElem(event.currentTarget as HTMLElement)
-  }, [])
-  const onDismiss = useCallback(() => {
-    setAnchorElem(undefined)
-  }, [])
-  const [, anchorX, anchorY] = useAnchorPosition(anchorOriginX, anchorOriginY, anchorElem ?? null)
+  const [topLeftOpen, openTopLeft, closeTopLeft] = usePopoverController()
+  const [topRightOpen, openTopRight, closeTopRight] = usePopoverController()
+  const [bottomLeftOpen, openBottomLeft, closeBottomLeft] = usePopoverController()
+  const [bottomRightOpen, openBottomRight, closeBottomRight] = usePopoverController()
+
+  const [topLeftAnchor, topLeftAnchorX, topLeftAnchorY] = useAnchorPosition(
+    anchorOriginX,
+    anchorOriginY,
+  )
+  const [topRightAnchor, topRightAnchorX, topRightAnchorY] = useAnchorPosition(
+    anchorOriginX,
+    anchorOriginY,
+  )
+  const [bottomLeftAnchor, bottomLeftAnchorX, bottomLeftAnchorY] = useAnchorPosition(
+    anchorOriginX,
+    anchorOriginY,
+  )
+  const [bottomRightAnchor, bottomRightAnchorX, bottomRightAnchorY] = useAnchorPosition(
+    anchorOriginX,
+    anchorOriginY,
+  )
+
+  const popoverContents = (
+    <PopoverScrollable>
+      <PopoverContents>
+        <Headline4>Hello</Headline4>
+        <Headline5>World</Headline5>
+        <Subtitle1>How are you?</Subtitle1>
+
+        <Headline4>Hello</Headline4>
+        <Headline5>World</Headline5>
+        <Subtitle1>How are you?</Subtitle1>
+
+        <Headline4>Hello</Headline4>
+        <Headline5>World</Headline5>
+        <Subtitle1>How are you?</Subtitle1>
+
+        <Headline4>Hello</Headline4>
+        <Headline5>World</Headline5>
+        <Subtitle1>How are you?</Subtitle1>
+
+        <Headline4>Hello</Headline4>
+        <Headline5>World</Headline5>
+        <Subtitle1>How are you?</Subtitle1>
+
+        <Headline4>Hello</Headline4>
+        <Headline5>World</Headline5>
+        <Subtitle1>How are you?</Subtitle1>
+
+        <Headline4>Hello</Headline4>
+        <Headline5>World</Headline5>
+        <Subtitle1>How are you?</Subtitle1>
+
+        <Headline4>Hello</Headline4>
+        <Headline5>World</Headline5>
+        <Subtitle1>How are you?</Subtitle1>
+
+        <Headline4>Hello</Headline4>
+        <Headline5>World</Headline5>
+        <Subtitle1>How are you?</Subtitle1>
+
+        <Headline4>Hello</Headline4>
+        <Headline5>World</Headline5>
+        <Subtitle1>How are you?</Subtitle1>
+
+        <Headline4>Hello</Headline4>
+        <Headline5>World</Headline5>
+        <Subtitle1>How are you?</Subtitle1>
+
+        <Headline4>Hello</Headline4>
+        <Headline5>World</Headline5>
+        <Subtitle1>How are you?</Subtitle1>
+
+        <Headline4>Hello</Headline4>
+        <Headline5>World</Headline5>
+        <Subtitle1>How are you?</Subtitle1>
+      </PopoverContents>
+    </PopoverScrollable>
+  )
 
   return (
     <Container>
       <Content>
-        <TopLeftButton icon={<VertMenuIcon />} onClick={onButtonClick} />
-        <TopRightButton icon={<VertMenuIcon />} onClick={onButtonClick} />
-        <BottomLeftButton icon={<VertMenuIcon />} onClick={onButtonClick} />
-        <BottomRightButton icon={<VertMenuIcon />} onClick={onButtonClick} />
+        <TopLeftButton ref={topLeftAnchor} icon={<VertMenuIcon />} onClick={openTopLeft} />
+        <TopRightButton ref={topRightAnchor} icon={<VertMenuIcon />} onClick={openTopRight} />
+        <BottomLeftButton ref={bottomLeftAnchor} icon={<VertMenuIcon />} onClick={openBottomLeft} />
+        <BottomRightButton
+          ref={bottomRightAnchor}
+          icon={<VertMenuIcon />}
+          onClick={openBottomRight}
+        />
 
         <OptionsContainer>
           <Select value={anchorOriginX} label='Anchor origin X' onChange={setAnchorOriginX}>
@@ -109,67 +190,43 @@ export default function PopoverTest() {
         </OptionsContainer>
 
         <Popover
-          open={!!anchorElem}
-          onDismiss={onDismiss}
+          open={topLeftOpen}
+          onDismiss={closeTopLeft}
           originX={popoverOriginX}
           originY={popoverOriginY}
-          anchorX={anchorX ?? 0}
-          anchorY={anchorY ?? 0}>
-          <PopoverScrollable>
-            <PopoverContents>
-              <Headline4>Hello</Headline4>
-              <Headline5>World</Headline5>
-              <Subtitle1>How are you?</Subtitle1>
+          anchorX={topLeftAnchorX ?? 0}
+          anchorY={topLeftAnchorY ?? 0}>
+          {popoverContents}
+        </Popover>
 
-              <Headline4>Hello</Headline4>
-              <Headline5>World</Headline5>
-              <Subtitle1>How are you?</Subtitle1>
+        <Popover
+          open={topRightOpen}
+          onDismiss={closeTopRight}
+          originX={popoverOriginX}
+          originY={popoverOriginY}
+          anchorX={topRightAnchorX ?? 0}
+          anchorY={topRightAnchorY ?? 0}>
+          {popoverContents}
+        </Popover>
 
-              <Headline4>Hello</Headline4>
-              <Headline5>World</Headline5>
-              <Subtitle1>How are you?</Subtitle1>
+        <Popover
+          open={bottomLeftOpen}
+          onDismiss={closeBottomLeft}
+          originX={popoverOriginX}
+          originY={popoverOriginY}
+          anchorX={bottomLeftAnchorX ?? 0}
+          anchorY={bottomLeftAnchorY ?? 0}>
+          {popoverContents}
+        </Popover>
 
-              <Headline4>Hello</Headline4>
-              <Headline5>World</Headline5>
-              <Subtitle1>How are you?</Subtitle1>
-
-              <Headline4>Hello</Headline4>
-              <Headline5>World</Headline5>
-              <Subtitle1>How are you?</Subtitle1>
-
-              <Headline4>Hello</Headline4>
-              <Headline5>World</Headline5>
-              <Subtitle1>How are you?</Subtitle1>
-
-              <Headline4>Hello</Headline4>
-              <Headline5>World</Headline5>
-              <Subtitle1>How are you?</Subtitle1>
-
-              <Headline4>Hello</Headline4>
-              <Headline5>World</Headline5>
-              <Subtitle1>How are you?</Subtitle1>
-
-              <Headline4>Hello</Headline4>
-              <Headline5>World</Headline5>
-              <Subtitle1>How are you?</Subtitle1>
-
-              <Headline4>Hello</Headline4>
-              <Headline5>World</Headline5>
-              <Subtitle1>How are you?</Subtitle1>
-
-              <Headline4>Hello</Headline4>
-              <Headline5>World</Headline5>
-              <Subtitle1>How are you?</Subtitle1>
-
-              <Headline4>Hello</Headline4>
-              <Headline5>World</Headline5>
-              <Subtitle1>How are you?</Subtitle1>
-
-              <Headline4>Hello</Headline4>
-              <Headline5>World</Headline5>
-              <Subtitle1>How are you?</Subtitle1>
-            </PopoverContents>
-          </PopoverScrollable>
+        <Popover
+          open={bottomRightOpen}
+          onDismiss={closeBottomRight}
+          originX={popoverOriginX}
+          originY={popoverOriginY}
+          anchorX={bottomRightAnchorX ?? 0}
+          anchorY={bottomRightAnchorY ?? 0}>
+          {popoverContents}
         </Popover>
       </Content>
     </Container>

--- a/client/material/popover.tsx
+++ b/client/material/popover.tsx
@@ -23,16 +23,21 @@ type PopoverOpenState = Opaque<boolean, 'PopoverOpenState'>
 const OPENING_EVENTS = new WeakSet<Event>()
 
 /**
- * A hook that keeps track of Popover's open state and makes sure that only one Popover is open for
- * the same target.
+ * A hook that returns controller methods for opening and closing a popover, as well as its current
+ * state.
  *
- * You *should* use this hook if you want to use Popovers.
+ * This hook ensures that only one popover will be triggered to open for any individual input event.
  */
-export function usePopoverController(
-  initialIsOpen = false,
-): [
+export function usePopoverController(initialIsOpen = false): [
+  /** A value indicating whether the popover is open or not. */
   open: PopoverOpenState,
-  openPopover: (triggerringEvent: Event | React.SyntheticEvent) => boolean,
+  /**
+   * A method to use to open a popover. Requires the triggering event to be sent as a parameter
+   * which will be used to check whether to open the popover or not. Returns `true` if the popover
+   * was opened now, or `false` if the popover was already opened for this event.
+   */
+  openPopover: (triggeringEvent: Event | React.SyntheticEvent) => boolean,
+  /** A method to use to close a popover. */
   closePopover: () => void,
 ] {
   const [open, setOpen] = useState(initialIsOpen)

--- a/client/material/popover.tsx
+++ b/client/material/popover.tsx
@@ -18,9 +18,9 @@ import { zIndexMenu } from './zindex'
 
 const ESCAPE = 'Escape'
 
-export type PopoverOpenState = Opaque<boolean, 'PopoverOpenState'>
+type PopoverOpenState = Opaque<boolean, 'PopoverOpenState'>
 
-const OPENING_EVENTS = new WeakSet()
+const OPENING_EVENTS = new WeakSet<Event>()
 
 /**
  * A hook that keeps track of Popover's open state and makes sure that only one Popover is open for
@@ -36,20 +36,21 @@ export function usePopoverController(
   closePopover: () => void,
 ] {
   const [open, setOpen] = useState(initialIsOpen)
-  return [
-    open as PopoverOpenState,
-    (triggeringEvent: Event | React.SyntheticEvent) => {
-      if (!OPENING_EVENTS.has(triggeringEvent)) {
-        OPENING_EVENTS.add(triggeringEvent)
-        setOpen(true)
-        return true
-      }
-      return false
-    },
-    () => {
-      setOpen(false)
-    },
-  ]
+
+  const openPopover = useCallback((triggeringEvent: Event | React.SyntheticEvent) => {
+    const event = (triggeringEvent as React.SyntheticEvent).nativeEvent ?? triggeringEvent
+    if (!OPENING_EVENTS.has(event)) {
+      OPENING_EVENTS.add(event)
+      setOpen(true)
+      return true
+    }
+    return false
+  }, [])
+  const closePopover = useCallback(() => {
+    setOpen(false)
+  }, [])
+
+  return [open as PopoverOpenState, openPopover, closePopover]
 }
 
 const PositioningArea = styled.div`

--- a/client/material/select/select.tsx
+++ b/client/material/select/select.tsx
@@ -13,7 +13,7 @@ import { FloatingLabel } from '../input-floating-label'
 import { InputUnderline } from '../input-underline'
 import { MenuList } from '../menu/menu'
 import { isSelectableMenuItem } from '../menu/menu-item-symbol'
-import { Popover, useAnchorPosition } from '../popover'
+import { Popover, useAnchorPosition, usePopoverController } from '../popover'
 import { defaultSpring } from '../springs'
 
 const SPACE = 'Space'
@@ -186,8 +186,9 @@ export const Select = React.forwardRef<SelectRef, SelectProps>(
     const hookId = useId()
     const id = propsId ?? hookId
     const [focused, setFocused] = useState(false)
-    const [opened, setOpened] = useState(false)
     const inputRef = useRef<HTMLButtonElement>()
+
+    const [opened, openSelect, closeSelect] = usePopoverController()
     const [anchorRef, anchorX, anchorY] = useAnchorPosition('center', 'bottom')
 
     useImperativeHandle(forwardedRef, () => ({
@@ -203,15 +204,18 @@ export const Select = React.forwardRef<SelectRef, SelectProps>(
     const focusedRef = useValueAsRef(focused)
     const openedRef = useValueAsRef(opened)
 
-    const onOpen = useCallback(() => {
-      if (!disabled) {
-        setOpened(true)
-      }
-    }, [disabled])
+    const onOpen = useCallback(
+      (event: React.MouseEvent) => {
+        if (!disabled) {
+          openSelect(event)
+        }
+      },
+      [disabled, openSelect],
+    )
     const onClose = useCallback(() => {
-      setOpened(false)
+      closeSelect()
       inputRef.current?.focus()
-    }, [])
+    }, [closeSelect])
     const onFocus = useCallback(() => {
       if (!disabled) {
         setFocused(true)
@@ -239,7 +243,7 @@ export const Select = React.forwardRef<SelectRef, SelectProps>(
 
         if (!openedRef.current) {
           if (event.code === SPACE || event.code === ENTER || event.code === ENTER_NUMPAD) {
-            onOpen()
+            openSelect(event)
             return true
           }
         }

--- a/client/navigation/connected-left-nav.tsx
+++ b/client/navigation/connected-left-nav.tsx
@@ -1,5 +1,5 @@
 import keycode from 'keycode'
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useRef } from 'react'
 import { UseTransitionProps } from 'react-spring'
 import styled from 'styled-components'
 import { useLocation } from 'wouter'
@@ -39,14 +39,13 @@ import { SubheaderButton } from '../material/left-nav/subheader-button'
 import { Divider as MenuDivider } from '../material/menu/divider'
 import { MenuItem } from '../material/menu/item'
 import { MenuList } from '../material/menu/menu'
-import { Popover, useAnchorPosition } from '../material/popover'
+import { Popover, useAnchorPosition, usePopoverController } from '../material/popover'
 import { defaultSpring } from '../material/springs'
 import { Tooltip } from '../material/tooltip'
 import { leaveParty } from '../parties/action-creators'
 import { PartyNavEntry } from '../parties/party-nav-entry'
 import { useAppDispatch, useAppSelector } from '../redux-hooks'
 import { openSnackbar, TIMING_LONG } from '../snackbars/action-creators'
-import { useValueAsRef } from '../state-hooks'
 import { colorTextSecondary } from '../styles/colors'
 import { overline, singleLine } from '../styles/typography'
 import { getBatchUserInfo, navigateToUserProfile } from '../users/action-creators'
@@ -109,20 +108,9 @@ const MENU_TRANSITION: UseTransitionProps<boolean> = {
 }
 
 function LockupAndMenu() {
-  const [appMenuAnchor, setAppMenuAnchor] = useState<HTMLElement>()
-  const appMenuAnchorRef = useValueAsRef(appMenuAnchor)
-  const [, anchorX, anchorY] = useAnchorPosition('center', 'bottom', appMenuAnchor ?? null)
-  const onLockupClick = useCallback(
-    (event: React.MouseEvent) => {
-      if (!appMenuAnchorRef.current) {
-        setAppMenuAnchor(event.currentTarget as HTMLElement)
-      }
-    },
-    [appMenuAnchorRef],
-  )
-  const onAppMenuDismiss = useCallback(() => {
-    setAppMenuAnchor(undefined)
-  }, [])
+  const [appMenuOpen, openAppMenu, closeAppMenu] = usePopoverController()
+  const [appMenuAnchor, anchorX, anchorY] = useAnchorPosition('center', 'bottom')
+
   const appMenuItems = useMemo(
     () =>
       APP_MENU_LINKS.map(([text, icon, url], i) => {
@@ -134,7 +122,7 @@ function LockupAndMenu() {
               icon={icon}
               onClick={() => {
                 window.open(url as string, '_blank')
-                setAppMenuAnchor(undefined)
+                closeAppMenu()
               }}
             />
           )
@@ -144,15 +132,15 @@ function LockupAndMenu() {
           return <MenuDivider key={i} />
         }
       }),
-    [],
+    [closeAppMenu],
   )
 
   return (
     <LockupContainer>
-      <Lockup onClick={onLockupClick} menuOpened={!!appMenuAnchor} />
+      <Lockup ref={appMenuAnchor} onClick={openAppMenu} menuOpened={appMenuOpen} />
       <Popover
-        open={!!appMenuAnchor}
-        onDismiss={onAppMenuDismiss}
+        open={appMenuOpen}
+        onDismiss={closeAppMenu}
         anchorX={(anchorX ?? 0) - 8}
         anchorY={(anchorY ?? 0) + 8}
         originX='center'
@@ -406,7 +394,7 @@ export function ConnectedLeftNav() {
   const chatChannels = useAppSelector(s => s.chat.joinedChannels)
   const whisperSessions = useAppSelector(s => s.whispers.sessions)
 
-  const [profileOverlayOpen, setProfileOverlayOpen] = useState(false)
+  const [profileOverlayOpen, openProfileOverlay, closeProfileOverlay] = usePopoverController()
   const profileEntryRef = useRef<HTMLButtonElement>(null)
   const joinChannelButtonRef = useRef<HTMLButtonElement>(null)
   const startWhisperButtonRef = useRef<HTMLButtonElement>(null)
@@ -414,28 +402,22 @@ export function ConnectedLeftNav() {
   useButtonHotkey({ ref: joinChannelButtonRef, hotkey: ALT_H })
   useButtonHotkey({ ref: startWhisperButtonRef, hotkey: ALT_W })
 
-  const onProfileEntryClick = useCallback(() => {
-    setProfileOverlayOpen(true)
-  }, [])
-  const onProfileOverlayClose = useCallback(() => {
-    setProfileOverlayOpen(false)
-  }, [])
   const onLogOutClick = useCallback(() => {
-    onProfileOverlayClose()
+    closeProfileOverlay()
     dispatch(logOut().action)
-  }, [dispatch, onProfileOverlayClose])
+  }, [closeProfileOverlay, dispatch])
   const onChangelogClick = useCallback(() => {
-    onProfileOverlayClose()
+    closeProfileOverlay()
     dispatch(openChangelog())
-  }, [dispatch, onProfileOverlayClose])
+  }, [closeProfileOverlay, dispatch])
   const onEditAccountClick = useCallback(() => {
-    onProfileOverlayClose()
+    closeProfileOverlay()
     dispatch(openDialog({ type: DialogType.Account }))
-  }, [dispatch, onProfileOverlayClose])
+  }, [closeProfileOverlay, dispatch])
   const onViewProfileClick = useCallback(() => {
-    onProfileOverlayClose()
+    closeProfileOverlay()
     navigateToUserProfile(selfUser.id, selfUser.name)
-  }, [onProfileOverlayClose, selfUser.id, selfUser.name])
+  }, [closeProfileOverlay, selfUser.id, selfUser.name])
 
   const footer = (
     <>
@@ -443,7 +425,7 @@ export function ConnectedLeftNav() {
         key='profileEntry'
         ref={profileEntryRef}
         user={selfUser.name}
-        onProfileEntryClick={onProfileEntryClick}
+        onProfileEntryClick={openProfileOverlay}
         profileMenuOpen={profileOverlayOpen}
       />
     </>
@@ -514,7 +496,7 @@ export function ConnectedLeftNav() {
 
       <SelfProfileOverlay
         open={profileOverlayOpen}
-        onDismiss={onProfileOverlayClose}
+        onDismiss={closeProfileOverlay}
         anchor={profileEntryRef.current}
         username={selfUser.name}>
         <MenuItem icon={<PortraitIcon />} text='View profile' onClick={onViewProfileClick} />

--- a/client/navigation/connected-left-nav.tsx
+++ b/client/navigation/connected-left-nav.tsx
@@ -495,8 +495,10 @@ export function ConnectedLeftNav() {
       </Section>
 
       <SelfProfileOverlay
-        open={profileOverlayOpen}
-        onDismiss={closeProfileOverlay}
+        popoverProps={{
+          open: profileOverlayOpen,
+          onDismiss: closeProfileOverlay,
+        }}
         anchor={profileEntryRef.current}
         username={selfUser.name}>
         <MenuItem icon={<PortraitIcon />} text='View profile' onClick={onViewProfileClick} />

--- a/client/navigation/lockup.tsx
+++ b/client/navigation/lockup.tsx
@@ -46,15 +46,19 @@ export interface LockupProps {
   menuOpened?: boolean
 }
 
-export default function Lockup({ onClick, menuOpened }: LockupProps) {
-  const [buttonProps, rippleRef] = useButtonState({ onClick })
+export const Lockup = React.forwardRef(
+  ({ onClick, menuOpened }: LockupProps, ref: React.ForwardedRef<HTMLButtonElement>) => {
+    const [buttonProps, rippleRef] = useButtonState({ onClick })
 
-  return (
-    <Container aria-label='ShieldBattery' {...buttonProps}>
-      <SizedLogo />
-      <SizedLogoText />
-      <AnimatedExpandIcon $pointUp={!!menuOpened} />
-      <Ripple ref={rippleRef} />
-    </Container>
-  )
-}
+    return (
+      <Container ref={ref} aria-label='ShieldBattery' {...buttonProps}>
+        <SizedLogo />
+        <SizedLogoText />
+        <AnimatedExpandIcon $pointUp={!!menuOpened} />
+        <Ripple ref={rippleRef} />
+      </Container>
+    )
+  },
+)
+
+export default Lockup

--- a/client/notifications/activity-bar-entry.tsx
+++ b/client/notifications/activity-bar-entry.tsx
@@ -1,9 +1,9 @@
 import keycode from 'keycode'
-import React, { useCallback, useMemo, useRef, useState } from 'react'
+import React, { useCallback, useMemo, useRef } from 'react'
 import styled from 'styled-components'
 import NotificationsIcon from '../icons/material/notifications-24px.svg'
 import { HotkeyProp, IconButton, useButtonHotkey } from '../material/button'
-import { Popover, useAnchorPosition } from '../material/popover'
+import { Popover, useAnchorPosition, usePopoverController } from '../material/popover'
 import { Tooltip } from '../material/tooltip'
 import { useAppDispatch, useAppSelector } from '../redux-hooks'
 import { amberA200 } from '../styles/colors'
@@ -66,23 +66,21 @@ export function NotificationsButton() {
 
   const hasUnread = localUnreadNotifications.length + serverUnreadNotifications.length > 0
 
-  const [anchor, setAnchor] = useState<HTMLElement>()
-  const onClick = useCallback((event: React.MouseEvent) => {
-    setAnchor(event.currentTarget as HTMLElement)
-  }, [])
+  const [activityBarOpen, openActivityBar, closeActivityBar] = usePopoverController()
   const onDismiss = useCallback(() => {
-    setAnchor(undefined)
+    closeActivityBar()
     if (localUnreadNotifications.length) {
       dispatch(markLocalNotificationsRead(localUnreadNotifications))
     }
     if (serverUnreadNotifications.length) {
       dispatch(markNotificationsRead(serverUnreadNotifications))
     }
-  }, [localUnreadNotifications, serverUnreadNotifications, dispatch])
-  const [, anchorX, anchorY] = useAnchorPosition('right', 'bottom', anchor ?? null)
+  }, [closeActivityBar, localUnreadNotifications, serverUnreadNotifications, dispatch])
 
   const buttonRef = useRef<HTMLButtonElement>(null)
   useButtonHotkey({ ref: buttonRef, hotkey: ALT_N })
+
+  const [, anchorX, anchorY] = useAnchorPosition('right', 'bottom', buttonRef.current)
 
   return (
     <>
@@ -93,14 +91,14 @@ export function NotificationsButton() {
           <IconButton
             ref={buttonRef}
             icon={<NotificationsIcon />}
-            onClick={onClick}
+            onClick={openActivityBar}
             testName='notifications-button'
           />
         </Tooltip>
         {hasUnread ? <UnreadIndicator /> : null}
       </ButtonContainer>
       <Popover
-        open={!!anchor}
+        open={activityBarOpen}
         onDismiss={onDismiss}
         anchorX={(anchorX ?? 0) - 8}
         anchorY={(anchorY ?? 0) - 8}

--- a/client/users/friends-list.tsx
+++ b/client/users/friends-list.tsx
@@ -1,5 +1,5 @@
 import keycode from 'keycode'
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useRef } from 'react'
 import { Virtuoso } from 'react-virtuoso'
 import styled, { css } from 'styled-components'
 import { appendToMultimap } from '../../common/data-structures/maps'
@@ -15,7 +15,7 @@ import FriendAddIcon from '../icons/material/group_add-24px.svg'
 import FriendSettingsIcon from '../icons/material/manage_accounts-24px.svg'
 import { JsonLocalStorageValue } from '../local-storage'
 import { HotkeyProp, IconButton, useButtonHotkey } from '../material/button'
-import { Popover, useAnchorPosition } from '../material/popover'
+import { Popover, useAnchorPosition, usePopoverController } from '../material/popover'
 import { ScrollDivider, useScrollIndicatorState } from '../material/scroll-indicator'
 import { TabItem, Tabs } from '../material/tabs'
 import { Tooltip } from '../material/tooltip'
@@ -101,17 +101,12 @@ function useRelationshipsLoader() {
 
 export function FriendsListActivityButton() {
   useRelationshipsLoader()
-  const [anchor, setAnchor] = useState<HTMLElement>()
-  const onClick = useStableCallback((event: React.MouseEvent) => {
-    setAnchor(event.currentTarget as HTMLElement)
-  })
-  const onDismiss = useStableCallback(() => {
-    setAnchor(undefined)
-  })
-  const [, anchorX, anchorY] = useAnchorPosition('right', 'bottom', anchor ?? null)
+  const [friendsListOpen, openFriendsList, closeFriendsList] = usePopoverController()
 
   const buttonRef = useRef<HTMLButtonElement>(null)
   useButtonHotkey({ ref: buttonRef, hotkey: ALT_E })
+
+  const [, anchorX, anchorY] = useAnchorPosition('right', 'bottom', buttonRef.current)
 
   const friendActivityStatus = useAppSelector(s => s.relationships.friendActivityStatus)
   const friendCount = useMemo(() => {
@@ -126,19 +121,19 @@ export function FriendsListActivityButton() {
         <IconButton
           ref={buttonRef}
           icon={<NumberedFriendsIcon count={friendCount} />}
-          onClick={onClick}
+          onClick={openFriendsList}
           testName={'friends-list-button'}
         />
       </Tooltip>
       <Popover
-        open={!!anchor}
-        onDismiss={onDismiss}
+        open={friendsListOpen}
+        onDismiss={closeFriendsList}
         anchorX={(anchorX ?? 0) - 8}
         anchorY={(anchorY ?? 0) - 8}
         originX='right'
         originY='bottom'>
         <PopoverContents>
-          <FriendsPopover onDismiss={onDismiss} />
+          <FriendsPopover onDismiss={closeFriendsList} />
         </PopoverContents>
       </Popover>
     </>

--- a/client/users/nav-entry.tsx
+++ b/client/users/nav-entry.tsx
@@ -60,7 +60,7 @@ const User = styled.div`
 
 export interface ProfileNavEntryProps {
   user: string
-  onProfileEntryClick: () => void
+  onProfileEntryClick: (event: React.MouseEvent) => void
   profileMenuOpen: boolean
 }
 

--- a/client/users/self-profile-overlay.tsx
+++ b/client/users/self-profile-overlay.tsx
@@ -40,7 +40,7 @@ const Actions = styled.div`
 interface SelfProfileOverlayProps {
   username: string
   anchor: HTMLElement | null
-  popoverProps: Pick<PopoverProps, 'open' | 'onDismiss'>
+  popoverProps: Omit<PopoverProps, 'children' | 'anchorX' | 'anchorY' | 'originX' | 'originY'>
   children: React.ReactNode
 }
 

--- a/client/users/self-profile-overlay.tsx
+++ b/client/users/self-profile-overlay.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { UseTransitionProps } from 'react-spring'
 import styled from 'styled-components'
 import { Avatar } from '../avatars/avatar'
-import { Popover, useAnchorPosition } from '../material/popover'
+import { Popover, PopoverOpenState, useAnchorPosition } from '../material/popover'
 import { defaultSpring } from '../material/springs'
 import { body1, headline6, singleLine } from '../styles/typography'
 
@@ -38,7 +38,7 @@ const Actions = styled.div`
 `
 
 interface SelfProfileOverlayProps {
-  open: boolean
+  open: PopoverOpenState
   username: string
   anchor: HTMLElement | null
   children: React.ReactNode

--- a/client/users/self-profile-overlay.tsx
+++ b/client/users/self-profile-overlay.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { UseTransitionProps } from 'react-spring'
 import styled from 'styled-components'
 import { Avatar } from '../avatars/avatar'
-import { Popover, PopoverOpenState, useAnchorPosition } from '../material/popover'
+import { Popover, PopoverProps, useAnchorPosition } from '../material/popover'
 import { defaultSpring } from '../material/springs'
 import { body1, headline6, singleLine } from '../styles/typography'
 
@@ -38,11 +38,10 @@ const Actions = styled.div`
 `
 
 interface SelfProfileOverlayProps {
-  open: PopoverOpenState
   username: string
   anchor: HTMLElement | null
+  popoverProps: Pick<PopoverProps, 'open' | 'onDismiss'>
   children: React.ReactNode
-  onDismiss: () => void
 }
 
 const VERTICAL_TRANSITION: UseTransitionProps<boolean> = {
@@ -54,13 +53,12 @@ const VERTICAL_TRANSITION: UseTransitionProps<boolean> = {
 }
 
 export function SelfProfileOverlay(props: SelfProfileOverlayProps) {
-  const { username, children, open, onDismiss, anchor } = props
+  const { username, anchor, popoverProps, children } = props
   const [, anchorX, anchorY] = useAnchorPosition('center', 'top', anchor ?? null)
 
   return (
     <Popover
-      open={open}
-      onDismiss={onDismiss}
+      {...popoverProps}
       anchorX={anchorX ?? 0}
       anchorY={(anchorY ?? 0) - 8}
       originX='center'


### PR DESCRIPTION
And use it in all Popover usages.

This hook makes sure that there's only one Popover opened for the same source event.

Also, inadvertently fixes #771 and other places where we used the same open/onDismiss state for different Popovers.