### PR TITLE
Add automatic language detection and a way to change language for signed

### DIFF
--- a/client/auth/login-layout.tsx
+++ b/client/auth/login-layout.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
+import { TopLinks } from '../landing/top-links'
 import LogoText from '../logos/logotext-640x100.svg'
 import { makePublicAssetUrl } from '../network/server-url'
 
@@ -7,6 +8,10 @@ const Wrapper = styled.div`
   width: 100%;
   padding-left: var(--pixel-shove-x, 0);
   overflow: auto;
+`
+
+const StyledTopLinks = styled(TopLinks)`
+  margin: 8px auto;
 `
 
 const Contents = styled.div`
@@ -34,6 +39,7 @@ export interface LoginLayoutProps {
 export default function LoginLayout({ children }: LoginLayoutProps) {
   return (
     <Wrapper>
+      <StyledTopLinks />
       <Contents>
         <Logo src={makePublicAssetUrl('/images/logo.svg')} />
         <StyledLogoText>

--- a/client/i18n/i18next.ts
+++ b/client/i18n/i18next.ts
@@ -25,8 +25,7 @@ export const i18nextPromise = i18n.use(HttpBackend).use(initReactI18next)
 
 if (LANGUAGE_SUPPORT) {
   const languageDetector = new LanguageDetector(null, {
-    order: ['localStorage', 'navigator'],
-    caches: ['localStorage'],
+    order: ['navigator'],
   })
 
   i18n.use(languageDetector)

--- a/client/i18n/i18next.ts
+++ b/client/i18n/i18next.ts
@@ -1,6 +1,8 @@
 import i18n from 'i18next'
+import LanguageDetector from 'i18next-browser-languagedetector'
 import HttpBackend, { HttpBackendOptions } from 'i18next-http-backend'
 import { initReactI18next } from 'react-i18next'
+import { LANGUAGE_SUPPORT } from '../../common/flags'
 import {
   ALL_TRANSLATION_LANGUAGES,
   TranslationLanguage,
@@ -19,34 +21,42 @@ const isDev = __WEBPACK_ENV.NODE_ENV !== 'production'
  */
 export type TransInterpolation = any
 
-export const i18nextPromise = i18n
-  .use(HttpBackend)
-  .use(initReactI18next)
-  .init<HttpBackendOptions>({
-    backend: {
-      loadPath: makeServerUrl('/locales/{{lng}}/{{ns}}.json'),
-      addPath: makeServerUrl('/locales/add/{{lng}}/{{ns}}'),
-    },
+export const i18nextPromise = i18n.use(HttpBackend).use(initReactI18next)
 
-    saveMissing: isDev,
-    saveMissingTo: 'all', // Save the missing keys to all languages
-
-    supportedLngs: ALL_TRANSLATION_LANGUAGES,
-    fallbackLng: TranslationLanguage.English,
-
-    // These are basically the defaults, but just defining them explicitly if we ever decide to use
-    // namespaces.
-    ns: TranslationNamespace.Global,
-    defaultNS: TranslationNamespace.Global,
-    fallbackNS: false,
-
-    interpolation: {
-      escapeValue: false, // Not needed for react as it escapes by default
-    },
-
-    // Some HTML attributes (e.g. `title`, `label`) only accept `string | undefined` as valid
-    // values, so we configure our `t` function to not be able to return `null` values.
-    returnNull: false,
+if (LANGUAGE_SUPPORT) {
+  const languageDetector = new LanguageDetector(null, {
+    order: ['localStorage', 'navigator'],
+    caches: ['localStorage'],
   })
+
+  i18n.use(languageDetector)
+}
+
+i18n.init<HttpBackendOptions>({
+  backend: {
+    loadPath: makeServerUrl('/locales/{{lng}}/{{ns}}.json'),
+    addPath: makeServerUrl('/locales/add/{{lng}}/{{ns}}'),
+  },
+
+  saveMissing: isDev,
+  saveMissingTo: 'all', // Save the missing keys to all languages
+
+  supportedLngs: ALL_TRANSLATION_LANGUAGES,
+  fallbackLng: TranslationLanguage.English,
+
+  // These are basically the defaults, but just defining them explicitly if we ever decide to use
+  // namespaces.
+  ns: TranslationNamespace.Global,
+  defaultNS: TranslationNamespace.Global,
+  fallbackNS: false,
+
+  interpolation: {
+    escapeValue: false, // Not needed for react as it escapes by default
+  },
+
+  // Some HTML attributes (e.g. `title`, `label`) only accept `string | undefined` as valid
+  // values, so we configure our `t` function to not be able to return `null` values.
+  returnNull: false,
+})
 
 export default i18n

--- a/client/i18n/i18next.ts
+++ b/client/i18n/i18next.ts
@@ -26,6 +26,7 @@ export const i18nextPromise = i18n.use(HttpBackend).use(initReactI18next)
 if (LANGUAGE_SUPPORT) {
   const languageDetector = new LanguageDetector(null, {
     order: ['navigator'],
+    caches: [],
   })
 
   i18n.use(languageDetector)

--- a/client/i18n/i18next.ts
+++ b/client/i18n/i18next.ts
@@ -2,7 +2,6 @@ import i18n from 'i18next'
 import LanguageDetector from 'i18next-browser-languagedetector'
 import HttpBackend, { HttpBackendOptions } from 'i18next-http-backend'
 import { initReactI18next } from 'react-i18next'
-import { LANGUAGE_SUPPORT } from '../../common/flags'
 import {
   ALL_TRANSLATION_LANGUAGES,
   TranslationLanguage,
@@ -21,42 +20,40 @@ const isDev = __WEBPACK_ENV.NODE_ENV !== 'production'
  */
 export type TransInterpolation = any
 
-export const i18nextPromise = i18n.use(HttpBackend).use(initReactI18next)
+export const i18nextPromise = i18n
+  .use(HttpBackend)
+  .use(LanguageDetector)
+  .use(initReactI18next)
+  .init<HttpBackendOptions>({
+    backend: {
+      loadPath: makeServerUrl('/locales/{{lng}}/{{ns}}.json'),
+      addPath: makeServerUrl('/locales/add/{{lng}}/{{ns}}'),
+    },
 
-if (LANGUAGE_SUPPORT) {
-  const languageDetector = new LanguageDetector(null, {
-    order: ['navigator'],
-    caches: [],
+    saveMissing: isDev,
+    saveMissingTo: 'all', // Save the missing keys to all languages
+
+    supportedLngs: ALL_TRANSLATION_LANGUAGES,
+    fallbackLng: TranslationLanguage.English,
+
+    detection: {
+      order: ['navigator'],
+      caches: [],
+    },
+
+    // These are basically the defaults, but just defining them explicitly if we ever decide to use
+    // namespaces.
+    ns: TranslationNamespace.Global,
+    defaultNS: TranslationNamespace.Global,
+    fallbackNS: false,
+
+    interpolation: {
+      escapeValue: false, // Not needed for react as it escapes by default
+    },
+
+    // Some HTML attributes (e.g. `title`, `label`) only accept `string | undefined` as valid
+    // values, so we configure our `t` function to not be able to return `null` values.
+    returnNull: false,
   })
-
-  i18n.use(languageDetector)
-}
-
-i18n.init<HttpBackendOptions>({
-  backend: {
-    loadPath: makeServerUrl('/locales/{{lng}}/{{ns}}.json'),
-    addPath: makeServerUrl('/locales/add/{{lng}}/{{ns}}'),
-  },
-
-  saveMissing: isDev,
-  saveMissingTo: 'all', // Save the missing keys to all languages
-
-  supportedLngs: ALL_TRANSLATION_LANGUAGES,
-  fallbackLng: TranslationLanguage.English,
-
-  // These are basically the defaults, but just defining them explicitly if we ever decide to use
-  // namespaces.
-  ns: TranslationNamespace.Global,
-  defaultNS: TranslationNamespace.Global,
-  fallbackNS: false,
-
-  interpolation: {
-    escapeValue: false, // Not needed for react as it escapes by default
-  },
-
-  // Some HTML attributes (e.g. `title`, `label`) only accept `string | undefined` as valid
-  // values, so we configure our `t` function to not be able to return `null` values.
-  returnNull: false,
-})
 
 export default i18n

--- a/client/landing/top-links.tsx
+++ b/client/landing/top-links.tsx
@@ -106,13 +106,13 @@ export function TopLinks({ className }: { className?: string }) {
   const [anchor, anchorX, anchorY] = useAnchorPosition('left', 'bottom')
 
   const onChangeLanguage = useStableCallback(async (language: TranslationLanguage) => {
+    closeLanguageMenu()
     try {
       await i18n.changeLanguage(language)
     } catch (error) {
       dispatch(openSnackbar({ message: 'Something went wrong changing the language' }))
       logger.error(`There was an error changing the language: ${error}`)
     }
-    closeLanguageMenu()
   })
 
   return (

--- a/client/landing/top-links.tsx
+++ b/client/landing/top-links.tsx
@@ -177,7 +177,7 @@ export function TopLinks({ className }: { className?: string }) {
       <Spacer />
       {LANGUAGE_SUPPORT ? (
         <li>
-          <Tooltip text='Change language'>
+          <Tooltip text='Change language' disabled={languageMenuOpen}>
             <IconButton ref={anchor} icon={<LanguageIcon />} onClick={openLanguageMenu} />
           </Tooltip>
         </li>

--- a/client/landing/top-links.tsx
+++ b/client/landing/top-links.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useTranslation } from 'react-i18next'
+import { Trans, useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 import { Link } from 'wouter'
 import {
@@ -100,7 +100,7 @@ const HideWhenSmall = styled.span`
 `
 
 export function TopLinks({ className }: { className?: string }) {
-  const { i18n } = useTranslation()
+  const { t, i18n } = useTranslation()
   const dispatch = useAppDispatch()
   const [languageMenuOpen, openLanguageMenu, closeLanguageMenu] = usePopoverController()
   const [anchor, anchorX, anchorY] = useAnchorPosition('left', 'bottom')
@@ -110,7 +110,14 @@ export function TopLinks({ className }: { className?: string }) {
     try {
       await i18n.changeLanguage(language)
     } catch (error) {
-      dispatch(openSnackbar({ message: 'Something went wrong changing the language' }))
+      dispatch(
+        openSnackbar({
+          message: t(
+            'landing.topLinks.changeLanguageError',
+            'Something went wrong when changing the language',
+          ),
+        }),
+      )
       logger.error(`There was an error changing the language: ${error}`)
     }
   })
@@ -138,16 +145,24 @@ export function TopLinks({ className }: { className?: string }) {
       {!IS_ELECTRON ? (
         <>
           <li>
-            <Link href='/splash'>Home</Link>
+            <Trans t={t} i18nKey='landing.topLinks.home'>
+              <Link href='/splash'>Home</Link>
+            </Trans>
           </li>
           <li>
-            <Link href='/faq'>FAQ</Link>
+            <Trans t={t} i18nKey='landing.topLinks.faq'>
+              <Link href='/faq'>FAQ</Link>
+            </Trans>
           </li>
           <li>
-            <Link href='/ladder'>Ladder</Link>
+            <Trans t={t} i18nKey='landing.topLinks.ladder'>
+              <Link href='/ladder'>Ladder</Link>
+            </Trans>
           </li>
           <li>
-            <Link href='/leagues'>Leagues</Link>
+            <Trans t={t} i18nKey='landing.topLinks.leagues'>
+              <Link href='/leagues'>Leagues</Link>
+            </Trans>
           </li>
           <Spacer />
           <li>
@@ -173,12 +188,16 @@ export function TopLinks({ className }: { className?: string }) {
       ) : null}
       <Spacer />
       <li>
-        <Tooltip text='Change language' disabled={languageMenuOpen}>
+        <Tooltip
+          text={t('landing.topLinks.changeLanguage', 'Change language')}
+          disabled={languageMenuOpen}>
           <IconButton ref={anchor} icon={<LanguageIcon />} onClick={openLanguageMenu} />
         </Tooltip>
       </li>
       <li>
-        <Link href='/login'>Log&nbsp;in</Link>
+        <Trans t={t} i18nKey='landing.topLinks.login'>
+          <Link href='/login'>Log&nbsp;in</Link>
+        </Trans>
       </li>
     </TopLinksList>
   )

--- a/client/landing/top-links.tsx
+++ b/client/landing/top-links.tsx
@@ -2,9 +2,12 @@ import React from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 import { Link } from 'wouter'
-import { assertUnreachable } from '../../common/assert-unreachable'
 import { LANGUAGE_SUPPORT } from '../../common/flags'
-import { ALL_TRANSLATION_LANGUAGES, TranslationLanguage } from '../../common/i18n'
+import {
+  ALL_TRANSLATION_LANGUAGES,
+  TranslationLanguage,
+  translationLanguageToLabel,
+} from '../../common/i18n'
 import GithubLogo from '../icons/brands/github.svg'
 import TwitterLogo from '../icons/brands/twitter.svg'
 import { MaterialIcon } from '../icons/material/material-icon'
@@ -97,10 +100,6 @@ const HideWhenSmall = styled.span`
   }
 `
 
-const HideWhenElectron = styled.li`
-  visibility: ${IS_ELECTRON ? 'hidden' : 'visible'};
-`
-
 export function TopLinks({ className }: { className?: string }) {
   const { i18n } = useTranslation()
   const dispatch = useAppDispatch()
@@ -128,73 +127,54 @@ export function TopLinks({ className }: { className?: string }) {
           originX={'left'}
           originY={'top'}>
           <MenuList dense={true}>
-            {ALL_TRANSLATION_LANGUAGES.map(language => {
-              let languageLabel: string
-              switch (language) {
-                case TranslationLanguage.ChineseSimplified:
-                  languageLabel = '简体中文'
-                  break
-                case TranslationLanguage.English:
-                  languageLabel = 'English'
-                  break
-                case TranslationLanguage.Korean:
-                  languageLabel = '한국어'
-                  break
-                case TranslationLanguage.Russian:
-                  languageLabel = 'Русский'
-                  break
-                case TranslationLanguage.Spanish:
-                  languageLabel = 'Español'
-                  break
-                default:
-                  return assertUnreachable(language)
-              }
-
-              return (
-                <MenuItem
-                  key={language}
-                  text={languageLabel}
-                  onClick={() => onChangeLanguage(language)}
-                />
-              )
-            })}
+            {ALL_TRANSLATION_LANGUAGES.map(language => (
+              <MenuItem
+                key={language}
+                text={translationLanguageToLabel(language)}
+                onClick={() => onChangeLanguage(language)}
+              />
+            ))}
           </MenuList>
         </Popover>
       ) : null}
 
-      <HideWhenElectron>
-        <Link href='/splash'>Home</Link>
-      </HideWhenElectron>
-      <HideWhenElectron>
-        <Link href='/faq'>FAQ</Link>
-      </HideWhenElectron>
-      <HideWhenElectron>
-        <Link href='/ladder'>Ladder</Link>
-      </HideWhenElectron>
-      <HideWhenElectron>
-        <Link href='/leagues'>Leagues</Link>
-      </HideWhenElectron>
-      <Spacer />
-      <HideWhenElectron>
-        <IconLink href='https://twitter.com/shieldbatterybw' target='_blank' rel='noopener'>
-          <StyledTwitterLogo />
-          <HideWhenSmall>Twitter</HideWhenSmall>
-        </IconLink>
-      </HideWhenElectron>
-      <HideWhenElectron>
-        <IconLink href='https://github.com/ShieldBattery' target='_blank' rel='noopener'>
-          <StyledGithubLogo />
-          <HideWhenSmall>GitHub</HideWhenSmall>
-        </IconLink>
-      </HideWhenElectron>
-      <HideWhenElectron>
-        <HideWhenSmall>
-          <a href='https://patreon.com/tec27' target='_blank' rel='noopener'>
-            Patreon
-          </a>
-        </HideWhenSmall>
-      </HideWhenElectron>
-      <Spacer />
+      {!IS_ELECTRON ? (
+        <>
+          <li>
+            <Link href='/splash'>Home</Link>
+          </li>
+          <li>
+            <Link href='/faq'>FAQ</Link>
+          </li>
+          <li>
+            <Link href='/ladder'>Ladder</Link>
+          </li>
+          <li>
+            <Link href='/leagues'>Leagues</Link>
+          </li>
+          <Spacer />
+          <li>
+            <IconLink href='https://twitter.com/shieldbatterybw' target='_blank' rel='noopener'>
+              <StyledTwitterLogo />
+              <HideWhenSmall>Twitter</HideWhenSmall>
+            </IconLink>
+          </li>
+          <li>
+            <IconLink href='https://github.com/ShieldBattery' target='_blank' rel='noopener'>
+              <StyledGithubLogo />
+              <HideWhenSmall>GitHub</HideWhenSmall>
+            </IconLink>
+          </li>
+          <li>
+            <HideWhenSmall>
+              <a href='https://patreon.com/tec27' target='_blank' rel='noopener'>
+                Patreon
+              </a>
+            </HideWhenSmall>
+          </li>
+          <Spacer />
+        </>
+      ) : null}
       {LANGUAGE_SUPPORT ? (
         <li>
           <Tooltip text='Change language'>

--- a/client/landing/top-links.tsx
+++ b/client/landing/top-links.tsx
@@ -172,9 +172,9 @@ export function TopLinks({ className }: { className?: string }) {
               </a>
             </HideWhenSmall>
           </li>
-          <Spacer />
         </>
       ) : null}
+      <Spacer />
       {LANGUAGE_SUPPORT ? (
         <li>
           <Tooltip text='Change language'>

--- a/client/landing/top-links.tsx
+++ b/client/landing/top-links.tsx
@@ -2,7 +2,6 @@ import React from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 import { Link } from 'wouter'
-import { LANGUAGE_SUPPORT } from '../../common/flags'
 import {
   ALL_TRANSLATION_LANGUAGES,
   TranslationLanguage,
@@ -118,25 +117,23 @@ export function TopLinks({ className }: { className?: string }) {
 
   return (
     <TopLinksList className={className}>
-      {LANGUAGE_SUPPORT ? (
-        <Popover
-          open={languageMenuOpen}
-          onDismiss={closeLanguageMenu}
-          anchorX={anchorX ?? 0}
-          anchorY={anchorY ?? 0}
-          originX={'left'}
-          originY={'top'}>
-          <MenuList dense={true}>
-            {ALL_TRANSLATION_LANGUAGES.map(language => (
-              <MenuItem
-                key={language}
-                text={translationLanguageToLabel(language)}
-                onClick={() => onChangeLanguage(language)}
-              />
-            ))}
-          </MenuList>
-        </Popover>
-      ) : null}
+      <Popover
+        open={languageMenuOpen}
+        onDismiss={closeLanguageMenu}
+        anchorX={anchorX ?? 0}
+        anchorY={anchorY ?? 0}
+        originX={'left'}
+        originY={'top'}>
+        <MenuList dense={true}>
+          {ALL_TRANSLATION_LANGUAGES.map(language => (
+            <MenuItem
+              key={language}
+              text={translationLanguageToLabel(language)}
+              onClick={() => onChangeLanguage(language)}
+            />
+          ))}
+        </MenuList>
+      </Popover>
 
       {!IS_ELECTRON ? (
         <>
@@ -175,13 +172,11 @@ export function TopLinks({ className }: { className?: string }) {
         </>
       ) : null}
       <Spacer />
-      {LANGUAGE_SUPPORT ? (
-        <li>
-          <Tooltip text='Change language' disabled={languageMenuOpen}>
-            <IconButton ref={anchor} icon={<LanguageIcon />} onClick={openLanguageMenu} />
-          </Tooltip>
-        </li>
-      ) : null}
+      <li>
+        <Tooltip text='Change language' disabled={languageMenuOpen}>
+          <IconButton ref={anchor} icon={<LanguageIcon />} onClick={openLanguageMenu} />
+        </Tooltip>
+      </li>
       <li>
         <Link href='/login'>Log&nbsp;in</Link>
       </li>

--- a/common/flags.ts
+++ b/common/flags.ts
@@ -20,8 +20,3 @@ export const USE_STATIC_TURNRATE = ON()
 // TODO(2Pac): Flip this flag to ON once we have a news/home page
 /** Allows users to leave the ShieldBattery chat channel. */
 export const CAN_LEAVE_SHIELDBATTERY_CHANNEL = OFF()
-/**
- * Allows users to change their language. Shouldn't be turned on until we have some actual
- * translations of languages other than English.
- */
-export const LANGUAGE_SUPPORT = DEV()

--- a/common/flags.ts
+++ b/common/flags.ts
@@ -20,3 +20,8 @@ export const USE_STATIC_TURNRATE = ON()
 // TODO(2Pac): Flip this flag to ON once we have a news/home page
 /** Allows users to leave the ShieldBattery chat channel. */
 export const CAN_LEAVE_SHIELDBATTERY_CHANNEL = OFF()
+/**
+ * Allows users to change their language. Shouldn't be turned on until we have some actual
+ * translations of languages other than English.
+ */
+export const LANGUAGE_SUPPORT = DEV()

--- a/common/i18n.ts
+++ b/common/i18n.ts
@@ -1,3 +1,5 @@
+import { assertUnreachable } from './assert-unreachable'
+
 /**
  * A string representation of each of the languages that we support and expect to have a translation
  * file for.
@@ -23,3 +25,20 @@ export enum TranslationNamespace {
 
 export const ALL_TRANSLATION_NAMESPACES: ReadonlyArray<TranslationNamespace> =
   Object.values(TranslationNamespace)
+
+export function translationLanguageToLabel(language: TranslationLanguage) {
+  switch (language) {
+    case TranslationLanguage.ChineseSimplified:
+      return '简体中文'
+    case TranslationLanguage.English:
+      return 'English'
+    case TranslationLanguage.Korean:
+      return '한국어'
+    case TranslationLanguage.Russian:
+      return 'Русский'
+    case TranslationLanguage.Spanish:
+      return 'Español'
+    default:
+      return assertUnreachable(language)
+  }
+}

--- a/common/i18n.ts
+++ b/common/i18n.ts
@@ -3,7 +3,11 @@
  * file for.
  */
 export enum TranslationLanguage {
+  ChineseSimplified = 'zh_Hans',
   English = 'en',
+  Korean = 'kr',
+  Russian = 'ru',
+  Spanish = 'es',
 }
 
 export const ALL_TRANSLATION_LANGUAGES: ReadonlyArray<TranslationLanguage> =

--- a/package.json
+++ b/package.json
@@ -244,6 +244,7 @@
     "google-fonts-helper": "^3.3.0",
     "html-loader": "^4.2.0",
     "i18next": "^22.2.0",
+    "i18next-browser-languagedetector": "^7.0.1",
     "i18next-fs-backend": "^2.1.0",
     "i18next-http-backend": "^2.1.0",
     "i18next-parser": "^8.0.0",

--- a/server/public/locales/en/global.json
+++ b/server/public/locales/en/global.json
@@ -160,6 +160,17 @@
       "tabSummary": "Summary"
     }
   },
+  "landing": {
+    "topLinks": {
+      "changeLanguage": "Change language",
+      "changeLanguageError": "Something went wrong when changing the language",
+      "faq": "<0>FAQ</0>",
+      "home": "<0>Home</0>",
+      "ladder": "<0>Ladder</0>",
+      "leagues": "<0>Leagues</0>",
+      "login": "<0>Log&nbsp;in</0>"
+    }
+  },
   "settings": {
     "app": {
       "sound": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -999,6 +999,13 @@
   dependencies:
     regenerator-runtime "^0.13.11"
 
+"@babel/runtime@^7.19.4":
+  version "7.21.5"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.21.5.tgz#8492dddda9644ae3bda3b45eabe87382caee7200"
+  integrity sha512-8jI69toZqqcsnqGGqwGS4Qb1VwLOEp4hz+CXPywcvjs60u3B4Pom/U/7rm4W8tMOYEB+E9wgD0mW1l3r8qlI9Q==
+  dependencies:
+    regenerator-runtime "^0.13.11"
+
 "@babel/template@^7.18.10", "@babel/template@^7.20.7", "@babel/template@^7.3.3":
   version "7.20.7"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.20.7.tgz#a15090c2839a83b02aa996c0b4994005841fd5a8"
@@ -6817,6 +6824,13 @@ hyphenate-style-name@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/hyphenate-style-name/-/hyphenate-style-name-1.0.4.tgz#691879af8e220aea5750e8827db4ef62a54e361d"
   integrity sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ==
+
+i18next-browser-languagedetector@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/i18next-browser-languagedetector/-/i18next-browser-languagedetector-7.0.1.tgz#ead34592edc96c6c3a618a51cb57ad027c5b5d87"
+  integrity sha512-Pa5kFwaczXJAeHE56CHG2aWzFBMJNUNghf0Pm4SwSrEMps/PTKqW90EYWlIvhuYStf3Sn1K0vw+gH3+TLdkH1g==
+  dependencies:
+    "@babel/runtime" "^7.19.4"
 
 i18next-fs-backend@^2.1.0:
   version "2.1.1"


### PR DESCRIPTION
out users.

The detected language is first detected from the "navigator" settings and saved into the local storage and is not currently being sent to the server during the signup process. That will come in the next commit.

User can change the language on all of the pages that render top-links; basically splash/faq/login/signup.