### PR TITLE
Fix the channel banner card trying to display a name of the deleted

### DIFF
--- a/client/chat/admin/channel-content.tsx
+++ b/client/chat/admin/channel-content.tsx
@@ -216,7 +216,7 @@ function ChannelBannerCard({
             <ChannelList>
               {banner.availableIn.map(channelId => (
                 <ChannelListEntry key={channelId}>
-                  {channelInfos.get(channelId)!.name}
+                  {channelInfos.get(channelId)?.name ?? 'Deleted channel'}
                 </ChannelListEntry>
               ))}
             </ChannelList>


### PR DESCRIPTION
channel.

When the last person leaves a non-official channel, it gets deleted. However, there might've been some channel banners which were available in this now-deleted channel, so we can't display its name in the channel banner card.

Note that this still leaves the deleted channel in the banners table in DB, so an ideal fix would be where each `channelId` in the `available_in` column in the `channel_banners` table is a foreign key to the `channels` table. Is that even possible? :/
Although this also might leave things in a weird state, where a channel banner is marked as `limited`, but doesn't have any channel that it's available in.