### PR TITLE
Add historical rankings to the ladder page.

### DIFF
--- a/client/ladder/action-creators.ts
+++ b/client/ladder/action-creators.ts
@@ -22,7 +22,7 @@ export function getCurrentSeasonRankings(
 ): ThunkAction {
   return abortableThunk(spec, async dispatch => {
     const fetchTime = performance.now()
-    const cacheKey = `${matchmakingType}|undefined` as MatchmakingTypeAndSeasonId
+    const cacheKey: MatchmakingTypeAndSeasonId = `${matchmakingType}|undefined`
     const lastFetchTime = lastFetchTimeByMatchmakingTypeAndSeasonId.get(cacheKey)
 
     if (lastFetchTime !== undefined && fetchTime - lastFetchTime < LADDER_RANKINGS_CACHE_TIME_MS) {
@@ -58,7 +58,7 @@ export function getPreviousSeasonRankings(
 ): ThunkAction {
   return abortableThunk(spec, async dispatch => {
     const fetchTime = performance.now()
-    const cacheKey = `${matchmakingType}|${seasonId}` as MatchmakingTypeAndSeasonId
+    const cacheKey: MatchmakingTypeAndSeasonId = `${matchmakingType}|${seasonId}`
     const lastFetchTime = lastFetchTimeByMatchmakingTypeAndSeasonId.get(cacheKey)
 
     if (lastFetchTime !== undefined && fetchTime - lastFetchTime < LADDER_RANKINGS_CACHE_TIME_MS) {
@@ -92,7 +92,7 @@ export function searchCurrentSeasonRankings(
 ): ThunkAction {
   return abortableThunk(spec, async dispatch => {
     const fetchTime = performance.now()
-    const cacheKey = `${matchmakingType}|undefined` as MatchmakingTypeAndSeasonId
+    const cacheKey: MatchmakingTypeAndSeasonId = `${matchmakingType}|undefined`
     let { fetchTime: lastFetchTime, searchQuery: lastSearchQuery } =
       lastSearchInfoByMatchmakingTypeAndSeasonId.get(cacheKey) ?? {}
 
@@ -143,7 +143,7 @@ export function searchPreviousSeasonRankings(
 ): ThunkAction {
   return abortableThunk(spec, async dispatch => {
     const fetchTime = performance.now()
-    const cacheKey = `${matchmakingType}|${seasonId}` as MatchmakingTypeAndSeasonId
+    const cacheKey: MatchmakingTypeAndSeasonId = `${matchmakingType}|${seasonId}`
     let { fetchTime: lastFetchTime, searchQuery: lastSearchQuery } =
       lastSearchInfoByMatchmakingTypeAndSeasonId.get(cacheKey) ?? {}
 

--- a/client/ladder/action-creators.ts
+++ b/client/ladder/action-creators.ts
@@ -13,9 +13,9 @@ import { fetchJson } from '../network/fetch'
 
 const LADDER_RANKINGS_CACHE_TIME_MS = 60 * 1000
 
-const lastFetchTimeBySeasonIdAndMatchmakingType = new Map<MatchmakingTypeAndSeasonId, number>()
-const lastSearchTimeBySeasonIdAndMatchmakingType = new Map<MatchmakingTypeAndSeasonId, number>()
-const lastSearchQueryBySeasonIdAndMatchmakingType = new Map<MatchmakingTypeAndSeasonId, string>()
+const lastFetchTimeByMatchmakingTypeAndSeasonId = new Map<MatchmakingTypeAndSeasonId, number>()
+const lastSearchTimeByMatchmakingTypeAndSeasonId = new Map<MatchmakingTypeAndSeasonId, number>()
+const lastSearchQueryByMatchmakingTypeAndSeasonId = new Map<MatchmakingTypeAndSeasonId, string>()
 
 export function getCurrentSeasonRankings(
   matchmakingType: MatchmakingType,
@@ -23,8 +23,8 @@ export function getCurrentSeasonRankings(
 ): ThunkAction {
   return abortableThunk(spec, async dispatch => {
     const fetchTime = performance.now()
-    const mapKey = makeMatchmakingTypeAndSeasonId(matchmakingType)
-    const lastFetchTime = lastFetchTimeBySeasonIdAndMatchmakingType.get(mapKey)
+    const cacheKey = makeMatchmakingTypeAndSeasonId(matchmakingType)
+    const lastFetchTime = lastFetchTimeByMatchmakingTypeAndSeasonId.get(cacheKey)
 
     if (lastFetchTime !== undefined && fetchTime - lastFetchTime < LADDER_RANKINGS_CACHE_TIME_MS) {
       return
@@ -35,8 +35,8 @@ export function getCurrentSeasonRankings(
     })
 
     // Don't update the state if we aren't the last request outstanding
-    if (fetchTime >= (lastFetchTimeBySeasonIdAndMatchmakingType.get(mapKey) ?? 0)) {
-      lastFetchTimeBySeasonIdAndMatchmakingType.set(mapKey, fetchTime)
+    if (fetchTime >= (lastFetchTimeByMatchmakingTypeAndSeasonId.get(cacheKey) ?? 0)) {
+      lastFetchTimeByMatchmakingTypeAndSeasonId.set(cacheKey, fetchTime)
 
       dispatch({
         type: '@ladder/getRankings',
@@ -59,8 +59,8 @@ export function getPreviousSeasonRankings(
 ): ThunkAction {
   return abortableThunk(spec, async dispatch => {
     const fetchTime = performance.now()
-    const mapKey = makeMatchmakingTypeAndSeasonId(matchmakingType, seasonId)
-    const lastFetchTime = lastFetchTimeBySeasonIdAndMatchmakingType.get(mapKey)
+    const cacheKey = makeMatchmakingTypeAndSeasonId(matchmakingType, seasonId)
+    const lastFetchTime = lastFetchTimeByMatchmakingTypeAndSeasonId.get(cacheKey)
 
     if (lastFetchTime !== undefined && fetchTime - lastFetchTime < LADDER_RANKINGS_CACHE_TIME_MS) {
       return
@@ -74,8 +74,8 @@ export function getPreviousSeasonRankings(
     )
 
     // Don't update the state if we aren't the last request outstanding
-    if (fetchTime >= (lastFetchTimeBySeasonIdAndMatchmakingType.get(mapKey) ?? 0)) {
-      lastFetchTimeBySeasonIdAndMatchmakingType.set(mapKey, fetchTime)
+    if (fetchTime >= (lastFetchTimeByMatchmakingTypeAndSeasonId.get(cacheKey) ?? 0)) {
+      lastFetchTimeByMatchmakingTypeAndSeasonId.set(cacheKey, fetchTime)
 
       dispatch({
         type: '@ladder/getRankings',
@@ -93,9 +93,9 @@ export function searchCurrentSeasonRankings(
 ): ThunkAction {
   return abortableThunk(spec, async dispatch => {
     const fetchTime = performance.now()
-    const mapKey = makeMatchmakingTypeAndSeasonId(matchmakingType)
-    const lastSearchTime = lastSearchTimeBySeasonIdAndMatchmakingType.get(mapKey)
-    const lastSearchQuery = lastSearchQueryBySeasonIdAndMatchmakingType.get(mapKey)
+    const cacheKey = makeMatchmakingTypeAndSeasonId(matchmakingType)
+    const lastSearchTime = lastSearchTimeByMatchmakingTypeAndSeasonId.get(cacheKey)
+    const lastSearchQuery = lastSearchQueryByMatchmakingTypeAndSeasonId.get(cacheKey)
 
     if (
       lastSearchTime !== undefined &&
@@ -113,9 +113,9 @@ export function searchCurrentSeasonRankings(
     )
 
     // Don't update the state if we aren't the last request outstanding
-    if (fetchTime >= (lastSearchTimeBySeasonIdAndMatchmakingType.get(mapKey) ?? 0)) {
-      lastSearchTimeBySeasonIdAndMatchmakingType.set(mapKey, fetchTime)
-      lastSearchQueryBySeasonIdAndMatchmakingType.set(mapKey, searchQuery)
+    if (fetchTime >= (lastSearchTimeByMatchmakingTypeAndSeasonId.get(cacheKey) ?? 0)) {
+      lastSearchTimeByMatchmakingTypeAndSeasonId.set(cacheKey, fetchTime)
+      lastSearchQueryByMatchmakingTypeAndSeasonId.set(cacheKey, searchQuery)
 
       dispatch({
         type: '@ladder/searchRankings',
@@ -139,9 +139,9 @@ export function searchPreviousSeasonRankings(
 ): ThunkAction {
   return abortableThunk(spec, async dispatch => {
     const fetchTime = performance.now()
-    const mapKey = makeMatchmakingTypeAndSeasonId(matchmakingType, seasonId)
-    const lastSearchTime = lastSearchTimeBySeasonIdAndMatchmakingType.get(mapKey)
-    const lastSearchQuery = lastSearchQueryBySeasonIdAndMatchmakingType.get(mapKey)
+    const cacheKey = makeMatchmakingTypeAndSeasonId(matchmakingType, seasonId)
+    const lastSearchTime = lastSearchTimeByMatchmakingTypeAndSeasonId.get(cacheKey)
+    const lastSearchQuery = lastSearchQueryByMatchmakingTypeAndSeasonId.get(cacheKey)
 
     if (
       lastSearchTime !== undefined &&
@@ -160,9 +160,9 @@ export function searchPreviousSeasonRankings(
     )
 
     // Don't update the state if we aren't the last request outstanding
-    if (fetchTime >= (lastSearchTimeBySeasonIdAndMatchmakingType.get(mapKey) ?? 0)) {
-      lastSearchTimeBySeasonIdAndMatchmakingType.set(mapKey, fetchTime)
-      lastSearchQueryBySeasonIdAndMatchmakingType.set(mapKey, searchQuery)
+    if (fetchTime >= (lastSearchTimeByMatchmakingTypeAndSeasonId.get(cacheKey) ?? 0)) {
+      lastSearchTimeByMatchmakingTypeAndSeasonId.set(cacheKey, fetchTime)
+      lastSearchQueryByMatchmakingTypeAndSeasonId.set(cacheKey, searchQuery)
 
       dispatch({
         type: '@ladder/searchRankings',

--- a/client/ladder/action-creators.ts
+++ b/client/ladder/action-creators.ts
@@ -1,5 +1,5 @@
 import { GetRankForUserResponse, GetRankingsResponse } from '../../common/ladder/ladder'
-import { MatchmakingType } from '../../common/matchmaking'
+import { MatchmakingType, SeasonId } from '../../common/matchmaking'
 import { apiUrl, urlPath } from '../../common/urls'
 import { ThunkAction } from '../dispatch-registry'
 import { push } from '../navigation/routing'
@@ -11,6 +11,13 @@ const LADDER_RANKINGS_CACHE_TIME_MS = 60 * 1000
 const lastFetchTimeByMatchmakingType = new Map<MatchmakingType, number>()
 const lastSearchTimeByMatchmakingType = new Map<MatchmakingType, number>()
 const lastSearchQueryByMatchmakingType = new Map<MatchmakingType, string>()
+
+const lastFetchTimeBySeasonIdAndMatchmakingType = new Map<SeasonId, Map<MatchmakingType, number>>()
+const lastSearchTimeBySeasonIdAndMatchmakingType = new Map<SeasonId, Map<MatchmakingType, number>>()
+const lastSearchQueryBySeasonIdAndMatchmakingType = new Map<
+  SeasonId,
+  Map<MatchmakingType, string>
+>()
 
 export function getRankings(
   matchmakingType: MatchmakingType,
@@ -41,6 +48,51 @@ export function getRankings(
   })
 }
 
+export function getRankingsForPastSeason(
+  seasonId: SeasonId,
+  matchmakingType: MatchmakingType,
+  spec: RequestHandlingSpec<void>,
+): ThunkAction {
+  return abortableThunk(spec, async dispatch => {
+    const fetchTime = performance.now()
+    const lastFetchTime = lastFetchTimeBySeasonIdAndMatchmakingType
+      .get(seasonId)
+      ?.get(matchmakingType)
+
+    if (lastFetchTime !== undefined && fetchTime - lastFetchTime < LADDER_RANKINGS_CACHE_TIME_MS) {
+      return
+    }
+
+    if (lastFetchTimeBySeasonIdAndMatchmakingType.has(seasonId)) {
+      lastFetchTimeBySeasonIdAndMatchmakingType.get(seasonId)!.set(matchmakingType, fetchTime)
+    } else {
+      lastFetchTimeBySeasonIdAndMatchmakingType.set(
+        seasonId,
+        new Map([[matchmakingType, fetchTime]]),
+      )
+    }
+
+    const result = await fetchJson<GetRankingsResponse>(
+      apiUrl`ladder/${matchmakingType}/${seasonId}`,
+      {
+        signal: spec.signal,
+      },
+    )
+
+    // Don't update the state if we aren't the last request outstanding
+    if (
+      fetchTime >=
+      (lastFetchTimeBySeasonIdAndMatchmakingType.get(seasonId)?.get(matchmakingType) ?? 0)
+    ) {
+      dispatch({
+        type: '@ladder/getRankings',
+        payload: result,
+        meta: { matchmakingType, fetchTime: new Date() },
+      })
+    }
+  })
+}
+
 export function searchRankings(
   matchmakingType: MatchmakingType,
   searchQuery: string,
@@ -48,7 +100,7 @@ export function searchRankings(
 ): ThunkAction {
   return abortableThunk(spec, async dispatch => {
     const fetchTime = performance.now()
-    const lastSearchTime = lastFetchTimeByMatchmakingType.get(matchmakingType)
+    const lastSearchTime = lastSearchTimeByMatchmakingType.get(matchmakingType)
     const lastSearchQuery = lastSearchQueryByMatchmakingType.get(matchmakingType)
 
     if (
@@ -64,6 +116,65 @@ export function searchRankings(
 
     const result = await fetchJson<GetRankingsResponse>(
       apiUrl`ladder/${matchmakingType}` + (searchQuery ? urlPath`?q=${searchQuery}` : ''),
+      {
+        signal: spec.signal,
+      },
+    )
+
+    // Don't update the state if we aren't the last request outstanding
+    if (fetchTime >= (lastFetchTimeByMatchmakingType.get(matchmakingType) ?? 0)) {
+      dispatch({
+        type: '@ladder/searchRankings',
+        payload: result,
+        meta: { matchmakingType, searchQuery, fetchTime: new Date() },
+      })
+    }
+  })
+}
+
+export function searchRankingsForPastSeason(
+  seasonId: SeasonId,
+  matchmakingType: MatchmakingType,
+  searchQuery: string,
+  spec: RequestHandlingSpec<void>,
+): ThunkAction {
+  return abortableThunk(spec, async dispatch => {
+    const fetchTime = performance.now()
+    const lastSearchTime = lastSearchTimeBySeasonIdAndMatchmakingType
+      .get(seasonId)
+      ?.get(matchmakingType)
+    const lastSearchQuery = lastSearchQueryBySeasonIdAndMatchmakingType
+      .get(seasonId)
+      ?.get(matchmakingType)
+
+    if (
+      lastSearchTime !== undefined &&
+      fetchTime - lastSearchTime < LADDER_RANKINGS_CACHE_TIME_MS &&
+      lastSearchQuery === searchQuery
+    ) {
+      return
+    }
+
+    if (lastSearchTimeBySeasonIdAndMatchmakingType.has(seasonId)) {
+      lastSearchTimeBySeasonIdAndMatchmakingType.get(seasonId)!.set(matchmakingType, fetchTime)
+    } else {
+      lastSearchTimeBySeasonIdAndMatchmakingType.set(
+        seasonId,
+        new Map([[matchmakingType, fetchTime]]),
+      )
+    }
+    if (lastSearchQueryBySeasonIdAndMatchmakingType.has(seasonId)) {
+      lastSearchQueryBySeasonIdAndMatchmakingType.get(seasonId)!.set(matchmakingType, searchQuery)
+    } else {
+      lastSearchQueryBySeasonIdAndMatchmakingType.set(
+        seasonId,
+        new Map([[matchmakingType, searchQuery]]),
+      )
+    }
+
+    const result = await fetchJson<GetRankingsResponse>(
+      apiUrl`ladder/${matchmakingType}/${seasonId}` +
+        (searchQuery ? urlPath`?q=${searchQuery}` : ''),
       {
         signal: spec.signal,
       },
@@ -97,6 +208,6 @@ export function getInstantaneousSelfRank(spec: RequestHandlingSpec<void>): Thunk
 }
 
 /** Navigates to the ladder standings (optionally for a given matchmaking type). */
-export function navigateToLadder(type?: MatchmakingType, transitionFn = push) {
-  transitionFn(urlPath`/ladder/${type ?? ''}`)
+export function navigateToLadder(type?: MatchmakingType, seasonId?: SeasonId, transitionFn = push) {
+  transitionFn(urlPath`/ladder/${type ?? ''}` + (seasonId ? urlPath`/${seasonId}` : ''))
 }

--- a/client/ladder/devonly/table-test.tsx
+++ b/client/ladder/devonly/table-test.tsx
@@ -95,7 +95,9 @@ export function TableTest() {
       players={players}
       usersById={usersById}
       curTime={Date.now()}
+      seasons={new Map([[SEASON.id, SEASON]])}
       season={SEASON}
+      onSeasonChange={() => {}}
       searchQuery={searchQuery}
       onSearchChange={onSearchChange}
       filteredDivision={(filteredDivision || 'all') as DivisionFilter}

--- a/client/ladder/ladder-reducer.ts
+++ b/client/ladder/ladder-reducer.ts
@@ -1,6 +1,10 @@
 import { Immutable } from 'immer'
 import { LadderPlayer } from '../../common/ladder/ladder'
-import { MatchmakingType, SeasonId } from '../../common/matchmaking'
+import {
+  makeMatchmakingTypeAndSeasonId,
+  MatchmakingTypeAndSeasonId,
+  SeasonId,
+} from '../../common/matchmaking'
 import { immerKeyedReducer } from '../reducers/keyed-reducer'
 
 export interface RetrievedRankings {
@@ -15,33 +19,16 @@ export interface SearchResults extends RetrievedRankings {
   searchQuery: string
 }
 
-// NOTE(2Pac): The reason why we have two separate maps for rankings and search results is so we
-// we don't have to re-fetch rankings when user clears the search query. Also, we keep the rankings
-// for current season separately from previous seasons because we don't immediately know the current
-// season ID.
 export interface LadderState {
-  /** A map of matchmaking type -> rankings. This is meant to be used for the current season. */
-  typeToRankings: Map<MatchmakingType, RetrievedRankings>
-  /**
-   * A map of matchmaking type -> search results. This is meant to be used for the current season.
-   */
-  typeToSearchResults: Map<MatchmakingType, SearchResults>
-  /**
-   * A map of season ID -> matchmaking type -> rankings. This is meant to be used for past seasons.
-   */
-  seasonToTypeToRankings: Map<SeasonId, Map<MatchmakingType, RetrievedRankings>>
-  /**
-   * A map of season ID -> matchmaking type -> search results. This is meant to be used for past
-   * seasons.
-   */
-  seasonToTypeToSearchResults: Map<SeasonId, Map<MatchmakingType, SearchResults>>
+  /** A map of a matchmaking type and season ID -> rankings. */
+  typeAndSeasonToRankings: Map<MatchmakingTypeAndSeasonId, RetrievedRankings>
+  /** A map of a matchmaking type and season ID -> search results. */
+  typeAndSeasonToSearchResults: Map<MatchmakingTypeAndSeasonId, SearchResults>
 }
 
 const DEFAULT_LADDER_STATE: Immutable<LadderState> = {
-  typeToRankings: new Map(),
-  typeToSearchResults: new Map(),
-  seasonToTypeToRankings: new Map(),
-  seasonToTypeToSearchResults: new Map(),
+  typeAndSeasonToRankings: new Map(),
+  typeAndSeasonToSearchResults: new Map(),
 }
 
 export default immerKeyedReducer(DEFAULT_LADDER_STATE, {
@@ -55,28 +42,13 @@ export default immerKeyedReducer(DEFAULT_LADDER_STATE, {
       season: { id: seasonId },
     } = action.payload
 
-    state.typeToRankings.set(matchmakingType, {
+    state.typeAndSeasonToRankings.set(makeMatchmakingTypeAndSeasonId(matchmakingType, seasonId), {
       players,
       lastUpdated,
       totalCount,
       seasonId,
       fetchTime,
     })
-
-    if (state.seasonToTypeToRankings.has(seasonId)) {
-      state.seasonToTypeToRankings.get(seasonId)!.set(matchmakingType, {
-        players,
-        lastUpdated,
-        totalCount,
-        seasonId,
-        fetchTime,
-      })
-    } else {
-      state.seasonToTypeToRankings.set(
-        seasonId,
-        new Map([[matchmakingType, { players, lastUpdated, totalCount, seasonId, fetchTime }]]),
-      )
-    }
   },
 
   ['@ladder/searchRankings'](state, action) {
@@ -89,31 +61,16 @@ export default immerKeyedReducer(DEFAULT_LADDER_STATE, {
       season: { id: seasonId },
     } = action.payload
 
-    state.typeToSearchResults.set(matchmakingType, {
-      players,
-      lastUpdated,
-      totalCount,
-      seasonId,
-      searchQuery,
-      fetchTime,
-    })
-
-    if (state.seasonToTypeToSearchResults.has(seasonId)) {
-      state.seasonToTypeToSearchResults.get(seasonId)!.set(matchmakingType, {
+    state.typeAndSeasonToSearchResults.set(
+      makeMatchmakingTypeAndSeasonId(matchmakingType, seasonId),
+      {
         players,
         lastUpdated,
         totalCount,
         seasonId,
-        searchQuery,
         fetchTime,
-      })
-    } else {
-      state.seasonToTypeToSearchResults.set(
-        seasonId,
-        new Map([
-          [matchmakingType, { players, lastUpdated, totalCount, seasonId, searchQuery, fetchTime }],
-        ]),
-      )
-    }
+        searchQuery,
+      },
+    )
   },
 })

--- a/client/ladder/ladder-reducer.ts
+++ b/client/ladder/ladder-reducer.ts
@@ -1,10 +1,6 @@
 import { Immutable } from 'immer'
 import { LadderPlayer } from '../../common/ladder/ladder'
-import {
-  makeMatchmakingTypeAndSeasonId,
-  MatchmakingTypeAndSeasonId,
-  SeasonId,
-} from '../../common/matchmaking'
+import { MatchmakingType, SeasonId } from '../../common/matchmaking'
 import { immerKeyedReducer } from '../reducers/keyed-reducer'
 
 export interface RetrievedRankings {
@@ -21,9 +17,9 @@ export interface SearchResults extends RetrievedRankings {
 
 export interface LadderState {
   /** A map of a matchmaking type and season ID -> rankings. */
-  typeAndSeasonToRankings: Map<MatchmakingTypeAndSeasonId, RetrievedRankings>
+  typeAndSeasonToRankings: Map<`${MatchmakingType}|${SeasonId}`, RetrievedRankings>
   /** A map of a matchmaking type and season ID -> search results. */
-  typeAndSeasonToSearchResults: Map<MatchmakingTypeAndSeasonId, SearchResults>
+  typeAndSeasonToSearchResults: Map<`${MatchmakingType}|${SeasonId}`, SearchResults>
 }
 
 const DEFAULT_LADDER_STATE: Immutable<LadderState> = {
@@ -42,7 +38,7 @@ export default immerKeyedReducer(DEFAULT_LADDER_STATE, {
       season: { id: seasonId },
     } = action.payload
 
-    state.typeAndSeasonToRankings.set(makeMatchmakingTypeAndSeasonId(matchmakingType, seasonId), {
+    state.typeAndSeasonToRankings.set(`${matchmakingType}|${seasonId}`, {
       players,
       lastUpdated,
       totalCount,
@@ -61,16 +57,13 @@ export default immerKeyedReducer(DEFAULT_LADDER_STATE, {
       season: { id: seasonId },
     } = action.payload
 
-    state.typeAndSeasonToSearchResults.set(
-      makeMatchmakingTypeAndSeasonId(matchmakingType, seasonId),
-      {
-        players,
-        lastUpdated,
-        totalCount,
-        seasonId,
-        fetchTime,
-        searchQuery,
-      },
-    )
+    state.typeAndSeasonToSearchResults.set(`${matchmakingType}|${seasonId}`, {
+      players,
+      lastUpdated,
+      totalCount,
+      seasonId,
+      fetchTime,
+      searchQuery,
+    })
   },
 })

--- a/client/ladder/ladder.tsx
+++ b/client/ladder/ladder.tsx
@@ -13,7 +13,9 @@ import {
   MatchmakingSeasonJson,
   MatchmakingType,
   NUM_PLACEMENT_MATCHES,
+  SeasonId,
   getTotalBonusPoolForSeason,
+  makeSeasonId,
   matchmakingDivisionToLabel,
   matchmakingTypeToLabel,
 } from '../../common/matchmaking'
@@ -24,6 +26,7 @@ import { useTrackPageView } from '../analytics/analytics'
 import { Avatar } from '../avatars/avatar'
 import { longTimestamp, narrowDuration, shortTimestamp } from '../i18n/date-formats'
 import { JsonLocalStorageValue } from '../local-storage'
+import { getMatchmakingSeasons } from '../matchmaking/action-creators'
 import { LadderPlayerIcon } from '../matchmaking/rank-icon'
 import { useButtonState } from '../material/button'
 import { buttonReset } from '../material/button-reset'
@@ -48,6 +51,7 @@ import {
   colorTextSecondary,
   getRaceColor,
 } from '../styles/colors'
+import { FlexSpacer } from '../styles/flex-spacer'
 import {
   Headline6,
   body1,
@@ -58,7 +62,13 @@ import {
   subtitle2,
 } from '../styles/typography'
 import { navigateToUserProfile } from '../users/action-creators'
-import { getRankings, navigateToLadder, searchRankings } from './action-creators'
+import {
+  getRankings,
+  getRankingsForPastSeason,
+  navigateToLadder,
+  searchRankings,
+  searchRankingsForPastSeason,
+} from './action-creators'
 
 const LadderPage = styled.div`
   width: 100%;
@@ -111,7 +121,7 @@ const LastUpdatedText = styled.div`
 const savedLadderTab = new JsonLocalStorageValue<MatchmakingType>('ladderTab')
 
 export function LadderRouteComponent(props: { params: any }) {
-  const [matches, params] = useRoute('/ladder/:matchmakingType?')
+  const [matches, params] = useRoute('/ladder/:matchmakingType?/:seasonId?')
 
   if (!matches) {
     return null
@@ -120,38 +130,54 @@ export function LadderRouteComponent(props: { params: any }) {
   const matchmakingType = ALL_MATCHMAKING_TYPES.includes(params.matchmakingType as MatchmakingType)
     ? (params.matchmakingType as MatchmakingType)
     : undefined
+  const seasonId = params.seasonId ? makeSeasonId(Number(params.seasonId)) : undefined
 
-  return <Ladder matchmakingType={matchmakingType} />
+  return <Ladder matchmakingType={matchmakingType} seasonId={seasonId} />
 }
 
 export interface LadderProps {
   matchmakingType?: MatchmakingType
+  seasonId?: SeasonId
 }
 
 /**
  * Displays a ranked table of players on the ladder(s).
  */
-export function Ladder({ matchmakingType: routeType }: LadderProps) {
+export function Ladder({ matchmakingType: routeType, seasonId }: LadderProps) {
   const matchmakingType = routeType ?? savedLadderTab.getValue() ?? MatchmakingType.Match1v1
   useTrackPageView(urlPath`/ladder/${matchmakingType}`)
   const { t } = useTranslation()
   const dispatch = useAppDispatch()
-  const rankings = useAppSelector(s => s.ladder.typeToRankings.get(matchmakingType))
-  const searchResults = useAppSelector(s => s.ladder.typeToSearchResults.get(matchmakingType))
+  const seasons = useAppSelector(s => s.matchmakingSeasons.byId)
+  const currentSeasonId = useAppSelector(s => s.matchmakingSeasons.currentSeasonId)
+  const currentSeasonIdRef = useValueAsRef(currentSeasonId)
+  const rankings = useAppSelector(s =>
+    seasonId
+      ? s.ladder.seasonToTypeToRankings.get(seasonId)?.get(matchmakingType)
+      : s.ladder.typeToRankings.get(matchmakingType),
+  )
+  const searchResults = useAppSelector(s =>
+    seasonId
+      ? s.ladder.seasonToTypeToSearchResults.get(seasonId)?.get(matchmakingType)
+      : s.ladder.typeToSearchResults.get(matchmakingType),
+  )
   const usersById = useAppSelector(s => s.users.byId)
 
-  const rankingsSeason = useAppSelector(s =>
-    rankings?.seasonId ? s.matchmakingSeasons.byId.get(rankings.seasonId) : undefined,
-  )
-  const searchResultsSeason = useAppSelector(s =>
-    searchResults?.seasonId ? s.matchmakingSeasons.byId.get(searchResults.seasonId) : undefined,
+  const searchInputRef = useRef<SearchInputHandle>(null)
+  const onTabChange = useCallback(
+    (tab: MatchmakingType) => {
+      searchInputRef.current?.clear()
+      navigateToLadder(tab, seasonId)
+    },
+    [seasonId],
   )
 
-  const searchInputRef = useRef<SearchInputHandle>(null)
-  const onTabChange = useCallback((tab: MatchmakingType) => {
-    searchInputRef.current?.clear()
-    navigateToLadder(tab)
-  }, [])
+  const onSeasonChange = useCallback(
+    (seasonId: SeasonId) => {
+      navigateToLadder(matchmakingType, seasonId)
+    },
+    [matchmakingType],
+  )
 
   const [lastError, setLastError] = useState<Error>()
   const [searchQuery, setSearchQuery] = useLocationSearchParam('q')
@@ -184,34 +210,71 @@ export function Ladder({ matchmakingType: routeType }: LadderProps) {
   )
 
   useEffect(() => {
+    dispatch(
+      getMatchmakingSeasons({
+        onSuccess: () => setLastError(undefined),
+        onError: err => setLastError(err),
+      }),
+    )
+  }, [dispatch])
+
+  useEffect(() => {
     const getRankingsAbortController = new AbortController()
     const searchRankingsAbortController = new AbortController()
+    const getPastRankingsAbortController = new AbortController()
+    const searchPastRankingsAbortController = new AbortController()
     const debouncedSearch = debouncedSearchRef.current
 
-    if (searchQuery) {
-      dispatch(
-        searchRankings(matchmakingType, searchQuery, {
-          signal: searchRankingsAbortController.signal,
-          onSuccess: () => setLastError(undefined),
-          onError: err => setLastError(err),
-        }),
-      )
+    // NOTE(2Pac): Using the ref here to avoid re-fetching rankings when the season changes. Also,
+    // there is a bug somewhere that aborts the initial request when the current season changes from
+    // `undefined` -> actual value; which is fine on its own, but the way we check for last fetch
+    // time in the action creator cause it to not re-run the request.
+    if (!seasonId || !currentSeasonIdRef.current || seasonId === currentSeasonIdRef.current) {
+      if (searchQuery) {
+        dispatch(
+          searchRankings(matchmakingType, searchQuery, {
+            signal: searchRankingsAbortController.signal,
+            onSuccess: () => setLastError(undefined),
+            onError: err => setLastError(err),
+          }),
+        )
+      } else {
+        dispatch(
+          getRankings(matchmakingType, {
+            signal: getRankingsAbortController.signal,
+            onSuccess: () => setLastError(undefined),
+            onError: err => setLastError(err),
+          }),
+        )
+      }
     } else {
-      dispatch(
-        getRankings(matchmakingType, {
-          signal: getRankingsAbortController.signal,
-          onSuccess: () => setLastError(undefined),
-          onError: err => setLastError(err),
-        }),
-      )
+      if (searchQuery) {
+        dispatch(
+          searchRankingsForPastSeason(seasonId, matchmakingType, searchQuery, {
+            signal: searchPastRankingsAbortController.signal,
+            onSuccess: () => setLastError(undefined),
+            onError: err => setLastError(err),
+          }),
+        )
+      } else {
+        dispatch(
+          getRankingsForPastSeason(seasonId, matchmakingType, {
+            signal: getPastRankingsAbortController.signal,
+            onSuccess: () => setLastError(undefined),
+            onError: err => setLastError(err),
+          }),
+        )
+      }
     }
 
     return () => {
       getRankingsAbortController.abort()
       searchRankingsAbortController.abort()
+      getPastRankingsAbortController.abort()
+      searchPastRankingsAbortController.abort()
       debouncedSearch.cancel()
     }
-  }, [dispatch, matchmakingType, searchQuery])
+  }, [currentSeasonIdRef, dispatch, matchmakingType, searchQuery, seasonId])
 
   useEffect(() => {
     if (routeType) {
@@ -232,7 +295,6 @@ export function Ladder({ matchmakingType: routeType }: LadderProps) {
     totalCount: 0,
     players: [] as Immutable<LadderPlayer[]>,
     curTime: 0,
-    season: undefined as MatchmakingSeasonJson | undefined,
   }
   if (searchQuery && searchResults) {
     rankingsData = {
@@ -240,7 +302,6 @@ export function Ladder({ matchmakingType: routeType }: LadderProps) {
       totalCount: searchResults.totalCount,
       players: searchResults.players,
       curTime: Number(searchResults.fetchTime),
-      season: searchResultsSeason,
     }
   } else if (rankings) {
     rankingsData = {
@@ -248,7 +309,6 @@ export function Ladder({ matchmakingType: routeType }: LadderProps) {
       totalCount: rankings.totalCount,
       players: rankings.players,
       curTime: Number(rankings.fetchTime),
-      season: rankingsSeason,
     }
   }
 
@@ -282,9 +342,12 @@ export function Ladder({ matchmakingType: routeType }: LadderProps) {
         <ScrollDivider $show={!isAtTop} $showAt='bottom' />
       </PageHeader>
       <Content>
-        {rankingsData ? (
+        {rankingsData && currentSeasonId ? (
           <LadderTable
             {...rankingsData}
+            seasons={seasons}
+            season={seasonId ? seasons.get(seasonId) : seasons.get(currentSeasonId)}
+            onSeasonChange={onSeasonChange}
             usersById={usersById}
             lastError={lastError}
             searchInputRef={searchInputRef}
@@ -315,8 +378,8 @@ const TableContainer = styled.div`
 const FiltersContainer = styled.div`
   display: flex;
   flex-direction: row;
-  justify-content: space-between;
   align-items: center;
+  gap: 8px;
 
   width: 100%;
   max-width: min(800px, 100% - 32px);
@@ -325,6 +388,10 @@ const FiltersContainer = styled.div`
 
 const StyledSearchInput = styled(SearchInput)`
   width: 256px;
+`
+
+const SeasonSelect = styled(Select)`
+  width: 180px;
 `
 
 const DivisionSelect = styled(Select)`
@@ -491,7 +558,9 @@ export interface LadderTableProps {
   players?: ReadonlyArray<LadderPlayer>
   usersById: Immutable<Map<SbUserId, SbUser>>
   lastUpdated: number
+  seasons: Immutable<Map<SeasonId, MatchmakingSeasonJson>>
   season: MatchmakingSeasonJson | undefined
+  onSeasonChange: (seasonId: SeasonId) => void
   lastError?: Error
   searchInputRef?: React.RefObject<SearchInputHandle>
   searchQuery: string
@@ -522,7 +591,9 @@ export function LadderTable(props: LadderTableProps) {
     usersById,
     lastError,
     curTime,
+    seasons,
     season,
+    onSeasonChange,
     searchInputRef,
     searchQuery,
     onSearchChange,
@@ -651,6 +722,20 @@ export function LadderTable(props: LadderTableProps) {
           searchQuery={searchQuery}
           onSearchChange={onSearchChange}
         />
+
+        <FlexSpacer />
+
+        <SeasonSelect
+          dense={true}
+          label={t('ladder.season', 'Season')}
+          value={season?.id}
+          onChange={onSeasonChange}
+          allowErrors={false}>
+          {Array.from(seasons.values()).map(s => (
+            <SelectOption key={s.id} value={s.id} text={s.name} />
+          ))}
+        </SeasonSelect>
+
         <DivisionSelect
           dense={true}
           label={t('ladder.division', 'Division')}

--- a/client/matchmaking/action-creators.ts
+++ b/client/matchmaking/action-creators.ts
@@ -4,12 +4,10 @@ import { TypedIpcRenderer } from '../../common/ipc'
 import {
   defaultPreferences,
   FindMatchRequest,
-  GetCurrentMatchmakingSeasonResponse,
   GetMatchmakingMapPoolBody,
   GetMatchmakingSeasonsResponse,
   GetPreferencesResponse,
   MatchmakingPreferences,
-  MatchmakingSeasonJson,
   MatchmakingServiceErrorCode,
   MatchmakingType,
   PartialMatchmakingPreferences,
@@ -235,23 +233,6 @@ export function updateLastQueuedMatchmakingType(
     type: '@matchmaking/updateLastQueuedMatchmakingType',
     payload: type,
   }
-}
-
-// TODO(2Pac): I Don't think this is used anymore, remove it?
-export function getCurrentMatchmakingSeason(
-  spec: RequestHandlingSpec<MatchmakingSeasonJson>,
-): ThunkAction {
-  return abortableThunk(spec, async () => {
-    // TODO(tec27): Add a reducer for this and dispatch it?
-    const response = await fetchJson<GetCurrentMatchmakingSeasonResponse>(
-      apiUrl`matchmaking/seasons/current`,
-      {
-        signal: spec.signal,
-      },
-    )
-
-    return response.season
-  })
 }
 
 export function getMatchmakingSeasons(

--- a/client/matchmaking/action-creators.ts
+++ b/client/matchmaking/action-creators.ts
@@ -6,6 +6,7 @@ import {
   FindMatchRequest,
   GetCurrentMatchmakingSeasonResponse,
   GetMatchmakingMapPoolBody,
+  GetMatchmakingSeasonsResponse,
   GetPreferencesResponse,
   MatchmakingPreferences,
   MatchmakingSeasonJson,
@@ -236,6 +237,7 @@ export function updateLastQueuedMatchmakingType(
   }
 }
 
+// TODO(2Pac): I Don't think this is used anymore, remove it?
 export function getCurrentMatchmakingSeason(
   spec: RequestHandlingSpec<MatchmakingSeasonJson>,
 ): ThunkAction {
@@ -249,5 +251,20 @@ export function getCurrentMatchmakingSeason(
     )
 
     return response.season
+  })
+}
+
+export function getMatchmakingSeasons(
+  spec: RequestHandlingSpec<GetMatchmakingSeasonsResponse>,
+): ThunkAction {
+  return abortableThunk(spec, async dispatch => {
+    const result = await fetchJson<GetMatchmakingSeasonsResponse>(apiUrl`matchmaking/seasons`)
+
+    dispatch({
+      type: '@matchmaking/getMatchmakingSeasons',
+      payload: result,
+    })
+
+    return result
   })
 }

--- a/client/matchmaking/actions.ts
+++ b/client/matchmaking/actions.ts
@@ -1,6 +1,7 @@
 import { Immutable } from 'immer'
 import {
   GetMatchmakingMapPoolBody,
+  GetMatchmakingSeasonsResponse,
   GetPreferencesResponse,
   MatchmakingStatusJson,
   MatchmakingType,
@@ -39,7 +40,7 @@ export type MatchmakingActions =
   | MatchmakingStatusUpdate
   | StartMatchSearch
   | RequeueSearch
-
+  | GetMatchmakingSeasons
 export interface GetCurrentMapPoolBegin {
   type: '@matchmaking/getCurrentMapPoolBegin'
   payload: {
@@ -207,4 +208,9 @@ export interface QueueStatus {
 export interface MatchmakingStatusUpdate {
   type: '@matchmaking/statusUpdate'
   payload: MatchmakingStatusJson[]
+}
+
+export interface GetMatchmakingSeasons {
+  type: '@matchmaking/getMatchmakingSeasons'
+  payload: GetMatchmakingSeasonsResponse
 }

--- a/client/matchmaking/actions.ts
+++ b/client/matchmaking/actions.ts
@@ -3,6 +3,7 @@ import {
   GetMatchmakingMapPoolBody,
   GetMatchmakingSeasonsResponse,
   GetPreferencesResponse,
+  MatchmakingSeasonJson,
   MatchmakingStatusJson,
   MatchmakingType,
   MatchReadyEvent,
@@ -41,6 +42,8 @@ export type MatchmakingActions =
   | StartMatchSearch
   | RequeueSearch
   | GetMatchmakingSeasons
+  | GetCurrentMatchmakingSeason
+
 export interface GetCurrentMapPoolBegin {
   type: '@matchmaking/getCurrentMapPoolBegin'
   payload: {
@@ -213,4 +216,9 @@ export interface MatchmakingStatusUpdate {
 export interface GetMatchmakingSeasons {
   type: '@matchmaking/getMatchmakingSeasons'
   payload: GetMatchmakingSeasonsResponse
+}
+
+export interface GetCurrentMatchmakingSeason {
+  type: '@matchmaking/getCurrentMatchmakingSeason'
+  payload: MatchmakingSeasonJson
 }

--- a/client/matchmaking/matchmaking-seasons-reducer.ts
+++ b/client/matchmaking/matchmaking-seasons-reducer.ts
@@ -20,13 +20,17 @@ export default immerKeyedReducer(DEFAULT_STATE, {
     state.currentSeasonId = current
   },
 
+  ['@matchmaking/getCurrentMatchmakingSeason'](state, { payload: season }) {
+    state.currentSeasonId = season.id
+  },
+
   ['@ladder/getRankings'](state, action) {
-    const { season } = action.payload
+    const { season: season } = action.payload
     state.byId.set(season.id, season)
   },
 
   ['@ladder/searchRankings'](state, action) {
-    const { season } = action.payload
+    const { season: season } = action.payload
     state.byId.set(season.id, season)
   },
 

--- a/client/matchmaking/matchmaking-seasons-reducer.ts
+++ b/client/matchmaking/matchmaking-seasons-reducer.ts
@@ -4,13 +4,22 @@ import { immerKeyedReducer } from '../reducers/keyed-reducer'
 
 export interface MatchmakingSeasonsState {
   byId: Map<SeasonId, MatchmakingSeasonJson>
+  currentSeasonId?: SeasonId
 }
 
 const DEFAULT_STATE: ReadonlyDeep<MatchmakingSeasonsState> = {
   byId: new Map(),
+  currentSeasonId: undefined,
 }
 
 export default immerKeyedReducer(DEFAULT_STATE, {
+  ['@matchmaking/getMatchmakingSeasons'](state, { payload: { seasons, current } }) {
+    for (const season of seasons) {
+      state.byId.set(season.id, season)
+    }
+    state.currentSeasonId = current
+  },
+
   ['@ladder/getRankings'](state, action) {
     const { season } = action.payload
     state.byId.set(season.id, season)

--- a/client/matchmaking/matchmaking-seasons-reducer.ts
+++ b/client/matchmaking/matchmaking-seasons-reducer.ts
@@ -25,12 +25,12 @@ export default immerKeyedReducer(DEFAULT_STATE, {
   },
 
   ['@ladder/getRankings'](state, action) {
-    const { season: season } = action.payload
+    const { season } = action.payload
     state.byId.set(season.id, season)
   },
 
   ['@ladder/searchRankings'](state, action) {
-    const { season: season } = action.payload
+    const { season } = action.payload
     state.byId.set(season.id, season)
   },
 

--- a/common/matchmaking.ts
+++ b/common/matchmaking.ts
@@ -945,7 +945,8 @@ export type MatchmakingTypeAndSeasonId = Tagged<
 /**
  * Converts a matchmaking type and a season ID into a new type made up of both values. This is
  * useful for creating a unique key for a matchmaking type and a season ID, so we don't have to
- * use nested maps.
+ * use nested maps. Season ID can be `undefined` which should be used to indicate the current season
+ * in case its ID is not yet known.
  */
 export function makeMatchmakingTypeAndSeasonId(
   matchmakingType: MatchmakingType,

--- a/common/matchmaking.ts
+++ b/common/matchmaking.ts
@@ -936,3 +936,20 @@ export interface AddMatchmakingSeasonResponse {
 export interface GetCurrentMatchmakingSeasonResponse {
   season: MatchmakingSeasonJson
 }
+
+export type MatchmakingTypeAndSeasonId = Tagged<
+  `${MatchmakingType}|${SeasonId | undefined}`,
+  'MatchmakingTypeAndSeasonId'
+>
+
+/**
+ * Converts a matchmaking type and a season ID into a new type made up of both values. This is
+ * useful for creating a unique key for a matchmaking type and a season ID, so we don't have to
+ * use nested maps.
+ */
+export function makeMatchmakingTypeAndSeasonId(
+  matchmakingType: MatchmakingType,
+  seasonId?: SeasonId,
+): MatchmakingTypeAndSeasonId {
+  return `${matchmakingType}|${seasonId}` as MatchmakingTypeAndSeasonId
+}

--- a/common/matchmaking.ts
+++ b/common/matchmaking.ts
@@ -932,25 +932,3 @@ export type AddMatchmakingSeasonRequest = Jsonify<ServerAddMatchmakingSeasonRequ
 export interface AddMatchmakingSeasonResponse {
   season: MatchmakingSeasonJson
 }
-
-export interface GetCurrentMatchmakingSeasonResponse {
-  season: MatchmakingSeasonJson
-}
-
-export type MatchmakingTypeAndSeasonId = Tagged<
-  `${MatchmakingType}|${SeasonId | undefined}`,
-  'MatchmakingTypeAndSeasonId'
->
-
-/**
- * Converts a matchmaking type and a season ID into a new type made up of both values. This is
- * useful for creating a unique key for a matchmaking type and a season ID, so we don't have to
- * use nested maps. Season ID can be `undefined` which should be used to indicate the current season
- * in case its ID is not yet known.
- */
-export function makeMatchmakingTypeAndSeasonId(
-  matchmakingType: MatchmakingType,
-  seasonId?: SeasonId,
-): MatchmakingTypeAndSeasonId {
-  return `${matchmakingType}|${seasonId}` as MatchmakingTypeAndSeasonId
-}

--- a/server/lib/ladder/ladder-api.ts
+++ b/server/lib/ladder/ladder-api.ts
@@ -23,7 +23,7 @@ import { httpBefore, httpGet } from '../http/route-decorators'
 import logger from '../logging/logger'
 import { MatchmakingSeasonsService } from '../matchmaking/matchmaking-seasons'
 import {
-  getManyMatchmakingFinalizedRanks,
+  getFinalizedRanksForSeason,
   getManyMatchmakingRatings,
   getMatchmakingRatingsForUser,
   getMatchmakingSeasonsByIds,
@@ -157,70 +157,9 @@ export class LadderApi {
     }
   }
 
-  @httpGet('/:matchmakingType/:seasonId')
-  @httpBefore(throttleMiddleware(getRankingsThrottle, ctx => ctx.ip))
-  async getPreviousSeasonRankings(ctx: RouterContext): Promise<GetRankingsResponse> {
-    const { params, query } = validateRequest(ctx, {
-      params: Joi.object<{ matchmakingType: MatchmakingType; seasonId: SeasonId }>({
-        matchmakingType: Joi.valid(...ALL_MATCHMAKING_TYPES).required(),
-        seasonId: Joi.number().required(),
-      }),
-      query: Joi.object<{ q?: string }>({
-        q: Joi.string().allow(''),
-      }),
-    })
-
-    const [season] = await getMatchmakingSeasonsByIds([params.seasonId])
-    if (!season) {
-      throw new LadderApiError(LadderErrorCode.NotFound, 'season not found')
-    }
-
-    const ranks = await getManyMatchmakingFinalizedRanks(params.matchmakingType, season.id, query.q)
-    const users = await findUsersById(ranks.map(r => r.userId))
-
-    const players: LadderPlayer[] = ranks.map(
-      r =>
-        ({
-          userId: r.userId,
-          matchmakingType: r.matchmakingType,
-          seasonId: r.seasonId,
-          rank: r.rank,
-          rating: r.rating,
-          points: r.points,
-          bonusUsed: r.bonusUsed,
-          wins: r.wins,
-          losses: r.losses,
-          lifetimeGames: r.lifetimeGames,
-          pWins: r.pWins,
-          pLosses: r.pLosses,
-          tWins: r.tWins,
-          tLosses: r.tLosses,
-          zWins: r.zWins,
-          zLosses: r.zLosses,
-          rWins: r.rWins,
-          rLosses: r.rLosses,
-          rPWins: r.rPWins,
-          rPLosses: r.rPLosses,
-          rTWins: r.rTWins,
-          rTLosses: r.rTLosses,
-          rZWins: r.rZWins,
-          rZLosses: r.rZLosses,
-          lastPlayedDate: Number(r.lastPlayedDate),
-        }) satisfies LadderPlayer,
-    )
-
-    return {
-      totalCount: ranks.length,
-      players,
-      users,
-      lastUpdated: Date.now(),
-      season: toMatchmakingSeasonJson(season),
-    }
-  }
-
   @httpGet('/:matchmakingType')
   @httpBefore(throttleMiddleware(getRankingsThrottle, ctx => ctx.ip))
-  async getRankings(ctx: RouterContext): Promise<GetRankingsResponse> {
+  async getCurrentSeasonRankings(ctx: RouterContext): Promise<GetRankingsResponse> {
     const { params, query } = validateRequest(ctx, {
       params: Joi.object<{ matchmakingType: MatchmakingType }>({
         matchmakingType: Joi.valid(...ALL_MATCHMAKING_TYPES).required(),
@@ -283,6 +222,67 @@ export class LadderApi {
 
     return {
       totalCount: rankings.length,
+      players,
+      users,
+      lastUpdated: Date.now(),
+      season: toMatchmakingSeasonJson(season),
+    }
+  }
+
+  @httpGet('/:matchmakingType/:seasonId')
+  @httpBefore(throttleMiddleware(getRankingsThrottle, ctx => ctx.ip))
+  async getPreviousSeasonRankings(ctx: RouterContext): Promise<GetRankingsResponse> {
+    const { params, query } = validateRequest(ctx, {
+      params: Joi.object<{ matchmakingType: MatchmakingType; seasonId: SeasonId }>({
+        matchmakingType: Joi.valid(...ALL_MATCHMAKING_TYPES).required(),
+        seasonId: Joi.number().required(),
+      }),
+      query: Joi.object<{ q?: string }>({
+        q: Joi.string().allow(''),
+      }),
+    })
+
+    const [season] = await getMatchmakingSeasonsByIds([params.seasonId])
+    if (!season) {
+      throw new LadderApiError(LadderErrorCode.NotFound, 'season not found')
+    }
+
+    const ranks = await getFinalizedRanksForSeason(params.matchmakingType, season.id, query.q)
+    const users = await findUsersById(ranks.map(r => r.userId))
+
+    const players: LadderPlayer[] = ranks.map(
+      r =>
+        ({
+          userId: r.userId,
+          matchmakingType: r.matchmakingType,
+          seasonId: r.seasonId,
+          rank: r.rank,
+          rating: r.rating,
+          points: r.points,
+          bonusUsed: r.bonusUsed,
+          wins: r.wins,
+          losses: r.losses,
+          lifetimeGames: r.lifetimeGames,
+          pWins: r.pWins,
+          pLosses: r.pLosses,
+          tWins: r.tWins,
+          tLosses: r.tLosses,
+          zWins: r.zWins,
+          zLosses: r.zLosses,
+          rWins: r.rWins,
+          rLosses: r.rLosses,
+          rPWins: r.rPWins,
+          rPLosses: r.rPLosses,
+          rTWins: r.rTWins,
+          rTLosses: r.rTLosses,
+          rZWins: r.rZWins,
+          rZLosses: r.rZLosses,
+          lastPlayedDate: Number(r.lastPlayedDate),
+        }) satisfies LadderPlayer,
+    )
+
+    return {
+      totalCount: ranks.length,
       players,
       users,
       lastUpdated: Date.now(),

--- a/server/lib/ladder/ladder-api.ts
+++ b/server/lib/ladder/ladder-api.ts
@@ -12,6 +12,7 @@ import {
   ALL_MATCHMAKING_TYPES,
   MatchmakingType,
   NUM_PLACEMENT_MATCHES,
+  SeasonId,
   toMatchmakingSeasonJson,
 } from '../../../common/matchmaking'
 import { SbUserId } from '../../../common/users/sb-user'
@@ -21,7 +22,12 @@ import { httpApi, httpBeforeAll } from '../http/http-api'
 import { httpBefore, httpGet } from '../http/route-decorators'
 import logger from '../logging/logger'
 import { MatchmakingSeasonsService } from '../matchmaking/matchmaking-seasons'
-import { getManyMatchmakingRatings, getMatchmakingRatingsForUser } from '../matchmaking/models'
+import {
+  getManyMatchmakingFinalizedRanks,
+  getManyMatchmakingRatings,
+  getMatchmakingRatingsForUser,
+  getMatchmakingSeasonsByIds,
+} from '../matchmaking/models'
 import { Redis } from '../redis/redis'
 import ensureLoggedIn from '../session/ensure-logged-in'
 import createThrottle from '../throttle/create-throttle'
@@ -148,6 +154,67 @@ export class LadderApi {
       }, {}),
       user,
       currentSeason: toMatchmakingSeasonJson(currentSeason),
+    }
+  }
+
+  @httpGet('/:matchmakingType/:seasonId')
+  @httpBefore(throttleMiddleware(getRankingsThrottle, ctx => ctx.ip))
+  async getPreviousSeasonRankings(ctx: RouterContext): Promise<GetRankingsResponse> {
+    const { params, query } = validateRequest(ctx, {
+      params: Joi.object<{ matchmakingType: MatchmakingType; seasonId: SeasonId }>({
+        matchmakingType: Joi.valid(...ALL_MATCHMAKING_TYPES).required(),
+        seasonId: Joi.number().required(),
+      }),
+      query: Joi.object<{ q?: string }>({
+        q: Joi.string().allow(''),
+      }),
+    })
+
+    const [season] = await getMatchmakingSeasonsByIds([params.seasonId])
+    if (!season) {
+      throw new LadderApiError(LadderErrorCode.NotFound, 'season not found')
+    }
+
+    const ranks = await getManyMatchmakingFinalizedRanks(params.matchmakingType, season.id, query.q)
+    const users = await findUsersById(ranks.map(r => r.userId))
+
+    const players: LadderPlayer[] = ranks.map(
+      r =>
+        ({
+          userId: r.userId,
+          matchmakingType: r.matchmakingType,
+          seasonId: r.seasonId,
+          rank: r.rank,
+          rating: r.rating,
+          points: r.points,
+          bonusUsed: r.bonusUsed,
+          wins: r.wins,
+          losses: r.losses,
+          lifetimeGames: r.lifetimeGames,
+          pWins: r.pWins,
+          pLosses: r.pLosses,
+          tWins: r.tWins,
+          tLosses: r.tLosses,
+          zWins: r.zWins,
+          zLosses: r.zLosses,
+          rWins: r.rWins,
+          rLosses: r.rLosses,
+          rPWins: r.rPWins,
+          rPLosses: r.rPLosses,
+          rTWins: r.rTWins,
+          rTLosses: r.rTLosses,
+          rZWins: r.rZWins,
+          rZLosses: r.rZLosses,
+          lastPlayedDate: Number(r.lastPlayedDate),
+        }) satisfies LadderPlayer,
+    )
+
+    return {
+      totalCount: ranks.length,
+      players,
+      users,
+      lastUpdated: Date.now(),
+      season: toMatchmakingSeasonJson(season),
     }
   }
 

--- a/server/lib/matchmaking/matchmaking-api.ts
+++ b/server/lib/matchmaking/matchmaking-api.ts
@@ -5,7 +5,6 @@ import { assertUnreachable } from '../../../common/assert-unreachable'
 import {
   AddMatchmakingSeasonResponse,
   FindMatchRequest,
-  GetCurrentMatchmakingSeasonResponse,
   GetMatchmakingSeasonsResponse,
   hasVetoes,
   MatchmakingSeasonsServiceErrorCode,
@@ -166,18 +165,6 @@ export class MatchmakingApi {
         toMatchmakingSeasonJson(s),
       ),
       current: (await this.matchmakingSeasonsService.getCurrentSeason()).id,
-    }
-  }
-
-  @httpGet('/seasons/current')
-  @httpBefore(
-    throttleMiddleware(seasonsRetrievalThrottle, ctx => String(ctx.session?.user?.id) ?? ctx.ip),
-  )
-  async getCurrentMatchmakingSeason(
-    ctx: RouterContext,
-  ): Promise<GetCurrentMatchmakingSeasonResponse> {
-    return {
-      season: toMatchmakingSeasonJson(await this.matchmakingSeasonsService.getCurrentSeason()),
     }
   }
 

--- a/server/lib/matchmaking/models.ts
+++ b/server/lib/matchmaking/models.ts
@@ -422,7 +422,7 @@ export async function getManyMatchmakingRatings(
  * Returns a list of players's finalized matchmaking ranks, and optionally filtered by a search
  * query, for a particular matchmaking type and season.
  */
-export async function getManyMatchmakingFinalizedRanks(
+export async function getFinalizedRanksForSeason(
   matchmakingType: MatchmakingType,
   seasonId: SeasonId,
   searchStr?: string,

--- a/server/lib/matchmaking/models.ts
+++ b/server/lib/matchmaking/models.ts
@@ -419,6 +419,52 @@ export async function getManyMatchmakingRatings(
 }
 
 /**
+ * Returns a list of players's finalized matchmaking ranks, and optionally filtered by a search
+ * query, for a particular matchmaking type and season.
+ */
+export async function getManyMatchmakingFinalizedRanks(
+  matchmakingType: MatchmakingType,
+  seasonId: SeasonId,
+  searchStr?: string,
+): Promise<FinalizedMatchmakingRank[]> {
+  const { client, done } = await db()
+  try {
+    const optionalJoin = searchStr ? sql`JOIN users u ON mfr.user_id = u.id` : sql``
+
+    let query = sql`
+      SELECT mfr.user_id, mfr.season_id, mfr.matchmaking_type, mfr.rank, mr.rating, mr.points,
+        mr.bonus_used, mr.lifetime_games, mr.wins, mr.losses,
+        mr.p_wins, mr.p_losses,
+        mr.t_wins, mr.t_losses,
+        mr.z_wins, mr.z_losses,
+        mr.r_wins, mr.r_losses,
+        mr.r_p_wins, mr.r_p_losses, mr.r_t_wins, mr.r_t_losses, mr.r_z_wins, mr.r_z_losses,
+        mr.last_played_date
+      FROM matchmaking_finalized_ranks mfr
+      INNER JOIN matchmaking_ratings mr ON mfr.season_id = mr.season_id
+        AND mfr.user_id = mr.user_id
+        AND mfr.matchmaking_type = mr.matchmaking_type
+      ${optionalJoin}
+      WHERE mfr.matchmaking_type = ${matchmakingType}
+      AND mfr.season_id = ${seasonId}
+    `
+
+    if (searchStr) {
+      const escapedStr = `%${escapeSearchString(searchStr)}%`
+      query = query.append(sql`
+        AND u.name ILIKE ${escapedStr}
+      `)
+    }
+
+    const result = await client.query<DbMatchmakingFinalizedRank>(query)
+
+    return result.rows.map(r => fromDbMatchmakingFinalizedRank(r))
+  } finally {
+    done()
+  }
+}
+
+/**
  * Returns a user's rating for all matchmaking types. Any matchmaking types that the user has not
  * completed a game in will not be included in the result.
  */

--- a/server/public/locales/en/global.json
+++ b/server/public/locales/en/global.json
@@ -384,6 +384,7 @@
     "playerHeader": "Player",
     "pointsHeader": "Points",
     "rankHeader": "Rank",
+    "season": "Season",
     "updatedText": "Updated: {{timestamp}}",
     "winLossHeader": "Win/loss"
   },


### PR DESCRIPTION
This adds a select for past seasons on the ladder page, defaulting to the current season.

The action creators and reducers for all of this state got a bit messy, but not sure if there's a better way to deal with it.

Closes #1108 