### PR TITLE
Fix a bug in channel list search leading to potentially not searching.

### DIFF
--- a/client/chat/channel-list.tsx
+++ b/client/chat/channel-list.tsx
@@ -82,6 +82,9 @@ export function ChannelList() {
       // Just need to clear the search results here and let the infinite scroll list initiate the
       // network request.
       setSearchQuery(searchQuery)
+      // TODO(2Pac): Make the infinite scroll lost in charge of the loading state, so we don't have
+      // to do this here, which is pretty unintuitive.
+      setIsLoadingMoreChannels(false)
       setSearchError(undefined)
       setChannels(undefined)
       setHasMoreChannels(true)


### PR DESCRIPTION
This fixes a bug that could've happened if the previous request was still loading, the new one wouldn't be executed because infinite-scroll-list only runs the load more data callback if it's not already loading.

This is a band aid fix; the proper fix would involve fixing infinite-scroll-list, but is also a bit more work so this will have to do for now.