### PR TITLE
Add some common actions when right-clicking selected text in chat.

### DIFF
--- a/client/chat/channel-menu-items.tsx
+++ b/client/chat/channel-menu-items.tsx
@@ -7,7 +7,7 @@ import { useSelfPermissions } from '../auth/auth-utils'
 import { openDialog } from '../dialogs/action-creators'
 import { DialogType } from '../dialogs/dialog-type'
 import { DestructiveMenuItem } from '../material/menu/item'
-import { MessageMenuProps } from '../messaging/chat-context'
+import { MessageMenuProps } from '../messaging/message-context-menu'
 import { useAppDispatch, useAppSelector } from '../redux-hooks'
 import { useSnackbarController } from '../snackbars/snackbar-overlay'
 import { MenuItemCategory, UserMenuProps } from '../users/user-context-menu'
@@ -199,10 +199,11 @@ export function ChannelMessageMenu({
   const selfPermissions = useSelfPermissions()
   const { channelId } = useContext(ChannelContext)
 
-  const menuItems = items.slice(0)
-
+  const menuItems = new Map(items)
   if (selfPermissions?.moderateChatChannels) {
-    menuItems.push(
+    appendToMultimap(
+      menuItems,
+      MenuItemCategory.Destructive,
       <DestructiveMenuItem
         key='delete-message'
         text='Delete message'

--- a/client/dom/use-context-menu.tsx
+++ b/client/dom/use-context-menu.tsx
@@ -27,15 +27,18 @@ interface UseContextMenuProps {
 export function useContextMenu(props?: UseContextMenuProps): {
   onContextMenu: (event: React.MouseEvent) => void
   contextMenuPopoverProps: Omit<PopoverProps, 'children'>
+  selectedText: string
 } {
   const [anchor, setAnchor] = useState<Element>()
   const [anchorX, setAnchorX] = useState(0)
   const [anchorY, setAnchorY] = useState(0)
+  const [selectedText, setSelectedText] = useState('')
 
   const [isContextMenuOpen, openContextMenu, closeContextMenu] = usePopoverController()
 
   const onOpen = useCallback(
     (event: React.MouseEvent) => {
+      setSelectedText(window.getSelection()?.toString() ?? '')
       event.preventDefault()
 
       // NOTE(2Pac): This callback will be called each time user right-clicks inside an anchor, even
@@ -74,5 +77,6 @@ export function useContextMenu(props?: UseContextMenuProps): {
       originX: props?.originX ?? 'left',
       originY: props?.originY ?? 'top',
     },
+    selectedText,
   }
 }

--- a/client/messaging/chat-context.tsx
+++ b/client/messaging/chat-context.tsx
@@ -1,44 +1,7 @@
 import * as React from 'react'
 import { SbUserId } from '../../common/users/sb-user-id'
 import { UserMenuComponent } from '../users/user-context-menu'
-
-/**
- * Props passed to the component that customizes/displays context menu items for a message within
- * a chat area.
- */
-export interface MessageMenuProps {
-  /** The message this context menu is for. */
-  messageId: string
-  /**
-   * The base items in the context menu. All of these items should be displayed to the user, but
-   * more can be added as well.
-   */
-  items: ReadonlyArray<React.ReactNode>
-  /**
-   * An event handler that will be called when the menu closes.
-   */
-  onMenuClose: (event?: MouseEvent) => void
-
-  /**
-   * Component type to use to render the menu items in the `MessageMenuItemsComponent`.
-   */
-  MenuComponent: React.ComponentType<{
-    items: ReadonlyArray<React.ReactNode>
-    messageId: string
-    onMenuClose: (event?: MouseEvent) => void
-  }>
-}
-
-export type MessageMenuComponent = React.ComponentType<MessageMenuProps>
-
-export function DefaultMessageMenu({
-  items,
-  MenuComponent,
-  messageId,
-  onMenuClose,
-}: MessageMenuProps) {
-  return <MenuComponent items={items} messageId={messageId} onMenuClose={onMenuClose} />
-}
+import { DefaultMessageMenu, MessageMenuComponent } from './message-context-menu'
 
 export interface ChatContextValue {
   /** Callback called when the user requests to mention a particular user in chat. */
@@ -54,14 +17,4 @@ export interface ChatContextValue {
 export const ChatContext = React.createContext<ChatContextValue>({
   mentionUser: () => {},
   MessageMenu: DefaultMessageMenu,
-})
-
-export interface MessageMenuContextValue {
-  messageId: string
-  onMenuClose: (event?: MouseEvent) => void
-}
-
-export const MessageMenuContext = React.createContext<MessageMenuContextValue>({
-  messageId: '',
-  onMenuClose: () => {},
 })

--- a/client/messaging/chat.tsx
+++ b/client/messaging/chat.tsx
@@ -15,7 +15,8 @@ import {
   UserMenuComponent,
   UserMenuContext,
 } from '../users/user-context-menu'
-import { ChatContext, DefaultMessageMenu, MessageMenuComponent } from './chat-context'
+import { ChatContext } from './chat-context'
+import { DefaultMessageMenu, MessageMenuComponent } from './message-context-menu'
 
 const MessagesAndInput = styled.div`
   position: relative;

--- a/client/messaging/common-message-layout.tsx
+++ b/client/messaging/common-message-layout.tsx
@@ -14,7 +14,7 @@ import { titleSmall } from '../styles/typography'
 import { ConnectedUsername } from '../users/connected-username'
 import { ChatContext } from './chat-context'
 import { useMentionFilterClick } from './mention-hooks'
-import { ConnectedMessageContextMenu } from './message-context-menu'
+import { MessageContextMenu } from './message-context-menu'
 import {
   InfoImportant,
   SeparatedInfoMessage,
@@ -157,7 +157,7 @@ export function TextMessage({ msgId, userId, selfUserId, time, text, testId }: T
         <Text>{parsedText}</Text>
       </TimestampMessageLayout>
 
-      <ConnectedMessageContextMenu
+      <MessageContextMenu
         messageId={msgId}
         selectedText={selectedText}
         MessageMenu={MessageMenu}

--- a/client/messaging/common-message-layout.tsx
+++ b/client/messaging/common-message-layout.tsx
@@ -9,13 +9,12 @@ import { makeSbUserId, SbUserId } from '../../common/users/sb-user-id'
 import { ConnectedChannelName } from '../chat/connected-channel-name'
 import { useContextMenu } from '../dom/use-context-menu'
 import { TransInterpolation } from '../i18n/i18next'
-import { MenuList } from '../material/menu/menu'
-import { Popover } from '../material/popover'
 import { ExternalLink } from '../navigation/external-link'
 import { titleSmall } from '../styles/typography'
 import { ConnectedUsername } from '../users/connected-username'
-import { ChatContext, MessageMenuContext } from './chat-context'
+import { ChatContext } from './chat-context'
 import { useMentionFilterClick } from './mention-hooks'
+import { ConnectedMessageContextMenu } from './message-context-menu'
 import {
   InfoImportant,
   SeparatedInfoMessage,
@@ -73,7 +72,7 @@ export function TextMessage({ msgId, userId, selfUserId, time, text, testId }: T
   const filterClick = useMentionFilterClick()
   const { UserMenu, MessageMenu, disallowMentionInteraction } = useContext(ChatContext)
 
-  const { onContextMenu, contextMenuPopoverProps } = useContextMenu()
+  const { onContextMenu, contextMenuPopoverProps, selectedText } = useContextMenu()
 
   const parsedText: React.ReactNode[] = []
   let isHighlighted = false
@@ -140,8 +139,6 @@ export function TextMessage({ msgId, userId, selfUserId, time, text, testId }: T
     parsedText.push(text.substring(lastIndex))
   }
 
-  // TODO(tec27): Get the base menu items from a context value if/when we need it
-  const baseMenuItems: React.ReactNode[] = []
   return (
     <>
       <TimestampMessageLayout
@@ -160,31 +157,13 @@ export function TextMessage({ msgId, userId, selfUserId, time, text, testId }: T
         <Text>{parsedText}</Text>
       </TimestampMessageLayout>
 
-      <Popover {...contextMenuPopoverProps}>
-        <MessageMenu
-          messageId={msgId}
-          items={baseMenuItems}
-          onMenuClose={contextMenuPopoverProps.onDismiss}
-          MenuComponent={MessageMenuList}
-        />
-      </Popover>
+      <ConnectedMessageContextMenu
+        messageId={msgId}
+        selectedText={selectedText}
+        MessageMenu={MessageMenu}
+        popoverProps={contextMenuPopoverProps}
+      />
     </>
-  )
-}
-
-function MessageMenuList({
-  items,
-  messageId,
-  onMenuClose,
-}: {
-  items: ReadonlyArray<React.ReactNode>
-  messageId: string
-  onMenuClose: (event?: MouseEvent) => void
-}) {
-  return (
-    <MessageMenuContext.Provider value={{ messageId, onMenuClose }}>
-      {items.length ? <MenuList dense={true}>{items}</MenuList> : null}
-    </MessageMenuContext.Provider>
   )
 }
 

--- a/client/messaging/message-context-menu.tsx
+++ b/client/messaging/message-context-menu.tsx
@@ -1,0 +1,193 @@
+import * as React from 'react'
+import { useTranslation } from 'react-i18next'
+import { appendToMultimap } from '../../common/data-structures/maps'
+import logger from '../logging/logger'
+import { Divider } from '../material/menu/divider'
+import { MenuItem } from '../material/menu/item'
+import { MenuList } from '../material/menu/menu'
+import { Popover, PopoverProps } from '../material/popover'
+
+/**
+ * All the possible categories of the menu items in the message context menu. In case you're not
+ * sure what constitues a new category, a divider will be inserted between each category, so it
+ * might help to think of it in those terms.
+ *
+ * **IMPORTANT**: The order of the values in this enum is used to render the menu item categories in
+ * that same order.
+ */
+export enum MenuItemCategory {
+  /** Contains general menu items, like copy, search with google */
+  General = 'General',
+  /** Contains destructive menu items, like delete message */
+  Destructive = 'Destructive',
+}
+
+export const ALL_MENU_ITEM_CATEGORIES: ReadonlyArray<MenuItemCategory> =
+  Object.values(MenuItemCategory)
+
+/**
+ * Props passed to the component that customizes/displays context menu items for a message within
+ * a chat area.
+ */
+export interface MessageMenuProps {
+  /** The message this context menu is for. */
+  messageId: string
+  /**
+   * The base items in the context menu. All of these items should be displayed to the user, but
+   * more can be added as well.
+   */
+  items: ReadonlyMap<MenuItemCategory, React.ReactNode[]>
+  /**
+   * An event handler that will be called when the menu closes.
+   */
+  onMenuClose: (event?: MouseEvent) => void
+
+  /**
+   * Component type to use to render the menu items in the `MessageMenuItemsComponent`.
+   */
+  MenuComponent: React.ComponentType<{
+    items: ReadonlyMap<MenuItemCategory, React.ReactNode[]>
+    messageId: string
+    onMenuClose: (event?: MouseEvent) => void
+  }>
+}
+
+export type MessageMenuComponent = React.ComponentType<MessageMenuProps>
+
+export interface MessageMenuContextValue {
+  messageId: string
+  onMenuClose: (event?: MouseEvent) => void
+}
+
+export const MessageMenuContext = React.createContext<MessageMenuContextValue>({
+  messageId: '',
+  onMenuClose: () => {},
+})
+
+export function DefaultMessageMenu({
+  items,
+  MenuComponent,
+  messageId,
+  onMenuClose,
+}: MessageMenuProps) {
+  return <MenuComponent items={items} messageId={messageId} onMenuClose={onMenuClose} />
+}
+
+export interface ConnectedMessageContextMenuProps {
+  messageId: string
+  /** Text that was selected by the user at the point they opened the message context menu. */
+  selectedText: string
+  /**
+   * An optional component that will be used for rendering menu items. This component can modify
+   * the menu items given before passing them for rendering.
+   */
+  MessageMenu?: MessageMenuComponent
+  popoverProps: Omit<PopoverProps, 'children'>
+}
+
+// Even though this component is not technically connected yet, it *could* be at some point, so we
+// preemptively called it this.
+export function ConnectedMessageContextMenu({
+  messageId,
+  selectedText,
+  MessageMenu,
+  popoverProps,
+}: ConnectedMessageContextMenuProps) {
+  return (
+    <Popover {...popoverProps}>
+      <ConnectedMessageContextMenuContents
+        messageId={messageId}
+        selectedText={selectedText}
+        MessageMenu={MessageMenu}
+        onDismiss={popoverProps.onDismiss}
+      />
+    </Popover>
+  )
+}
+
+/**
+ * Helper component for message context menu to make sure the hooks are only run when the menu is
+ * open.
+ */
+function ConnectedMessageContextMenuContents({
+  messageId,
+  selectedText,
+  MessageMenu = DefaultMessageMenu,
+  onDismiss,
+}: Omit<ConnectedMessageContextMenuProps, 'popoverProps'> & {
+  onDismiss: () => void
+}) {
+  const { t } = useTranslation()
+
+  const items: Map<MenuItemCategory, React.ReactNode[]> = new Map()
+  if (selectedText) {
+    appendToMultimap(
+      items,
+      MenuItemCategory.General,
+      <MenuItem
+        key='copy'
+        text={t('common.actions.copy', 'Copy')}
+        onClick={() => {
+          navigator.clipboard
+            .writeText(selectedText)
+            .catch(err => logger.error('Error writing to clipboard: ' + (err?.stack ?? err)))
+          onDismiss()
+        }}
+      />,
+    )
+    appendToMultimap(
+      items,
+      MenuItemCategory.General,
+      <MenuItem
+        key='search-with-google'
+        text={t('messaging.searchWithGoogle', 'Search with Google')}
+        onClick={() => {
+          const a = document.createElement('a')
+          a.href = `https://www.google.com/search?q=${encodeURIComponent(selectedText)}`
+          a.target = '_blank'
+          a.click()
+          onDismiss()
+        }}
+      />,
+    )
+  }
+
+  return (
+    <MessageMenu
+      messageId={messageId}
+      items={items}
+      onMenuClose={onDismiss}
+      MenuComponent={MessageContextMenuList}
+    />
+  )
+}
+
+function MessageContextMenuList({
+  items,
+  messageId,
+  onMenuClose,
+}: {
+  items: ReadonlyMap<MenuItemCategory, React.ReactNode[]>
+  messageId: string
+  onMenuClose: (event?: MouseEvent) => void
+}) {
+  const orderedMenuItems = ALL_MENU_ITEM_CATEGORIES.reduce<React.ReactNode[]>(
+    (elems, category, index) => {
+      const categoryItems = items.get(category) ?? []
+
+      if (elems.length > 0 && categoryItems.length > 0 && index > 0) {
+        elems.push(<Divider key={`divider-${index}`} $dense={true} />)
+      }
+
+      elems.push(...categoryItems)
+      return elems
+    },
+    [],
+  )
+
+  return (
+    <MessageMenuContext.Provider value={{ messageId, onMenuClose }}>
+      <MenuList dense={true}>{orderedMenuItems}</MenuList>
+    </MessageMenuContext.Provider>
+  )
+}

--- a/client/users/user-context-menu.tsx
+++ b/client/users/user-context-menu.tsx
@@ -464,19 +464,16 @@ function UserContextMenuList({
   userId: SbUserId
   onMenuClose: (event?: MouseEvent) => void
 }) {
-  const orderedMenuItems = ALL_MENU_ITEM_CATEGORIES.reduce<React.ReactNode[]>(
-    (elems, category, index) => {
-      const categoryItems = items.get(category) ?? []
+  const orderedMenuItems = ALL_MENU_ITEM_CATEGORIES.reduce<React.ReactNode[]>((elems, category) => {
+    const categoryItems = items.get(category) ?? []
 
-      if (elems.length > 0 && categoryItems.length > 0 && index > 0) {
-        elems.push(<Divider key={`divider-${index}`} $dense={true} />)
-      }
+    if (elems.length > 0 && categoryItems.length > 0) {
+      elems.push(<Divider key={`divider-${category}`} $dense={true} />)
+    }
 
-      elems.push(...categoryItems)
-      return elems
-    },
-    [],
-  )
+    elems.push(...categoryItems)
+    return elems
+  }, [])
 
   return (
     <UserMenuContext.Provider value={{ userId, onMenuClose }}>

--- a/client/users/user-context-menu.tsx
+++ b/client/users/user-context-menu.tsx
@@ -468,7 +468,7 @@ function UserContextMenuList({
     (elems, category, index) => {
       const categoryItems = items.get(category) ?? []
 
-      if (categoryItems.length > 0 && index > 0) {
+      if (elems.length > 0 && categoryItems.length > 0 && index > 0) {
         elems.push(<Divider key={`divider-${index}`} $dense={true} />)
       }
 

--- a/server/public/locales/en/global.json
+++ b/server/public/locales/en/global.json
@@ -256,6 +256,7 @@
       "cancel": "Cancel",
       "clear": "Clear",
       "close": "Close",
+      "copy": "Copy",
       "decline": "Decline",
       "download": "Download",
       "edit": "Edit",
@@ -817,6 +818,7 @@
     "blockedMessage": "Blocked message",
     "mention": "Mention",
     "newDayMessage": "Day changed to <2>{{day}}</2>",
+    "searchWithGoogle": "Search with Google",
     "sendMessage": "Send a message",
     "sendMessageChatRestricted": "Restricted from sending messages until {{date}}"
   },


### PR DESCRIPTION
Currently we add 2 actions:
- "Copy" -> copies selected text to the clipboard
- "Search with Google" -> opens a new tab in browser and initiates a google search

Maybe we could add an action to translate the selected text as well? But that seems like more work, so gonna leave it for later :d