### PR TITLE
Fix the maps API to work with single option selected in array params.

### DIFF
--- a/server/lib/maps/map-api.ts
+++ b/server/lib/maps/map-api.ts
@@ -16,9 +16,7 @@ import {
   MapSortType,
   MapVisibility,
   MAX_MAP_FILE_SIZE_BYTES,
-  NumPlayers,
   SbMapId,
-  Tileset,
   toMapInfoJson,
   UpdateMapResponse,
   UploadMapResponse,
@@ -88,18 +86,12 @@ function getValidatedMapId(ctx: RouterContext) {
 }
 
 type ServerGetMapsQueryParams = SetRequired<
-  Omit<GetMapsQueryParams, 'numPlayers' | 'tilesets'> & {
-    numPlayers?: NumPlayers | NumPlayers[]
-    tilesets?: Tileset | Tileset[]
-  },
+  GetMapsQueryParams,
   'visibility' | 'sort' | 'numPlayers' | 'tilesets'
 >
 
 type ServerGetFavoritedMapsQueryParams = SetRequired<
-  Omit<GetFavoritedMapsQueryParams, 'numPlayers' | 'tilesets'> & {
-    numPlayers?: NumPlayers | NumPlayers[]
-    tilesets?: Tileset | Tileset[]
-  },
+  GetFavoritedMapsQueryParams,
   'sort' | 'numPlayers' | 'tilesets'
 >
 
@@ -118,16 +110,13 @@ export class MapsApi {
         sort: Joi.number()
           .valid(...ALL_MAP_SORT_TYPES)
           .default(MapSortType.Name),
-        // When sending only one value with URLSearchParams, it doesn't get parsed as an array
-        numPlayers: Joi.alternatives()
-          .try(Joi.array().items(Joi.number().min(2).max(8)), Joi.number().min(2).max(8))
+        numPlayers: Joi.array()
+          .items(Joi.number().min(2).max(8))
+          .single()
           .default([2, 3, 4, 5, 6, 7, 8]),
-        // When sending only one value with URLSearchParams, it doesn't get parsed as an array
-        tilesets: Joi.alternatives()
-          .try(
-            Joi.array().items(Joi.number().valid(...ALL_TILESETS)),
-            Joi.number().valid(...ALL_TILESETS),
-          )
+        tilesets: Joi.array()
+          .items(Joi.number().valid(...ALL_TILESETS))
+          .single()
           .default(ALL_TILESETS),
         q: Joi.string().allow(''),
         offset: Joi.number().min(0),
@@ -143,8 +132,8 @@ export class MapsApi {
     const mapsResult = await getMaps({
       visibility,
       sort,
-      numPlayers: Array.isArray(numPlayers) ? numPlayers : [numPlayers],
-      tilesets: Array.isArray(tilesets) ? tilesets : [tilesets],
+      numPlayers,
+      tilesets,
       uploadedBy,
       searchStr: searchQuery,
       limit: MAP_LIST_LIMIT,
@@ -176,16 +165,13 @@ export class MapsApi {
         sort: Joi.number()
           .valid(...ALL_MAP_SORT_TYPES)
           .default(MapSortType.Name),
-        // When sending only one value with URLSearchParams, it doesn't get parsed as an array
-        numPlayers: Joi.alternatives()
-          .try(Joi.array().items(Joi.number().min(2).max(8)), Joi.number().min(2).max(8))
+        numPlayers: Joi.array()
+          .items(Joi.number().min(2).max(8))
+          .single()
           .default([2, 3, 4, 5, 6, 7, 8]),
-        // When sending only one value with URLSearchParams, it doesn't get parsed as an array
-        tilesets: Joi.alternatives()
-          .try(
-            Joi.array().items(Joi.number().valid(...ALL_TILESETS)),
-            Joi.number().valid(...ALL_TILESETS),
-          )
+        tilesets: Joi.array()
+          .items(Joi.number().valid(...ALL_TILESETS))
+          .single()
           .default(ALL_TILESETS),
         q: Joi.string().allow(''),
       }),
@@ -194,8 +180,8 @@ export class MapsApi {
     const favoritedBy = ctx.session!.user.id
     const mapResult = await getFavoritedMaps({
       sort,
-      numPlayers: Array.isArray(numPlayers) ? numPlayers : [numPlayers],
-      tilesets: Array.isArray(tilesets) ? tilesets : [tilesets],
+      numPlayers,
+      tilesets,
       searchStr: searchQuery,
       favoritedBy,
     })


### PR DESCRIPTION
When there's only one option added for params that expect an array (numPlayers, tileset) in URLSearchParams, the backend middleware which parses those params (not sure which one does it?) doesn't create an array for them so it needs to be specially handled.