### PR TITLE
Don't render the context menu contents if it doesn't have any items.

### DIFF
--- a/client/messaging/message-context-menu.tsx
+++ b/client/messaging/message-context-menu.tsx
@@ -154,14 +154,14 @@ function MessageContextMenuContents({
     )
   }
 
-  return (
+  return items.size > 0 ? (
     <MessageMenu
       messageId={messageId}
       items={items}
       onMenuClose={onDismiss}
       MenuComponent={MessageContextMenuList}
     />
-  )
+  ) : null
 }
 
 function MessageContextMenuList({

--- a/client/users/user-context-menu.tsx
+++ b/client/users/user-context-menu.tsx
@@ -464,14 +464,14 @@ function ConnectedUserContextMenuContents({
   }
   const mergedItems = mergeMultimaps(items, baseItems)
 
-  return (
+  return mergedItems.size > 0 ? (
     <UserMenu
       MenuComponent={UserContextMenuList}
       items={mergedItems}
       userId={userId}
       onMenuClose={onDismiss}
     />
-  )
+  ) : null
 }
 
 function UserContextMenuList({


### PR DESCRIPTION
Can be reproduced by trying to right-click a chat message in the whispers session; or for users who don't have the "Delete message" action, by right-clicking any message in the chat.

This keeps the Popover still open, but figuring out how to close/not open the Popover in that case seems much harder :d, and I think just not rendering the Popover contents might be fine?