### PR TITLE
Add keyboard accessibility to ConnectedUsername and ConnectedChannelName.

### DIFF
--- a/client/chat/connected-channel-name.tsx
+++ b/client/chat/connected-channel-name.tsx
@@ -65,7 +65,7 @@ export function ConnectedChannelName({
   const onKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === 'Enter' || e.key === ' ') {
       e.preventDefault()
-      openChannelInfoCard()
+      openChannelInfoCard(e)
     }
   }
 

--- a/client/messaging/mention-hooks.tsx
+++ b/client/messaging/mention-hooks.tsx
@@ -8,7 +8,10 @@ import { ChatContext } from './chat-context'
  * things that use it, such as ConnectedUsername). The resulting method will filter any clicks that
  * should be forward to the ChatContext instead of opening a user overlay.
  */
-export function useMentionFilterClick(): (userId: SbUserId, e: React.MouseEvent) => boolean {
+export function useMentionFilterClick(): (
+  userId: SbUserId,
+  e: React.MouseEvent | React.KeyboardEvent,
+) => boolean {
   const chatContext = useContext(ChatContext)
   return useCallback(
     (userId, e) => {

--- a/client/users/connected-username.tsx
+++ b/client/users/connected-username.tsx
@@ -44,7 +44,7 @@ export interface ConnectedUsernameProps {
    * was handled by the callback, it should return `true` to indicate the normal behavior should
    * not occur.
    */
-  filterClick?: (userId: SbUserId, e: React.MouseEvent) => boolean
+  filterClick?: (userId: SbUserId, e: React.MouseEvent | React.KeyboardEvent) => boolean
   UserMenu?: UserMenuComponent
   /** Whether the username can be interacted with (clicked, focused, etc.). Defaults to true. */
   interactive?: boolean
@@ -88,7 +88,7 @@ export function ConnectedUsername({
   const onKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === 'Enter' || e.key === ' ') {
       e.preventDefault()
-      onClick(e as any)
+      onClick(e)
     }
   }
 

--- a/client/users/user-overlays.tsx
+++ b/client/users/user-overlays.tsx
@@ -14,14 +14,14 @@ export interface UserOverlaysProps {
   profileOriginY?: OriginY
   profileOffsetX?: number
   profileOffsetY?: number
-  filterClick?: (userId: SbUserId, e: React.MouseEvent) => boolean
+  filterClick?: (userId: SbUserId, e: React.MouseEvent | React.KeyboardEvent) => boolean
   UserMenu?: UserMenuComponent
 }
 
 export interface UserOverlays {
   profileOverlayProps: ConnectedUserProfileOverlayProps
   contextMenuProps: ConnectedUserContextMenuProps
-  onClick: (event: React.MouseEvent) => void
+  onClick: (event: React.MouseEvent | React.KeyboardEvent) => void
   onContextMenu: (event: React.MouseEvent) => void
   isOverlayOpen: boolean
 }


### PR DESCRIPTION
These components now respond to Enter and Space key presses, allowing users to open overlays using keyboard navigation. Previously, they could only be activated by mouse clicks.

Fixes #1204