### PR TITLE
Move s3cmd to use the alpine package.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,6 @@ RUN apk add --no-cache git
 # Clone the `wait-for-it` repository which contains a script we'll copy over to our final image, and
 # use it to control our services startup order
 RUN git clone --depth 1 https://github.com/vishnubob/wait-for-it.git
-# Clone the `s3cmd` repository which contains a script we'll copy over to our final image, and use
-# it to sync our public assets to the cloud
-RUN git clone --depth 1 https://github.com/s3tools/s3cmd.git
 
 # Install dependencies in a separate stage for better caching
 FROM node:22-alpine AS deps
@@ -79,8 +76,6 @@ COPY --chown=node:node --from=rust-tools /usr/local/bin/sqlx tools/sqlx
 
 # Copy the installed dependencies from the external-tools stage
 COPY --chown=node:node --from=external-tools /wait-for-it/wait-for-it.sh tools/wait-for-it.sh
-COPY --chown=node:node --from=external-tools /s3cmd/s3cmd tools/s3cmd/s3cmd
-COPY --chown=node:node --from=external-tools /s3cmd/S3 tools/s3cmd/S3
 
 # Copy just the sources the server needs
 COPY --chown=node:node --from=builder /shieldbattery/node_modules ./node_modules
@@ -90,6 +85,8 @@ COPY --chown=node:node --from=builder /shieldbattery/migrations ./migrations
 COPY --chown=node:node --from=builder /shieldbattery/package.json /shieldbattery/babel.config.json ./
 COPY --chown=node:node --from=builder /shieldbattery/babel-register.js /shieldbattery/babel-register.js ./
 COPY --chown=node:node --from=builder /shieldbattery/server/deployment_files/entrypoint.sh /entrypoint.sh
+
+RUN apk --no-cache add s3cmd
 
 # Allow the various scripts to be run
 RUN chmod +x ./server/update_server.sh ./server/testing/run_mailgun.sh ./server/testing/run_google_cloud.sh /entrypoint.sh

--- a/server/update_server.sh
+++ b/server/update_server.sh
@@ -28,7 +28,7 @@ echo "DO Spaces Name: $SPACE_NAME"
 
 if [[ ! -z "$ACCESS_KEY" ]] && [[ ! -z "$SECRET_KEY" ]] && [[ ! -z "$HOST_BASE" ]] && [[ ! -z "$SPACE_NAME" ]]; then
   echo "Syncing public assets to the cloud"
-  python3 ./tools/s3cmd/s3cmd sync \
+  s3cmd sync \
     --access_key="$ACCESS_KEY" \
     --secret_key="$SECRET_KEY" \
     --host="$HOST_BASE" \


### PR DESCRIPTION
Hello!

This is a small one to pull s3cmd from it's [alpine package](https://pkgs.alpinelinux.org/package/v3.17/community/aarch64/s3cmd) instead of the git remote.

It gives you _just_ a little extra security because you have to go through alpine's package change process to update the package. Updating the package in git is fairly trivial and so your a bit more susceptible to the original owner getting hacked and a bad actor taking over the package.

Plus, the packaged version of the script is tested against the Alpine Linux version it's deployed against, where as [the branch you're currently pulling](https://github.com/s3tools/s3cmd) is just whatever the latest code is and could me more unstable/unpredictable. 

Please let me know if you have any problems with the pull!

P.S. I saw the project on Artosis's stream and I love it! Well done! I wish we could do something similar for SC2.
2nd P.S. If you like this pull, please let me know if you want me to take a look at the wait-for-it.sh script as well :).