### PR TITLE
Focus the replay entry in the file browser when Watch Replay is clicked.

### DIFF
--- a/client/file-browser/file-browser-entries.tsx
+++ b/client/file-browser/file-browser-entries.tsx
@@ -130,17 +130,20 @@ export const FileEntry = React.memo(
     isFocused,
     isExpanded,
     onClick,
+    onFocusedPathChange,
   }: FileBrowserEntryProps & {
     file: FileBrowserFileEntry
     fileEntryConfig: FileBrowserFileEntryConfig
     isFocused: boolean
     isExpanded?: boolean
     onClick: (entry: FileBrowserFileEntry) => void
+    onFocusedPathChange: (path: string) => void
   }) => {
     const { icon, ExpansionPanelComponent, onSelect, onSelectTitle } = fileEntryConfig
 
     const onSelectClick = useStableCallback((event: React.MouseEvent) => {
       event.stopPropagation()
+      onFocusedPathChange(file.path)
       onSelect(file)
     })
 

--- a/client/file-browser/file-browser.tsx
+++ b/client/file-browser/file-browser.tsx
@@ -470,6 +470,7 @@ export function FileBrowser({
           isFocused={isFocused}
           isExpanded={expandedFileEntry === entry.path}
           onClick={onFileClick}
+          onFocusedPathChange={setFocusedPath}
           key={entry.path}
         />
       )


### PR DESCRIPTION
This is mostly useful if you click on Watch Replay button without focusing that replay entry first. The replay would start fine, but the file entry would not be focused, confusing you what was the last replay you watched.

I couldn't just remove the `event.stopPropagation()` on the Watch Replay button, because that would also expand the replay info panel as well as started the replay.