### PR TITLE
Fix a bug in infinite-scroll-list which would sometimes not load chat

### DIFF
--- a/client/lists/infinite-scroll-list.tsx
+++ b/client/lists/infinite-scroll-list.tsx
@@ -72,7 +72,7 @@ interface InfiniteListProps {
  *      same row for example), it won't be possible to load more items from that point on.
  */
 export default function InfiniteList(props: InfiniteListProps) {
-  const { root, rootMargin, threshold, refreshToken } = props
+  const { root, rootMargin, threshold, refreshToken, hasPrevData, hasNextData } = props
   const prevLoadingEnabledRef = useValueAsRef(props.prevLoadingEnabled)
   const nextLoadingEnabledRef = useValueAsRef(props.nextLoadingEnabled)
   const isLoadingPrevRef = useValueAsRef(props.isLoadingPrev)
@@ -147,10 +147,15 @@ export default function InfiniteList(props: InfiniteListProps) {
     }
   }, [root, rootMargin, threshold, onIntersection, startObserving])
 
+  // NOTE(2Pac): We restart the observer in a couple of cases:
+  //   - `hasPrevData`/`hasNextData` has changed; this allows InfiniteScrollList to be rendered
+  //     without more data being available initially, and then it starts observing if that changes.
+  //   - `refreshToken` has changed; this means the user of this component forcefully wants to
+  //     restart observing for whatever reason.
   useEffect(() => {
     observer.current?.disconnect()
     startObserving()
-  }, [refreshToken, startObserving])
+  }, [hasPrevData, hasNextData, refreshToken, startObserving])
 
   return (
     <>


### PR DESCRIPTION
messages.

The problem was when the initial state of `hasPrevData`/`hasNextData` was `false` (or `undefined`), which was the case in receiving the `chatReady` event *before* the chat `init` event. So we would start rendering the channel and channel messages with the default state and `hasMoreHistory` would be `undefined`. This meant that the inifnite-scroll-list would not render the observing element (i.e. LoadingArea) and nothing would be observed.

Once we've received the `init` event and `hasMoreHistory` would become `true`, the observing element would finally render, but there was nothing in the infinite-scroll-list that would try to observe the element again, and it would get stuck like that. Now the infinite-scroll-list automatically restars observing if `hasPrevData`/`hasNextData` changes.