### PR TITLE
Show target user profile info in the whisper page.

### DIFF
--- a/client/messaging/message-list.tsx
+++ b/client/messaging/message-list.tsx
@@ -1,6 +1,7 @@
 import { List } from 'immutable'
 import PropTypes from 'prop-types'
 import React, { ReactNode } from 'react'
+import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 import { ReadonlyDeep } from 'type-fest'
 import { ServerChatMessageType } from '../../common/chat'
@@ -10,7 +11,9 @@ import { useSelfUser } from '../auth/auth-utils'
 import InfiniteScrollList from '../lists/infinite-scroll-list'
 import { animationFrameHandler } from '../material/animation-frame-handler'
 import { useAppSelector } from '../redux-hooks'
+import { colorTextFaint } from '../styles/colors'
 import { selectableTextContainer } from '../styles/text-selection'
+import { subtitle1 } from '../styles/typography'
 import { BlockedMessage, NewDayMessage, TextMessage } from './common-message-layout'
 import { CommonMessageType, NewDayMessageRecord, SbMessage } from './message-records'
 
@@ -31,6 +34,14 @@ const AUTOSCROLL_LEEWAY_PX = 8
 const Scrollable = styled.div`
   padding: 8px 16px 0px 8px;
   overflow-y: auto;
+`
+
+const EmptyList = styled.div`
+  ${subtitle1};
+  padding: 32px 16px 48px;
+
+  color: ${colorTextFaint};
+  text-align: center;
 `
 
 const Messages = styled.div`
@@ -110,8 +121,14 @@ interface PureMessageListProps {
 // This contains just the messages, to avoid needing to re-render them all if e.g. loading state
 // changes on the actual message list
 const PureMessageList = React.memo<PureMessageListProps>(({ messages, renderMessage }) => {
+  const { t } = useTranslation()
   const selfUserId = useSelfUser()!.id
   const blocks = useAppSelector(s => s.relationships.blocks)
+
+  const messagesLength = getMessagesLength(messages)
+  if (messagesLength < 1) {
+    return <EmptyList>{t('common.lists.empty', 'Nothing to see here')}</EmptyList>
+  }
 
   return (
     <Messages>

--- a/client/users/user-profile-overlay.tsx
+++ b/client/users/user-profile-overlay.tsx
@@ -57,7 +57,7 @@ export function ConnectedUserProfileOverlay({
 
   return (
     <Popover {...popoverProps}>
-      <OverlayContents userId={userId} onDismiss={onDismiss} />
+      <UserProfileOverlayContents userId={userId} onDismiss={onDismiss} />
     </Popover>
   )
 }
@@ -181,7 +181,15 @@ const RankDisplaySection = styled.div`
 // NOTE(tec27): We need to push this content down a level from the Popover so the hooks inside only
 // run when it's visible (otherwise we'd request all the user profiles once they e.g. appeared in
 // the user list)
-function OverlayContents({ userId, onDismiss }: { userId: SbUserId; onDismiss: () => void }) {
+export function UserProfileOverlayContents({
+  userId,
+  showHintText = true,
+  onDismiss,
+}: {
+  userId: SbUserId
+  showHintText?: boolean
+  onDismiss?: () => void
+}) {
   const { t } = useTranslation()
   const dispatch = useAppDispatch()
   const cancelLoadRef = useRef(new AbortController())
@@ -192,7 +200,7 @@ function OverlayContents({ userId, onDismiss }: { userId: SbUserId; onDismiss: (
 
   const username = user?.name
   const onIdentityClick = useCallback(() => {
-    onDismiss()
+    onDismiss?.()
     navigateToUserProfile(userId, username ?? '')
   }, [userId, username, onDismiss])
 
@@ -282,9 +290,11 @@ function OverlayContents({ userId, onDismiss }: { userId: SbUserId; onDismiss: (
         <LoadingDotsArea />
       )}
 
-      <HintText>
-        {t('users.profileOverlay.rightClick', 'Right-click user for more actions')}
-      </HintText>
+      {showHintText ? (
+        <HintText>
+          {t('users.profileOverlay.rightClick', 'Right-click user for more actions')}
+        </HintText>
+      ) : null}
     </PopoverContents>
   )
 }

--- a/client/whispers/whisper.tsx
+++ b/client/whispers/whisper.tsx
@@ -9,6 +9,8 @@ import LoadingIndicator from '../progress/dots'
 import { useAppDispatch, useAppSelector } from '../redux-hooks'
 import { TIMING_LONG, openSnackbar } from '../snackbars/action-creators'
 import { usePrevious, useStableCallback } from '../state-hooks'
+import { background700, background800 } from '../styles/colors'
+import { UserProfileOverlayContents } from '../users/user-profile-overlay'
 import {
   activateWhisperSession,
   correctUsernameForWhisper,
@@ -21,9 +23,18 @@ import {
 const MESSAGES_LIMIT = 50
 
 const Container = styled.div`
-  max-width: 884px;
+  width: 100%;
   height: 100%;
+  margin: 0;
   padding: 0;
+  display: flex;
+  background-color: ${background700};
+`
+
+const StyledChat = styled(Chat)`
+  max-width: 960px;
+  flex-grow: 1;
+  background-color: ${background800};
 `
 
 const LoadingArea = styled.div`
@@ -167,7 +178,11 @@ export function ConnectedWhisper({ userId, username: usernameFromRoute }: Connec
 
   return (
     <Container>
-      <Chat listProps={listProps} inputProps={inputProps} />
+      <StyledChat
+        listProps={listProps}
+        inputProps={inputProps}
+        extraContent={<UserProfileOverlayContents userId={userId} showHintText={false} />}
+      />
     </Container>
   )
 }


### PR DESCRIPTION
Also adds an empty state for the message list component. I guess it could potentially be useful to show a different empty message in different chat contexts, but this is mostly only relevant in the whispers page anyway. In all other chat contexts we have so far, we pretty much always have at least one message showing.

Closes #1099 