### PR TITLE
Fix the issue where the channels can potentially end up in wrong order.

### DIFF
--- a/client/chat/socket-handlers.ts
+++ b/client/chat/socket-handlers.ts
@@ -17,14 +17,6 @@ type EventToChatActionMap = {
 }
 
 const eventToChatAction: EventToChatActionMap = {
-  init3(channelId, event) {
-    return {
-      type: '@chat/initChannel',
-      payload: event,
-      meta: { channelId },
-    }
-  },
-
   join2(channelId, event) {
     return {
       type: '@chat/updateJoin',
@@ -177,6 +169,13 @@ type EventToChatUserActionMap = {
 }
 
 const eventToChatUserAction: EventToChatUserActionMap = {
+  init3(channelId, event) {
+    return {
+      type: '@chat/initChannel',
+      payload: event,
+      meta: { channelId },
+    }
+  },
   permissionsChanged(channelId, event) {
     return {
       type: '@chat/permissionsChanged',

--- a/common/chat.ts
+++ b/common/chat.ts
@@ -33,6 +33,7 @@ export enum ChatServiceErrorCode {
   ChannelNotFound = 'ChannelNotFound',
   MaximumJoinedChannels = 'MaximumJoinedChannels',
   MaximumOwnedChannels = 'MaximumOwnedChannels',
+  NoInitialChannelData = 'NoChannelData',
   NotEnoughPermissions = 'NotEnoughPermissions',
   NotInChannel = 'NotInChannel',
   TargetNotInChannel = 'TargetNotInChannel',
@@ -293,11 +294,9 @@ export interface ChatUserOfflineEvent {
 }
 
 /**
- * Events that are sent to all clients in a particular chat channel (except the "init" event which
- * is sent only to the client that initially subscribes to these events).
+ * Events that are sent to all clients in a particular chat channel.
  */
 export type ChatEvent =
-  | ChatInitEvent
   | ChatJoinEvent
   | ChatLeaveEvent
   | ChatKickEvent
@@ -315,7 +314,7 @@ export interface ChatPermissionsChangedEvent {
 }
 
 /** Events that are sent to a particular user in a particular chat channel. */
-export type ChatUserEvent = ChatPermissionsChangedEvent
+export type ChatUserEvent = ChatInitEvent | ChatPermissionsChangedEvent
 
 /**
  * The response returned when joining a specific chat channel.

--- a/server/lib/chat/chat-api.ts
+++ b/server/lib/chat/chat-api.ts
@@ -98,6 +98,7 @@ function convertChatServiceError(err: unknown) {
     case ChatServiceErrorCode.CannotModerateYourself:
     case ChatServiceErrorCode.CannotLeaveShieldBattery:
     case ChatServiceErrorCode.CannotModerateShieldBattery:
+    case ChatServiceErrorCode.NoInitialChannelData:
       throw asHttpError(400, err)
     case ChatServiceErrorCode.CannotChangeChannelOwner:
     case ChatServiceErrorCode.CannotModerateChannelOwner:

--- a/server/lib/chat/chat-service.test.ts
+++ b/server/lib/chat/chat-service.test.ts
@@ -539,14 +539,17 @@ describe('chat/chat-service', () => {
         getChannelUserPath(shieldBatteryChannel.id, user1.id),
         undefined,
       )
-      expect(client1.publish).toHaveBeenCalledWith(getChannelPath(shieldBatteryChannel.id), {
-        action: 'init3',
-        channelInfo: shieldBatteryBasicInfo,
-        detailedChannelInfo: shieldBatteryDetailedInfo,
-        joinedChannelInfo: shieldBatteryJoinedInfo,
-        activeUserIds: [user2.id, user1.id],
-        selfPermissions: channelPermissions,
-      })
+      expect(client1.publish).toHaveBeenCalledWith(
+        getChannelUserPath(shieldBatteryChannel.id, user1.id),
+        {
+          action: 'init3',
+          channelInfo: shieldBatteryBasicInfo,
+          detailedChannelInfo: shieldBatteryDetailedInfo,
+          joinedChannelInfo: shieldBatteryJoinedInfo,
+          activeUserIds: [user2.id, user1.id],
+          selfPermissions: channelPermissions,
+        },
+      )
     })
   })
 
@@ -657,14 +660,17 @@ describe('chat/chat-service', () => {
         getChannelUserPath(shieldBatteryChannel.id, user1.id),
         undefined,
       )
-      expect(client1.publish).toHaveBeenCalledWith(getChannelPath(shieldBatteryChannel.id), {
-        action: 'init3',
-        channelInfo: shieldBatteryBasicInfo,
-        detailedChannelInfo: shieldBatteryDetailedInfo,
-        joinedChannelInfo: shieldBatteryJoinedInfo,
-        activeUserIds: [user2.id, user1.id],
-        selfPermissions: channelPermissions,
-      })
+      expect(client1.publish).toHaveBeenCalledWith(
+        getChannelUserPath(shieldBatteryChannel.id, user1.id),
+        {
+          action: 'init3',
+          channelInfo: shieldBatteryBasicInfo,
+          detailedChannelInfo: shieldBatteryDetailedInfo,
+          joinedChannelInfo: shieldBatteryJoinedInfo,
+          activeUserIds: [user2.id, user1.id],
+          selfPermissions: channelPermissions,
+        },
+      )
     })
 
     test("creates a new channel when it doesn't exist", async () => {
@@ -702,7 +708,7 @@ describe('chat/chat-service', () => {
         getChannelUserPath(testChannel.id, user1.id),
         undefined,
       )
-      expect(client1.publish).toHaveBeenCalledWith(getChannelPath(testChannel.id), {
+      expect(client1.publish).toHaveBeenCalledWith(getChannelUserPath(testChannel.id, user1.id), {
         action: 'init3',
         channelInfo: testBasicInfo,
         detailedChannelInfo: testDetailedInfo,

--- a/server/lib/chat/chat-service.test.ts
+++ b/server/lib/chat/chat-service.test.ts
@@ -529,6 +529,16 @@ describe('chat/chat-service', () => {
       // TODO(2Pac): Add something to FakeNydusServer to resolve when all current subscription
       // promises are complete?
       await new Promise(resolve => setTimeout(resolve, 20))
+      expect(nydus.subscribeClient).toHaveBeenCalledWith(
+        client1,
+        getChannelPath(shieldBatteryChannel.id),
+        undefined,
+      )
+      expect(nydus.subscribeClient).toHaveBeenCalledWith(
+        client1,
+        getChannelUserPath(shieldBatteryChannel.id, user1.id),
+        undefined,
+      )
       expect(client1.publish).toHaveBeenCalledWith(getChannelPath(shieldBatteryChannel.id), {
         action: 'init3',
         channelInfo: shieldBatteryBasicInfo,
@@ -537,11 +547,6 @@ describe('chat/chat-service', () => {
         activeUserIds: [user2.id, user1.id],
         selfPermissions: channelPermissions,
       })
-      expect(nydus.subscribeClient).toHaveBeenCalledWith(
-        client1,
-        getChannelUserPath(shieldBatteryChannel.id, user1.id),
-        undefined,
-      )
     })
   })
 
@@ -642,6 +647,16 @@ describe('chat/chat-service', () => {
       // TODO(2Pac): Add something to FakeNydusServer to resolve when all current subscription
       // promises are complete?
       await new Promise(resolve => setTimeout(resolve, 20))
+      expect(nydus.subscribeClient).toHaveBeenCalledWith(
+        client1,
+        getChannelPath(shieldBatteryChannel.id),
+        undefined,
+      )
+      expect(nydus.subscribeClient).toHaveBeenCalledWith(
+        client1,
+        getChannelUserPath(shieldBatteryChannel.id, user1.id),
+        undefined,
+      )
       expect(client1.publish).toHaveBeenCalledWith(getChannelPath(shieldBatteryChannel.id), {
         action: 'init3',
         channelInfo: shieldBatteryBasicInfo,
@@ -650,11 +665,6 @@ describe('chat/chat-service', () => {
         activeUserIds: [user2.id, user1.id],
         selfPermissions: channelPermissions,
       })
-      expect(nydus.subscribeClient).toHaveBeenCalledWith(
-        client1,
-        getChannelUserPath(shieldBatteryChannel.id, user1.id),
-        undefined,
-      )
     })
 
     test("creates a new channel when it doesn't exist", async () => {
@@ -682,6 +692,16 @@ describe('chat/chat-service', () => {
       // TODO(2Pac): Add something to FakeNydusServer to resolve when all current subscription
       // promises are complete?
       await new Promise(resolve => setTimeout(resolve, 20))
+      expect(nydus.subscribeClient).toHaveBeenCalledWith(
+        client1,
+        getChannelPath(testChannel.id),
+        undefined,
+      )
+      expect(nydus.subscribeClient).toHaveBeenCalledWith(
+        client1,
+        getChannelUserPath(testChannel.id, user1.id),
+        undefined,
+      )
       expect(client1.publish).toHaveBeenCalledWith(getChannelPath(testChannel.id), {
         action: 'init3',
         channelInfo: testBasicInfo,
@@ -690,11 +710,6 @@ describe('chat/chat-service', () => {
         activeUserIds: [user1.id],
         selfPermissions: channelPermissions,
       })
-      expect(nydus.subscribeClient).toHaveBeenCalledWith(
-        client1,
-        getChannelUserPath(testChannel.id, user1.id),
-        undefined,
-      )
     })
   })
 

--- a/server/lib/chat/chat-service.ts
+++ b/server/lib/chat/chat-service.ts
@@ -366,6 +366,7 @@ export default class ChatService {
         throw new ChatServiceError(
           ChatServiceErrorCode.NoInitialChannelData,
           'Error retrieving the initial channel data for the user',
+          { cause: err },
         )
       }
     }

--- a/server/lib/errors/coded-error.ts
+++ b/server/lib/errors/coded-error.ts
@@ -4,8 +4,15 @@ import Koa from 'koa'
  * A generic Error type that includes a `code` to identify what type of error it is.
  */
 export class CodedError<CodeType extends string, DataType = any> extends Error {
-  constructor(readonly code: CodeType, message: string, readonly data?: DataType) {
-    super(message)
+  readonly data?: DataType
+
+  constructor(
+    readonly code: CodeType,
+    message: string,
+    options?: { data?: DataType; cause?: unknown },
+  ) {
+    super(message, options?.cause ? { cause: options?.cause } : undefined)
+    this.data = options?.data
   }
 }
 

--- a/server/lib/games/game-loader.ts
+++ b/server/lib/games/game-loader.ts
@@ -57,11 +57,7 @@ interface GameLoadErrorTypeToData {
 export class GameLoaderError<T extends GameLoadErrorType> extends CodedError<
   T,
   GameLoadErrorTypeToData[T]
-> {
-  constructor(code: T, message: string, data: GameLoadErrorTypeToData[T]) {
-    super(code, message, data)
-  }
-}
+> {}
 
 function generateSeed() {
   // BWChart and some other replay sites/libraries utilize the random seed as the date the game was
@@ -279,7 +275,7 @@ export class GameLoader {
     return this.maybeCancelLoadingFromSystem(
       gameId,
       new GameLoaderError(GameLoadErrorType.PlayerFailed, `${playerName} failed to load`, {
-        userId: loadingPlayer.userId,
+        data: { userId: loadingPlayer.userId },
       }),
     )
   }

--- a/server/lib/parties/party-service.ts
+++ b/server/lib/parties/party-service.ts
@@ -190,7 +190,7 @@ export default class PartyService implements InPartyChecker {
         throw new PartyServiceError(
           PartyServiceErrorCode.AlreadyMember,
           'This user is already a member of this party',
-          { user: invitedUser },
+          { data: { user: invitedUser } },
         )
       }
 
@@ -503,7 +503,7 @@ export default class PartyService implements InPartyChecker {
       throw new PartyServiceError(
         PartyServiceErrorCode.AlreadyInGameplayActivity,
         'One or more player is already in a gameplay activity',
-        { users: alreadyActive },
+        { data: { users: alreadyActive } },
       )
     }
 

--- a/server/lib/session/session-api.ts
+++ b/server/lib/session/session-api.ts
@@ -148,8 +148,10 @@ export class SessionApi {
       const banHistory = await retrieveBanHistory(user.id, 1)
       const banEntry = banHistory.length ? banHistory[0] : undefined
       throw new UserApiError(UserErrorCode.AccountBanned, 'This account has been banned', {
-        reason: banEntry?.reason,
-        expiration: Number(banEntry?.endTime),
+        data: {
+          reason: banEntry?.reason,
+          expiration: Number(banEntry?.endTime),
+        },
       })
     } else if (await this.userIdentifierManager.banUserIfNeeded(user.id)) {
       // NOTE(tec27): We make sure to do this check *after* checking the account ban only, otherwise
@@ -157,8 +159,10 @@ export class SessionApi {
       const banHistory = await retrieveBanHistory(user.id, 1)
       const banEntry = banHistory.length ? banHistory[0] : undefined
       throw new UserApiError(UserErrorCode.AccountBanned, 'This account has been banned', {
-        reason: banEntry?.reason,
-        expiration: Number(banEntry?.endTime),
+        data: {
+          reason: banEntry?.reason,
+          expiration: Number(banEntry?.endTime),
+        },
       })
     }
 


### PR DESCRIPTION
The previous code could produce a bug in a following case:
- connect with one client to the server and create a channel
- connect with the second client to the server
- second client will receive both the `chatReady` and `init3` events in the non-consistent order (depends on how things execute on the server)
- if the second client receives the `init3` event before the `chatReady` event, their channel list will be out of order

This fix makes it so we don't send the `init3` event when they connect to the server, but only immediatelly after they join a channel.

Additionally, we could also change the reducer on the frontend to always rewrite the channel list when it receives the `chatReady` event, but it seems unnecessary to me.