### PR TITLE
Properly clean up state when users leave during countdown/loading.

### DIFF
--- a/.github/workflows/server-rs-ci.yml
+++ b/.github/workflows/server-rs-ci.yml
@@ -134,7 +134,7 @@ jobs:
 
       - name: Display typeshare
         if: ${{ steps.check-typeshare.outputs.files_changed == 'true' || failure() && steps.gen-typeshare.conclusion == 'failure' }}
-        uses: actions/github-script@v6
-        with:
-          script: |
-            core.setFailed('The typeshare types seem outdated. Please run "pnpm gen-typeshare" in the directory root and commit the updated files.')
+        env:
+          CHANGED_FILES: ${{ steps.verify-changed-files.outputs.changed_files }}
+        with: |
+          echo "Changed files: $CHANGED_FILES"

--- a/.github/workflows/server-rs-ci.yml
+++ b/.github/workflows/server-rs-ci.yml
@@ -136,5 +136,11 @@ jobs:
         if: ${{ steps.check-typeshare.outputs.files_changed == 'true' || failure() && steps.gen-typeshare.conclusion == 'failure' }}
         env:
           CHANGED_FILES: ${{ steps.verify-changed-files.outputs.changed_files }}
-        with: |
-          echo "Changed files: $CHANGED_FILES"
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const { CHANGED_FILES } = process.env
+
+            console.log(`Changed files: ${CHANGED_FILES}`)
+
+            core.setFailed('The typeshare types seem outdated. Please run "pnpm gen-typeshare" in the directory root and commit the updated files.')

--- a/.github/workflows/server-rs-ci.yml
+++ b/.github/workflows/server-rs-ci.yml
@@ -127,7 +127,7 @@ jobs:
         run: pnpm gen-typeshare
 
       - name: Check typeshare
-        uses: tj-actions/verify-changed-files@v15
+        uses: tj-actions/verify-changed-files@v20
         id: check-typeshare
         with:
           files: common/typeshare.ts

--- a/.github/workflows/server-rs-ci.yml
+++ b/.github/workflows/server-rs-ci.yml
@@ -141,7 +141,7 @@ jobs:
         with:
           script: |
             const util = require('node:util')
-            const exec = util.promisify(require('node:child_process').exec)
+            const node_exec = util.promisify(require('node:child_process').exec)
 
             const { FILES_CHANGED, CHANGED_FILES } = process.env
 
@@ -149,7 +149,7 @@ jobs:
             console.log(`Changed files: ${CHANGED_FILES}`)
 
             async function runGitDiff() {
-              const { stdout, stderr } = await exec('git diff')
+              const { stdout, stderr } = await node_exec('git diff')
               console.log('stdout:', stdout)
               console.error('stderr:', stderr)
             }

--- a/.github/workflows/server-rs-ci.yml
+++ b/.github/workflows/server-rs-ci.yml
@@ -135,12 +135,14 @@ jobs:
       - name: Display typeshare
         if: ${{ steps.check-typeshare.outputs.files_changed == 'true' || failure() && steps.gen-typeshare.conclusion == 'failure' }}
         env:
-          CHANGED_FILES: ${{ steps.verify-changed-files.outputs.changed_files }}
+          FILES_CHANGED: ${{ steps.check-typeshare.outputs.files_changed }}
+          CHANGED_FILES: ${{ steps.check-typeshare.outputs.changed_files }}
         uses: actions/github-script@v6
         with:
           script: |
-            const { CHANGED_FILES } = process.env
+            const { FILES_CHANGED, CHANGED_FILES } = process.env
 
+            console.log(`Files changed: ${FILES_CHANGED}`)
             console.log(`Changed files: ${CHANGED_FILES}`)
 
             core.setFailed('The typeshare types seem outdated. Please run "pnpm gen-typeshare" in the directory root and commit the updated files.')

--- a/.github/workflows/server-rs-ci.yml
+++ b/.github/workflows/server-rs-ci.yml
@@ -140,9 +140,19 @@ jobs:
         uses: actions/github-script@v6
         with:
           script: |
+            const util = require('node:util')
+            const exec = util.promisify(require('node:child_process').exec)
+
             const { FILES_CHANGED, CHANGED_FILES } = process.env
 
             console.log(`Files changed: ${FILES_CHANGED}`)
             console.log(`Changed files: ${CHANGED_FILES}`)
+
+            async function runGitDiff() {
+              const { stdout, stderr } = await exec('git diff')
+              console.log('stdout:', stdout)
+              console.error('stderr:', stderr)
+            }
+            runGitDiff()
 
             core.setFailed('The typeshare types seem outdated. Please run "pnpm gen-typeshare" in the directory root and commit the updated files.')

--- a/client/lobbies/socket-handlers.ts
+++ b/client/lobbies/socket-handlers.ts
@@ -471,6 +471,9 @@ const eventToAction: EventToActionMap = {
     // the loading screen anyway, even after it's been canceled.
     clearCountdownTimer()
     dispatch({
+      // TODO(2Pac): This should probably be a different action than the countdown canceled one? As
+      // it is currently, this displays the same chat message twice in the lobby if someone leaves
+      // during countdown.
       type: LOBBY_UPDATE_COUNTDOWN_CANCELED,
     } as any)
 

--- a/server/lib/wsapi/lobbies.js
+++ b/server/lib/wsapi/lobbies.js
@@ -806,7 +806,7 @@ export class LobbyApi {
     })
   }
 
-  _maybeCancelLoading(lobby, isLobbyEmpty) {
+  _maybeCancelLoading(lobby, isLobbyEmpty = false) {
     if (!this.loadingLobbies.has(lobby.name)) {
       // This lobby was closed before loading completed, likely because all the human users left or
       // disconnected.
@@ -844,7 +844,7 @@ export class LobbyApi {
   }
 
   // Cancels the countdown if one was occurring (no-op if it was not)
-  _maybeCancelCountdown(lobby, isLobbyEmpty) {
+  _maybeCancelCountdown(lobby, isLobbyEmpty = false) {
     if (!this.lobbyCountdowns.has(lobby.name)) {
       return
     }


### PR DESCRIPTION
So there are 2 issues that were happening in the previous code when user would leave the lobby:
- We would publish the `cancelLoading` event only to the user who left, instead of the whole lobby.
- We would delete the lobby from the loading state only in case everyone left, instead of always.

I made the loading cleanup a bit more consistent now and similar to how/when cancel countdown happens. The only slightly weird thing here is that we publish the event to the lobby list to add the lobby back to the list when the loading gets canceled. However this is also done when cleaning up the countdown state as well, so we have two events fire each time, because those two cleanup functions are called in unison. We could perhaps combine these two functions into one, but I don't think it's a big deal to publish the event twice either?

I also fixed a rare bug that would happen if the last user would leave the lobby during countdown/loading (this is possible if you start the game with a computer and leave). The lobby would get deleted, but the cancel countdown/loading cleanup functions would publish the "add" event back to the lobby list, making the clients show a non-existent lobby. This wasn't a huge issue since it would only show the non-existent lobby if someone else already had the lobby list open. As soon as they close it and open it again they would get a full lobby list without the non-existent lobby.

Fixes #663 