### PR TITLE
fix(landing): sign up and login buttons width

### DIFF
--- a/client/landing/splash.tsx
+++ b/client/landing/splash.tsx
@@ -125,10 +125,21 @@ const ButtonsContainer = styled.div`
   flex-direction: row;
   flex-wrap: wrap;
   justify-content: center;
+  width: 100%;
+`
+
+const ContainerButtonAligner = styled.div.attrs(p => p)<{ align: 'left' | 'right' | 'center' }>`
+  flex: 1 1 0px;
+  display: flex;
+  justify-content: ${p => ({ center: 'center', left: 'flex-start', right: 'flex-end' })[p.align]};
+  @media (max-width: 800px) {
+    flex: 1 1 9999px;
+    justify-content: center;
+  }
 `
 
 const SplashButton = styled(RaisedButton)`
-  width: 200px;
+  min-width: 200px;
   height: 54px;
   margin: 16px 32px;
 
@@ -495,25 +506,31 @@ export function Splash() {
       </Blurb>
       {!IS_ELECTRON ? (
         <ButtonsContainer>
+          <ContainerButtonAligner align='right'>
+            <SplashButton
+              label={t('landing.splash.signUp', 'Sign Up')}
+              color='primary'
+              onClick={onSignUpClick}
+              testName='sign-up-button'
+            />
+          </ContainerButtonAligner>
+          <ContainerButtonAligner align='left'>
+            <SplashButton
+              label={t('common.actions.download', 'Download')}
+              color='primary'
+              onClick={() => dispatch(openDialog({ type: DialogType.Download }))}
+            />
+          </ContainerButtonAligner>
+        </ButtonsContainer>
+      ) : (
+        <ContainerButtonAligner align='center'>
           <SplashButton
             label={t('landing.splash.signUp', 'Sign Up')}
             color='primary'
             onClick={onSignUpClick}
             testName='sign-up-button'
           />
-          <SplashButton
-            label={t('common.actions.download', 'Download')}
-            color='primary'
-            onClick={() => dispatch(openDialog({ type: DialogType.Download }))}
-          />
-        </ButtonsContainer>
-      ) : (
-        <SplashButton
-          label={t('landing.splash.signUp', 'Sign Up')}
-          color='primary'
-          onClick={onSignUpClick}
-          testName='sign-up-button'
-        />
+        </ContainerButtonAligner>
       )}
       <StyledGameCount />
       <BenefitContainer>


### PR DESCRIPTION
Landing buttons have fixed `width` which may squeeze inner text if it's too long (that happens with different locales)
[Current RU locale "sign up" button being broken](https://github-production-user-asset-6210df.s3.amazonaws.com/102466089/261858336-bd0e36fc-ad33-4fd7-a5fa-8ea426b3654e.png)

A possible solution could be changing `width` to `min-width` but in that case a bigger button may cause extra skewing from its side

This PR solution: 
1. Makes buttons responsive relative to its text (preserving `min-width`)
2. Ensures that a button will be positioned within its space only
3. Wraps buttons to new lines on 800px `media` corresponding to `BenefitContainer` wrap