### PR TITLE
Replacing wait-for-it.sh with something we can provide multiple endpo…

### DIFF
--- a/deployment/appserver/docker-compose.yml
+++ b/deployment/appserver/docker-compose.yml
@@ -70,7 +70,7 @@ services:
 
     # NOTE: `depends_on` only waits for the services listed below to start; it doesn't wait for them
     # to actually be "ready" (whatever "ready" means for a particular service). If you need to
-    # control the startup of services more granularly, use the `wait-for-it.sh` script available in
+    # control the startup of services more granularly, use the `./server/deployment_files/wait.sh` script available in
     # this image. The reason why we're not waiting for `db` service to actually be ready here is
     # because we're waiting for the `update_server` service to start, and `update_server` service
     # won't start until the `db` service is ready.
@@ -222,11 +222,7 @@ services:
       - SB_REDIS_PORT=6379
       - SB_FILE_STORE=${SB_FILE_STORE}
       - DATABASE_URL=postgres://${SB_DB_USER:-shieldbattery}:${SB_DB_PASSWORD}@db/${SB_DB:-shieldbattery}
-    # TODO(tec27): These scripts also touch redis so we should probably wait for it as well, but
-    # it's kind of a pain with this script so I haven't. General assumption is that by the time we
-    # get to that point, redis will be ready anyway (or the redis library will wait properly), but
-    # I guess we'll see?
-    command: ['./tools/wait-for-it.sh', 'db:5432', '--', 'bash', '-c', './server/update_server.sh']
+    command: ['./server/deployment_files/wait.sh', '--endpoint db:5432:15', '--endpoint redis:6379:15', 'bash', '-c', './server/update_server.sh']
     networks:
       - backend
     depends_on:

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -155,9 +155,6 @@ location you uploaded it to.
 
 Docker offers a way for one service to wait for another service before starting. However, their mechanism doesn't wait for other services to actually be "ready" before starting a service that depends on those services, because the "ready" state is subjective to each service.
 
-In the current version of our `docker-compose.yml` file, we've utilized a
-[third party script](https://github.com/vishnubob/wait-for-it) to wait for the service that contains the database to actually be ready before running the server migrations. Perhaps we should extend this to other services as well, eg. actually wait for `redis` service to be ready before starting the server. However, I have not noticed any problems so far so it might be an overkill.
-
 ### Healthcheck
 
 Docker also offers a way to perform a health check when trying to run a container which can make it easier to spot when a service falls down. Not sure what we could be testing here off the top of my head, but it's good to have an option and be mindful of it in future.

--- a/integration/docker-compose.yml
+++ b/integration/docker-compose.yml
@@ -9,7 +9,7 @@ services:
   # app_server and migration
   _app-server-build:
     image: app_server
-    build: 
+    build:
       context: '../'
       cache_from:
         - type=gha
@@ -60,7 +60,7 @@ services:
       - redis
 
   server-rs:
-    build: 
+    build:
       context: '../server-rs/'
       cache_from:
         - type=gha
@@ -126,11 +126,7 @@ services:
       - SB_REDIS_HOST=redis
       - SB_REDIS_PORT=6379
       - DATABASE_URL=postgres://shieldbattery:shieldbattery_pass@db/shieldbattery
-    # TODO(tec27): These scripts also touch redis so we should probably wait for it as well, but
-    # it's kind of a pain with this script so I haven't. General assumption is that by the time we
-    # get to that point, redis will be ready anyway (or the redis library will wait properly), but
-    # I guess we'll see?
-    command: ['./tools/wait-for-it.sh', 'db:5432', '--', 'bash', '-c', './server/update_server.sh']
+    command: ['./server/deployment_files/wait.sh', '--endpoint db:5432:15', '--endpoint redis:6379:15', 'bash', '-c', './server/update_server.sh']
     depends_on:
       - _app-server-build
       - db

--- a/integration/docker-compose.yml
+++ b/integration/docker-compose.yml
@@ -126,7 +126,7 @@ services:
       - SB_REDIS_HOST=redis
       - SB_REDIS_PORT=6379
       - DATABASE_URL=postgres://shieldbattery:shieldbattery_pass@db/shieldbattery
-    command: ['./server/deployment_files/wait.sh', '--endpoint db:5432:15', '--endpoint redis:6379:15', 'bash', '-c', './server/update_server.sh']
+    command: ['./server/deployment_files/wait.sh', '--endpoint', 'db:5432:15', '--endpoint', 'redis:6379:15', 'bash', '-c', './server/update_server.sh']
     depends_on:
       - _app-server-build
       - db

--- a/server/deployment_files/wait.sh
+++ b/server/deployment_files/wait.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# A small script that executes a bash command _after_
+# a bunch of remote TCP ports have become available.
+#
+# This is generally to help make sure that other
+# services e.g. database, cache, have started
+# before starting the main process.
+#
+# To specify an endpoint, call this script with:
+# --endpoint <hostname>:<TCP port number>:<ttl in seconds>
+# I.e.
+# --endpoint db:3306:10
+#
+# You can repeat the --endpoint flag as many times as you like.
+#
+# Part of the logic in this script within the 'wait_for_endpoint' function
+# block, is taken from it's predecessor `wait-for-it.sh`
+# which is `Copyright (c) 2016 Giles Hall` and
+# is also available (at the time of writing this) at the following link:
+# https://github.com/vishnubob/wait-for-it.
+
+############################# FUNCS #############################
+function wait_for_endpoint
+{
+    WAIT_HOST="$1"
+    WAIT_PORT="$2"
+    WAIT_TIMEOUT="$3"
+
+    TIMEOUT_PATH="$(type -p timeout)"
+    TIMEOUT_PATH="$(realpath "${TIMEOUT_PATH}" 2>/dev/null || readlink -f "${TIMEOUT_PATH}")"
+
+    echo "Waiting for ${WAIT_HOST}:${WAIT_PORT}"
+
+    declare -i NUM_SECS=0
+
+    while :
+    do
+        if [[ $TIMEOUT_PATH =~ "busybox" ]]; then
+            nc -z "${WAIT_HOST}" "${WAIT_PORT}"
+            RES=$?
+        else
+            (echo -n > "/dev/tcp/${WAIT_HOST}/${WAIT_PORT}") >/dev/null 2>&1
+            RES=$?
+        fi
+
+        if [[ $RES -eq 0 ]]; then
+            echo "${WAIT_HOST}:${WAIT_PORT} is now available."
+            break
+        fi
+
+        sleep 1
+        NUM_SECS=$(($NUM_SECS+1))
+
+        if [ $NUM_SECS -ge ${WAIT_TIMEOUT} ]; then
+            echo "${WAIT_HOST}:${WAIT_PORT} isn't available after ${WAIT_TIMEOUT} seconds."
+            RES=1
+            break
+        fi
+    done
+
+    return $RES
+}
+########################### END FUNCS ###########################
+
+declare -a WAIT_ENDPOINTS=()
+WAIT_CMD=()
+
+while [[ $# -gt 0 ]]
+do
+    case "$1" in
+      "--endpoint")
+        readarray -d ":" -t endpoint <<< $2
+
+        # If there's no timeout length, use the default 15s
+        if [ "${endpoint[2]}" == "" ]; then
+            endpoint[2]=15
+        else
+            endpoint[2]="$(echo "${endpoint[2]}" | sed 's/[^0-9]//g')"
+        fi
+
+        WAIT_ENDPOINTS+=("${endpoint[*]}")
+
+        shift 2
+      ;;
+      *)
+          WAIT_CMD+=("$1")
+          shift 1
+      ;;
+    esac
+done
+
+if [ ${#WAIT_ENDPOINTS[@]} -eq 0 ]; then
+    echo "No endpoints were specified. Please try again using: '--endpoint <hostname>:<TCP port number>:<ttl in seconds>'."
+    exit 1
+fi
+
+COUNT=${#WAIT_ENDPOINTS[@]}
+for ((i=0; i<$COUNT; i++))
+do
+    BITS=(${WAIT_ENDPOINTS[$i]})
+    HOST=(${BITS[@]:0})
+    PORT=(${BITS[@]:1})
+    TO=(${BITS[@]:2})
+
+    wait_for_endpoint ${HOST} ${PORT} ${TO}
+    RES=$?
+
+    if [[ ${RES} -gt 0 ]]; then
+        echo "Unable to run command, some services have refused to start."
+        exit $RES
+    fi
+done
+
+exec ${WAIT_CMD[@]}


### PR DESCRIPTION
…ints to check at the same time.

Hey again!

This one is a very quick wait script that allows you to specify multiple TCP endpoints that you want to be checked.

The script essentially checks each of the endpoints one after the other, with a different timeout each time.

I think the _expected_ behaviour is that the script spawns each check at the same time. This one is purposely simpler than that just because I didn't want to give you anything more complicated than this in case I'm not available to help with any issues.

The reasons are the same as [https://github.com/ShieldBattery/ShieldBattery/pull/1249](the s3cmd PR) where pulling a script without any supply chain mitigations leaves you open to someone being an asshat.

This one doesn't protect you from those either except that the script itself is actually inside the repository.

Hope you're having a good week!