### PR TITLE
Fix Node modules installation before running

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,17 @@ ShieldBattery is a modern platform for playing StarCraft: Brood War/Remastered. 
 
 ## Common Development Commands
 
+### Dependencies Installation
+
+**IMPORTANT**: Before running any pnpm commands, always check if `node_modules` exists in the project root. If it doesn't exist or you encounter errors about missing dependencies:
+
+```bash
+# Check if node_modules exists and install if needed
+ls node_modules || pnpm install
+```
+
+This step is critical when working in web environments where the repository may be freshly cloned without dependencies installed.
+
 ### Development Servers
 
 ```bash


### PR DESCRIPTION
Added a new section at the top of Common Development Commands that instructs Claude to check for node_modules and run pnpm install if needed before executing any pnpm scripts. This helps prevent issues when working in web environments where dependencies may not be installed.