### PR TITLE
Add translation system to aria-labels

### DIFF
--- a/client/chat/channel-user-list.tsx
+++ b/client/chat/channel-user-list.tsx
@@ -128,6 +128,7 @@ interface UserListEntryProps {
 }
 
 const ConnectedUserListEntry = React.memo<UserListEntryProps>(props => {
+  const { t } = useTranslation()
   const user = useAppSelector(s => s.users.byId.get(props.userId))
   const filterClick = useMentionFilterClick()
 
@@ -158,7 +159,7 @@ const ConnectedUserListEntry = React.memo<UserListEntryProps>(props => {
         {user ? (
           <UserListName>{user.name}</UserListName>
         ) : (
-          <LoadingName aria-label='Username loading…' />
+          <LoadingName aria-label={t('common.loading.username', 'Username loading…')} />
         )}
       </UserListEntryItem>
     </div>

--- a/client/chat/connected-channel-name.tsx
+++ b/client/chat/connected-channel-name.tsx
@@ -100,7 +100,7 @@ export function ConnectedChannelName({
           #{basicChannelInfo.name}
         </ChannelName>
       ) : (
-        <LoadingChannelName aria-label={'Channel name loading…'}>
+        <LoadingChannelName aria-label={t('common.loading.channelName', 'Channel name loading…')}>
           &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
         </LoadingChannelName>
       )}

--- a/client/social/social-sidebar.tsx
+++ b/client/social/social-sidebar.tsx
@@ -530,7 +530,7 @@ function ChannelEntry({
   const displayName = basicInfo?.name ? (
     <span>#{basicInfo.name}</span>
   ) : (
-    <LoadingName aria-label={'Channel name loading…'}>
+    <LoadingName aria-label={t('common.loading.channelName', 'Channel name loading…')}>
       &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
     </LoadingName>
   )
@@ -594,7 +594,7 @@ function WhisperEntry({ userId }: { userId: SbUserId }) {
   )
 
   const usernameElem = username ?? (
-    <LoadingName aria-label={'Username loading…'}>
+    <LoadingName aria-label={t('common.loading.username', 'Username loading…')}>
       &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
     </LoadingName>
   )

--- a/client/users/connected-username.tsx
+++ b/client/users/connected-username.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import { useEffect } from 'react'
+import { useTranslation } from 'react-i18next'
 import styled, { css } from 'styled-components'
 import { SbUserId } from '../../common/users/sb-user-id'
 import { useOverflowingElement } from '../dom/overflowing-element'
@@ -66,6 +67,7 @@ export function ConnectedUsername({
   // TODO(tec27): We could probably make this true? Just not sure what layouts it might break
   showTooltipForOverflow,
 }: ConnectedUsernameProps) {
+  const { t } = useTranslation()
   const dispatch = useAppDispatch()
   const user = useAppSelector(s => s.users.byId.get(userId))
   const [nameRef, isNameOverflowing] = useOverflowingElement()
@@ -93,7 +95,7 @@ export function ConnectedUsername({
   }
 
   const username = user?.name ?? (
-    <LoadingName aria-label={'Username loading…'}>
+    <LoadingName aria-label={t('common.loading.username', 'Username loading…')}>
       &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
     </LoadingName>
   )

--- a/client/users/user-profile-overlay.tsx
+++ b/client/users/user-profile-overlay.tsx
@@ -247,7 +247,7 @@ export function UserProfileOverlayContents({
           {user ? (
             <Username>{user.name}</Username>
           ) : (
-            <LoadingUsername aria-label='Username loading…' />
+            <LoadingUsername aria-label={t('common.loading.username', 'Username loading…')} />
           )}
           <Title>{t('users.titles.novice', 'Novice')}</Title>
         </UsernameAndTitle>

--- a/server/public/locales/en/global.json
+++ b/server/public/locales/en/global.json
@@ -291,6 +291,10 @@
     "lists": {
       "empty": "Nothing to see here"
     },
+    "loading": {
+      "channelName": "Channel name loading…",
+      "username": "Username loading…"
+    },
     "validators": {
       "maxLength_one": "Enter at most {{count}} character",
       "maxLength_other": "Enter at most {{count}} characters",


### PR DESCRIPTION
Updated all hardcoded aria-label strings to use the i18next translation system for better internationalization support.

Changes:
- Updated loading state aria-labels in user components
- Updated loading state aria-labels in chat components
- Added translation keys: common.loading.username and common.loading.channelName
- Generated translation files using pnpm run gen-translations

Fixes #1175