### PR TITLE
Add ability to "ban" users from a particular league.

### DIFF
--- a/client/leagues/action-creators.ts
+++ b/client/leagues/action-creators.ts
@@ -92,7 +92,10 @@ export function joinLeague(id: LeagueId, spec: RequestHandlingSpec<void>): Thunk
   })
 }
 
-export function getLeagueLeaderboard(id: LeagueId, spec: RequestHandlingSpec<void>): ThunkAction {
+export function getLeagueLeaderboard(
+  id: LeagueId,
+  spec: RequestHandlingSpec<GetLeagueLeaderboardResponse>,
+): ThunkAction {
   return abortableThunk(spec, async dispatch => {
     const result = await fetchJson<GetLeagueLeaderboardResponse>(
       apiUrl`leagues/${id}/leaderboard/`,
@@ -105,6 +108,8 @@ export function getLeagueLeaderboard(id: LeagueId, spec: RequestHandlingSpec<voi
       type: '@leagues/getLeaderboard',
       payload: result,
     })
+
+    return result
   })
 }
 
@@ -203,6 +208,32 @@ export function adminUpdateLeague({
       method: 'PATCH',
       signal: spec.signal,
       body: formData,
+    })
+  })
+}
+
+export function adminBanUser(
+  leagueId: LeagueId,
+  userId: number,
+  spec: RequestHandlingSpec<void>,
+): ThunkAction {
+  return abortableThunk(spec, async () => {
+    await fetchJson(apiUrl`admin/leagues/${leagueId}/${userId}/ban`, {
+      method: 'PATCH',
+      signal: spec.signal,
+    })
+  })
+}
+
+export function adminUnbanUser(
+  leagueId: LeagueId,
+  userId: number,
+  spec: RequestHandlingSpec<void>,
+): ThunkAction {
+  return abortableThunk(spec, async () => {
+    await fetchJson(apiUrl`admin/leagues/${leagueId}/${userId}/unban`, {
+      method: 'PATCH',
+      signal: spec.signal,
     })
   })
 }

--- a/client/leagues/action-creators.ts
+++ b/client/leagues/action-creators.ts
@@ -13,6 +13,7 @@ import {
   LeagueJson,
 } from '../../common/leagues/leagues'
 import { apiUrl, urlPath } from '../../common/urls'
+import { SbUserId } from '../../common/users/sb-user-id'
 import { ThunkAction } from '../dispatch-registry'
 import { push, replace } from '../navigation/routing'
 import { RequestHandlingSpec, abortableThunk } from '../network/abortable-thunk'
@@ -214,7 +215,7 @@ export function adminUpdateLeague({
 
 export function adminBanUser(
   leagueId: LeagueId,
-  userId: number,
+  userId: SbUserId,
   spec: RequestHandlingSpec<void>,
 ): ThunkAction {
   return abortableThunk(spec, async () => {
@@ -227,7 +228,7 @@ export function adminBanUser(
 
 export function adminUnbanUser(
   leagueId: LeagueId,
-  userId: number,
+  userId: SbUserId,
   spec: RequestHandlingSpec<void>,
 ): ThunkAction {
   return abortableThunk(spec, async () => {

--- a/client/leagues/league-admin.tsx
+++ b/client/leagues/league-admin.tsx
@@ -135,6 +135,7 @@ export function LeagueAdmin() {
                     league={l}
                     type={LeagueSectionType.Current}
                     joined={false}
+                    banned={false}
                     curDate={curDate}
                     actionText={'Edit'}
                     href={urlPath`/leagues/admin/${toRouteLeagueId(l.id)}`}

--- a/client/leagues/league-ban-notification-ui.tsx
+++ b/client/leagues/league-ban-notification-ui.tsx
@@ -1,0 +1,87 @@
+import React from 'react'
+import { Trans, useTranslation } from 'react-i18next'
+import { LeagueBanNotification, LeagueUnbanNotification } from '../../common/notifications'
+import { TransInterpolation } from '../i18n/i18next'
+import { MaterialIcon } from '../icons/material/material-icon'
+import { ActionlessNotification } from '../notifications/notifications'
+import { styledWithAttrs } from '../styles/styled-with-attrs'
+
+const BanIcon = styledWithAttrs(MaterialIcon, { icon: 'gavel', size: 36 })`
+  flex-shrink: 0;
+  color: var(--theme-negative);
+`
+
+const UnbanIcon = styledWithAttrs(MaterialIcon, { icon: 'how_to_reg', size: 36 })`
+  flex-shrink: 0;
+  color: var(--theme-positive);
+`
+
+export interface LeagueBanNotificationUiProps {
+  ref?: React.Ref<HTMLDivElement>
+  showDivider: boolean
+  read: boolean
+  notification: LeagueBanNotification
+}
+
+export function LeagueBanNotificationUi({
+  ref,
+  showDivider,
+  read,
+  notification,
+}: LeagueBanNotificationUiProps) {
+  const { t } = useTranslation()
+  const leagueName = notification.leagueName
+
+  console.log('leagueName', leagueName)
+
+  return (
+    <ActionlessNotification
+      ref={ref}
+      showDivider={showDivider}
+      read={read}
+      icon={<BanIcon />}
+      text={
+        <span>
+          <Trans t={t} i18nKey='leagues.notifications.ban'>
+            You have been banned from the <strong>{{ leagueName } as TransInterpolation}</strong>{' '}
+            league.
+          </Trans>
+        </span>
+      }
+    />
+  )
+}
+
+export interface LeagueUnbanNotificationUiProps {
+  ref?: React.Ref<HTMLDivElement>
+  showDivider: boolean
+  read: boolean
+  notification: LeagueUnbanNotification
+}
+
+export function LeagueUnbanNotificationUi({
+  ref,
+  showDivider,
+  read,
+  notification,
+}: LeagueUnbanNotificationUiProps) {
+  const { t } = useTranslation()
+  const leagueName = notification.leagueName
+
+  return (
+    <ActionlessNotification
+      ref={ref}
+      showDivider={showDivider}
+      read={read}
+      icon={<UnbanIcon />}
+      text={
+        <span>
+          <Trans t={t} i18nKey='leagues.notifications.unban'>
+            Your ban from the <strong>{{ leagueName } as TransInterpolation}</strong> league has
+            been lifted.
+          </Trans>
+        </span>
+      }
+    />
+  )
+}

--- a/client/leagues/league-ban-notification-ui.tsx
+++ b/client/leagues/league-ban-notification-ui.tsx
@@ -32,8 +32,6 @@ export function LeagueBanNotificationUi({
   const { t } = useTranslation()
   const leagueName = notification.leagueName
 
-  console.log('leagueName', leagueName)
-
   return (
     <ActionlessNotification
       ref={ref}

--- a/client/leagues/league-card.tsx
+++ b/client/leagues/league-card.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 import { ReadonlyDeep } from 'type-fest'
@@ -99,6 +100,7 @@ export function LeagueCard({
   type,
   curDate,
   joined,
+  banned,
   actionText,
   href,
 }: {
@@ -106,6 +108,7 @@ export function LeagueCard({
   type: LeagueSectionType
   curDate: number
   joined: boolean
+  banned: boolean
   actionText: string
   href: string
 }) {
@@ -139,6 +142,25 @@ export function LeagueCard({
       assertUnreachable(type)
   }
 
+  let joinedIndicator: React.ReactNode
+  if (banned) {
+    joinedIndicator = (
+      <JoinedIndicator>
+        <MaterialIcon icon='block' />
+        <span>{t('leagues.list.banned', 'Banned')}</span>
+      </JoinedIndicator>
+    )
+  } else if (joined) {
+    joinedIndicator = (
+      <JoinedIndicator>
+        <MaterialIcon icon='check' />
+        <span>{t('leagues.list.joined', 'Joined')}</span>
+      </JoinedIndicator>
+    )
+  } else {
+    joinedIndicator = <div />
+  }
+
   return (
     <LinkButton href={href} tabIndex={0}>
       <LeagueCardRoot {...buttonProps}>
@@ -158,14 +180,7 @@ export function LeagueCard({
         <LeagueDescription>{league.description}</LeagueDescription>
         <FlexSpacer />
         <LeagueActions>
-          {joined ? (
-            <JoinedIndicator>
-              <MaterialIcon icon='check' />
-              <span>{t('leagues.list.joined', 'Joined')}</span>
-            </JoinedIndicator>
-          ) : (
-            <div />
-          )}
+          {joinedIndicator}
           {/*
           NOTE(tec27): This intentionally doesn't have an onClick handler as it is handled by the
           card and having both would cause 2 navigations to occur.

--- a/client/leagues/league-details.tsx
+++ b/client/leagues/league-details.tsx
@@ -323,6 +323,15 @@ export function LeagueDetails({ id, subPage, container }: LeagueDetailsProps) {
   const isJoinable = !selfLeagueUser && league.endAt > curTime
   const isRunningOrEnded = league.startAt <= curTime
 
+  let joinButtonLabel: string
+  if (selfLeagueUser?.isBanned) {
+    joinButtonLabel = t('leagues.leagueDetails.banned', 'Banned')
+  } else if (selfLeagueUser) {
+    joinButtonLabel = t('leagues.leagueDetails.joined', 'Joined')
+  } else {
+    joinButtonLabel = t('common.actions.join', 'Join')
+  }
+
   const activeTab = subPage ?? DetailsSubPage.Info
 
   let content: React.ReactNode
@@ -361,11 +370,7 @@ export function LeagueDetails({ id, subPage, container }: LeagueDetailsProps) {
         </Tabs>
         {(isJoinable || selfLeagueUser) && (!isFetching || selfLeagueUser) ? (
           <FilledButton
-            label={
-              selfLeagueUser
-                ? t('leagues.leagueDetails.joined', 'Joined')
-                : t('common.actions.join', 'Join')
-            }
+            label={joinButtonLabel}
             disabled={!!selfLeagueUser || isJoining}
             onClick={onJoinClick}
           />
@@ -693,10 +698,14 @@ function Leaderboard({
               leagueUser.isBanned = true
             }
           })
-          snackbarController.showSnackbar('User banned')
+          snackbarController.showSnackbar(
+            t('leagues.leagueDetails.userBannedSuccess', 'User banned'),
+          )
         },
         onError(err) {
-          snackbarController.showSnackbar('Error banning user')
+          snackbarController.showSnackbar(
+            t('leagues.leagueDetails.userBannedError', 'Error banning user'),
+          )
         },
       }),
     )
@@ -712,10 +721,14 @@ function Leaderboard({
               leagueUser.isBanned = false
             }
           })
-          snackbarController.showSnackbar('User unbanned')
+          snackbarController.showSnackbar(
+            t('leagues.leagueDetails.userUnbannedSuccess', 'User unbanned'),
+          )
         },
         onError(err) {
-          snackbarController.showSnackbar('Error unbanning user')
+          snackbarController.showSnackbar(
+            t('leagues.leagueDetails.userUnbannedError', 'Error unbanning user'),
+          )
         },
       }),
     )
@@ -878,7 +891,7 @@ const LeaderboardRow = React.memo(
             <AdminActionsCell>
               <IconButton
                 icon={<MaterialIcon icon='more_vert' />}
-                title='Admin actions'
+                title={t('leagues.leagueDetails.adminActions', 'Admin actions')}
                 ref={anchorRef}
                 onClick={openOverlay}
               />
@@ -893,7 +906,10 @@ const LeaderboardRow = React.memo(
                   {leagueUser.isBanned ? (
                     <MenuItem
                       key='unban'
-                      text={`Unban ${user.name}`}
+                      text={t('leagues.leagueDetails.unbanUser', {
+                        defaultValue: 'Unban {{name}}',
+                        name: user.name,
+                      })}
                       onClick={() => {
                         closeOverlay()
                         onUnbanUserClick(leagueUser.userId)
@@ -902,7 +918,10 @@ const LeaderboardRow = React.memo(
                   ) : (
                     <MenuItem
                       key='ban'
-                      text={`Ban ${user.name}`}
+                      text={t('leagues.leagueDetails.banUser', {
+                        defaultValue: 'Ban {{name}}',
+                        name: user.name,
+                      })}
                       onClick={() => {
                         closeOverlay()
                         onBanUserClick(leagueUser.userId)

--- a/client/leagues/league-list.tsx
+++ b/client/leagues/league-list.tsx
@@ -193,6 +193,7 @@ function LeagueSection({
               type={type}
               curDate={curDate}
               joined={joinedLeagues.has(l.id)}
+              banned={joinedLeagues.get(l.id)?.isBanned ?? false}
               actionText={t('leagues.list.viewInfo', 'View info')}
               href={urlForLeague(l.id, l)}
             />

--- a/client/leagues/league-reducer.ts
+++ b/client/leagues/league-reducer.ts
@@ -1,6 +1,5 @@
 import { ReadonlyDeep } from 'type-fest'
 import { ClientLeagueUserJson, LeagueId, LeagueJson } from '../../common/leagues/leagues'
-import { SbUserId } from '../../common/users/sb-user-id'
 import { immerKeyedReducer } from '../reducers/keyed-reducer'
 
 export interface LeagueState {
@@ -10,11 +9,6 @@ export interface LeagueState {
   future: LeagueId[]
 
   selfLeagues: Map<LeagueId, ClientLeagueUserJson>
-
-  // TODO(tec27): Don't store these in reducer state probably, just use them locally in the
-  // component instead
-  leaderboard: Map<LeagueId, SbUserId[]>
-  leaderboardUsers: Map<LeagueId, Map<SbUserId, ClientLeagueUserJson>>
 }
 
 const DEFAULT_STATE: ReadonlyDeep<LeagueState> = {
@@ -24,9 +18,6 @@ const DEFAULT_STATE: ReadonlyDeep<LeagueState> = {
   future: [],
 
   selfLeagues: new Map(),
-
-  leaderboard: new Map(),
-  leaderboardUsers: new Map(),
 }
 
 export default immerKeyedReducer(DEFAULT_STATE, {
@@ -63,10 +54,8 @@ export default immerKeyedReducer(DEFAULT_STATE, {
     state.selfLeagues.set(league.id, selfLeagueUser)
   },
 
-  ['@leagues/getLeaderboard'](state, { payload: { league, leaderboard, leagueUsers } }) {
+  ['@leagues/getLeaderboard'](state, { payload: { league } }) {
     state.byId.set(league.id, league)
-    state.leaderboard.set(league.id, leaderboard)
-    state.leaderboardUsers.set(league.id, new Map(leagueUsers.map(l => [l.userId, l])))
   },
 
   ['@auth/loadCurrentSession']() {

--- a/client/matchmaking/admin-matchmaking-times.tsx
+++ b/client/matchmaking/admin-matchmaking-times.tsx
@@ -20,9 +20,9 @@ import { longTimestamp } from '../i18n/date-formats'
 import { MaterialIcon } from '../icons/material/material-icon'
 import { FilledButton, TextButton } from '../material/button'
 import { CheckBox } from '../material/check-box'
+import { DateTimeTextField } from '../material/datetime-text-field'
 import { elevationPlus1 } from '../material/shadows'
 import { TabItem, Tabs } from '../material/tabs'
-import { TextField } from '../material/text-field'
 import { abortableThunk, RequestHandlingSpec } from '../network/abortable-thunk'
 import { encodeBodyAsParams, fetchJson } from '../network/fetch'
 import { LoadingDotsArea } from '../progress/dots'
@@ -416,8 +416,7 @@ function FutureMatchmakingTimes({ activeTab }: { activeTab: MatchmakingType }) {
     <>
       <AddNewCard>
         <DateInputContainer>
-          <TextField
-            type='datetime-local'
+          <DateTimeTextField
             dense={true}
             value={startDate}
             errorText={invalidDate ? 'Start date must be set into the future' : undefined}

--- a/client/notifications/notification-to-ui.tsx
+++ b/client/notifications/notification-to-ui.tsx
@@ -1,6 +1,10 @@
 import React from 'react'
 import { NotificationType, SbNotification } from '../../common/notifications'
 import { UserRestrictedNotificationUi } from '../auth/user-restricted-notification-ui'
+import {
+  LeagueBanNotificationUi,
+  LeagueUnbanNotificationUi,
+} from '../leagues/league-ban-notification-ui'
 import { logger } from '../logging/logger'
 import { PolicyUpdateNotificationUi } from '../policies/policy-update-notification-ui'
 import {
@@ -19,6 +23,8 @@ export function notificationHasUi(notification: SbNotification) {
     case NotificationType.FriendRequest:
     case NotificationType.FriendStart:
     case NotificationType.UserRestricted:
+    case NotificationType.LeagueBan:
+    case NotificationType.LeagueUnban:
       return true
     case NotificationType.PartyInvite:
       return false
@@ -80,6 +86,24 @@ export function NotificationUi({ notification, showDivider, ref }: NotificationU
           kind={notification.kind}
           endTime={notification.endTime}
           reason={notification.reason}
+        />
+      )
+    case NotificationType.LeagueBan:
+      return (
+        <LeagueBanNotificationUi
+          ref={ref}
+          showDivider={showDivider}
+          read={notification.read}
+          notification={notification}
+        />
+      )
+    case NotificationType.LeagueUnban:
+      return (
+        <LeagueUnbanNotificationUi
+          ref={ref}
+          showDivider={showDivider}
+          read={notification.read}
+          notification={notification}
         />
       )
     default:

--- a/common/leagues/leagues.ts
+++ b/common/leagues/leagues.ts
@@ -57,6 +57,7 @@ export function toLeagueJson(league: League): LeagueJson {
 export interface ClientLeagueUser extends RaceStats {
   leagueId: LeagueId
   userId: SbUserId
+  isBanned: boolean
   points: number
   wins: number
   losses: number
@@ -69,6 +70,7 @@ export function toClientLeagueUserJson(user: ClientLeagueUser): ClientLeagueUser
   return {
     leagueId: user.leagueId,
     userId: user.userId,
+    isBanned: user.isBanned,
     points: user.points,
     wins: user.wins,
     losses: user.losses,

--- a/common/notifications.ts
+++ b/common/notifications.ts
@@ -17,6 +17,10 @@ export enum NotificationType {
   PolicyUpdated = 'policyUpdated',
   /** A restriction has been applied to this user. */
   UserRestricted = 'userRestricted',
+  /** A user has been banned from a league. */
+  LeagueBan = 'leagueBan',
+  /** A user has been unbanned from a league. */
+  LeagueUnban = 'leagueUnban',
 }
 
 export type SbNotification =
@@ -25,6 +29,8 @@ export type SbNotification =
   | PartyInviteNotification
   | PolicyUpdatedNotification
   | UserRestrictedNotification
+  | LeagueBanNotification
+  | LeagueUnbanNotification
 
 export interface BaseNotification {
   /**
@@ -71,6 +77,16 @@ export interface UserRestrictedNotification extends BaseNotification {
   kind: RestrictionKind
   endTime: number
   reason: RestrictionReason
+}
+
+export interface LeagueBanNotification extends BaseNotification {
+  type: NotificationType.LeagueBan
+  leagueName: string
+}
+
+export interface LeagueUnbanNotification extends BaseNotification {
+  type: NotificationType.LeagueUnban
+  leagueName: string
 }
 
 export type NotificationEvent =

--- a/migrations/20260107151429_add-banned-league-user-column.sql
+++ b/migrations/20260107151429_add-banned-league-user-column.sql
@@ -1,0 +1,2 @@
+-- Add column to track banned league users
+ALTER TABLE league_users ADD COLUMN is_banned boolean NOT NULL DEFAULT false;

--- a/server/lib/games/game-result-service.ts
+++ b/server/lib/games/game-result-service.ts
@@ -449,17 +449,24 @@ export default class GameResultService {
           }
 
           for (const leagueChange of leagueChanges) {
-            matchmakingDbPromises.push(insertLeagueUserChange(leagueChange, client))
-
-            const winCount = leagueChange.outcome === 'win' ? 1 : 0
-            const lossCount = leagueChange.outcome === 'win' ? 0 : 1
             const oldLeagueUser = activeLeagues
               .get(leagueChange.userId)!
               .find(l => l.leagueId === leagueChange.leagueId)!
 
+            if (oldLeagueUser.isBanned) {
+              // Don't process league changes for banned users
+              continue
+            }
+
+            matchmakingDbPromises.push(insertLeagueUserChange(leagueChange, client))
+
+            const winCount = leagueChange.outcome === 'win' ? 1 : 0
+            const lossCount = leagueChange.outcome === 'win' ? 0 : 1
+
             const updatedLeagueUser: LeagueUser = {
               leagueId: oldLeagueUser.leagueId,
               userId: oldLeagueUser.userId,
+              isBanned: oldLeagueUser.isBanned,
               lastPlayedDate: reconcileDate,
               points: leagueChange.points,
               pointsConverged: leagueChange.pointsConverged,

--- a/server/lib/leagues/league-api.ts
+++ b/server/lib/leagues/league-api.ts
@@ -26,6 +26,7 @@ import {
   toLeagueJson,
 } from '../../../common/leagues/leagues'
 import { ALL_MATCHMAKING_TYPES } from '../../../common/matchmaking'
+import { NotificationType } from '../../../common/notifications'
 import { Patch } from '../../../common/patch'
 import { SbUserId } from '../../../common/users/sb-user-id'
 import { UNIQUE_VIOLATION } from '../db/pg-error-codes'
@@ -37,6 +38,7 @@ import { handleMultipartFiles } from '../files/handle-multipart-files'
 import { createImagePath, resizeImage } from '../files/images'
 import { httpApi, httpBeforeAll } from '../http/http-api'
 import { httpBefore, httpGet, httpPatch, httpPost } from '../http/route-decorators'
+import NotificationService from '../notifications/notification-service'
 import { checkAllPermissions } from '../permissions/check-permissions'
 import { Redis } from '../redis/redis'
 import ensureLoggedIn from '../session/ensure-logged-in'
@@ -201,6 +203,8 @@ export class LeagueApi {
 @httpApi('/admin/leagues/')
 @httpBeforeAll(ensureLoggedIn, checkAllPermissions('manageLeagues'))
 export class LeagueAdminApi {
+  constructor(private notificationService: NotificationService) {}
+
   @httpGet('/')
   async getLeagues(ctx: RouterContext): Promise<AdminGetLeaguesResponse> {
     const leagues = await adminGetAllLeagues()
@@ -450,6 +454,13 @@ export class LeagueAdminApi {
     }
 
     await banLeagueUser(leagueUser)
+    await this.notificationService.addNotification({
+      userId,
+      data: {
+        type: NotificationType.LeagueBan,
+        leagueName: league.name,
+      },
+    })
   }
 
   @httpPatch('/:leagueId/:userId/unban')
@@ -476,5 +487,12 @@ export class LeagueAdminApi {
     }
 
     await unbanLeagueUser(leagueUser)
+    await this.notificationService.addNotification({
+      userId,
+      data: {
+        type: NotificationType.LeagueUnban,
+        leagueName: league.name,
+      },
+    })
   }
 }

--- a/server/lib/leagues/league-api.ts
+++ b/server/lib/leagues/league-api.ts
@@ -201,7 +201,7 @@ export class LeagueApi {
 }
 
 @httpApi('/admin/leagues/')
-@httpBeforeAll(ensureLoggedIn, checkAllPermissions('manageLeagues'))
+@httpBeforeAll(convertLeagueApiErrors, ensureLoggedIn, checkAllPermissions('manageLeagues'))
 export class LeagueAdminApi {
   constructor(private notificationService: NotificationService) {}
 
@@ -453,6 +453,11 @@ export class LeagueAdminApi {
       throw new LeagueApiError(LeagueErrorCode.NotFound, 'user is not in the league')
     }
 
+    if (leagueUser.isBanned) {
+      // Already banned, so this is a no-op (and we avoid sending a duplicate notification)
+      return
+    }
+
     await banLeagueUser(leagueUser)
     await this.notificationService.addNotification({
       userId,
@@ -484,6 +489,11 @@ export class LeagueAdminApi {
 
     if (!leagueUser) {
       throw new LeagueApiError(LeagueErrorCode.NotFound, 'user is not in the league')
+    }
+
+    if (!leagueUser.isBanned) {
+      // Not banned, so this is a no-op (and we avoid sending a spurious notification)
+      return
     }
 
     await unbanLeagueUser(leagueUser)

--- a/server/lib/leagues/league-models.ts
+++ b/server/lib/leagues/league-models.ts
@@ -264,6 +264,7 @@ export async function adminGetLeague(
 export interface LeagueUser extends RaceStats {
   leagueId: LeagueId
   userId: SbUserId
+  isBanned: boolean
   lastPlayedDate?: Date
   points: number
   pointsConverged: boolean
@@ -277,6 +278,7 @@ function convertLeagueUserFromDb(dbUser: DbLeagueUser): LeagueUser {
   return {
     leagueId: dbUser.league_id,
     userId: dbUser.user_id,
+    isBanned: dbUser.is_banned,
     lastPlayedDate: dbUser.last_played_date ?? undefined,
     points: dbUser.points,
     pointsConverged: dbUser.points_converged,
@@ -396,6 +398,32 @@ export async function updateLeagueUser(leagueUser: LeagueUser, client: DbClient)
       r_z_losses = ${leagueUser.rZLosses}
     WHERE league_id = ${leagueUser.leagueId} AND user_id = ${leagueUser.userId}
   `)
+}
+
+export async function banLeagueUser(leagueUser: LeagueUser, withClient?: DbClient) {
+  const { client, done } = await db(withClient)
+  try {
+    await client.query(sql`
+      UPDATE league_users
+      SET is_banned = TRUE
+      WHERE league_id = ${leagueUser.leagueId} AND user_id = ${leagueUser.userId}
+    `)
+  } finally {
+    done()
+  }
+}
+
+export async function unbanLeagueUser(leagueUser: LeagueUser, withClient?: DbClient) {
+  const { client, done } = await db(withClient)
+  try {
+    await client.query(sql`
+      UPDATE league_users
+      SET is_banned = FALSE
+      WHERE league_id = ${leagueUser.leagueId} AND user_id = ${leagueUser.userId}
+    `)
+  } finally {
+    done()
+  }
 }
 
 /**

--- a/server/lib/matchmaking/rating.test.ts
+++ b/server/lib/matchmaking/rating.test.ts
@@ -69,6 +69,7 @@ function createLeagueUser(
     ...data,
     userId: makeSbUserId(data.userId),
     leagueId: makeLeagueId(data.leagueId),
+    isBanned: false,
   }
 }
 

--- a/server/lib/notifications/notification-model.ts
+++ b/server/lib/notifications/notification-model.ts
@@ -20,6 +20,8 @@ export type NotificationData =
   | FriendRequestNotificationData
   | FriendStartNotificationData
   | UserRestrictedNotificationData
+  | LeagueBanNotificationData
+  | LeagueUnbanNotificationData
 
 export interface FriendRequestNotificationData extends BaseNotificationData {
   type: NotificationType.FriendRequest
@@ -52,6 +54,20 @@ export interface UserRestrictedNotificationData extends BaseNotificationData {
 
 type UserRestrictedSearchNotificationData = MakeSearchable<UserRestrictedNotificationData>
 
+export interface LeagueBanNotificationData extends BaseNotificationData {
+  type: NotificationType.LeagueBan
+  leagueName: string
+}
+
+type LeagueBanSearchNotificationData = MakeSearchable<LeagueBanNotificationData>
+
+export interface LeagueUnbanNotificationData extends BaseNotificationData {
+  type: NotificationType.LeagueUnban
+  leagueName: string
+}
+
+type LeagueUnbanSearchNotificationData = MakeSearchable<LeagueUnbanNotificationData>
+
 /**
  * Notification data type that can be used to retrieve notifications by.
  */
@@ -60,6 +76,8 @@ export type SearchNotificationData =
   | FriendStartSearchNotificationData
   | PartyInviteSearchNotificationData
   | UserRestrictedSearchNotificationData
+  | LeagueBanSearchNotificationData
+  | LeagueUnbanSearchNotificationData
   | Record<string, never>
 
 export interface Notification {

--- a/server/public/locales/en/global.json
+++ b/server/public/locales/en/global.json
@@ -528,6 +528,9 @@
     },
     "leagueDetails": {
       "about": "About",
+      "adminActions": "Admin actions",
+      "banned": "Banned",
+      "banUser": "Ban {{name}}",
       "copyLink": "Copy link to league",
       "dateText": "{{startDate}} to {{endDate}}",
       "goBack": "Go back to list",
@@ -549,7 +552,12 @@
       "notFound": "League not found",
       "retrieveError": "There was an error retrieving this league: {{errorMessage}}",
       "rulesAndInfo": "Rules and info",
-      "userBanned": "This user has been banned from the league"
+      "unbanUser": "Unban {{name}}",
+      "userBanned": "This user has been banned from the league",
+      "userBannedError": "Error banning user",
+      "userBannedSuccess": "User banned",
+      "userUnbannedError": "Error unbanning user",
+      "userUnbannedSuccess": "User unbanned"
     },
     "list": {
       "acceptingSignups": "Accepting signups",

--- a/server/public/locales/en/global.json
+++ b/server/public/locales/en/global.json
@@ -553,6 +553,7 @@
     },
     "list": {
       "acceptingSignups": "Accepting signups",
+      "banned": "Banned",
       "currentlyRunning": "Currently running",
       "ends": "Ends {{endDate}}",
       "finished": "Finished",
@@ -566,6 +567,10 @@
       "starts": "Starts {{startDate}}",
       "viewAll": "View all leagues",
       "viewInfo": "View info"
+    },
+    "notifications": {
+      "ban": "You have been banned from the <1>{{leagueName}}</1> league.",
+      "unban": "Your ban from the <1>{{leagueName}}</1> league has been lifted."
     }
   },
   "lobbies": {

--- a/server/public/locales/en/global.json
+++ b/server/public/locales/en/global.json
@@ -548,7 +548,8 @@
       "noPlayers": "No matching players.",
       "notFound": "League not found",
       "retrieveError": "There was an error retrieving this league: {{errorMessage}}",
-      "rulesAndInfo": "Rules and info"
+      "rulesAndInfo": "Rules and info",
+      "userBanned": "This user has been banned from the league"
     },
     "list": {
       "acceptingSignups": "Accepting signups",


### PR DESCRIPTION
Users can be banned by admins with "manageLeague" permission. Banned user are still left in a league, but just marked as banned and their league points are not updated anymore. This serves as a built-in mechanism to prevent them from re-joining a league after being banned.

For now, we're just banning the single account of a user, and not all of their accounts.