### PR TITLE
Fix the scroll divider sometimes being visible even when it shouldn't.

### DIFF
--- a/client/material/scroll-indicator.tsx
+++ b/client/material/scroll-indicator.tsx
@@ -3,7 +3,7 @@ import { useCallback, useEffect, useId, useLayoutEffect, useMemo, useRef, useSta
 import styled from 'styled-components'
 
 const ScrollObserved = styled.div`
-  width: 0px;
+  width: 1px;
   height: 0px;
 `
 


### PR DESCRIPTION
This was happening every time when opening the social sidebar. For some reason when the observed element had the 0x0 size, the intersection observer would somehow trigger the interaction event multiple times during the opening animation, and somehow always ending up on "false", even though the observed element was clearly visible in the UI.

I'm not entirely sure *why* this was happening or even why this change fixes it, but it does and that's all it matters for now :d

Fixes #1237 