### PR TITLE
Add a more defensive code when user leaves the channel.

### DIFF
--- a/server/lib/chat/chat-service.ts
+++ b/server/lib/chat/chat-service.ts
@@ -1093,10 +1093,12 @@ export default class ChatService {
   ): Promise<SbUserId | undefined> {
     const { newOwnerId } = await removeUserFromChannel(userId, channelId)
 
-    const updated = this.state.channels.get(channelId)!.delete(userId)
-    this.state = updated.size
-      ? this.state.setIn(['channels', channelId], updated)
-      : this.state.deleteIn(['channels', channelId])
+    if (this.state.channels.has(channelId)) {
+      const updated = this.state.channels.get(channelId)!.delete(userId)
+      this.state = updated.size
+        ? this.state.setIn(['channels', channelId], updated)
+        : this.state.deleteIn(['channels', channelId])
+    }
 
     if (this.state.users.has(userId) && this.state.users.get(userId)!.has(channelId)) {
       // TODO(tec27): Remove `any` cast once Immutable properly types this call again


### PR DESCRIPTION
Not *entirely* sure how this could happen, but it happened at least once that the user tried to leave the channel that didn't exist in the state anymore.

Fixes #1123 