### PR TITLE
Remove SbUser dependency from MessageInput for mentionable users.

### DIFF
--- a/client/chat/channel.tsx
+++ b/client/chat/channel.tsx
@@ -163,23 +163,30 @@ export function ConnectedChatChannel({
     areUserEntriesEqual,
   )
 
-  const mentionableUsers = useMemo(
-    () =>
-      sortedActiveUserEntries
-        .concat(sortedIdleUserEntries)
-        .concat(sortedOfflineUserEntries)
-        .filter(([id, username]) => username !== undefined)
-        .map(([id, username]) => ({ id, name: username! })),
-    [sortedActiveUserEntries, sortedIdleUserEntries, sortedOfflineUserEntries],
-  )
+  const mentionableUsers = useMemo(() => {
+    const onlineUsers = sortedActiveUserEntries
+      .concat(sortedIdleUserEntries)
+      .filter(([_, username]) => username !== undefined)
+      .map(([id, username]) => ({ id, name: username!, online: true }))
+    const offlineUsers = sortedOfflineUserEntries
+      .filter(([_, username]) => username !== undefined)
+      .map(([id, username]) => ({ id, name: username!, online: false }))
 
-  const baseMentionableUsers = useMemo(
-    () =>
-      sortedRecentChattersEntries
-        .filter(([id, username]) => username !== undefined)
-        .map(([id, username]) => ({ id, name: username! })),
-    [sortedRecentChattersEntries],
-  )
+    return onlineUsers.concat(offlineUsers)
+  }, [sortedActiveUserEntries, sortedIdleUserEntries, sortedOfflineUserEntries])
+
+  const baseMentionableUsers = useMemo(() => {
+    const onlineRecentChatters = sortedRecentChattersEntries
+      .filter(([id]) => channelUsers?.active.has(id) || channelUsers?.idle.has(id))
+      .filter(([_, username]) => username !== undefined)
+      .map(([id, username]) => ({ id, name: username!, online: true }))
+    const offlineRecentChatters = sortedRecentChattersEntries
+      .filter(([id]) => channelUsers?.offline.has(id))
+      .filter(([_, username]) => username !== undefined)
+      .map(([id, username]) => ({ id, name: username!, online: false }))
+
+    return onlineRecentChatters.concat(offlineRecentChatters)
+  }, [channelUsers?.active, channelUsers?.idle, channelUsers?.offline, sortedRecentChattersEntries])
 
   const sortedActiveUserIds = useMemo(
     () => sortedActiveUserEntries.map(([id]) => id),

--- a/client/material/menu/item.tsx
+++ b/client/material/menu/item.tsx
@@ -56,10 +56,11 @@ export function MenuItem({
   disabled,
   trailingContent,
   onClick,
+  onKeyDown,
   className,
   testName,
 }: MenuItemProps) {
-  const [buttonProps, rippleRef] = useButtonState({ onClick, disabled })
+  const [buttonProps, rippleRef] = useButtonState({ onClick, onKeyDown, disabled })
   const buttonRef = useRef<HTMLButtonElement>(null)
 
   useEffect(() => {

--- a/client/material/menu/menu-item-symbol.ts
+++ b/client/material/menu/menu-item-symbol.ts
@@ -47,4 +47,5 @@ export interface BaseMenuItemProps {
   trailingContent?: React.ReactNode
   testName?: string
   onClick?: (event: React.MouseEvent | KeyboardEvent) => void
+  onKeyDown?: (event: React.KeyboardEvent) => void
 }


### PR DESCRIPTION
Also, some minor improvements to the mention popover:
- Offline users are now displayed as faded (similar to their UI in the channel user list) so it's easier to find online users in the list
- 'Tab' key now selects the focused user

I was also gonna make the first user focused by default when the popover is open, but that's a bit trickier to do since focused menu items steal keyboard focus from the message input and we obviously don't want.

The only way to get around that from what I see would be to add a "fake" focus style to the menu item, which would then have to be controlled by the message input itself. Or not use our existing MenuList/MenuItem components and create something custom specifically for this use case.

But I think it works good enough for now. User can still focus the first menu item by pressing the down arrow, even though it might not be the most obvious thing in the world.

Fixes #1207 