### PR TITLE
Add a way to zoom in and pan around map image preview.

### DIFF
--- a/client/dom/auto-size-image.tsx
+++ b/client/dom/auto-size-image.tsx
@@ -15,10 +15,12 @@ type ImgProps = React.JSX.IntrinsicElements['img']
 
 /**
  * Returns an image that will set its `sizes` attribute to its current width automatically for use
- * with `srcSet`.
+ * with `srcSet`, optionally scaled by the value of the `scale` prop.
  */
-export function AutoSizeImage(props: Simplify<SetRequired<Except<ImgProps, 'sizes'>, 'srcSet'>>) {
-  const { ref, src, srcSet, ...rest } = props
+export function AutoSizeImage(
+  props: Simplify<SetRequired<Except<ImgProps, 'sizes'>, 'srcSet'> & { scale?: number }>,
+) {
+  const { ref, src, srcSet, scale, ...rest } = props
   const [imageRef, imageRect] = useObservedDimensions()
 
   const multiRef = useMultiplexRef(ref, imageRef)
@@ -32,7 +34,7 @@ export function AutoSizeImage(props: Simplify<SetRequired<Except<ImgProps, 'size
       ref={multiRef}
       src={imageRect ? src : undefined}
       srcSet={imageRect ? srcSet : undefined}
-      sizes={imageRect ? `${Math.round(imageRect.width)}px` : undefined}
+      sizes={imageRect ? `${Math.round(imageRect.width * (scale ?? 1))}px` : undefined}
     />
   )
 }

--- a/client/maps/map-image.tsx
+++ b/client/maps/map-image.tsx
@@ -50,6 +50,7 @@ export function MapNoImage() {
 
 export interface MapInfoImageProps {
   map: ReadonlyDeep<MapInfoJson>
+  scale?: number
   altText?: string
   noImageElem?: React.ReactNode
   forceAspectRatio?: number
@@ -68,6 +69,7 @@ export function MapInfoImage({
     name,
     mapData: { width, height },
   },
+  scale,
   altText,
   noImageElem,
   forceAspectRatio,
@@ -84,6 +86,7 @@ export function MapInfoImage({
       name={name}
       width={width}
       height={height}
+      scale={scale}
       altText={altText}
       noImageElem={noImageElem}
       forceAspectRatio={forceAspectRatio}
@@ -101,6 +104,7 @@ export function UploadedMapImage({
     mapFile: { image256Url, image512Url, image1024Url, image2048Url, width, height },
     name,
   },
+  scale,
   altText,
   noImageElem,
   forceAspectRatio,
@@ -119,6 +123,7 @@ export function UploadedMapImage({
     }
     name: string
   }
+  scale?: number
   altText?: string
   noImageElem?: React.ReactNode
   forceAspectRatio?: number
@@ -135,6 +140,7 @@ export function UploadedMapImage({
       name={name}
       width={width}
       height={height}
+      scale={scale}
       altText={altText}
       noImageElem={noImageElem}
       forceAspectRatio={forceAspectRatio}
@@ -153,6 +159,7 @@ function MapImage({
   name,
   width,
   height,
+  scale,
   altText,
   noImageElem = <MapNoImage />,
   forceAspectRatio,
@@ -167,6 +174,7 @@ function MapImage({
   name: string
   width: number
   height: number
+  scale?: number
   altText?: string
   noImageElem?: React.ReactNode
   forceAspectRatio?: number
@@ -199,10 +207,12 @@ function MapImage({
             width={imgWidth}
             height={imgHeight}
             srcSet={srcSet}
+            scale={scale}
             src={image256Url}
             alt={altText ?? name}
             draggable={false}
-            decoding={'async'}
+            decoding='async'
+            loading='lazy'
             onMouseDown={onMouseDown}
           />
         </ImgContainer>

--- a/client/maps/map-image.tsx
+++ b/client/maps/map-image.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 import { ReadonlyDeep } from 'type-fest'
 import { MapInfoJson } from '../../common/maps'
+import { AutoSizeImage } from '../dom/auto-size-image'
 import { MaterialIcon } from '../icons/material/material-icon'
 import { styledWithAttrs } from '../styles/styled-with-attrs'
 import { BodyLarge } from '../styles/typography'
@@ -13,7 +14,7 @@ const ImgContainer = styled.div`
   height: 100%;
 `
 
-const ImgElement = styled.img`
+const ImgElement = styled(AutoSizeImage)`
   display: block;
   aspect-ratio: var(--sb-map-image-aspect-ratio, 1);
   width: 100%;
@@ -49,11 +50,12 @@ export function MapNoImage() {
 
 export interface MapInfoImageProps {
   map: ReadonlyDeep<MapInfoJson>
-  size?: number
   altText?: string
   noImageElem?: React.ReactNode
   forceAspectRatio?: number
   className?: string
+  style?: React.CSSProperties
+  onMouseDown?: (e: React.MouseEvent) => void
 }
 
 /** Displays the map image for `MapInfo` data. */
@@ -66,11 +68,12 @@ export function MapInfoImage({
     name,
     mapData: { width, height },
   },
-  size,
   altText,
   noImageElem,
   forceAspectRatio,
   className,
+  style,
+  onMouseDown,
 }: MapInfoImageProps) {
   return (
     <MapImage
@@ -81,11 +84,12 @@ export function MapInfoImage({
       name={name}
       width={width}
       height={height}
-      size={size}
       altText={altText}
       noImageElem={noImageElem}
       forceAspectRatio={forceAspectRatio}
       className={className}
+      style={style}
+      onMouseDown={onMouseDown}
     />
   )
 }
@@ -97,11 +101,12 @@ export function UploadedMapImage({
     mapFile: { image256Url, image512Url, image1024Url, image2048Url, width, height },
     name,
   },
-  size,
   altText,
   noImageElem,
   forceAspectRatio,
   className,
+  style,
+  onMouseDown,
 }: {
   map: {
     mapFile: {
@@ -114,11 +119,12 @@ export function UploadedMapImage({
     }
     name: string
   }
-  size?: number
   altText?: string
   noImageElem?: React.ReactNode
   forceAspectRatio?: number
   className?: string
+  style?: React.CSSProperties
+  onMouseDown?: (e: React.MouseEvent) => void
 }) {
   return (
     <MapImage
@@ -129,11 +135,12 @@ export function UploadedMapImage({
       name={name}
       width={width}
       height={height}
-      size={size}
       altText={altText}
       noImageElem={noImageElem}
       forceAspectRatio={forceAspectRatio}
       className={className}
+      style={style}
+      onMouseDown={onMouseDown}
     />
   )
 }
@@ -146,11 +153,12 @@ function MapImage({
   name,
   width,
   height,
-  size = 256,
   altText,
   noImageElem = <MapNoImage />,
   forceAspectRatio,
   className,
+  style,
+  onMouseDown,
 }: {
   image256Url?: string
   image512Url?: string
@@ -159,11 +167,12 @@ function MapImage({
   name: string
   width: number
   height: number
-  size?: number
   altText?: string
   noImageElem?: React.ReactNode
   forceAspectRatio?: number
   className?: string
+  style?: React.CSSProperties
+  onMouseDown?: (e: React.MouseEvent) => void
 }) {
   const srcSet = `
     ${image256Url} 256w,
@@ -173,27 +182,28 @@ function MapImage({
   `
 
   const aspectRatio = width / height
-  const imgWidth = size || width
+  const imgWidth = width
   const imgHeight = imgWidth / aspectRatio
 
-  const style = {
+  const imgStyle = {
     '--sb-map-image-aspect-ratio': forceAspectRatio !== undefined ? forceAspectRatio : aspectRatio,
+    ...style,
   } as React.CSSProperties
 
   // TODO(2Pac): handle 404s
   return (
     <>
       {image256Url ? (
-        <ImgContainer className={className} style={style}>
+        <ImgContainer className={className} style={imgStyle}>
           <ImgElement
             width={imgWidth}
             height={imgHeight}
             srcSet={srcSet}
-            sizes={`${size}px`}
             src={image256Url}
             alt={altText ?? name}
             draggable={false}
             decoding={'async'}
+            onMouseDown={onMouseDown}
           />
         </ImgContainer>
       ) : (

--- a/client/maps/map-preview.tsx
+++ b/client/maps/map-preview.tsx
@@ -1,11 +1,25 @@
-import { useEffect, useMemo } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 import { SbMapId } from '../../common/maps'
 import { CommonDialogProps } from '../dialogs/common-dialog-props'
+import { MaterialIcon } from '../icons/material/material-icon'
+import { IconButton } from '../material/button'
+import { fastOutSlowInShort } from '../material/curves'
 import { Dialog } from '../material/dialog'
+import { elevationPlus2 } from '../material/shadows'
+import { Slider } from '../material/slider'
+import { useValueAsRef } from '../react/state-hooks'
 import { useAppDispatch, useAppSelector } from '../redux-hooks'
+import { ContainerLevel, containerStyles } from '../styles/colors'
 import { batchGetMapInfo } from './action-creators'
 import { MapInfoImage } from './map-image'
+
+const ZOOM_MIN = 1
+const ZOOM_MAX = 4
+const ZOOM_STEP_SLIDER = 0.1
+const ZOOM_STEP_BUTTON = 0.5
+const MOUSE_LEFT = 0
 
 const StyledDialog = styled(Dialog)`
   --sb-map-preview-aspect-ratio: calc(var(--sb-map-width, 1) / var(--sb-map-height, 1));
@@ -20,11 +34,6 @@ const StyledDialog = styled(Dialog)`
   */
   background-color: transparent;
   max-width: min(var(--sb-map-preview-height-restricted), var(--sb-map-preview-width-restricted));
-`
-
-const StyledMapImage = styled(MapInfoImage)`
-  background-color: var(--theme-container-low);
-  border-radius: 4px;
 `
 
 export interface MapPreviewDialogProps extends CommonDialogProps {
@@ -53,7 +62,189 @@ export function MapPreviewDialog({ mapId, onCancel }: MapPreviewDialogProps) {
       fullBleed={true}
       showCloseButton={true}
       title={map?.name ?? ''}>
-      {map ? <StyledMapImage map={map} size={1024} /> : null}
+      {map ? <ZoomableMapImage map={map} /> : null}
     </StyledDialog>
+  )
+}
+
+const ZoomableMapImageContainer = styled.div`
+  position: relative;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+
+  background-color: var(--theme-container-low);
+  border-radius: 4px;
+`
+
+const StyledMapInfoImage = styled(MapInfoImage)<{ $zoom: number }>`
+  ${fastOutSlowInShort};
+
+  transform: scale(${props => props.$zoom});
+  transform-origin: var(--sb-map-image-x-origin) var(--sb-map-image-y-origin);
+
+  cursor: ${props => (props.$zoom > 1 ? 'grab' : 'default')};
+
+  &:active {
+    cursor: ${props => (props.$zoom > 1 ? 'grabbing' : 'default')};
+  }
+`
+
+const ControlsContainer = styled.div`
+  ${containerStyles(ContainerLevel.High)};
+  ${elevationPlus2};
+
+  position: absolute;
+  bottom: 16px;
+  left: 50%;
+  transform: translateX(-50%);
+
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 12px;
+  border-radius: 8px;
+`
+
+const StyledIconButton = styled(IconButton)`
+  width: 32px;
+  min-height: 32px;
+  flex-shrink: 0;
+`
+
+const StyledSlider = styled(Slider)`
+  width: 156px;
+`
+
+const ZoomableMapImage = ({ map }: { map: any }) => {
+  const { t } = useTranslation()
+
+  const containerRef = useRef<HTMLDivElement>(null)
+  const [zoom, setZoom] = useState(1)
+  const zoomRef = useValueAsRef(zoom)
+  const [x, setX] = useState<number>()
+  const [y, setY] = useState<number>()
+  const [isDragging, setIsDragging] = useState(false)
+
+  const onMouseDown = (e: React.MouseEvent) => {
+    if (e.button !== MOUSE_LEFT) {
+      return
+    }
+
+    e.preventDefault()
+    setIsDragging(true)
+  }
+
+  useEffect(() => {
+    if (!isDragging) {
+      return () => {}
+    }
+
+    const onMouseMove = (e: MouseEvent) => {
+      if (!containerRef.current) {
+        return
+      }
+
+      const rect = containerRef.current.getBoundingClientRect()
+
+      // NOTE(2Pac): This pan speed was chosen pretty randomly. I feel like some logarithmic
+      // function based on the zoom level would maybe feel a bit nicer, but we don't really have
+      // huge pan areas where this would become much noticeable.
+      const panSpeed = zoomRef.current / 2
+      const deltaX = e.movementX / panSpeed
+      const deltaY = e.movementY / panSpeed
+
+      setX(x => {
+        const initialX = x !== undefined ? x : rect.width / 2
+        return Math.max(0, Math.min(rect.width, initialX - deltaX))
+      })
+      setY(y => {
+        const initialY = y !== undefined ? y : rect.height / 2
+        return Math.max(0, Math.min(rect.height, initialY - deltaY))
+      })
+    }
+    const onMouseUp = () => {
+      setIsDragging(false)
+    }
+
+    window.addEventListener('mousemove', onMouseMove)
+    window.addEventListener('mouseup', onMouseUp)
+    return () => {
+      window.removeEventListener('mousemove', onMouseMove)
+      window.removeEventListener('mouseup', onMouseUp)
+    }
+  }, [isDragging, zoomRef])
+
+  useEffect(() => {
+    const onWheel = (e: WheelEvent) => {
+      if (e.deltaMode !== WheelEvent.DOM_DELTA_PIXEL) {
+        return
+      }
+
+      const isZoomingIn = e.deltaY < 0
+
+      if (
+        (zoomRef.current === ZOOM_MAX && isZoomingIn) ||
+        (zoomRef.current === ZOOM_MIN && !isZoomingIn)
+      ) {
+        return
+      }
+
+      e.preventDefault()
+
+      const newStep = isZoomingIn ? ZOOM_STEP_BUTTON : -ZOOM_STEP_BUTTON
+      setZoom(zoom => Math.max(ZOOM_MIN, Math.min(ZOOM_MAX, zoom + newStep)))
+
+      if (isZoomingIn) {
+        setX(e.offsetX)
+        setY(e.offsetY)
+      }
+    }
+
+    const container = containerRef.current
+    container?.addEventListener('wheel', onWheel)
+    return () => {
+      container?.removeEventListener('wheel', onWheel)
+    }
+  }, [zoomRef])
+
+  return (
+    <ZoomableMapImageContainer ref={containerRef}>
+      <StyledMapInfoImage
+        map={map}
+        $zoom={zoom}
+        style={
+          {
+            '--sb-map-image-x-origin': x !== undefined ? `${x}px` : 'center',
+            '--sb-map-image-y-origin': y !== undefined ? `${y}px` : 'center',
+          } as React.CSSProperties
+        }
+        onMouseDown={onMouseDown}
+      />
+
+      <ControlsContainer>
+        <StyledIconButton
+          icon={<MaterialIcon icon='zoom_out' size={20} />}
+          onClick={() => setZoom(zoom => Math.max(ZOOM_MIN, zoom - ZOOM_STEP_BUTTON))}
+          title={t('common.actions.zoomOut', 'Zoom out')}
+          disabled={zoom <= ZOOM_MIN}
+        />
+        <StyledSlider
+          min={ZOOM_MIN}
+          max={ZOOM_MAX}
+          step={ZOOM_STEP_SLIDER}
+          showTicks={false}
+          showBalloon={false}
+          value={zoom}
+          onChange={setZoom}
+        />
+        <StyledIconButton
+          icon={<MaterialIcon icon='zoom_in' size={20} />}
+          onClick={() => setZoom(zoom => Math.min(ZOOM_MAX, zoom + ZOOM_STEP_BUTTON))}
+          title={t('common.actions.zoomIn', 'Zoom in')}
+          disabled={zoom >= ZOOM_MAX}
+        />
+      </ControlsContainer>
+    </ZoomableMapImageContainer>
   )
 }

--- a/client/maps/map-preview.tsx
+++ b/client/maps/map-preview.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
-import { SbMapId } from '../../common/maps'
+import { ReadonlyDeep } from 'type-fest'
+import { MapInfoJson, SbMapId } from '../../common/maps'
 import { CommonDialogProps } from '../dialogs/common-dialog-props'
 import { MaterialIcon } from '../icons/material/material-icon'
 import { IconButton } from '../material/button'
@@ -77,16 +78,16 @@ const ZoomableMapImageContainer = styled.div`
   border-radius: 4px;
 `
 
-const StyledMapInfoImage = styled(MapInfoImage)<{ $zoom: number }>`
+const StyledMapInfoImage = styled(MapInfoImage)`
   ${fastOutSlowInShort};
 
-  transform: scale(${props => props.$zoom});
+  transform: scale(var(--sb-map-image-zoom));
   transform-origin: var(--sb-map-image-x-origin) var(--sb-map-image-y-origin);
 
-  cursor: ${props => (props.$zoom > 1 ? 'grab' : 'default')};
+  cursor: var(--sb-map-image-cursor);
 
   &:active {
-    cursor: ${props => (props.$zoom > 1 ? 'grabbing' : 'default')};
+    cursor: var(--sb-map-image-active-cursor);
   }
 `
 
@@ -116,7 +117,7 @@ const StyledSlider = styled(Slider)`
   width: 156px;
 `
 
-const ZoomableMapImage = ({ map }: { map: any }) => {
+const ZoomableMapImage = ({ map }: { map: ReadonlyDeep<MapInfoJson> }) => {
   const { t } = useTranslation()
 
   const containerRef = useRef<HTMLDivElement>(null)
@@ -212,11 +213,14 @@ const ZoomableMapImage = ({ map }: { map: any }) => {
     <ZoomableMapImageContainer ref={containerRef}>
       <StyledMapInfoImage
         map={map}
-        $zoom={zoom}
+        scale={zoom}
         style={
           {
+            '--sb-map-image-zoom': zoom,
             '--sb-map-image-x-origin': x !== undefined ? `${x}px` : 'center',
             '--sb-map-image-y-origin': y !== undefined ? `${y}px` : 'center',
+            '--sb-map-image-cursor': zoom > 1 ? 'grab' : 'default',
+            '--sb-map-image-active-cursor': zoom > 1 ? 'grabbing' : 'default',
           } as React.CSSProperties
         }
         onMouseDown={onMouseDown}

--- a/client/maps/map-thumbnail.tsx
+++ b/client/maps/map-thumbnail.tsx
@@ -269,12 +269,7 @@ export function MapThumbnail({
 
   return (
     <Container className={className} style={style}>
-      <MapInfoImage
-        map={map}
-        size={size}
-        noImageElem={<NoImage />}
-        forceAspectRatio={forceAspectRatio}
-      />
+      <MapInfoImage map={map} noImageElem={<NoImage />} forceAspectRatio={forceAspectRatio} />
       {onClick ? (
         <Overlay
           $isSelected={isSelected}

--- a/client/matchmaking/live-games-home-feed.tsx
+++ b/client/matchmaking/live-games-home-feed.tsx
@@ -321,7 +321,7 @@ function MapAndTypeDisplay({
 
   return (
     <MapAndTypeRoot>
-      <StyledMapImage map={game.map} size={256} />
+      <StyledMapImage map={game.map} />
       <GameType>{matchmakingTypeToLabel(game.config.gameSourceExtra.matchmakingType, t)}</GameType>
       <MapName>{game.map.name}</MapName>
     </MapAndTypeRoot>

--- a/client/material/devonly/slider-test.jsx
+++ b/client/material/devonly/slider-test.jsx
@@ -26,6 +26,8 @@ export default class SliderTest extends Component {
     value5: 0,
     value6: 2,
     value7: 2,
+    value8: 2,
+    value9: 2,
   }
 
   render() {
@@ -102,6 +104,23 @@ export default class SliderTest extends Component {
             value={this.state.value7}
             step={1}
             onChange={value => this.onChange('7', value)}
+          />
+          <Slider
+            min={0}
+            max={4}
+            value={this.state.value8}
+            step={1}
+            showBalloon={false}
+            onChange={value => this.onChange('8', value)}
+          />
+          <Slider
+            min={0}
+            max={4}
+            value={this.state.value9}
+            step={1}
+            label='Slide this'
+            showBalloon={false}
+            onChange={value => this.onChange('9', value)}
           />
         </StyledCard>
       </Container>

--- a/server/public/locales/en/global.json
+++ b/server/public/locales/en/global.json
@@ -276,7 +276,9 @@
       "submit": "Submit",
       "test": "Test",
       "unblock": "Unblock",
-      "view": "View"
+      "view": "View",
+      "zoomIn": "Zoom in",
+      "zoomOut": "Zoom out"
     },
     "lists": {
       "empty": "Nothing to see here"


### PR DESCRIPTION
Not a perfect implementation by all means, but might be enough for now?

Things that could be improved:
- add pinch/touch gestures for mobile support
- make the pan speed smoother on all zoom levels
- add the "slide" effect when panning fast and releasing a mouse (similar to what happens on phones / google maps)
- make the image quality even better than 2048x2048 on the highest zoom level?
- pull this logic into a common hook / control component that can be used on any element? (might come in handy if/when we add tournament brackets)

Also fixes one issue with buttons where if you release a mouse on a disabled button, a `mouseup` event on the document would not run (this conflicted with the slider), and adds a prop to render the slider component without a balloon that shows the value.