### PR TITLE
Right-align the map name and game type in match history.

### DIFF
--- a/client/users/match-history.tsx
+++ b/client/users/match-history.tsx
@@ -201,6 +201,7 @@ const MapName = styled.div`
 
   min-width: 0;
   width: 100%;
+  text-align: right;
 `
 
 const GameType = styled.div`
@@ -210,6 +211,7 @@ const GameType = styled.div`
 
   min-width: 0;
   width: 100%;
+  text-align: right;
 `
 
 const StyledMapThumbnail = styled(MapThumbnail)`


### PR DESCRIPTION
We already did have the code that tried to do this with flex, but since both of these items have `width: 100%` set (to make `singleLine` CSS work), the flex align had no effect.

I'm still of the opinion that this whole table could probably be rewritten with CSS Grid in a better way, but that will have to wait for some other time :d