### PR TITLE
Change the default replays sort order to be most recent stuff first.

### DIFF
--- a/client/file-browser/file-browser.tsx
+++ b/client/file-browser/file-browser.tsx
@@ -136,7 +136,8 @@ interface FileBrowserProps {
   title: string
   titleButton?: React.ReactElement
   fileEntryConfig: FileBrowserFileEntryConfig
-  sortFunc?: (a: FileBrowserEntry, b: FileBrowserEntry) => number
+  folderSortFunc?: (a: FileBrowserFolderEntry, b: FileBrowserFolderEntry) => number
+  fileSortFunc?: (a: FileBrowserFileEntry, b: FileBrowserFileEntry) => number
 }
 
 export function FileBrowser({
@@ -145,7 +146,8 @@ export function FileBrowser({
   title = 'Files',
   titleButton,
   fileEntryConfig,
-  sortFunc = sortByName,
+  folderSortFunc = sortByName,
+  fileSortFunc = sortByName,
 }: FileBrowserProps) {
   const { t } = useTranslation()
 
@@ -255,10 +257,10 @@ export function FileBrowser({
 
           const folders: FileBrowserFolderEntry[] = result
             .filter((e): e is FileBrowserFolderEntry => e.type === FileBrowserEntryType.Folder)
-            .sort(sortFunc)
+            .sort(folderSortFunc)
           const files: FileBrowserFileEntry[] = result
             .filter((e): e is FileBrowserFileEntry => e.type === FileBrowserEntryType.File)
-            .sort(sortFunc)
+            .sort(fileSortFunc)
 
           setUpOneDir(upOneDir)
           setFolders(folders)

--- a/client/replays/browse-local-replays.tsx
+++ b/client/replays/browse-local-replays.tsx
@@ -7,6 +7,7 @@ import { closeOverlay } from '../activities/action-creators'
 import { FileBrowser } from '../file-browser/file-browser'
 import {
   ExpansionPanelProps,
+  FileBrowserEntry,
   FileBrowserFileEntry,
   FileBrowserFileEntryConfig,
   FileBrowserRootFolderId,
@@ -25,6 +26,9 @@ async function getReplayFolderPath() {
     '\\',
   )
 }
+
+const sortByNameReverse = (a: FileBrowserEntry, b: FileBrowserEntry) => b.name.localeCompare(a.name)
+const sortByDateReverse = (a: FileBrowserFileEntry, b: FileBrowserFileEntry) => +b.date - +a.date
 
 const StyledReplayInfoDisplay = styled(ReplayInfoDisplay)`
   padding: 16px;
@@ -85,6 +89,8 @@ export function BrowseLocalReplays() {
       title={t('replays.local.title', 'Local Replays')}
       rootFolders={rootFolders}
       fileEntryConfig={fileEntryConfig}
+      folderSortFunc={sortByNameReverse}
+      fileSortFunc={sortByDateReverse}
     />
   )
 }


### PR DESCRIPTION
For folders we're using a reverse-alphabetical order since that's what Battle.net seems to be doing and people are used to it.

Also, this will matter less once we make the sort order customizable.