### PR TITLE
Always show kick/ban actions in user's channel context menu.

### DIFF
--- a/client/material/menu/item.tsx
+++ b/client/material/menu/item.tsx
@@ -22,6 +22,12 @@ const Item = styled.button<{ $dense?: boolean; $focused?: boolean }>`
 
   border-radius: 4px;
   text-align: left;
+
+  &:disabled,
+  &[disabled] {
+    color: rgb(from var(--theme-on-surface) r g b / var(--theme-disabled-opacity));
+    pointer-events: none;
+  }
 `
 
 const ItemText = styled.div`
@@ -47,12 +53,13 @@ export function MenuItem({
   icon,
   dense,
   focused,
+  disabled,
   trailingContent,
   onClick,
   className,
   testName,
 }: MenuItemProps) {
-  const [buttonProps, rippleRef] = useButtonState({ onClick })
+  const [buttonProps, rippleRef] = useButtonState({ onClick, disabled })
   const buttonRef = useRef<HTMLButtonElement>(null)
 
   useEffect(() => {

--- a/client/material/menu/menu-item-symbol.ts
+++ b/client/material/menu/menu-item-symbol.ts
@@ -43,6 +43,7 @@ export interface BaseMenuItemProps {
   className?: string
   focused?: boolean
   dense?: boolean
+  disabled?: boolean
   trailingContent?: React.ReactNode
   testName?: string
   onClick?: (event: React.MouseEvent | KeyboardEvent) => void

--- a/server/lib/chat/chat-service.ts
+++ b/server/lib/chat/chat-service.ts
@@ -995,7 +995,7 @@ export default class ChatService {
       throw new ChatServiceError(ChatServiceErrorCode.ChannelNotFound, 'Channel not found')
     }
 
-    const isOwner = channelInfo.ownerId === userId
+    const isOwner = channelInfo.ownerId === chatUser.userId
 
     const { channelPermissions: perms } = chatUser
     return {


### PR DESCRIPTION
Previously these actions would only show up *after* we fetched the target user's chat profile, which could potentially make the whole context menu change the position due to new increased height.

Now these actions are always shown and enabled for server moderators and channel owners, and we only need to wait for the target's chat profile in case a channel moderator is opening the context menu.

This commit also does the following two things:
- adds disabled state to the menu items
- fixes a condition which checks if the user is a channel owner in the service method that returns the user's chat profile