### PR TITLE
Improve the settings visuals.

### DIFF
--- a/client/settings/game/gameplay-settings.tsx
+++ b/client/settings/game/gameplay-settings.tsx
@@ -20,11 +20,7 @@ import { useStableCallback } from '../../state-hooks'
 import { colorTextSecondary } from '../../styles/colors'
 import { overline } from '../../styles/typography'
 import { mergeLocalSettings, mergeScrSettings } from '../action-creators'
-import { FormContainer } from '../settings-content'
-
-const ApmAlertCheckbox = styled(CheckBox)`
-  margin-top: 32px;
-`
+import { FormContainer, Spacer } from '../settings-content'
 
 const SectionOverline = styled.div`
   ${overline};
@@ -146,6 +142,7 @@ export function GameplaySettings() {
               <SelectOption key={skin} value={skin} text={getConsoleSkinName(skin)} />
             ))}
           </Select>
+          <Spacer />
         </div>
         <div>
           <CheckBox
@@ -168,7 +165,8 @@ export function GameplaySettings() {
             label='APM display'
             inputProps={{ tabIndex: 0 }}
           />
-          <ApmAlertCheckbox
+          <Spacer />
+          <CheckBox
             {...bindCheckable('apmAlertOn')}
             label='Alert when APM falls below'
             inputProps={{ tabIndex: 0 }}
@@ -196,6 +194,7 @@ export function GameplaySettings() {
         </div>
         {DEV_INDICATOR ? (
           <div>
+            <Spacer />
             <SectionOverline>Dev-only settings</SectionOverline>
             <CheckBox
               {...bindCheckable('visualizeNetworkStalls')}

--- a/client/settings/game/input-settings.tsx
+++ b/client/settings/game/input-settings.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import styled from 'styled-components'
 import { useForm } from '../../forms/form-hook'
 import SubmitOnEnter from '../../forms/submit-on-enter'
 import CheckBox from '../../material/check-box'
@@ -7,11 +6,7 @@ import Slider from '../../material/slider'
 import { useAppDispatch, useAppSelector } from '../../redux-hooks'
 import { useStableCallback } from '../../state-hooks'
 import { mergeScrSettings } from '../action-creators'
-import { FormContainer } from '../settings-content'
-
-const MouseSensitivitySlider = styled(Slider)`
-  margin-bottom: 40px;
-`
+import { FormContainer, Spacer } from '../settings-content'
 
 interface GameInputSettingsModel {
   keyboardScrollSpeed: number
@@ -66,6 +61,7 @@ export function GameInputSettings() {
             max={6}
             step={1}
           />
+          <Spacer />
           <Slider
             {...bindCustom('mouseScrollSpeed')}
             label='Mouse scroll speed'
@@ -74,6 +70,7 @@ export function GameInputSettings() {
             max={6}
             step={1}
           />
+          <Spacer />
         </div>
         <div>
           <CheckBox
@@ -81,7 +78,7 @@ export function GameInputSettings() {
             label='Custom mouse sensitivity'
             inputProps={{ tabIndex: 0 }}
           />
-          <MouseSensitivitySlider
+          <Slider
             {...bindCustom('mouseSensitivity')}
             label='Mouse sensitivity'
             tabIndex={0}
@@ -91,6 +88,7 @@ export function GameInputSettings() {
             disabled={!getInputValue('mouseSensitivityOn')}
             showTicks={false}
           />
+          <Spacer />
           <CheckBox
             {...bindCheckable('mouseScalingOn')}
             label='Use mouse scaling'

--- a/client/settings/game/sound-settings.tsx
+++ b/client/settings/game/sound-settings.tsx
@@ -16,16 +16,11 @@ import { useStableCallback } from '../../state-hooks'
 import { colorTextSecondary } from '../../styles/colors'
 import { overline } from '../../styles/typography'
 import { mergeScrSettings } from '../action-creators'
-import { FormContainer } from '../settings-content'
-
-const MusicVolumeSlider = styled(Slider)`
-  margin-bottom: 40px;
-`
+import { FormContainer, Spacer } from '../settings-content'
 
 const AnnouncerOverline = styled.div`
   ${overline};
   color: ${colorTextSecondary};
-  margin-top: 40px;
   margin-bottom: 8px;
 `
 
@@ -85,7 +80,7 @@ export function GameSoundSettings() {
       <FormContainer>
         <div>
           <CheckBox {...bindCheckable('musicOn')} label='Music' inputProps={{ tabIndex: 0 }} />
-          <MusicVolumeSlider
+          <Slider
             {...bindCustom('musicVolume')}
             label='Music volume'
             tabIndex={0}
@@ -95,6 +90,7 @@ export function GameSoundSettings() {
             disabled={!getInputValue('musicOn')}
             showTicks={false}
           />
+          <Spacer />
           <CheckBox
             {...bindCheckable('soundOn')}
             label='Game sounds'
@@ -110,6 +106,7 @@ export function GameSoundSettings() {
             disabled={!getInputValue('soundOn')}
             showTicks={false}
           />
+          <Spacer />
 
           <AnnouncerOverline>Packs (must be purchased from Blizzard)</AnnouncerOverline>
           <Select {...bindCustom('selectedAnnouncer')} label='Announcer' tabIndex={0}>

--- a/client/settings/game/video-settings.tsx
+++ b/client/settings/game/video-settings.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import styled from 'styled-components'
 import {
   ALL_DISPLAY_MODES,
   DisplayMode,
@@ -14,12 +13,7 @@ import Slider from '../../material/slider'
 import { useAppDispatch, useAppSelector } from '../../redux-hooks'
 import { useStableCallback } from '../../state-hooks'
 import { mergeScrSettings } from '../action-creators'
-import { FormContainer } from '../settings-content'
-
-const Spacer = styled.div`
-  width: 100%;
-  height: 32px;
-`
+import { FormContainer, Spacer } from '../settings-content'
 
 // NOTE(tec27): Vsync is weird and is a number in the settings, but actually a boolean value. This
 // component just acts as a custom one and does the conversion
@@ -130,6 +124,7 @@ export function GameVideoSettings() {
             disabled={!getInputValue('fpsLimitOn')}
             showTicks={false}
           />
+          <Spacer />
         </div>
         <div>
           <VsyncCheckBox

--- a/client/settings/settings-content.tsx
+++ b/client/settings/settings-content.tsx
@@ -1,8 +1,8 @@
 import styled from 'styled-components'
 
-export const FormContainer = styled.div<{ $doubleColumn?: boolean }>`
+export const FormContainer = styled.div`
   display: grid;
-  grid-template-columns: ${props => (props.$doubleColumn ? '1fr 1fr' : '1fr')};
+  grid-template-columns: 1fr;
   column-gap: 40px;
   width: 100%;
 `

--- a/client/settings/settings-content.tsx
+++ b/client/settings/settings-content.tsx
@@ -1,8 +1,13 @@
 import styled from 'styled-components'
 
-export const FormContainer = styled.div`
+export const FormContainer = styled.div<{ $doubleColumn?: boolean }>`
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: ${props => (props.$doubleColumn ? '1fr 1fr' : '1fr')};
   column-gap: 40px;
   width: 100%;
+`
+
+export const Spacer = styled.div`
+  width: 100%;
+  height: 32px;
 `

--- a/client/settings/settings.tsx
+++ b/client/settings/settings.tsx
@@ -277,9 +277,18 @@ function NavEntry({
 
 const ContentContainer = styled.div`
   width: 100%;
-  max-width: 960px;
+  max-width: 840px;
   padding: 16px;
   overflow-y: auto;
+
+  display: flex;
+  flex-direction: row;
+  align-items: flex-start;
+  gap: 16px;
+`
+
+const Content = styled.div`
+  flex-grow: 1;
 `
 
 const TitleBar = styled.div`
@@ -297,7 +306,7 @@ const Title = styled(SettingsSubPageTitle)`
   ${headline4};
 `
 
-const CloseIcon = styled(MaterialIcon).attrs({ icon: 'close' })`
+const CloseIcon = styled(MaterialIcon).attrs({ icon: 'close', size: 36 })`
   flex-shrink: 0;
 `
 
@@ -310,14 +319,17 @@ function SettingsContent({
 }) {
   return (
     <ContentContainer>
-      <TitleBar>
-        <Title subPage={subPage} />
-        <Tooltip text='Close settings (ESC)' position='bottom' tabIndex={-1}>
-          <IconButton icon={<CloseIcon />} onClick={onCloseSettings} />
-        </Tooltip>
-      </TitleBar>
+      <Content>
+        <TitleBar>
+          <Title subPage={subPage} />
+        </TitleBar>
 
-      <SettingsSubPageDisplay subPage={subPage} onCloseSettings={onCloseSettings} />
+        <SettingsSubPageDisplay subPage={subPage} onCloseSettings={onCloseSettings} />
+      </Content>
+
+      <Tooltip text='Close settings (ESC)' position='bottom' tabIndex={-1}>
+        <IconButton icon={<CloseIcon />} onClick={onCloseSettings} />
+      </Tooltip>
     </ContentContainer>
   )
 }


### PR DESCRIPTION
- Move the Close button into its own column and increase its size
- Lower the max-width from 960px -> 840px
- Make all of the setting pages a single column
- Add/remove spacers where it made sense (probably botched this one)

Closes #945