### PR TITLE
Implement our own version of the language detector.

### DIFF
--- a/client/i18n/action-creators.ts
+++ b/client/i18n/action-creators.ts
@@ -8,13 +8,14 @@ import logger from '../logging/logger'
 import { RequestHandlingSpec, abortableThunk } from '../network/abortable-thunk'
 import { encodeBodyAsParams, fetchJson } from '../network/fetch'
 import { TIMING_LONG, openSnackbar } from '../snackbars/action-creators'
+import { getBestLanguage } from './language-detector'
 
 export function maybeChangeLanguageLocally(locale?: string): ThunkAction {
   return dispatch => {
     if (!locale || locale === i18n.language || !i18n.isInitialized) {
       return
     }
-    const detectedLanguage = i18n.services.languageUtils.getBestMatchFromCodes([locale])
+    const detectedLanguage = getBestLanguage([locale])
     if (!detectedLanguage || detectedLanguage === i18n.language) {
       return
     }

--- a/client/i18n/i18next.ts
+++ b/client/i18n/i18next.ts
@@ -1,5 +1,4 @@
 import i18n, { TFunction } from 'i18next'
-import LanguageDetector from 'i18next-browser-languagedetector'
 import HttpBackend, { HttpBackendOptions } from 'i18next-http-backend'
 import { initReactI18next } from 'react-i18next'
 import createDeferred from '../../common/async/deferred'
@@ -10,6 +9,7 @@ import {
 } from '../../common/i18n'
 import { makePublicAssetUrl, makeServerUrl } from '../network/server-url'
 import { JsonSessionStorageValue } from '../session-storage'
+import { getBestLanguage } from './language-detector'
 
 const isDev = __WEBPACK_ENV.NODE_ENV !== 'production'
 const CUR_VERSION = __WEBPACK_ENV.VERSION
@@ -30,11 +30,6 @@ export type TransInterpolation = any
  */
 export const detectedLocale = new JsonSessionStorageValue<string | undefined>('detectedLocale')
 
-export const languageDetector = new LanguageDetector(null, {
-  order: ['navigator'],
-  caches: [],
-})
-
 const i18nextDeferred = createDeferred<TFunction>()
 
 export const i18nextPromise = i18nextDeferred.then(i18next => i18next)
@@ -46,7 +41,6 @@ export const i18nextPromise = i18nextDeferred.then(i18next => i18next)
 export function initI18next() {
   const i18next = i18n
     .use(HttpBackend)
-    .use(languageDetector)
     .use(initReactI18next)
     .init<HttpBackendOptions>({
       backend: {
@@ -59,6 +53,7 @@ export function initI18next() {
       saveMissing: isDev,
       saveMissingTo: 'all', // Save the missing keys to all languages
 
+      lng: getBestLanguage(),
       supportedLngs: ALL_TRANSLATION_LANGUAGES,
       fallbackLng: TranslationLanguage.English,
 

--- a/client/i18n/language-detector.test.ts
+++ b/client/i18n/language-detector.test.ts
@@ -1,0 +1,22 @@
+import { TranslationLanguage } from '../../common/i18n'
+import { getBestLanguage } from './language-detector'
+
+describe('client/i18n/language-detector', () => {
+  test('returns the english language if none of the given languages are supported', () => {
+    const lng = getBestLanguage(['INVALID_LANGUAGE'])
+
+    expect(lng).toBe(TranslationLanguage.English)
+  })
+
+  test('returns the earliest matching language without dialect', () => {
+    const lng = getBestLanguage(['en-US', 'kr'])
+
+    expect(lng).toBe(TranslationLanguage.English)
+  })
+
+  test('returns the exact match for the language with dialect', () => {
+    const lng = getBestLanguage(['zh-Hans', 'en-US'])
+
+    expect(lng).toBe(TranslationLanguage.ChineseSimplified)
+  })
+})

--- a/client/i18n/language-detector.test.ts
+++ b/client/i18n/language-detector.test.ts
@@ -1,22 +1,30 @@
 import { TranslationLanguage } from '../../common/i18n'
 import { getBestLanguage } from './language-detector'
 
+const SUPPORTED_LANGUAGES = ['zh-Hans', 'en', 'ko', 'ru', 'es']
+
 describe('client/i18n/language-detector', () => {
   test('returns the english language if none of the given languages are supported', () => {
-    const lng = getBestLanguage(['INVALID_LANGUAGE'])
+    const lng = getBestLanguage(['INVALID_LANGUAGE'], SUPPORTED_LANGUAGES)
 
     expect(lng).toBe(TranslationLanguage.English)
   })
 
   test('returns the earliest matching language without dialect', () => {
-    const lng = getBestLanguage(['en-US', 'kr'])
+    const lng = getBestLanguage(['en-US', 'ko-KR'], SUPPORTED_LANGUAGES)
 
     expect(lng).toBe(TranslationLanguage.English)
   })
 
   test('returns the exact match for the language with dialect', () => {
-    const lng = getBestLanguage(['zh-Hans', 'en-US'])
+    const lng = getBestLanguage(['zh-Hans', 'en-US'], SUPPORTED_LANGUAGES)
 
     expect(lng).toBe(TranslationLanguage.ChineseSimplified)
+  })
+
+  test('language with a dialect will match a non-dialect code', () => {
+    const lng = getBestLanguage(['es-MX', 'en-US'], SUPPORTED_LANGUAGES)
+
+    expect(lng).toBe(TranslationLanguage.Spanish)
   })
 })

--- a/client/i18n/language-detector.ts
+++ b/client/i18n/language-detector.ts
@@ -1,0 +1,31 @@
+import { ALL_TRANSLATION_LANGUAGES, TranslationLanguage } from '../../common/i18n'
+
+const lowerCaseSupportedLanguages = ALL_TRANSLATION_LANGUAGES.map(l => l.toLowerCase())
+
+/**
+ * Choose the preferred language from the list of given languages. If no languages are given, we
+ * default to using `navigator.languages` as a list of available languages. The logic for choosing
+ * the preferred language is:
+ *  - for languages we support without dialects, prefer the earliest matching language in the list
+ *    of given languages.
+ *  - for languages we support with dialects, prefer only if exact match.
+ */
+export function getBestLanguage(languages = navigator.languages) {
+  for (let i = 0; i < languages.length; i++) {
+    const lng = languages[i].toLowerCase() as TranslationLanguage
+
+    let lngIndex = lowerCaseSupportedLanguages.indexOf(lng)
+    if (lngIndex > -1) {
+      return ALL_TRANSLATION_LANGUAGES[lngIndex]
+    }
+
+    const lngWithoutDialect = lng.split('-')[0]
+
+    lngIndex = lowerCaseSupportedLanguages.indexOf(lngWithoutDialect)
+    if (lngIndex > -1) {
+      return ALL_TRANSLATION_LANGUAGES[lngIndex]
+    }
+  }
+
+  return TranslationLanguage.English
+}

--- a/client/i18n/language-detector.ts
+++ b/client/i18n/language-detector.ts
@@ -1,7 +1,5 @@
 import { ALL_TRANSLATION_LANGUAGES, TranslationLanguage } from '../../common/i18n'
 
-const lowerCaseSupportedLanguages = ALL_TRANSLATION_LANGUAGES.map(l => l.toLowerCase())
-
 /**
  * Choose the preferred language from the list of given languages. If no languages are given, we
  * default to using `navigator.languages` as a list of available languages. The logic for choosing
@@ -10,20 +8,25 @@ const lowerCaseSupportedLanguages = ALL_TRANSLATION_LANGUAGES.map(l => l.toLower
  *    of given languages.
  *  - for languages we support with dialects, prefer only if exact match.
  */
-export function getBestLanguage(languages = navigator.languages) {
-  for (let i = 0; i < languages.length; i++) {
-    const lng = languages[i].toLowerCase() as TranslationLanguage
+export function getBestLanguage(
+  languages = navigator.languages,
+  supportedLanguages: string[] = ALL_TRANSLATION_LANGUAGES as string[],
+) {
+  const lowerCaseSupportedLanguages = supportedLanguages.map(l => l.toLowerCase())
 
-    let lngIndex = lowerCaseSupportedLanguages.indexOf(lng)
+  for (const lng of languages) {
+    const lowerCaseLanguage = lng.toLowerCase()
+
+    let lngIndex = lowerCaseSupportedLanguages.indexOf(lowerCaseLanguage)
     if (lngIndex > -1) {
-      return ALL_TRANSLATION_LANGUAGES[lngIndex]
+      return supportedLanguages[lngIndex]
     }
 
-    const lngWithoutDialect = lng.split('-')[0]
+    const lngWithoutDialect = lowerCaseLanguage.split('-', 1)[0]
 
     lngIndex = lowerCaseSupportedLanguages.indexOf(lngWithoutDialect)
     if (lngIndex > -1) {
-      return ALL_TRANSLATION_LANGUAGES[lngIndex]
+      return supportedLanguages[lngIndex]
     }
   }
 

--- a/client/index.jsx
+++ b/client/index.jsx
@@ -10,7 +10,8 @@ import { bootstrapSession, getCurrentSession } from './auth/action-creators'
 import { initBrowserprint } from './auth/browserprint'
 import createStore from './create-store'
 import { registerDispatch } from './dispatch-registry'
-import i18n, { detectedLocale, initI18next, languageDetector } from './i18n/i18next'
+import i18n, { detectedLocale, initI18next } from './i18n/i18next'
+import { getBestLanguage } from './i18n/language-detector'
 import log from './logging/logger'
 import { fetchJson } from './network/fetch'
 import registerSocketHandlers from './network/socket-handlers'
@@ -98,7 +99,7 @@ rootElemPromise
       store.dispatch({ type: AUDIO_MANAGER_INITIALIZED })
     })
 
-    const detected = languageDetector.detect()
+    const detected = getBestLanguage()
     detectedLocale.setValue(Array.isArray(detected) ? detected[0] : detected)
 
     let action
@@ -160,7 +161,7 @@ rootElemPromise
       })
 
       if (locale) {
-        await i18n.changeLanguage(i18n.services.languageUtils.getBestMatchFromCodes([locale]))
+        await i18n.changeLanguage(getBestLanguage([locale]))
       }
     } catch (err) {
       log.error(`Error initializing i18next: ${err?.stack ?? err}`)

--- a/package.json
+++ b/package.json
@@ -270,7 +270,6 @@
     "graphql-tag": "^2.12.6",
     "html-loader": "^4.2.0",
     "i18next": "^23.0.2",
-    "i18next-browser-languagedetector": "^7.0.1",
     "i18next-fs-backend": "^2.1.0",
     "i18next-http-backend": "^2.1.0",
     "i18next-parser": "^8.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1098,7 +1098,7 @@
   resolved "https://registry.yarnpkg.com/@babel/regjsgen/-/regjsgen-0.8.0.tgz#f0ba69b075e1f05fb2825b7fad991e7adbb18310"
   integrity sha512-x/rqGMdzj+fWZvCOYForTghzbtqPDZ5gPwaoNGHdgDfF2QA/XZbCBp4Moo5scrkAMPhB7z26XM/AaHuIJdgauA==
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.12.1", "@babel/runtime@^7.13.10", "@babel/runtime@^7.16.7", "@babel/runtime@^7.17.8", "@babel/runtime@^7.18.3", "@babel/runtime@^7.19.4", "@babel/runtime@^7.20.6", "@babel/runtime@^7.22.10", "@babel/runtime@^7.22.5", "@babel/runtime@^7.3.1", "@babel/runtime@^7.5.5", "@babel/runtime@^7.8.3", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.12.1", "@babel/runtime@^7.13.10", "@babel/runtime@^7.16.7", "@babel/runtime@^7.17.8", "@babel/runtime@^7.18.3", "@babel/runtime@^7.20.6", "@babel/runtime@^7.22.10", "@babel/runtime@^7.22.5", "@babel/runtime@^7.3.1", "@babel/runtime@^7.5.5", "@babel/runtime@^7.8.3", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
   version "7.22.15"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.22.15.tgz#38f46494ccf6cf020bd4eed7124b425e83e523b8"
   integrity sha512-T0O+aa+4w0u06iNmapipJXMV4HoUir03hpx3/YqXXhu9xim3w+dVphjFWl1OH8NbZHw5Lbm9k45drDkgq2VNNA==
@@ -8835,13 +8835,6 @@ hyphenate-style-name@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/hyphenate-style-name/-/hyphenate-style-name-1.0.4.tgz#691879af8e220aea5750e8827db4ef62a54e361d"
   integrity sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ==
-
-i18next-browser-languagedetector@^7.0.1:
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/i18next-browser-languagedetector/-/i18next-browser-languagedetector-7.1.0.tgz#01876fac51f86b78975e79b48ccb62e2313a2d7d"
-  integrity sha512-cr2k7u1XJJ4HTOjM9GyOMtbOA47RtUoWRAtt52z43r3AoMs2StYKyjS3URPhzHaf+mn10hY9dZWamga5WPQjhA==
-  dependencies:
-    "@babel/runtime" "^7.19.4"
 
 i18next-fs-backend@^2.1.0:
   version "2.1.5"


### PR DESCRIPTION
i18n's version had some very weird rules, so we just implement our own now. Fairly rudimentary at the moment, and I'm sure it doesn't cover *all* of the possible language codes, but should work for our supported languages.

Fixes #1051 