### PR TITLE
Adds custom error type for handling FS error codes

### DIFF
--- a/client/file-browser/get-files.ts
+++ b/client/file-browser/get-files.ts
@@ -1,4 +1,4 @@
-import { TypedIpcRenderer } from '../../common/ipc'
+import { FsErrorCode, TypedIpcRenderer } from '../../common/ipc'
 import { FileBrowserEntry, FileBrowserEntryType } from './file-browser-types'
 
 const ipcRenderer = new TypedIpcRenderer()
@@ -13,34 +13,43 @@ function splitExtension(filename: string): [base: string, ext: string] {
 }
 
 export default async function readFolder(folderPath: string): Promise<FileBrowserEntry[]> {
-  try {
-    const entries = (await ipcRenderer.invoke('fsReadDir', folderPath, { withFileTypes: true }))!
-    return await Promise.all(
-      entries.map(async entry => {
-        const isFolder = entry.isDirectory
-        const [name, extension] = isFolder ? [entry.name, ''] : splitExtension(entry.name)
-        const stats = await ipcRenderer.invoke('fsStat', folderPath + '\\' + entry.name)
-        const path = folderPath + '\\' + entry.name
-
-        return isFolder
-          ? {
-              type: FileBrowserEntryType.Folder,
-              name,
-              path,
-            }
-          : {
-              type: FileBrowserEntryType.File,
-              name,
-              path,
-              extension: extension.toLowerCase(),
-              date: stats?.mtime ?? new Date(0),
-            }
-      }),
-    )
-  } catch (err) {
-    if ((err as any).code === 'ENOENT') {
+  const readDirResult = (await ipcRenderer.invoke('fsReadDir', folderPath, {
+    withFileTypes: true,
+  }))!
+  if (readDirResult.error) {
+    if (readDirResult.code === FsErrorCode.FileOrFolderMissing) {
       throw new Error('Filepath ' + folderPath + " doesn't exist")
+    } else {
+      throw new Error('Unexpected FsError: ' + readDirResult.code)
     }
-    throw err
   }
+  return await Promise.all(
+    readDirResult.entries.map(async entry => {
+      const isFolder = entry.isDirectory
+      const [name, extension] = isFolder ? [entry.name, ''] : splitExtension(entry.name)
+      const statsResult = await ipcRenderer.invoke('fsStat', folderPath + '\\' + entry.name)!
+      if (statsResult.error) {
+        if (statsResult.code === FsErrorCode.FileOrFolderMissing) {
+          throw new Error('Filepath ' + folderPath + " doesn't exist")
+        } else {
+          throw new Error('Unexpected FsError: ' + statsResult.code)
+        }
+      }
+      const path = folderPath + '\\' + entry.name
+
+      return isFolder
+        ? {
+            type: FileBrowserEntryType.Folder,
+            name,
+            path,
+          }
+        : {
+            type: FileBrowserEntryType.File,
+            name,
+            path,
+            extension: extension.toLowerCase(),
+            date: statsResult.stats.mtime ?? new Date(0),
+          }
+    }),
+  )
 }

--- a/common/ipc.ts
+++ b/common/ipc.ts
@@ -53,6 +53,30 @@ export interface FsStats {
   birthtime: Date
 }
 
+export enum FsErrorCode {
+  FileOrFolderMissing,
+}
+
+export interface FsError {
+  error: true
+  code: FsErrorCode
+}
+
+export interface FsReadDirResult {
+  entries: FsDirent[]
+  error?: false
+}
+
+export interface FsReadFileResult {
+  file: ArrayBuffer
+  error?: false
+}
+
+export interface FsStatResult {
+  stats: FsStats
+  error?: false
+}
+
 /** RPCs that can be invoked by the renderer process to run code in the main process. */
 interface IpcInvokeables {
   activeGameStartWhenReady: (gameId: string) => void
@@ -61,10 +85,13 @@ interface IpcInvokeables {
 
   // TODO(tec27): Support the non-filetypes version if we need it, overloads don't seem to work
   // well with the current approach for typing these invokes =/
-  fsReadDir: (dirPath: string, options: { withFileTypes: true }) => Promise<FsDirent[]>
+  fsReadDir: (
+    dirPath: string,
+    options: { withFileTypes: true },
+  ) => Promise<FsReadDirResult | FsError>
   // TODO(tec27): Add types for options + returning a string if encoding is specified?
-  fsReadFile: (filePath: string) => Promise<ArrayBuffer>
-  fsStat: (filePath: string) => Promise<FsStats>
+  fsReadFile: (filePath: string) => Promise<FsReadFileResult | FsError>
+  fsStat: (filePath: string) => Promise<FsStatResult | FsError>
 
   logMessage: (level: string, message: string) => void
 


### PR DESCRIPTION
This partially fixes an electron issues where fs error code information isn't getting shared from the main process to the render process https://github.com/electron/electron/issues/24427. Currently the error code information is getting lost when communicating over IPC

