### PR TITLE
Use an explicit column order in INSERT INTO statements.

### DIFF
--- a/server/lib/chat/chat-models.ts
+++ b/server/lib/chat/chat-models.ts
@@ -493,7 +493,9 @@ export async function banAllIdentifiersFromChannel(
 
   try {
     const query = sql`
-      INSERT INTO channel_identifier_bans
+      INSERT INTO channel_identifier_bans (
+        channel_id, identifier_type, identifier_hash, time_banned, first_user_id
+      )
       SELECT
         ${channelId} AS "channel_id",
         identifier_type,

--- a/server/lib/users/user-identifiers.ts
+++ b/server/lib/users/user-identifiers.ts
@@ -222,7 +222,9 @@ export async function banAllIdentifiers(
 
   try {
     const query = sql`
-      INSERT INTO user_identifier_bans AS uib
+      INSERT INTO user_identifier_bans AS uib (
+        identifier_type, identifier_hash, time_banned, banned_until, first_user_id
+      )
       SELECT
         identifier_type,
         identifier_hash,


### PR DESCRIPTION
I've checked all of our usage of INSERT INTO statements, and these were the only two places that used an implicit column order. Which just seemed like a bug waiting to happen.

And in fact it did happen in chat banning case.

Fixes #894 