### PR TITLE
Add the option to make Tooltip interactive.

### DIFF
--- a/client/chat/channel-header.tsx
+++ b/client/chat/channel-header.tsx
@@ -243,6 +243,7 @@ export function ChannelHeader({
               text={parsedChannelTopic}
               position='bottom'
               disabled={!isChannelTopicOverflowing}
+              interactive={true}
               ContentComponent={StyledTooltipContent}>
               <ChannelTopic ref={channelTopicRef}>{parsedChannelTopic}</ChannelTopic>
             </StyledTooltip>

--- a/client/material/popover.tsx
+++ b/client/material/popover.tsx
@@ -208,6 +208,8 @@ export interface PopoverContentProps extends Omit<PopoverProps, 'open' | 'onDism
   /** The ARIA role to use for the content container. */
   role?: React.AriaRole
   styles: React.CSSProperties
+  onMouseEnter?: (event: React.MouseEvent | React.FocusEvent) => void
+  onMouseLeave?: (event: React.MouseEvent | React.FocusEvent) => void
 }
 
 /**
@@ -226,6 +228,8 @@ export function PopoverContent({
   originX,
   originY,
   styles,
+  onMouseEnter,
+  onMouseLeave,
 }: PopoverContentProps) {
   const [maxSizeRectRef, maxSizeRect] = useElementRect()
   // NOTE(tec27): We need this so that the component re-renders if the window is resized
@@ -339,7 +343,9 @@ export function PopoverContent({
         className={className}
         id={id}
         role={role}
-        style={{ ...styles, ...(containerStyle as any) }}>
+        style={{ ...styles, ...(containerStyle as any) }}
+        onMouseEnter={onMouseEnter}
+        onMouseLeave={onMouseLeave}>
         {children}
       </Container>
     </PositioningArea>


### PR DESCRIPTION
Interactive tooltips allow users to interact with the content inside it, e.g. pressing buttons and links.

Also, we're utilizing this interactive tooltip for the topic in channel header.

Closes #1007 