### PR TITLE
Fix a design issue with loading area in main layout.

### DIFF
--- a/client/app-routes.tsx
+++ b/client/app-routes.tsx
@@ -1,6 +1,5 @@
 import { AnimatePresence } from 'motion/react'
 import React, { cloneElement } from 'react'
-import styled from 'styled-components'
 import { Route } from 'wouter'
 import { useIsAdmin } from './admin/admin-permissions'
 import { ForgotPassword } from './auth/forgot-password'
@@ -16,6 +15,7 @@ import { Faq } from './home/faq'
 import { Home } from './home/home'
 import { LadderRouteComponent } from './ladder/ladder'
 import { LeagueRoot } from './leagues/league-routes'
+import { MainLayoutLoadingDotsArea } from './main-layout'
 import { MapsRoot } from './maps/maps-root'
 import { AnimatedSwitch } from './navigation/animated-switch'
 import { StaticNewsRoute } from './news/static-news-details'
@@ -24,7 +24,6 @@ import {
   PrivacyPolicyPage,
   TermsOfServicePage,
 } from './policies/policy-displays'
-import { LoadingDotsArea } from './progress/dots'
 import { ReplaysRoot } from './replays/replays-root'
 import { ProfileRouteComponent } from './users/route'
 import { WhisperRouteComponent } from './whispers/route'
@@ -38,10 +37,6 @@ const Signup = React.lazy(async () => ({
   default: (await import('./auth/signup')).Signup,
 }))
 
-const StyledLoadingDots = styled(LoadingDotsArea)`
-  height: 100%;
-`
-
 export function AppRoutes({
   container,
 }: {
@@ -49,7 +44,7 @@ export function AppRoutes({
 }) {
   const isAdmin = useIsAdmin()
 
-  const fallback = cloneElement(container, { children: <StyledLoadingDots /> })
+  const fallback = cloneElement(container, { children: <MainLayoutLoadingDotsArea /> })
 
   return (
     <React.Suspense fallback={fallback}>

--- a/client/app.tsx
+++ b/client/app.tsx
@@ -11,7 +11,7 @@ import { UpdateOverlay } from './download/update-overlay'
 import { FileDropZoneProvider } from './file-browser/file-drop-zone'
 import { KeyListenerBoundary } from './keyboard/key-listener'
 import { logger } from './logging/logger'
-import { MainLayout, MainLayoutContent } from './main-layout'
+import { MainLayout, MainLayoutContent, MainLayoutLoadingDotsArea } from './main-layout'
 import { UNAUTHORIZED_EMITTER } from './network/fetch'
 import { createGraphqlClient } from './network/graphql-client'
 import { SiteSocketManager } from './network/site-socket-manager'
@@ -174,7 +174,7 @@ function MainLayoutRoute() {
   // this reduces some of the visual layout changes
   return (
     <MainLayout key={selfUser?.id ?? -1}>
-      <React.Suspense fallback={<LoadingDotsArea />}>
+      <React.Suspense fallback={<MainLayoutLoadingDotsArea />}>
         <AppRoutes
           container={
             <MainLayoutContent

--- a/client/main-layout.tsx
+++ b/client/main-layout.tsx
@@ -43,6 +43,7 @@ import { push } from './navigation/routing'
 import { NotificationsButton } from './notifications/app-bar-entry'
 import NotificationPopups from './notifications/notifications-popup'
 import { useShowPolicyNotificationsIfNeeded } from './policies/show-notifications'
+import { LoadingDotsArea } from './progress/dots'
 import { useMultiplexRef } from './react/refs'
 import { useUserLocalStorageValue } from './react/state-hooks'
 import { useAppDispatch } from './redux-hooks'
@@ -112,7 +113,7 @@ const Root = styled.div<{ $sidebarOpen?: boolean; $sidebarPinned?: boolean }>`
     grid-template-columns:
       var(--_cur-sidebar-column-size)
       minmax(auto, 1fr)
-      var(--_ cur-sidebar-column-size);
+      var(--_cur-sidebar-column-size);
   }
 `
 
@@ -821,6 +822,10 @@ function AppBar({
 export const MainLayoutContent = styled(m.div)`
   grid-area: content;
   overflow: auto;
+`
+
+export const MainLayoutLoadingDotsArea = styled(LoadingDotsArea)`
+  grid-area: content;
 `
 
 export function MainLayout({ children }: { children: React.ReactNode }) {


### PR DESCRIPTION
Previously, the loading area would look like this:

![image](https://github.com/user-attachments/assets/3c4d3963-6e60-49c1-bdac-3171331613f4)

Also fixes a typo in a CSS variable. It's really unfortunate there are no tools that would catch these typos :/