### PR TITLE
Add a little bit of vertical padding to usernames in chat messages.

### DIFF
--- a/client/messaging/__snapshots__/common-message-layout.test.tsx.snap
+++ b/client/messaging/__snapshots__/common-message-layout.test.tsx.snap
@@ -31,7 +31,7 @@ exports[`client/messaging/common-message-layout/TextMessage message as a normal 
       </span>
     </div>
     <span
-      class="connected-username__Username-sc-1uo72rz-0 izvTty common-message-layout__Username-sc-hg9wkq-0 grLPH"
+      class="connected-username__Username-sc-1uo72rz-0 izvTty common-message-layout__Username-sc-hg9wkq-0 heSEqX"
     >
       <span
         aria-label="Username loading…"
@@ -86,7 +86,7 @@ exports[`client/messaging/common-message-layout/TextMessage message with a link 
       </span>
     </div>
     <span
-      class="connected-username__Username-sc-1uo72rz-0 izvTty common-message-layout__Username-sc-hg9wkq-0 grLPH"
+      class="connected-username__Username-sc-1uo72rz-0 izvTty common-message-layout__Username-sc-hg9wkq-0 heSEqX"
     >
       <span
         aria-label="Username loading…"
@@ -148,7 +148,7 @@ exports[`client/messaging/common-message-layout/TextMessage message with a link 
       </span>
     </div>
     <span
-      class="connected-username__Username-sc-1uo72rz-0 izvTty common-message-layout__Username-sc-hg9wkq-0 grLPH"
+      class="connected-username__Username-sc-1uo72rz-0 izvTty common-message-layout__Username-sc-hg9wkq-0 heSEqX"
     >
       <span
         aria-label="Username loading…"
@@ -222,7 +222,7 @@ exports[`client/messaging/common-message-layout/TextMessage message with a link 
       </span>
     </div>
     <span
-      class="connected-username__Username-sc-1uo72rz-0 izvTty common-message-layout__Username-sc-hg9wkq-0 grLPH"
+      class="connected-username__Username-sc-1uo72rz-0 izvTty common-message-layout__Username-sc-hg9wkq-0 heSEqX"
     >
       <span
         aria-label="Username loading…"
@@ -310,7 +310,7 @@ exports[`client/messaging/common-message-layout/TextMessage message with a menti
       </span>
     </div>
     <span
-      class="connected-username__Username-sc-1uo72rz-0 izvTty common-message-layout__Username-sc-hg9wkq-0 grLPH"
+      class="connected-username__Username-sc-1uo72rz-0 izvTty common-message-layout__Username-sc-hg9wkq-0 heSEqX"
     >
       <span
         aria-label="Username loading…"
@@ -377,7 +377,7 @@ exports[`client/messaging/common-message-layout/TextMessage message with a menti
       </span>
     </div>
     <span
-      class="connected-username__Username-sc-1uo72rz-0 izvTty common-message-layout__Username-sc-hg9wkq-0 grLPH"
+      class="connected-username__Username-sc-1uo72rz-0 izvTty common-message-layout__Username-sc-hg9wkq-0 heSEqX"
     >
       <span
         aria-label="Username loading…"
@@ -450,7 +450,7 @@ exports[`client/messaging/common-message-layout/TextMessage message with a menti
       </span>
     </div>
     <span
-      class="connected-username__Username-sc-1uo72rz-0 izvTty common-message-layout__Username-sc-hg9wkq-0 grLPH"
+      class="connected-username__Username-sc-1uo72rz-0 izvTty common-message-layout__Username-sc-hg9wkq-0 heSEqX"
     >
       <span
         aria-label="Username loading…"
@@ -532,7 +532,7 @@ exports[`client/messaging/common-message-layout/TextMessage message with a menti
       </span>
     </div>
     <span
-      class="connected-username__Username-sc-1uo72rz-0 izvTty common-message-layout__Username-sc-hg9wkq-0 grLPH"
+      class="connected-username__Username-sc-1uo72rz-0 izvTty common-message-layout__Username-sc-hg9wkq-0 heSEqX"
     >
       <span
         aria-label="Username loading…"

--- a/client/messaging/__snapshots__/common-message-layout.test.tsx.snap
+++ b/client/messaging/__snapshots__/common-message-layout.test.tsx.snap
@@ -31,17 +31,13 @@ exports[`client/messaging/common-message-layout/TextMessage message as a normal 
       </span>
     </div>
     <span
-      class="common-message-layout__Username-sc-hg9wkq-0 fnAgpT"
+      class="connected-username__Username-sc-1uo72rz-0 izvTty common-message-layout__Username-sc-hg9wkq-0 grLPH"
     >
       <span
-        class="connected-username__Username-sc-1uo72rz-0 izvTty"
+        aria-label="Username loading…"
+        class="connected-username__LoadingName-sc-1uo72rz-1 gRwppo"
       >
-        <span
-          aria-label="Username loading…"
-          class="connected-username__LoadingName-sc-1uo72rz-1 gRwppo"
-        >
-                     
-        </span>
+                   
       </span>
     </span>
     <i
@@ -90,17 +86,13 @@ exports[`client/messaging/common-message-layout/TextMessage message with a link 
       </span>
     </div>
     <span
-      class="common-message-layout__Username-sc-hg9wkq-0 fnAgpT"
+      class="connected-username__Username-sc-1uo72rz-0 izvTty common-message-layout__Username-sc-hg9wkq-0 grLPH"
     >
       <span
-        class="connected-username__Username-sc-1uo72rz-0 izvTty"
+        aria-label="Username loading…"
+        class="connected-username__LoadingName-sc-1uo72rz-1 gRwppo"
       >
-        <span
-          aria-label="Username loading…"
-          class="connected-username__LoadingName-sc-1uo72rz-1 gRwppo"
-        >
-                     
-        </span>
+                   
       </span>
     </span>
     <i
@@ -156,17 +148,13 @@ exports[`client/messaging/common-message-layout/TextMessage message with a link 
       </span>
     </div>
     <span
-      class="common-message-layout__Username-sc-hg9wkq-0 fnAgpT"
+      class="connected-username__Username-sc-1uo72rz-0 izvTty common-message-layout__Username-sc-hg9wkq-0 grLPH"
     >
       <span
-        class="connected-username__Username-sc-1uo72rz-0 izvTty"
+        aria-label="Username loading…"
+        class="connected-username__LoadingName-sc-1uo72rz-1 gRwppo"
       >
-        <span
-          aria-label="Username loading…"
-          class="connected-username__LoadingName-sc-1uo72rz-1 gRwppo"
-        >
-                     
-        </span>
+                   
       </span>
     </span>
     <i
@@ -234,17 +222,13 @@ exports[`client/messaging/common-message-layout/TextMessage message with a link 
       </span>
     </div>
     <span
-      class="common-message-layout__Username-sc-hg9wkq-0 fnAgpT"
+      class="connected-username__Username-sc-1uo72rz-0 izvTty common-message-layout__Username-sc-hg9wkq-0 grLPH"
     >
       <span
-        class="connected-username__Username-sc-1uo72rz-0 izvTty"
+        aria-label="Username loading…"
+        class="connected-username__LoadingName-sc-1uo72rz-1 gRwppo"
       >
-        <span
-          aria-label="Username loading…"
-          class="connected-username__LoadingName-sc-1uo72rz-1 gRwppo"
-        >
-                     
-        </span>
+                   
       </span>
     </span>
     <i
@@ -326,17 +310,13 @@ exports[`client/messaging/common-message-layout/TextMessage message with a menti
       </span>
     </div>
     <span
-      class="common-message-layout__Username-sc-hg9wkq-0 fnAgpT"
+      class="connected-username__Username-sc-1uo72rz-0 izvTty common-message-layout__Username-sc-hg9wkq-0 grLPH"
     >
       <span
-        class="connected-username__Username-sc-1uo72rz-0 izvTty"
+        aria-label="Username loading…"
+        class="connected-username__LoadingName-sc-1uo72rz-1 gRwppo"
       >
-        <span
-          aria-label="Username loading…"
-          class="connected-username__LoadingName-sc-1uo72rz-1 gRwppo"
-        >
-                     
-        </span>
+                   
       </span>
     </span>
     <i
@@ -397,17 +377,13 @@ exports[`client/messaging/common-message-layout/TextMessage message with a menti
       </span>
     </div>
     <span
-      class="common-message-layout__Username-sc-hg9wkq-0 fnAgpT"
+      class="connected-username__Username-sc-1uo72rz-0 izvTty common-message-layout__Username-sc-hg9wkq-0 grLPH"
     >
       <span
-        class="connected-username__Username-sc-1uo72rz-0 izvTty"
+        aria-label="Username loading…"
+        class="connected-username__LoadingName-sc-1uo72rz-1 gRwppo"
       >
-        <span
-          aria-label="Username loading…"
-          class="connected-username__LoadingName-sc-1uo72rz-1 gRwppo"
-        >
-                     
-        </span>
+                   
       </span>
     </span>
     <i
@@ -474,17 +450,13 @@ exports[`client/messaging/common-message-layout/TextMessage message with a menti
       </span>
     </div>
     <span
-      class="common-message-layout__Username-sc-hg9wkq-0 fnAgpT"
+      class="connected-username__Username-sc-1uo72rz-0 izvTty common-message-layout__Username-sc-hg9wkq-0 grLPH"
     >
       <span
-        class="connected-username__Username-sc-1uo72rz-0 izvTty"
+        aria-label="Username loading…"
+        class="connected-username__LoadingName-sc-1uo72rz-1 gRwppo"
       >
-        <span
-          aria-label="Username loading…"
-          class="connected-username__LoadingName-sc-1uo72rz-1 gRwppo"
-        >
-                     
-        </span>
+                   
       </span>
     </span>
     <i
@@ -560,17 +532,13 @@ exports[`client/messaging/common-message-layout/TextMessage message with a menti
       </span>
     </div>
     <span
-      class="common-message-layout__Username-sc-hg9wkq-0 fnAgpT"
+      class="connected-username__Username-sc-1uo72rz-0 izvTty common-message-layout__Username-sc-hg9wkq-0 grLPH"
     >
       <span
-        class="connected-username__Username-sc-1uo72rz-0 izvTty"
+        aria-label="Username loading…"
+        class="connected-username__LoadingName-sc-1uo72rz-1 gRwppo"
       >
-        <span
-          aria-label="Username loading…"
-          class="connected-username__LoadingName-sc-1uo72rz-1 gRwppo"
-        >
-                     
-        </span>
+                   
       </span>
     </span>
     <i

--- a/client/messaging/common-message-layout.tsx
+++ b/client/messaging/common-message-layout.tsx
@@ -33,7 +33,7 @@ const Username = styled(ConnectedUsername)`
   ${titleSmall};
 
   margin-right: 8px;
-  padding: 4px 0;
+  padding-block: 4px;
 
   color: var(--color-amber90);
   line-height: inherit;

--- a/client/messaging/common-message-layout.tsx
+++ b/client/messaging/common-message-layout.tsx
@@ -29,10 +29,11 @@ const newDayFormat = new Intl.DateTimeFormat(navigator.language, {
   day: '2-digit',
 })
 
-const Username = styled.span`
+const Username = styled(ConnectedUsername)`
   ${titleSmall};
 
   margin-right: 8px;
+  padding: 4px 0;
 
   color: var(--color-amber90);
   line-height: inherit;
@@ -144,9 +145,7 @@ export function TextMessage({ msgId, userId, selfUserId, time, text, testId }: T
         highlighted={isHighlighted}
         onContextMenu={onContextMenu}
         testId={testId}>
-        <Username>
-          <ConnectedUsername userId={userId} filterClick={filterClick} UserMenu={UserMenu} />
-        </Username>
+        <Username userId={userId} filterClick={filterClick} UserMenu={UserMenu} />
         <Separator>{': '}</Separator>
         <Text>{parsedText}</Text>
       </TimestampMessageLayout>


### PR DESCRIPTION
This should make it less likely for right-clicking the username to accidentally pop up chat message context menu if you were a couple of pixels off.