### PR TITLE
Display user's ranking history in their profiles.

### DIFF
--- a/client/ladder/devonly/table-test.tsx
+++ b/client/ladder/devonly/table-test.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useMemo, useState } from 'react'
 import { LadderPlayer } from '../../../common/ladder/ladder'
-import { makeSeasonId, MatchmakingSeasonJson } from '../../../common/matchmaking'
+import { makeSeasonId, MatchmakingSeasonJson, MatchmakingType } from '../../../common/matchmaking'
 import { makeSbUserId, SbUser, SbUserId } from '../../../common/users/sb-user'
 import { DivisionFilter, LadderTable } from '../ladder'
 
@@ -45,6 +45,8 @@ for (let i = 0; i < 1000; i++) {
   PLAYERS.push({
     rank: i + 1,
     userId: makeSbUserId(i),
+    matchmakingType: MatchmakingType.Match1v1,
+    seasonId: SEASON.id,
     rating,
     points: rating * (Math.random() * 4),
     bonusUsed: 0,

--- a/client/matchmaking/find-match.tsx
+++ b/client/matchmaking/find-match.tsx
@@ -10,6 +10,7 @@ import {
   MatchmakingPreferences,
   MatchmakingType,
   getTotalBonusPoolForSeason,
+  makeSeasonId,
   matchmakingDivisionToLabel,
   matchmakingTypeToLabel,
 } from '../../common/matchmaking'
@@ -428,6 +429,8 @@ function RankInfo({ matchmakingType }: { matchmakingType: MatchmakingType }) {
     ({
       rank: Number.MAX_SAFE_INTEGER,
       userId: selfUserId,
+      matchmakingType,
+      seasonId: season?.id ?? makeSeasonId(0),
       rating: 0,
       points: 0,
       bonusUsed: 0,

--- a/client/matchmaking/matchmaking-seasons-reducer.ts
+++ b/client/matchmaking/matchmaking-seasons-reducer.ts
@@ -26,4 +26,10 @@ export default immerKeyedReducer(DEFAULT_STATE, {
       state.byId.set(season.id, season)
     }
   },
+
+  ['@users/getRankingHistory'](state, { payload: { seasons } }) {
+    for (const season of seasons) {
+      state.byId.set(season.id, season)
+    }
+  },
 })

--- a/client/users/action-creators.ts
+++ b/client/users/action-creators.ts
@@ -11,6 +11,7 @@ import {
   AdminUpdatePermissionsRequest,
   GetBatchUserInfoResponse,
   GetUserProfileResponse,
+  GetUserRankingHistoryResponse,
   SbUserId,
   SearchMatchHistoryResponse,
 } from '../../common/users/sb-user'
@@ -305,5 +306,27 @@ export function unblockUser(targetId: SbUserId, spec: RequestHandlingSpec): Thun
       method: 'DELETE',
       signal: spec.signal,
     })
+  })
+}
+
+export function getUserRankingHistory(
+  userId: SbUserId,
+  spec: RequestHandlingSpec<GetUserRankingHistoryResponse>,
+): ThunkAction {
+  return abortableThunk(spec, async dispatch => {
+    const result = await fetchJson<GetUserRankingHistoryResponse>(
+      apiUrl`users/${userId}/ranking-history`,
+      {
+        signal: spec.signal,
+      },
+    )
+
+    dispatch({
+      type: '@users/getRankingHistory',
+      payload: result,
+      meta: { userId },
+    })
+
+    return result
   })
 }

--- a/client/users/actions.ts
+++ b/client/users/actions.ts
@@ -9,6 +9,7 @@ import {
   AdminGetUserIpsResponse,
   GetBatchUserInfoResponse,
   GetUserProfileResponse,
+  GetUserRankingHistoryResponse,
   SbUser,
   SbUserId,
   SearchMatchHistoryResponse,
@@ -26,6 +27,7 @@ export type UserActions =
   | UpsertUserRelationship
   | DeleteUserRelationship
   | UpdateFriendActivityStatus
+  | GetUserRankingHistory
 
 export interface GetUserProfile {
   type: '@users/getUserProfile'
@@ -99,4 +101,10 @@ export interface DeleteUserRelationship {
 export interface UpdateFriendActivityStatus {
   type: '@users/updateFriendActivityStatus'
   payload: FriendActivityStatusUpdateEvent
+}
+
+export type GetUserRankingHistory = {
+  type: '@users/getRankingHistory'
+  payload: GetUserRankingHistoryResponse
+  meta: { userId: SbUserId }
 }

--- a/client/users/match-history.tsx
+++ b/client/users/match-history.tsx
@@ -42,7 +42,7 @@ const ErrorText = styled.div`
 
 const SearchResults = styled.div`
   width: 100%;
-  padding: 8px 16px;
+  padding: 0 24px;
 
   display: flex;
   flex-direction: column;

--- a/client/users/user-profile-seasons.tsx
+++ b/client/users/user-profile-seasons.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 import { appendToMultimap } from '../../common/data-structures/maps'
@@ -40,19 +40,18 @@ export function UserProfileSeasons({ user }: { user: SbUser }) {
 
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<Error>()
-  const abortControllerRef = useRef<AbortController>()
 
   useEffect(() => {
     setIsLoading(true)
 
-    abortControllerRef.current?.abort()
-    abortControllerRef.current = new AbortController()
+    const abortController = new AbortController()
 
     dispatch(
       getUserRankingHistory(user.id, {
-        signal: abortControllerRef.current.signal,
+        signal: abortController.signal,
         onSuccess: data => {
           setIsLoading(false)
+          setError(undefined)
           setRanks(data.history)
         },
         onError: err => {
@@ -61,11 +60,11 @@ export function UserProfileSeasons({ user }: { user: SbUser }) {
         },
       }),
     )
-  }, [dispatch, user.id])
 
-  useEffect(() => {
-    return () => abortControllerRef.current?.abort()
-  }, [])
+    return () => {
+      abortController.abort()
+    }
+  }, [dispatch, user.id])
 
   if (isLoading) {
     return <LoadingDotsArea />

--- a/client/users/user-profile-seasons.tsx
+++ b/client/users/user-profile-seasons.tsx
@@ -1,0 +1,146 @@
+import React, { useEffect, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import styled from 'styled-components'
+import { appendToMultimap } from '../../common/data-structures/maps'
+import { LadderPlayer } from '../../common/ladder/ladder'
+import { SeasonId } from '../../common/matchmaking'
+import { SbUser } from '../../common/users/sb-user'
+import { LoadingDotsArea } from '../progress/dots'
+import { useAppDispatch, useAppSelector } from '../redux-hooks'
+import { colorError, colorTextFaint, colorTextPrimary } from '../styles/colors'
+import { headline6, subtitle1 } from '../styles/typography'
+import { getUserRankingHistory } from './action-creators'
+import { UserRankDisplay } from './user-rank-display'
+
+const Container = styled.div`
+  padding: 0 24px;
+
+  display: flex;
+  flex-direction: column;
+  gap: 48px;
+`
+
+const NoResults = styled.div`
+  ${subtitle1};
+
+  color: ${colorTextFaint};
+`
+
+const ErrorText = styled.div`
+  ${subtitle1};
+
+  color: ${colorError};
+`
+
+export function UserProfileSeasons({ user }: { user: SbUser }) {
+  const { t } = useTranslation()
+  const dispatch = useAppDispatch()
+
+  const [ranks, setRanks] = useState<LadderPlayer[]>()
+
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<Error>()
+  const abortControllerRef = useRef<AbortController>()
+
+  useEffect(() => {
+    setIsLoading(true)
+
+    abortControllerRef.current?.abort()
+    abortControllerRef.current = new AbortController()
+
+    dispatch(
+      getUserRankingHistory(user.id, {
+        signal: abortControllerRef.current.signal,
+        onSuccess: data => {
+          setIsLoading(false)
+          setRanks(data.history)
+        },
+        onError: err => {
+          setIsLoading(false)
+          setError(err)
+        },
+      }),
+    )
+  }, [dispatch, user.id])
+
+  useEffect(() => {
+    return () => abortControllerRef.current?.abort()
+  }, [])
+
+  if (isLoading) {
+    return <LoadingDotsArea />
+  } else if (error) {
+    return (
+      <Container>
+        <ErrorText>
+          {t('user.seasons.retrievingError', 'There was an error retrieving the ranking history.')}
+        </ErrorText>
+      </Container>
+    )
+  } else if (ranks?.length === 0) {
+    return (
+      <Container>
+        <NoResults>
+          {t('user.seasons.noMatchingGames', {
+            defaultValue: '{{user}} has played no games in previous seasons.',
+            user: user.name,
+          })}
+        </NoResults>
+      </Container>
+    )
+  } else if (ranks) {
+    const seasonIdToRanks = new Map<SeasonId, LadderPlayer[]>()
+    for (const r of ranks) {
+      appendToMultimap(seasonIdToRanks, r.seasonId, r)
+    }
+
+    return (
+      <Container>
+        {Array.from(seasonIdToRanks.entries()).map(([seasonId, seasonRanks]) => (
+          <PastSeasonItem key={seasonId} seasonId={seasonId} seasonRanks={seasonRanks} />
+        ))}
+      </Container>
+    )
+  }
+}
+
+const SeasonHeader = styled.div`
+  ${headline6};
+  color: ${colorTextPrimary};
+  margin-bottom: 16px;
+`
+
+const RanksContainer = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+`
+
+function PastSeasonItem({
+  seasonId,
+  seasonRanks,
+}: {
+  seasonId: SeasonId
+  seasonRanks: LadderPlayer[]
+}) {
+  const season = useAppSelector(state => state.matchmakingSeasons.byId.get(seasonId))
+  if (!season) {
+    return null
+  }
+
+  return (
+    <div>
+      <SeasonHeader>{season.name}</SeasonHeader>
+      <RanksContainer>
+        {seasonRanks.map(rank => (
+          <UserRankDisplay
+            key={rank.matchmakingType}
+            matchmakingType={rank.matchmakingType}
+            ladderPlayer={rank}
+            season={season}
+          />
+        ))}
+      </RanksContainer>
+    </div>
+  )
+}

--- a/client/users/user-rank-display.tsx
+++ b/client/users/user-rank-display.tsx
@@ -1,0 +1,146 @@
+import React from 'react'
+import { useTranslation } from 'react-i18next'
+import styled from 'styled-components'
+import { ReadonlyDeep } from 'type-fest'
+import { LadderPlayer, ladderPlayerToMatchmakingDivision } from '../../common/ladder/ladder'
+import {
+  getTotalBonusPoolForSeason,
+  MatchmakingDivision,
+  matchmakingDivisionToLabel,
+  MatchmakingSeasonJson,
+  MatchmakingType,
+  matchmakingTypeToLabel,
+} from '../../common/matchmaking'
+import { LadderPlayerIcon } from '../matchmaking/rank-icon'
+import { background700, colorDividers, colorTextFaint, colorTextSecondary } from '../styles/colors'
+import { caption, headline6, singleLine, subtitle1, subtitle2 } from '../styles/typography'
+
+const RankDisplayRoot = styled.div`
+  padding: 16px 16px 8px;
+
+  display: flex;
+
+  background-color: ${background700};
+  border-radius: 4px;
+`
+
+const DivisionInfo = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
+  border-right: 1px solid ${colorDividers};
+  padding-right: 15px;
+`
+
+const DivisionIcon = styled(LadderPlayerIcon)`
+  width: 88px;
+  height: 88px;
+`
+
+const RankDisplayDivisionLabel = styled.div`
+  ${headline6};
+  padding-top: 12px;
+`
+
+const RankDisplayType = styled.div`
+  ${subtitle2};
+  ${singleLine};
+  color: ${colorTextFaint};
+`
+
+const RankDisplayInfo = styled.div`
+  padding-left: 8px;
+
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 24px;
+
+  color: ${colorTextSecondary};
+`
+
+const RankDisplayInfoRow = styled.div`
+  height: 44px;
+  display: flex;
+  gap: 8px;
+`
+
+const RankDisplayInfoEntry = styled.div`
+  width: 96px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`
+
+const RankDisplayInfoLabel = styled.div`
+  ${caption};
+  ${singleLine};
+  color: ${colorTextFaint};
+`
+
+const RankDisplayInfoValue = styled.div`
+  ${subtitle1};
+  ${singleLine};
+`
+
+const RankDisplayPrefix = styled.span`
+  ${caption};
+`
+
+export function UserRankDisplay({
+  matchmakingType,
+  ladderPlayer,
+  season,
+}: {
+  matchmakingType: MatchmakingType
+  ladderPlayer: LadderPlayer
+  season: ReadonlyDeep<MatchmakingSeasonJson>
+}) {
+  const { t } = useTranslation()
+  const bonusPool = getTotalBonusPoolForSeason(new Date(), season)
+  const division = ladderPlayerToMatchmakingDivision(ladderPlayer, bonusPool)
+
+  if (division === MatchmakingDivision.Unrated) {
+    return null
+  }
+
+  const divisionLabel = matchmakingDivisionToLabel(division, t)
+
+  return (
+    <RankDisplayRoot>
+      <DivisionInfo>
+        <DivisionIcon player={ladderPlayer} size={88} bonusPool={bonusPool} />
+        <RankDisplayDivisionLabel>{divisionLabel}</RankDisplayDivisionLabel>
+        <RankDisplayType>{matchmakingTypeToLabel(matchmakingType, t)}</RankDisplayType>
+      </DivisionInfo>
+      <RankDisplayInfo>
+        <RankDisplayInfoRow>
+          <RankDisplayInfoEntry>
+            <RankDisplayInfoValue>
+              <RankDisplayPrefix>#</RankDisplayPrefix>
+              {ladderPlayer.rank}
+            </RankDisplayInfoValue>
+            <RankDisplayInfoLabel>{t('users.profile.rank', 'Rank')}</RankDisplayInfoLabel>
+          </RankDisplayInfoEntry>
+          <RankDisplayInfoEntry>
+            <RankDisplayInfoValue>{Math.round(ladderPlayer.points)}</RankDisplayInfoValue>
+            <RankDisplayInfoLabel>{t('users.profile.points', 'Points')}</RankDisplayInfoLabel>
+          </RankDisplayInfoEntry>
+        </RankDisplayInfoRow>
+        <RankDisplayInfoRow>
+          <RankDisplayInfoEntry>
+            <RankDisplayInfoValue>
+              {ladderPlayer.wins} &ndash; {ladderPlayer.losses}
+            </RankDisplayInfoValue>
+            <RankDisplayInfoLabel>{t('users.profile.record', 'Record')}</RankDisplayInfoLabel>
+          </RankDisplayInfoEntry>
+          <RankDisplayInfoEntry>
+            <RankDisplayInfoValue>{Math.round(ladderPlayer.rating)}</RankDisplayInfoValue>
+            <RankDisplayInfoLabel>{t('users.profile.rating', 'Rating')}</RankDisplayInfoLabel>
+          </RankDisplayInfoEntry>
+        </RankDisplayInfoRow>
+      </RankDisplayInfo>
+    </RankDisplayRoot>
+  )
+}

--- a/common/ladder/ladder.ts
+++ b/common/ladder/ladder.ts
@@ -3,17 +3,20 @@ import {
   MatchmakingSeasonJson,
   MatchmakingType,
   pointsToMatchmakingDivision,
+  SeasonId,
 } from '../matchmaking'
 import { RaceStats } from '../races'
 import { SbUser, SbUserId } from '../users/sb-user'
 
 /**
- * A ranked player for a particular matchmaking ladder. Contains information about their play
- * history and current rating.
+ * A ranked player for a particular matchmaking ladder in a particular season. Contains information
+ * about their play history and current rating.
  */
 export interface LadderPlayer extends RaceStats {
   rank: number
   userId: SbUserId
+  matchmakingType: MatchmakingType
+  seasonId: SeasonId
   rating: number
   points: number
   bonusUsed: number

--- a/common/users/sb-user.ts
+++ b/common/users/sb-user.ts
@@ -113,6 +113,11 @@ export interface SearchMatchHistoryResponse {
   hasMoreGames: boolean
 }
 
+export interface GetUserRankingHistoryResponse {
+  history: LadderPlayer[]
+  seasons: MatchmakingSeasonJson[]
+}
+
 export interface GetBatchUserInfoResponse {
   userInfos: SbUser[]
 }

--- a/server/lib/ladder/ladder-api.ts
+++ b/server/lib/ladder/ladder-api.ts
@@ -120,6 +120,8 @@ export class LadderApi {
         acc[r.matchmakingType] = {
           rank: ranks.get(r.matchmakingType) ?? -2,
           userId: r.userId,
+          matchmakingType: r.matchmakingType,
+          seasonId: r.seasonId,
           rating: r.lifetimeGames >= NUM_PLACEMENT_MATCHES ? r.rating : 0,
           points: r.points,
           bonusUsed: r.bonusUsed,
@@ -186,6 +188,8 @@ export class LadderApi {
       players.push({
         rank: lastRank,
         userId: r.userId,
+        matchmakingType: r.matchmakingType,
+        seasonId: r.seasonId,
         rating: r.lifetimeGames >= NUM_PLACEMENT_MATCHES ? r.rating : 0,
         points: r.points,
         bonusUsed: r.bonusUsed,

--- a/server/lib/matchmaking/models.ts
+++ b/server/lib/matchmaking/models.ts
@@ -71,6 +71,10 @@ export interface MatchmakingRating extends RaceStats {
   losses: number
 }
 
+export interface FinalizedMatchmakingRank extends MatchmakingRating {
+  rank: number
+}
+
 export const DEFAULT_MATCHMAKING_RATING: Readonly<
   Omit<MatchmakingRating, 'userId' | 'matchmakingType' | 'seasonId'>
 > = {
@@ -102,6 +106,7 @@ export const DEFAULT_MATCHMAKING_RATING: Readonly<
 }
 
 type DbMatchmakingRating = Dbify<MatchmakingRating>
+type DbMatchmakingFinalizedRank = Dbify<FinalizedMatchmakingRank>
 
 function fromDbMatchmakingRating(result: Readonly<DbMatchmakingRating>): MatchmakingRating {
   return {
@@ -133,6 +138,15 @@ function fromDbMatchmakingRating(result: Readonly<DbMatchmakingRating>): Matchma
     rTLosses: result.r_t_losses,
     rZWins: result.r_z_wins,
     rZLosses: result.r_z_losses,
+  }
+}
+
+function fromDbMatchmakingFinalizedRank(
+  result: Readonly<DbMatchmakingFinalizedRank>,
+): FinalizedMatchmakingRank {
+  return {
+    ...fromDbMatchmakingRating(result),
+    rank: result.rank,
   }
 }
 
@@ -375,7 +389,7 @@ export async function getManyMatchmakingRatings(
     const optionalJoin = searchStr ? sql`JOIN users u ON r.user_id = u.id` : sql``
 
     let query = sql`
-      SELECT r.matchmaking_type, r.user_id, r.rating, r.points,
+      SELECT r.matchmaking_type, r.user_id, r.season_id, r.rating, r.points,
         r.bonus_used, r.wins, r.losses, r.lifetime_games,
         r.p_wins, r.p_losses,
         r.t_wins, r.t_losses,
@@ -415,7 +429,7 @@ export async function getMatchmakingRatingsForUser(
   const { client, done } = await db()
   try {
     const result = await client.query<DbMatchmakingRating>(sql`
-      SELECT r.matchmaking_type, r.user_id, r.rating, r.points,
+      SELECT r.matchmaking_type, r.user_id, r.season_id, r.rating, r.points,
         r.bonus_used, r.lifetime_games, r.wins, r.losses,
         r.p_wins, r.p_losses,
         r.t_wins, r.t_losses,
@@ -428,6 +442,45 @@ export async function getMatchmakingRatingsForUser(
     `)
 
     return result.rows.map(r => fromDbMatchmakingRating(r))
+  } finally {
+    done()
+  }
+}
+
+/**
+ * Returns a user's finalized rank for all seasons and matchmaking type combos. Rank for the current
+ * season, as well as any season and matchmaking type combo that the user has not completed a game
+ * in will not be included in the result. The results are ordered by the start date of the season.
+ */
+export async function getMatchmakingFinalizedRanksForUser(
+  userId: SbUserId,
+  withClient?: DbClient,
+): Promise<FinalizedMatchmakingRank[]> {
+  const { client, done } = await db(withClient)
+
+  try {
+    const result = await client.query<DbMatchmakingFinalizedRank>(sql`
+      SELECT mfr.user_id, mfr.season_id, mfr.matchmaking_type, mfr.rank, mr.rating, mr.points,
+        mr.bonus_used, mr.lifetime_games, mr.wins, mr.losses,
+        mr.p_wins, mr.p_losses,
+        mr.t_wins, mr.t_losses,
+        mr.z_wins, mr.z_losses,
+        mr.r_wins, mr.r_losses,
+        mr.r_p_wins, mr.r_p_losses, mr.r_t_wins, mr.r_t_losses, mr.r_z_wins, mr.r_z_losses,
+        mr.last_played_date
+      FROM
+        matchmaking_finalized_ranks mfr
+        INNER JOIN matchmaking_ratings mr ON mfr.season_id = mr.season_id
+          AND mfr.user_id = mr.user_id
+          AND mfr.matchmaking_type = mr.matchmaking_type
+        INNER JOIN matchmaking_seasons ms ON mfr.season_id = ms.id
+      WHERE
+        mfr.user_id = ${userId}
+      ORDER BY
+        ms.start_date DESC
+    `)
+
+    return result.rows.map(r => fromDbMatchmakingFinalizedRank(r))
   } finally {
     done()
   }
@@ -603,6 +656,35 @@ export async function getMatchmakingSeasons(withClient?: DbClient): Promise<Matc
       SELECT *, LEAD(start_date, 1) OVER (ORDER BY start_date) as end_date
       FROM matchmaking_seasons
       ORDER BY start_date DESC;
+    `)
+    return result.rows.map(r => fromDbMatchmakingSeason(r))
+  } finally {
+    done()
+  }
+}
+
+/** Returns the matchmaking seasons with the given IDs, in descending order by start date. */
+export async function getMatchmakingSeasonsByIds(
+  seasonIds: SeasonId[],
+  withClient?: DbClient,
+): Promise<MatchmakingSeason[]> {
+  const { client, done } = await db(withClient)
+
+  try {
+    // NOTE(2Pac): We use a CTE to get the end date for each season, and then filter by the given
+    // season IDs. Otherwise, the first season in the result would not be able to get the end date
+    // of the previous season.
+    // TODO(2Pac): It might be worth it to simply save the end date in the database, and update it
+    // automatically with a trigger when a new season is added?
+    const result = await client.query<DbMatchmakingSeason>(sql`
+      WITH s AS (
+        SELECT *, LEAD(start_date, 1) OVER (ORDER BY start_date) AS end_date
+        FROM matchmaking_seasons
+        ORDER BY start_date DESC
+      )
+      SELECT *
+      FROM s
+      WHERE id = ANY(${seasonIds})
     `)
     return result.rows.map(r => fromDbMatchmakingSeason(r))
   } finally {

--- a/server/lib/matchmaking/models.ts
+++ b/server/lib/matchmaking/models.ts
@@ -477,7 +477,7 @@ export async function getMatchmakingFinalizedRanksForUser(
       WHERE
         mfr.user_id = ${userId}
       ORDER BY
-        ms.start_date DESC, mfr.matchmaking_type
+        ms.start_date DESC, mr.points DESC
     `)
 
     return result.rows.map(r => fromDbMatchmakingFinalizedRank(r))

--- a/server/lib/matchmaking/models.ts
+++ b/server/lib/matchmaking/models.ts
@@ -477,7 +477,7 @@ export async function getMatchmakingFinalizedRanksForUser(
       WHERE
         mfr.user_id = ${userId}
       ORDER BY
-        ms.start_date DESC
+        ms.start_date DESC, mfr.matchmaking_type
     `)
 
     return result.rows.map(r => fromDbMatchmakingFinalizedRank(r))

--- a/server/lib/users/user-api.ts
+++ b/server/lib/users/user-api.ts
@@ -138,8 +138,8 @@ const matchHistoryRetrievalThrottle = createThrottle('matchhistoryretrieval', {
 })
 
 const rankingsHistoryRetrievalThrottle = createThrottle('rankingshistoryretrieval', {
-  rate: 50,
-  burst: 150,
+  rate: 10,
+  burst: 30,
   window: 60000,
 })
 

--- a/server/lib/users/user-api.ts
+++ b/server/lib/users/user-api.ts
@@ -45,6 +45,7 @@ import {
   ChangeLanguagesResponse,
   GetBatchUserInfoResponse,
   GetUserProfileResponse,
+  GetUserRankingHistoryResponse,
   SbUser,
   SbUserId,
   SEARCH_MATCH_HISTORY_LIMIT,
@@ -65,7 +66,11 @@ import { getRankingsForUser } from '../ladder/rankings'
 import { sendMailTemplate } from '../mail/mailer'
 import { getMapInfo } from '../maps/map-models'
 import { MatchmakingSeasonsService } from '../matchmaking/matchmaking-seasons'
-import { getMatchmakingRatingsForUser } from '../matchmaking/models'
+import {
+  getMatchmakingFinalizedRanksForUser,
+  getMatchmakingRatingsForUser,
+  getMatchmakingSeasonsByIds,
+} from '../matchmaking/models'
 import { usePasswordResetCode } from '../models/password-resets'
 import { updatePermissions } from '../models/permissions'
 import { isElectronClient } from '../network/only-web-clients'
@@ -127,6 +132,12 @@ const accountRetrievalThrottle = createThrottle('accountretrieval', {
 })
 
 const matchHistoryRetrievalThrottle = createThrottle('matchhistoryretrieval', {
+  rate: 50,
+  burst: 150,
+  window: 60000,
+})
+
+const rankingsHistoryRetrievalThrottle = createThrottle('rankingshistoryretrieval', {
   rate: 50,
   burst: 150,
   window: 60000,
@@ -353,8 +364,10 @@ export class UserApi {
     const ladder: Partial<Record<MatchmakingType, LadderPlayer>> = {}
     for (const r of ratings) {
       ladder[r.matchmakingType] = {
-        rank: rankings.get(r.matchmakingType) ?? -1,
         userId: r.userId,
+        matchmakingType: r.matchmakingType,
+        seasonId: r.seasonId,
+        rank: rankings.get(r.matchmakingType) ?? -1,
         rating: r.lifetimeGames >= NUM_PLACEMENT_MATCHES ? r.rating : 0,
         points: r.points,
         bonusUsed: r.bonusUsed,
@@ -447,6 +460,65 @@ export class UserApi {
       maps: maps.map(m => toMapInfoJson(m)),
       users,
       hasMoreGames: games.length >= SEARCH_MATCH_HISTORY_LIMIT,
+    }
+  }
+
+  @httpGet('/:id/ranking-history')
+  @httpBefore(
+    throttleMiddleware(
+      rankingsHistoryRetrievalThrottle,
+      ctx => String(ctx.session?.user?.id) ?? ctx.ip,
+    ),
+  )
+  async getUserRankingHistory(ctx: RouterContext): Promise<GetUserRankingHistoryResponse> {
+    const { params } = validateRequest(ctx, {
+      params: Joi.object<{ id: SbUserId }>({
+        id: joiUserId().required(),
+      }),
+    })
+
+    const user = await findUserById(params.id)
+    if (!user) {
+      throw new UserApiError(UserErrorCode.NotFound, 'user not found')
+    }
+
+    const ranks = await getMatchmakingFinalizedRanksForUser(params.id)
+    const seasons = await getMatchmakingSeasonsByIds(ranks.map(r => r.seasonId))
+
+    const history: LadderPlayer[] = ranks.map(
+      r =>
+        ({
+          userId: r.userId,
+          matchmakingType: r.matchmakingType,
+          seasonId: r.seasonId,
+          rank: r.rank,
+          rating: r.rating,
+          points: r.points,
+          bonusUsed: r.bonusUsed,
+          wins: r.wins,
+          losses: r.losses,
+          lifetimeGames: r.lifetimeGames,
+          pWins: r.pWins,
+          pLosses: r.pLosses,
+          tWins: r.tWins,
+          tLosses: r.tLosses,
+          zWins: r.zWins,
+          zLosses: r.zLosses,
+          rWins: r.rWins,
+          rLosses: r.rLosses,
+          rPWins: r.rPWins,
+          rPLosses: r.rPLosses,
+          rTWins: r.rTWins,
+          rTLosses: r.rTLosses,
+          rZWins: r.rZWins,
+          rZLosses: r.rZLosses,
+          lastPlayedDate: Number(r.lastPlayedDate),
+        }) satisfies LadderPlayer,
+    )
+
+    return {
+      history,
+      seasons: seasons.map(s => toMatchmakingSeasonJson(s)),
     }
   }
 

--- a/server/public/locales/en/global.json
+++ b/server/public/locales/en/global.json
@@ -1211,6 +1211,9 @@
     "miniMatchHistory": {
       "noGameSelected": "No game selected",
       "viewDetails": "View details"
+    },
+    "seasons": {
+      "noMatchingGames": "{{user}} has played no games in previous seasons."
     }
   },
   "users": {

--- a/server/public/locales/en/global.json
+++ b/server/public/locales/en/global.json
@@ -1213,7 +1213,8 @@
       "viewDetails": "View details"
     },
     "seasons": {
-      "noMatchingGames": "{{user}} has played no games in previous seasons."
+      "noMatchingGames": "{{user}} has played no games in previous seasons.",
+      "retrievingError": "There was an error retrieving the ranking history."
     }
   },
   "users": {


### PR DESCRIPTION
The ranking history is displayed under the "Seasons" tab and only includes past seasons in which user had a rank. Doesn't include the current season.

Closes #1107 