### PR TITLE
Change the jotai devtools hotkey so it doesn't clash with chrome devtools.

### DIFF
--- a/client/debug/jotai-devtools.tsx
+++ b/client/debug/jotai-devtools.tsx
@@ -12,7 +12,7 @@ export function JotaiDevTools() {
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.keyCode === I && event.ctrlKey) {
+      if (event.keyCode === I && event.ctrlKey && !event.shiftKey) {
         setShow(s => !s)
       }
     }


### PR DESCRIPTION
Chrome uses Ctrl + Shift + I to open the devtools (and focus on the elements tab), so we explicitly check that the Shift key is not pressed when opening the jotai devtools.