### PR TITLE
Add match history filtering and matchup support.

### DIFF
--- a/client/games/game-filter-bar.tsx
+++ b/client/games/game-filter-bar.tsx
@@ -1,0 +1,381 @@
+import { Variants } from 'motion/react'
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import styled from 'styled-components'
+import {
+  ALL_GAME_FORMATS,
+  createEmptyMatchup,
+  decodeMatchup,
+  EncodedMatchupString,
+  encodeMatchup,
+  GameDurationFilter,
+  GameFormat,
+  GameSortOption,
+  getDurationLabel,
+  getSortLabel,
+} from '../../common/games/game-filters'
+import { MaterialIcon } from '../icons/material/material-icon'
+import { useKeyListener } from '../keyboard/key-listener'
+import { TextButton } from '../material/button'
+import { FilterChip } from '../material/filter-chip'
+import { SelectableMenuItem } from '../material/menu/selectable-item'
+import { Popover, usePopoverController, useRefAnchorPosition } from '../material/popover'
+import { TextField } from '../material/text-field'
+import { ContainerLevel, containerStyles } from '../styles/colors'
+import { FlexSpacer } from '../styles/flex-spacer'
+import { labelLarge, labelMedium } from '../styles/typography'
+import { MatchupFilter } from './matchup-filter'
+
+const FilterBarContainer = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 16px;
+  width: 100%;
+  min-height: 56px;
+`
+
+const FiltersLabel = styled.div`
+  ${labelLarge};
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  color: var(--theme-on-surface-variant);
+`
+
+const popoverVariants: Variants = {
+  entering: { opacity: 0, y: -8 },
+  visible: { opacity: 1, y: 0 },
+  exiting: { opacity: 0, y: -8 },
+}
+
+const DURATION_OPTIONS = [
+  GameDurationFilter.All,
+  GameDurationFilter.Under10,
+  GameDurationFilter.From10To20,
+  GameDurationFilter.From20To30,
+  GameDurationFilter.Over30,
+] as const
+
+const SORT_OPTIONS = [
+  GameSortOption.LatestFirst,
+  GameSortOption.OldestFirst,
+  GameSortOption.ShortestFirst,
+  GameSortOption.LongestFirst,
+] as const
+
+export interface GameFilterBarProps {
+  ranked: boolean
+  setRanked: (v: boolean) => void
+  custom: boolean
+  setCustom: (v: boolean) => void
+  duration: GameDurationFilter
+  setDuration: (v: GameDurationFilter) => void
+  sort: GameSortOption
+  setSort: (v: GameSortOption) => void
+  mapName: string
+  setMapName: (v: string) => void
+  playerName: string
+  setPlayerName: (v: string) => void
+  format?: GameFormat
+  setFormat: (v?: GameFormat) => void
+  matchup?: EncodedMatchupString
+  setMatchup: (v?: EncodedMatchupString) => void
+  className?: string
+}
+
+/**
+ * A filter bar for game history with immediate-apply filters (chips, dropdowns)
+ * and an advanced filters panel with draft state.
+ */
+export function GameFilterBar({
+  ranked,
+  setRanked,
+  custom,
+  setCustom,
+  duration,
+  setDuration,
+  sort,
+  setSort,
+  mapName,
+  setMapName,
+  playerName,
+  setPlayerName,
+  format,
+  setFormat,
+  matchup,
+  setMatchup,
+  className,
+}: GameFilterBarProps) {
+  const { t } = useTranslation()
+  const [anchorRef, anchorX, anchorY, refreshAnchorPos] = useRefAnchorPosition('left', 'bottom')
+  const [opened, openPopover, closePopover] = usePopoverController({ refreshAnchorPos })
+
+  const hasAdvancedFilters = !!mapName || !!playerName || !!format || !!matchup
+  const hasActiveFilters =
+    ranked || custom || duration !== GameDurationFilter.All || hasAdvancedFilters
+
+  return (
+    <FilterBarContainer className={className}>
+      <FiltersLabel>
+        <MaterialIcon icon='filter_list' size={20} />
+        {t('game.filters.label', 'Filters')}
+      </FiltersLabel>
+
+      <FilterChip
+        label={t('game.filters.ranked', 'Ranked')}
+        selected={ranked}
+        onClick={() => setRanked(!ranked)}
+      />
+      <FilterChip
+        label={t('game.filters.custom', 'Custom')}
+        selected={custom}
+        onClick={() => setCustom(!custom)}
+      />
+
+      <FilterChip
+        label={getDurationLabel(duration, t)}
+        icon={<MaterialIcon icon='timer' filled={false} size={18} />}>
+        {DURATION_OPTIONS.map(d => (
+          <SelectableMenuItem
+            key={d}
+            text={getDurationLabel(d, t)}
+            selected={duration === d}
+            onClick={() => setDuration(d)}
+          />
+        ))}
+      </FilterChip>
+
+      <FilterChip
+        ref={anchorRef}
+        label={t('game.filters.advanced', 'Advanced')}
+        icon={<MaterialIcon icon='instant_mix' size={18} />}
+        selected={!!hasAdvancedFilters || opened}
+        onClick={e => (opened ? closePopover() : openPopover(e))}
+      />
+
+      {hasActiveFilters && (
+        <TextButton
+          label={t('common.actions.clear', 'Clear')}
+          iconStart={<MaterialIcon icon='close' />}
+          onClick={() => {
+            setRanked(false)
+            setCustom(false)
+            setDuration(GameDurationFilter.All)
+            setMapName('')
+            setPlayerName('')
+            setFormat(undefined)
+            setMatchup(undefined)
+          }}
+        />
+      )}
+
+      <FlexSpacer />
+
+      <FilterChip label={getSortLabel(sort, t)} icon={<MaterialIcon icon='sort' size={18} />}>
+        {SORT_OPTIONS.map(s => (
+          <SelectableMenuItem
+            key={s}
+            text={getSortLabel(s, t)}
+            selected={sort === s}
+            onClick={() => setSort(s)}
+          />
+        ))}
+      </FilterChip>
+
+      <Popover
+        open={opened}
+        onDismiss={closePopover}
+        anchorX={anchorX ?? 0}
+        anchorY={anchorY ?? 0}
+        originX='left'
+        originY='top'
+        motionVariants={popoverVariants}
+        motionInitial='entering'
+        motionAnimate='visible'
+        motionExit='exiting'>
+        <AdvancedFiltersPanel
+          mapName={mapName}
+          playerName={playerName}
+          format={format}
+          matchup={matchup}
+          onApply={advancedValues => {
+            setMapName(advancedValues.mapName)
+            setPlayerName(advancedValues.playerName)
+            setFormat(advancedValues.format)
+            setMatchup(advancedValues.matchup)
+            closePopover()
+          }}
+          onClose={closePopover}
+        />
+      </Popover>
+    </FilterBarContainer>
+  )
+}
+
+const AdvancedPanelContainer = styled.div`
+  ${containerStyles(ContainerLevel.Low)};
+
+  display: flex;
+  flex-direction: column;
+
+  border-radius: 8px;
+  width: 364px;
+`
+
+const PanelContent = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 16px;
+`
+
+const PanelSection = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+`
+
+const SectionLabel = styled.div`
+  ${labelMedium};
+  color: var(--theme-on-surface-variant);
+`
+
+const FormatButtonsContainer = styled.div`
+  display: flex;
+  gap: 8px;
+`
+
+const PanelActions = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  padding: 8px 4px 4px;
+`
+
+interface AdvancedFiltersPanelProps {
+  mapName: string
+  playerName: string
+  format?: GameFormat
+  matchup?: EncodedMatchupString
+  onApply: (values: {
+    mapName: string
+    playerName: string
+    format?: GameFormat
+    matchup?: EncodedMatchupString
+  }) => void
+  onClose: () => void
+}
+
+function AdvancedFiltersPanel({
+  mapName,
+  playerName,
+  format,
+  matchup,
+  onApply,
+  onClose,
+}: AdvancedFiltersPanelProps) {
+  const { t } = useTranslation()
+
+  const [draftMapName, setDraftMapName] = useState(mapName)
+  const [draftPlayerName, setDraftPlayerName] = useState(playerName)
+  const [draftFormat, setDraftFormat] = useState(format)
+  const [draftMatchup, setDraftMatchup] = useState(matchup)
+
+  useKeyListener({
+    onKeyDown: (event: KeyboardEvent) => {
+      if (event.code === 'Enter' || event.code === 'NumpadEnter') {
+        onApply({
+          mapName: draftMapName,
+          playerName: draftPlayerName,
+          format: draftFormat,
+          matchup: draftMatchup,
+        })
+        return true
+      }
+
+      return false
+    },
+  })
+
+  return (
+    <AdvancedPanelContainer>
+      <PanelContent>
+        <PanelSection>
+          <SectionLabel>{t('common.actions.search', 'Search')}</SectionLabel>
+          <TextField
+            label={t('game.filters.mapName', 'Map name')}
+            value={draftMapName}
+            onChange={e => setDraftMapName(e.target.value)}
+            dense={true}
+            allowErrors={false}
+          />
+          <TextField
+            label={t('game.filters.playerName', 'Player name')}
+            value={draftPlayerName}
+            onChange={e => setDraftPlayerName(e.target.value)}
+            dense={true}
+            allowErrors={false}
+          />
+        </PanelSection>
+
+        <PanelSection>
+          <SectionLabel>{t('game.filters.format', 'Format')}</SectionLabel>
+          <FormatButtonsContainer>
+            {ALL_GAME_FORMATS.map(f => (
+              <FilterChip
+                key={f}
+                label={f}
+                selected={draftFormat === f}
+                onClick={() => {
+                  if (draftFormat === f) {
+                    setDraftFormat(undefined)
+                    setDraftMatchup(undefined)
+                  } else {
+                    setDraftFormat(f)
+                    setDraftMatchup(encodeMatchup(createEmptyMatchup(f)))
+                  }
+                }}
+              />
+            ))}
+          </FormatButtonsContainer>
+        </PanelSection>
+
+        {draftFormat && (
+          <PanelSection>
+            <SectionLabel>{t('game.filters.matchup', 'Matchup')}</SectionLabel>
+            <MatchupFilter
+              matchup={decodeMatchup(draftFormat, draftMatchup) ?? createEmptyMatchup(draftFormat)}
+              onMatchupChange={m => {
+                const hasNonUndefinedRace = [...m.team1, ...m.team2].some(r => r !== undefined)
+                setDraftMatchup(hasNonUndefinedRace ? encodeMatchup(m) : undefined)
+              }}
+            />
+          </PanelSection>
+        )}
+      </PanelContent>
+
+      <PanelActions>
+        <TextButton
+          label={t('common.actions.reset', 'Reset')}
+          onClick={() => {
+            setDraftMapName('')
+            setDraftPlayerName('')
+            setDraftFormat(undefined)
+            setDraftMatchup(undefined)
+          }}
+        />
+        <TextButton
+          label={t('common.actions.apply', 'Apply')}
+          onClick={() =>
+            onApply({
+              mapName: draftMapName,
+              playerName: draftPlayerName,
+              format: draftFormat,
+              matchup: draftMatchup,
+            })
+          }
+        />
+      </PanelActions>
+    </AdvancedPanelContainer>
+  )
+}

--- a/client/games/game-filter-bar.tsx
+++ b/client/games/game-filter-bar.tsx
@@ -332,7 +332,9 @@ function AdvancedFiltersPanel({
                     setDraftMatchup(undefined)
                   } else {
                     setDraftFormat(f)
-                    setDraftMatchup(encodeMatchup(createEmptyMatchup(f)))
+                    // Leave the matchup unset until an actual race is chosen, so we don't carry a
+                    // no-op all-wildcard matchup (e.g. `____-____`) around in the URL.
+                    setDraftMatchup(undefined)
                   }
                 }}
               />

--- a/client/games/game-reducer.ts
+++ b/client/games/game-reducer.ts
@@ -27,7 +27,7 @@ export default immerKeyedReducer(DEFAULT_STATE, {
     }
   },
 
-  ['@users/searchMatchHistory'](state, { payload: { games }, meta: { userId } }) {
+  ['@users/getMatchHistory'](state, { payload: { games }, meta: { userId } }) {
     for (const game of games) {
       state.byId.set(game.id, game)
     }

--- a/client/games/matchup-filter.tsx
+++ b/client/games/matchup-filter.tsx
@@ -1,0 +1,121 @@
+import { useTranslation } from 'react-i18next'
+import styled from 'styled-components'
+import {
+  MatchupFilter as MatchupFilterType,
+  MatchupRaceSlot,
+} from '../../common/games/game-filters'
+import { AssignedRaceChar } from '../../common/races'
+import { RaceButton, RacePickerSize, StyledRaceIcon } from '../lobbies/race-picker'
+import { useButtonState } from '../material/button'
+import { Ripple } from '../material/ripple'
+import { labelMedium } from '../styles/typography'
+
+const Container = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 16px;
+`
+
+const TeamContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+`
+
+const VsText = styled.span`
+  ${labelMedium};
+  color: var(--theme-on-surface-variant);
+`
+
+export interface MatchupFilterProps {
+  matchup: MatchupFilterType
+  onMatchupChange: (matchup: MatchupFilterType) => void
+  className?: string
+}
+
+/**
+ * A dynamic matchup filter that shows race selectors based on the selected game format.
+ * For example, 3v3 shows 3 race selectors per team (6 total).
+ */
+export function MatchupFilter({ matchup, onMatchupChange, className }: MatchupFilterProps) {
+  const { t } = useTranslation()
+
+  return (
+    <Container className={className}>
+      <TeamContainer>
+        {matchup.team1.map((_, i) => (
+          <MatchupRacePicker
+            key={`team1-${i}`}
+            race={matchup.team1[i]}
+            onSetRace={race => {
+              onMatchupChange({
+                team1: matchup.team1.map((r, j) => (j === i ? race : r)),
+                team2: matchup.team2,
+              })
+            }}
+          />
+        ))}
+      </TeamContainer>
+
+      <VsText>{t('game.filters.vs', 'vs')}</VsText>
+
+      <TeamContainer>
+        {matchup.team2.map((_, i) => (
+          <MatchupRacePicker
+            key={`team2-${i}`}
+            race={matchup.team2[i]}
+            onSetRace={race => {
+              onMatchupChange({
+                team1: matchup.team1,
+                team2: matchup.team2.map((r, j) => (j === i ? race : r)),
+              })
+            }}
+          />
+        ))}
+      </TeamContainer>
+    </Container>
+  )
+}
+
+interface MatchupRacePickerProps {
+  /** The currently selected race, or undefined for none selected. */
+  race: MatchupRaceSlot
+  onSetRace?: (race: MatchupRaceSlot) => void
+}
+
+/**
+ * A custom race picker component for the matchup filter, which allows unset slots.
+ */
+function MatchupRacePicker({ race, onSetRace }: MatchupRacePickerProps) {
+  const [zergButtonProps, zergRippleRef] = useButtonState({
+    onClick: () => onSetRace?.(race === 'z' ? undefined : 'z'),
+  })
+  const [protossButtonProps, protossRippleRef] = useButtonState({
+    onClick: () => onSetRace?.(race === 'p' ? undefined : 'p'),
+  })
+  const [terranButtonProps, terranRippleRef] = useButtonState({
+    onClick: () => onSetRace?.(race === 't' ? undefined : 't'),
+  })
+
+  const races: AssignedRaceChar[] = ['z', 'p', 't']
+  const buttonProps = [zergButtonProps, protossButtonProps, terranButtonProps]
+  const rippleRefs = [zergRippleRef, protossRippleRef, terranRippleRef]
+
+  return (
+    <div>
+      {races.map((r, i) => (
+        <RaceButton
+          key={r}
+          type='button'
+          $size={RacePickerSize.Medium}
+          $race={r}
+          $active={r === race}
+          $allowInteraction={true}
+          {...buttonProps[i]}>
+          <StyledRaceIcon race={r} applyRaceColor={false} $size={RacePickerSize.Medium} />
+          <Ripple ref={rippleRefs[i]} />
+        </RaceButton>
+      ))}
+    </div>
+  )
+}

--- a/client/maps/maps-reducer.ts
+++ b/client/maps/maps-reducer.ts
@@ -168,7 +168,7 @@ export default immerKeyedReducer(DEFAULT_STATE, {
     }
   },
 
-  ['@users/searchMatchHistory'](state, action) {
+  ['@users/getMatchHistory'](state, action) {
     const {
       payload: { maps },
       system: { monotonicTime },

--- a/client/matchmaking/devonly/post-match-dialog-test.tsx
+++ b/client/matchmaking/devonly/post-match-dialog-test.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components'
 import { GameSource } from '../../../common/games/configuration'
 import { GameType } from '../../../common/games/game-type'
 import { GameRecordJson } from '../../../common/games/games'
+import { makeMatchupString } from '../../../common/games/matchups'
 import {
   ClientLeagueUserChangeJson,
   LeagueJson,
@@ -59,6 +60,8 @@ const GAME: GameRecordJson = {
     [PLAYER_ID, { result: 'win', race: 'p', apm: 27 }],
     [OPPONENT_ID, { result: 'loss', race: 'z', apm: 350 }],
   ],
+  selectedMatchup: makeMatchupString('p-z'),
+  assignedMatchup: makeMatchupString('p-z'),
 }
 
 const SEASON: MatchmakingSeasonJson = {

--- a/client/material/devonly/chip-test.tsx
+++ b/client/material/devonly/chip-test.tsx
@@ -1,0 +1,166 @@
+import { useState } from 'react'
+import styled from 'styled-components'
+import { MaterialIcon } from '../../icons/material/material-icon'
+import { CenteredContentContainer } from '../../styles/centered-container'
+import { TitleLarge, TitleMedium } from '../../styles/typography'
+import { Card } from '../card'
+import { FilterChip } from '../filter-chip'
+import { SelectableMenuItem } from '../menu/selectable-item'
+
+const StyledCard = styled(Card)`
+  width: 100%;
+  max-width: 640px;
+  margin-inline: auto;
+  margin-top: 24px;
+
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 16px;
+`
+
+const Row = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+`
+
+type SortOption = 'latest' | 'oldest' | 'shortest' | 'longest'
+type DurationOption = 'all' | 'under10' | '10to20' | '20to30' | 'over30'
+
+const SORT_OPTIONS: SortOption[] = ['latest', 'oldest', 'shortest', 'longest']
+const DURATION_OPTIONS: DurationOption[] = ['all', 'under10', '10to20', '20to30', 'over30']
+
+const SORT_LABELS: Record<SortOption, string> = {
+  latest: 'Latest first',
+  oldest: 'Oldest first',
+  shortest: 'Shortest first',
+  longest: 'Longest first',
+}
+
+const DURATION_LABELS: Record<DurationOption, string> = {
+  all: 'All durations',
+  under10: 'Under 10min',
+  '10to20': '10-20min',
+  '20to30': '20-30min',
+  over30: 'Over 30min',
+}
+
+export function ChipTest() {
+  const [selectedChips, setSelectedChips] = useState<Set<string>>(new Set(['ranked']))
+  const [sortOption, setSortOption] = useState<SortOption>('latest')
+  const [durationOption, setDurationOption] = useState<DurationOption>('all')
+
+  const toggleChip = (id: string) => {
+    setSelectedChips(prev => {
+      const next = new Set(prev)
+      if (next.has(id)) {
+        next.delete(id)
+      } else {
+        next.add(id)
+      }
+      return next
+    })
+  }
+
+  return (
+    <CenteredContentContainer>
+      <StyledCard>
+        <TitleLarge>Filter Chips</TitleLarge>
+
+        <TitleMedium>Interactive Example</TitleMedium>
+        <Row>
+          <FilterChip
+            label='Ranked'
+            selected={selectedChips.has('ranked')}
+            onClick={() => toggleChip('ranked')}
+          />
+          <FilterChip
+            label='Custom'
+            selected={selectedChips.has('custom')}
+            onClick={() => toggleChip('custom')}
+          />
+          <FilterChip
+            label='Unranked'
+            selected={selectedChips.has('unranked')}
+            onClick={() => toggleChip('unranked')}
+          />
+        </Row>
+
+        <TitleMedium>States</TitleMedium>
+        <Row>
+          <FilterChip label='Unselected' />
+          <FilterChip label='Selected' selected={true} />
+          <FilterChip label='Disabled' disabled={true} />
+          <FilterChip label='Selected Disabled' selected={true} disabled={true} />
+        </Row>
+
+        <TitleMedium>With Icons</TitleMedium>
+        <Row>
+          <FilterChip
+            label='With Icon'
+            icon={<MaterialIcon icon='star' size={18} />}
+            selected={false}
+          />
+          <FilterChip
+            label='Selected with Icon'
+            icon={<MaterialIcon icon='star' size={18} />}
+            selected={true}
+          />
+          <FilterChip label='Selected (auto checkmark)' selected={true} />
+        </Row>
+
+        <TitleMedium>Game Source Filter Example</TitleMedium>
+        <Row>
+          <FilterChip
+            label='Ranked'
+            icon={<MaterialIcon icon='trophy' size={18} />}
+            selected={selectedChips.has('ranked-example')}
+            onClick={() => toggleChip('ranked-example')}
+          />
+          <FilterChip
+            label='Custom'
+            icon={<MaterialIcon icon='groups' size={18} />}
+            selected={selectedChips.has('custom-example')}
+            onClick={() => toggleChip('custom-example')}
+          />
+        </Row>
+
+        <TitleMedium>Filter Chips with Menu</TitleMedium>
+        <Row>
+          <FilterChip label={SORT_LABELS[sortOption]} icon={<MaterialIcon icon='sort' size={18} />}>
+            {SORT_OPTIONS.map(option => (
+              <SelectableMenuItem
+                key={option}
+                text={SORT_LABELS[option]}
+                selected={sortOption === option}
+                onClick={() => setSortOption(option)}
+              />
+            ))}
+          </FilterChip>
+
+          <FilterChip
+            label={DURATION_LABELS[durationOption]}
+            icon={<MaterialIcon icon='schedule' size={18} />}>
+            {DURATION_OPTIONS.map(option => (
+              <SelectableMenuItem
+                key={option}
+                text={DURATION_LABELS[option]}
+                selected={durationOption === option}
+                onClick={() => setDurationOption(option)}
+              />
+            ))}
+          </FilterChip>
+        </Row>
+
+        <TitleMedium>Filter Chip with Menu (disabled)</TitleMedium>
+        <Row>
+          <FilterChip label='Disabled chip' disabled={true}>
+            <SelectableMenuItem text='Option 1' selected={true} onClick={() => {}} />
+            <SelectableMenuItem text='Option 2' selected={false} onClick={() => {}} />
+          </FilterChip>
+        </Row>
+      </StyledCard>
+    </CenteredContentContainer>
+  )
+}

--- a/client/material/devonly/routes.tsx
+++ b/client/material/devonly/routes.tsx
@@ -1,5 +1,6 @@
 import { Link, Route, Switch } from 'wouter'
 import { ButtonsTest } from './buttons-test'
+import { ChipTest } from './chip-test'
 import { MenuTest } from './menu-test'
 import DevPopover from './popover-test'
 import { RadioTest } from './radio-test'
@@ -17,6 +18,9 @@ function DevMaterialDashboard() {
     <ul>
       <li>
         <Link href={`${BASE_URL}/button`}>Button component</Link>
+      </li>
+      <li>
+        <Link href={`${BASE_URL}/chip`}>Chip component</Link>
       </li>
       <li>
         <Link href={`${BASE_URL}/menu`}>Menu component</Link>
@@ -53,6 +57,7 @@ export default function DevMaterialRoutes() {
   return (
     <Switch>
       <Route path={`${BASE_URL}/button`} component={ButtonsTest} />
+      <Route path={`${BASE_URL}/chip`} component={ChipTest} />
       <Route path={`${BASE_URL}/menu`} component={MenuTest} />
       <Route path={`${BASE_URL}/popover`} component={DevPopover} />
       <Route path={`${BASE_URL}/radio`} component={RadioTest} />

--- a/client/material/filter-chip.tsx
+++ b/client/material/filter-chip.tsx
@@ -1,0 +1,204 @@
+import * as React from 'react'
+import styled from 'styled-components'
+import { MaterialIcon } from '../icons/material/material-icon'
+import { useMultiplexRef } from '../react/refs'
+import { labelLarge } from '../styles/typography'
+import { useButtonState } from './button'
+import { buttonReset } from './button-reset'
+import { fastOutSlowInShort } from './curves'
+import { MenuList } from './menu/menu'
+import { isMenuItem } from './menu/menu-item-symbol'
+import { Popover, usePopoverController, useRefAnchorPosition } from './popover'
+import { Ripple } from './ripple'
+
+const ICON_SIZE = 18
+
+const FilterChipRoot = styled.button<{
+  $highlighted: boolean
+  $hasLeadingIcon: boolean
+  $hasTrailingIcon: boolean
+}>`
+  ${buttonReset};
+  ${fastOutSlowInShort};
+
+  height: 32px;
+  padding-left: ${props => (props.$hasLeadingIcon ? '8px' : '16px')};
+  padding-right: ${props => (props.$hasTrailingIcon ? '8px' : '16px')};
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+
+  border-radius: 8px;
+  contain: content;
+
+  background-color: ${props =>
+    props.$highlighted ? 'rgb(from var(--theme-primary) r g b / 0.16)' : 'transparent'};
+  border: 1px solid
+    ${props =>
+      props.$highlighted ? 'rgb(from var(--theme-primary) r g b / 0.5)' : 'var(--theme-outline)'};
+  color: ${props => (props.$highlighted ? 'var(--color-blue80)' : 'var(--theme-on-surface)')};
+  outline-color: var(--theme-grey-blue);
+
+  --sb-ripple-color: ${props =>
+    props.$highlighted ? 'var(--theme-primary)' : 'var(--theme-on-surface)'};
+
+  &:hover {
+    background-color: ${props =>
+      props.$highlighted
+        ? 'rgb(from var(--theme-primary) r g b / 0.24)'
+        : 'rgb(from var(--theme-on-surface) r g b / 0.08)'};
+  }
+
+  &:disabled,
+  &[disabled] {
+    background-color: rgb(from var(--theme-on-surface) r g b / 0.04);
+    border-color: rgb(from var(--theme-on-surface) r g b / 0.12);
+    color: rgb(from var(--theme-on-surface) r g b / var(--theme-disabled-opacity));
+    pointer-events: none;
+  }
+
+  &:focus-visible {
+    outline: 3px solid var(--theme-grey-blue);
+    outline-offset: 2px;
+  }
+`
+
+const ChipLabel = styled.span`
+  ${labelLarge};
+  white-space: nowrap;
+`
+
+const IconContainer = styled.span`
+  width: ${ICON_SIZE}px;
+  height: ${ICON_SIZE}px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`
+
+const DropdownIcon = styled(MaterialIcon)<{ $open: boolean }>`
+  ${fastOutSlowInShort};
+  transform: rotate(${props => (props.$open ? 180 : 0)}deg);
+`
+
+const StyledMenuList = styled(MenuList)`
+  --sb-menu-min-width: 112px;
+`
+
+export interface FilterChipProps {
+  /** The text label displayed on the chip. */
+  label: string
+  /** Whether the chip is selected. */
+  selected?: boolean
+  /** Whether the chip is disabled. */
+  disabled?: boolean
+  /**
+   * An optional icon to display at the start of the chip. If `selected` is true and no icon is
+   * provided, a checkmark icon will be shown.
+   */
+  icon?: React.ReactNode
+  /**
+   * Callback when the chip is clicked. Not really useful when `children` (menu items) are provided,
+   * since the chip will open the menu on click in that case.
+   */
+  onClick?: (event: React.MouseEvent) => void
+  /**
+   * Optional menu items to show in a dropdown. When provided, the chip will show a dropdown
+   * arrow and open a menu when clicked. Use `SelectableMenuItem` components as children.
+   */
+  children?: React.ReactNode
+  className?: string
+  testName?: string
+  ref?: React.Ref<HTMLButtonElement>
+}
+
+/**
+ * A Material Design 3 filter chip. Filter chips use tags or descriptive words to filter content.
+ * They can be selected or unselected, and can optionally display an icon.
+ *
+ * When `children` (menu items) are provided, the chip will show a dropdown arrow and open a
+ * menu when clicked, allowing selection from multiple options.
+ */
+export function FilterChip({
+  label,
+  selected = false,
+  icon,
+  className,
+  disabled,
+  onClick,
+  children,
+  testName,
+  ref,
+}: FilterChipProps) {
+  const [anchorRef, anchorX, anchorY, refreshAnchorPos] = useRefAnchorPosition<HTMLButtonElement>(
+    'left',
+    'bottom',
+  )
+  const [open, openPopover, closePopover] = usePopoverController({ refreshAnchorPos })
+
+  const composedRef = useMultiplexRef(ref, anchorRef)
+
+  const menuItems = React.Children.toArray(children).filter(child => isMenuItem(child))
+  const hasMenu = menuItems.length > 0
+
+  const [buttonProps, rippleRef] = useButtonState({
+    disabled,
+    onClick: (event: React.MouseEvent) => {
+      if (hasMenu) {
+        if (open) {
+          closePopover()
+        } else {
+          openPopover(event)
+        }
+      }
+      onClick?.(event)
+    },
+  })
+
+  const clonedMenuItems = menuItems.map((item, index) => {
+    return React.cloneElement(item, {
+      key: index,
+      onClick: event => {
+        item.props.onClick?.(event)
+        closePopover()
+      },
+    })
+  })
+
+  const showLeadingIcon = selected || icon
+  const leadingIcon = selected && !icon ? <MaterialIcon icon='check' size={ICON_SIZE} /> : icon
+  const isHighlighted = selected || (hasMenu && open)
+
+  return (
+    <>
+      <FilterChipRoot
+        ref={composedRef}
+        className={className}
+        $highlighted={isHighlighted}
+        $hasLeadingIcon={!!showLeadingIcon}
+        $hasTrailingIcon={hasMenu}
+        data-test={testName}
+        {...buttonProps}>
+        {showLeadingIcon ? <IconContainer>{leadingIcon}</IconContainer> : null}
+        <ChipLabel>{label}</ChipLabel>
+        {hasMenu ? <DropdownIcon icon='arrow_drop_down' size={ICON_SIZE} $open={open} /> : null}
+        <Ripple ref={rippleRef} disabled={disabled} />
+      </FilterChipRoot>
+
+      {hasMenu ? (
+        <Popover
+          open={open}
+          onDismiss={() => {
+            closePopover()
+          }}
+          anchorX={anchorX ?? 0}
+          anchorY={anchorY ?? 0}
+          originX='left'
+          originY='top'>
+          <StyledMenuList dense={true}>{clonedMenuItems}</StyledMenuList>
+        </Popover>
+      ) : null}
+    </>
+  )
+}

--- a/client/material/popover.tsx
+++ b/client/material/popover.tsx
@@ -428,11 +428,11 @@ export function PopoverContent({
  * @param originY which location to use for calculating the Y position within the anchor's
  *   bounding rect
  */
-export function useRefAnchorPosition(
+export function useRefAnchorPosition<T extends HTMLElement>(
   originX: OriginX,
   originY: OriginY,
 ): [
-  ref: (instance: HTMLElement | null) => void,
+  ref: (instance: T | null) => void,
   x: number | undefined,
   y: number | undefined,
   refresh: () => void,

--- a/client/users/action-creators.ts
+++ b/client/users/action-creators.ts
@@ -13,14 +13,15 @@ import {
   AdminGetUserIpsResponse,
   AdminUpdatePermissionsRequest,
   GetBatchUserInfoResponse,
+  GetMatchHistoryQueryParams,
+  GetMatchHistoryResponse,
   GetUserProfileResponse,
   GetUserRankingHistoryResponse,
-  SearchMatchHistoryResponse,
 } from '../../common/users/user-network'
 import { ThunkAction } from '../dispatch-registry'
 import logger from '../logging/logger'
 import { push, replace } from '../navigation/routing'
-import { RequestHandlingSpec, abortableThunk } from '../network/abortable-thunk'
+import { abortableThunk, RequestHandlingSpec } from '../network/abortable-thunk'
 import { MicrotaskBatchRequester } from '../network/batch-requests'
 import { encodeBodyAsParams, fetchJson } from '../network/fetch'
 import { RequestCoalescer } from '../network/request-coalescer'
@@ -108,21 +109,28 @@ export function getBatchUserInfo(userId: SbUserId): ThunkAction {
   }
 }
 
-export function searchMatchHistory(
+export function getMatchHistory(
   userId: SbUserId,
-  offset: number,
-  spec: RequestHandlingSpec<SearchMatchHistoryResponse>,
+  params: GetMatchHistoryQueryParams,
+  spec: RequestHandlingSpec<GetMatchHistoryResponse>,
 ): ThunkAction {
   return abortableThunk(spec, async dispatch => {
-    const result = await fetchJson<SearchMatchHistoryResponse>(
-      apiUrl`users/${userId}/match-history?offset=${offset}`,
+    const queryParams = new URLSearchParams()
+    for (const [key, value] of Object.entries(params)) {
+      if (value !== undefined && value !== '') {
+        queryParams.set(key, String(value))
+      }
+    }
+
+    const result = await fetchJson<GetMatchHistoryResponse>(
+      apiUrl`users/${userId}/match-history?${queryParams}`,
       {
         signal: spec.signal,
       },
     )
 
     dispatch({
-      type: '@users/searchMatchHistory',
+      type: '@users/getMatchHistory',
       payload: result,
       meta: { userId },
     })

--- a/client/users/actions.ts
+++ b/client/users/actions.ts
@@ -5,16 +5,16 @@ import {
   AdminGetBansResponse,
   AdminGetUserIpsResponse,
   GetBatchUserInfoResponse,
+  GetMatchHistoryResponse,
   GetUserProfileResponse,
   GetUserRankingHistoryResponse,
-  SearchMatchHistoryResponse,
 } from '../../common/users/user-network'
 
 export type UserActions =
   | GetUserProfile
   | GetBatchUserInfo
   | LoadUsers
-  | SearchMatchHistory
+  | GetMatchHistory
   | AdminGetUserBanHistory
   | AdminBanUser
   | AdminGetUserIps
@@ -48,9 +48,9 @@ export interface LoadUsers {
   payload: SbUser[]
 }
 
-export interface SearchMatchHistory {
-  type: '@users/searchMatchHistory'
-  payload: SearchMatchHistoryResponse
+export interface GetMatchHistory {
+  type: '@users/getMatchHistory'
+  payload: GetMatchHistoryResponse
   meta: { userId: SbUserId }
 }
 

--- a/client/users/match-history.tsx
+++ b/client/users/match-history.tsx
@@ -1,10 +1,19 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
+import {
+  ALL_GAME_FORMATS,
+  EncodedMatchupString,
+  GameDurationFilter,
+  GameFormat,
+  GameSortOption,
+  makeEncodedMatchupString,
+} from '../../common/games/game-filters'
 import { GameRecordJson, getGameDurationString, getGameTypeLabel } from '../../common/games/games'
-import { ReconciledResult, getResultLabel } from '../../common/games/results'
+import { getResultLabel, ReconciledResult } from '../../common/games/results'
 import { SbUserId } from '../../common/users/sb-user-id'
 import { navigateToGameResults } from '../games/action-creators'
+import { GameFilterBar } from '../games/game-filter-bar'
 import { GamePlayersDisplay } from '../games/game-players-display'
 import { longTimestamp, narrowDuration } from '../i18n/date-formats'
 import { MaterialIcon } from '../icons/material/material-icon'
@@ -15,7 +24,8 @@ import { buttonReset } from '../material/button-reset'
 import { Ripple } from '../material/ripple'
 import { elevationPlus1 } from '../material/shadows'
 import { Tooltip } from '../material/tooltip'
-import { useStableCallback } from '../react/state-hooks'
+import { useLocationSearchParam } from '../navigation/router-hooks'
+import { useRefreshToken } from '../network/refresh-token'
 import { useAppDispatch, useAppSelector } from '../redux-hooks'
 import { styledWithAttrs } from '../styles/styled-with-attrs'
 import {
@@ -26,7 +36,7 @@ import {
   singleLine,
   titleSmall,
 } from '../styles/typography'
-import { searchMatchHistory } from './action-creators'
+import { getMatchHistory } from './action-creators'
 
 const NoResults = styled.div`
   ${bodyLarge};
@@ -40,70 +50,192 @@ const ErrorText = styled.div`
   color: var(--theme-error);
 `
 
-const SearchResults = styled.div`
+const MatchHistoryContainer = styled.div`
   width: 100%;
   padding: 0 24px;
 
   display: flex;
   flex-direction: column;
+  gap: 16px;
 `
+
+const SearchResults = styled.div`
+  width: 100%;
+
+  display: flex;
+  flex-direction: column;
+`
+
+function parseDuration(value: string): GameDurationFilter {
+  return Object.values(GameDurationFilter).includes(value as GameDurationFilter)
+    ? (value as GameDurationFilter)
+    : GameDurationFilter.All
+}
+
+function parseSort(value: string): GameSortOption {
+  return Object.values(GameSortOption).includes(value as GameSortOption)
+    ? (value as GameSortOption)
+    : GameSortOption.LatestFirst
+}
+
+function parseFormat(value: string): GameFormat | undefined {
+  return ALL_GAME_FORMATS.includes(value as GameFormat) ? (value as GameFormat) : undefined
+}
+
+function parseMatchup(value: string): EncodedMatchupString | undefined {
+  return value ? makeEncodedMatchupString(value) : undefined
+}
 
 export function ConnectedMatchHistory({ userId }: { userId: SbUserId }) {
   const { t } = useTranslation()
   const dispatch = useAppDispatch()
 
-  const [games, setGames] = useState<GameRecordJson[]>()
-  const [hasMoreGames, setHasMoreGames] = useState(true)
+  const [rankedParam, setRankedParam] = useLocationSearchParam('ranked')
+  const [customParam, setCustomParam] = useLocationSearchParam('custom')
+  const [durationParam, setDurationParam] = useLocationSearchParam('duration')
+  const [sortParam, setSortParam] = useLocationSearchParam('sort')
+  const [mapName, setMapNameParam] = useLocationSearchParam('mapName')
+  const [playerName, setPlayerNameParam] = useLocationSearchParam('playerName')
+  const [formatParam, setFormatParam] = useLocationSearchParam('format')
+  const [matchupParam, setMatchupParam] = useLocationSearchParam('matchup')
 
+  const ranked = rankedParam === 'true'
+  const custom = customParam === 'true'
+  const duration = parseDuration(durationParam)
+  const sort = parseSort(sortParam)
+  const format = parseFormat(formatParam)
+  const matchup = parseMatchup(matchupParam)
+
+  const [gameIds, setGameIds] = useState<string[]>()
+  const [hasMoreGames, setHasMoreGames] = useState(true)
   const [isLoadingMoreGames, setIsLoadingMoreGames] = useState(false)
   const [searchError, setSearchError] = useState<Error>()
   const abortControllerRef = useRef<AbortController>(undefined)
+  const [refreshToken, triggerRefresh] = useRefreshToken()
 
-  const onLoadMoreGames = useStableCallback(() => {
+  const games = useAppSelector(
+    s =>
+      gameIds
+        ?.map(id => s.games.byId.get(id))
+        .filter((g): g is GameRecordJson => g !== undefined) ?? [],
+  )
+
+  const reset = () => {
+    abortControllerRef.current?.abort()
+    setGameIds(undefined)
+    setHasMoreGames(true)
+    setIsLoadingMoreGames(false)
+    setSearchError(undefined)
+    triggerRefresh()
+  }
+
+  const onLoadMoreGames = () => {
     setIsLoadingMoreGames(true)
 
     abortControllerRef.current?.abort()
     abortControllerRef.current = new AbortController()
 
     dispatch(
-      searchMatchHistory(userId, games?.length ?? 0, {
-        signal: abortControllerRef.current.signal,
-        onSuccess: data => {
-          setIsLoadingMoreGames(false)
-          setGames((games ?? []).concat(data.games))
-          setHasMoreGames(data.hasMoreGames)
+      getMatchHistory(
+        userId,
+        {
+          ranked: ranked || undefined,
+          custom: custom || undefined,
+          duration: duration === GameDurationFilter.All ? undefined : duration,
+          sort: sort === GameSortOption.LatestFirst ? undefined : sort,
+          mapName: mapName || undefined,
+          playerName: playerName || undefined,
+          format,
+          matchup: matchup ? makeEncodedMatchupString(matchup) : undefined,
+          offset: gameIds?.length ?? 0,
         },
-        onError: err => {
-          setIsLoadingMoreGames(false)
-          setSearchError(err)
+        {
+          signal: abortControllerRef.current.signal,
+          onSuccess: data => {
+            setIsLoadingMoreGames(false)
+            setGameIds(prev => (prev ?? []).concat(data.games.map(g => g.id)))
+            setHasMoreGames(data.hasMoreGames)
+            setSearchError(undefined)
+          },
+          onError: err => {
+            setIsLoadingMoreGames(false)
+            setSearchError(err)
+          },
         },
-      }),
+      ),
     )
-  })
+  }
 
   useEffect(() => {
     return () => abortControllerRef.current?.abort()
   }, [])
 
+  const filterBar = (
+    <GameFilterBar
+      ranked={ranked}
+      setRanked={v => {
+        setRankedParam(v ? 'true' : '')
+        reset()
+      }}
+      custom={custom}
+      setCustom={v => {
+        setCustomParam(v ? 'true' : '')
+        reset()
+      }}
+      duration={duration}
+      setDuration={v => {
+        setDurationParam(v === GameDurationFilter.All ? '' : v)
+        reset()
+      }}
+      sort={sort}
+      setSort={v => {
+        setSortParam(v === GameSortOption.LatestFirst ? '' : v)
+        reset()
+      }}
+      mapName={mapName}
+      setMapName={v => {
+        setMapNameParam(v)
+        reset()
+      }}
+      playerName={playerName}
+      setPlayerName={v => {
+        setPlayerNameParam(v)
+        reset()
+      }}
+      format={format}
+      setFormat={v => {
+        setFormatParam(v ?? '')
+        reset()
+      }}
+      matchup={matchup}
+      setMatchup={v => {
+        setMatchupParam(v ?? '')
+        reset()
+      }}
+    />
+  )
+
   if (searchError) {
     return (
-      <SearchResults>
+      <MatchHistoryContainer>
+        {filterBar}
         <ErrorText>
           {t(
             'user.matchHistory.retrievingError',
             'There was an error retrieving the match history.',
           )}
         </ErrorText>
-      </SearchResults>
+      </MatchHistoryContainer>
     )
-  } else if (games?.length === 0) {
+  } else if (gameIds?.length === 0) {
     return (
-      <SearchResults>
+      <MatchHistoryContainer>
+        {filterBar}
         <NoResults>{t('user.matchHistory.noMatchingGames', 'No matching games.')}</NoResults>
-      </SearchResults>
+      </MatchHistoryContainer>
     )
   } else {
-    const gameItems = (games ?? []).map(game => (
+    const gameItems = games.map(game => (
       <MatchHistoryEntry key={game.id} forUserId={userId} game={game} />
     ))
 
@@ -112,8 +244,12 @@ export function ConnectedMatchHistory({ userId }: { userId: SbUserId }) {
         nextLoadingEnabled={true}
         isLoadingNext={isLoadingMoreGames}
         hasNextData={hasMoreGames}
+        refreshToken={refreshToken}
         onLoadNextData={onLoadMoreGames}>
-        <SearchResults>{gameItems}</SearchResults>
+        <MatchHistoryContainer>
+          {filterBar}
+          <SearchResults>{gameItems}</SearchResults>
+        </MatchHistoryContainer>
       </InfiniteScrollList>
     )
   }
@@ -243,10 +379,9 @@ function MatchHistoryEntry({ forUserId, game }: { forUserId: SbUserId; game: Gam
   const { t } = useTranslation()
   const map = useAppSelector(s => s.maps.byId.get(game.mapId))
 
-  const onClick = useStableCallback(() => {
-    navigateToGameResults(game.id)
+  const [buttonProps, rippleRef] = useButtonState({
+    onClick: () => navigateToGameResults(game.id),
   })
-  const [buttonProps, rippleRef] = useButtonState({ onClick })
 
   const { results, startTime } = game
   const result = useMemo(() => {

--- a/client/users/match-history.tsx
+++ b/client/users/match-history.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 import {
   ALL_GAME_FORMATS,
+  decodeMatchup,
   EncodedMatchupString,
   GameDurationFilter,
   GameFormat,
@@ -82,8 +83,18 @@ function parseFormat(value: string): GameFormat | undefined {
   return ALL_GAME_FORMATS.includes(value as GameFormat) ? (value as GameFormat) : undefined
 }
 
-function parseMatchup(value: string): EncodedMatchupString | undefined {
-  return value ? makeEncodedMatchupString(value) : undefined
+function parseMatchup(
+  value: string,
+  format: GameFormat | undefined,
+): EncodedMatchupString | undefined {
+  if (!value || !format) {
+    return undefined
+  }
+  // Only keep the matchup if it actually decodes for the current format. This mirrors what the
+  // server does and means a hand-edited URL (e.g. `?matchup=foo`) gets ignored rather than sent
+  // along to fail server-side validation and show the user a generic error screen.
+  const encoded = makeEncodedMatchupString(value)
+  return decodeMatchup(format, encoded) ? encoded : undefined
 }
 
 export function ConnectedMatchHistory({ userId }: { userId: SbUserId }) {
@@ -104,7 +115,7 @@ export function ConnectedMatchHistory({ userId }: { userId: SbUserId }) {
   const duration = parseDuration(durationParam)
   const sort = parseSort(sortParam)
   const format = parseFormat(formatParam)
-  const matchup = parseMatchup(matchupParam)
+  const matchup = parseMatchup(matchupParam, format)
 
   const [gameIds, setGameIds] = useState<string[]>()
   const [hasMoreGames, setHasMoreGames] = useState(true)
@@ -146,7 +157,7 @@ export function ConnectedMatchHistory({ userId }: { userId: SbUserId }) {
           mapName: mapName || undefined,
           playerName: playerName || undefined,
           format,
-          matchup: matchup ? makeEncodedMatchupString(matchup) : undefined,
+          matchup,
           offset: gameIds?.length ?? 0,
         },
         {

--- a/client/users/match-history.tsx
+++ b/client/users/match-history.tsx
@@ -216,6 +216,9 @@ export function ConnectedMatchHistory({ userId }: { userId: SbUserId }) {
       format={format}
       setFormat={v => {
         setFormatParam(v ?? '')
+        // A matchup is tied to a specific format (team size), so any existing value no longer
+        // applies once the format changes. Clear it so it doesn't linger in the URL as cruft.
+        setMatchupParam('')
         reset()
       }}
       matchup={matchup}

--- a/client/users/user-reducer.ts
+++ b/client/users/user-reducer.ts
@@ -146,7 +146,7 @@ export default immerKeyedReducer(DEFAULT_STATE, {
     state.idToMatchHistory.set(user.id, matchHistory.games)
   },
 
-  ['@users/searchMatchHistory'](state, { payload: { users } }) {
+  ['@users/getMatchHistory'](state, { payload: { users } }) {
     updateUsers(state, users)
   },
 

--- a/common/games/game-filters.test.ts
+++ b/common/games/game-filters.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, test } from 'vitest'
+import {
+  createEmptyMatchup,
+  decodeMatchup,
+  encodeMatchup,
+  GameFormat,
+  getTeamSizeForFormat,
+  makeEncodedMatchupString,
+  MatchupFilter,
+} from './game-filters'
+
+describe('getTeamSizeForFormat', () => {
+  test('maps each format to its team size', () => {
+    expect(getTeamSizeForFormat('1v1')).toBe(1)
+    expect(getTeamSizeForFormat('2v2')).toBe(2)
+    expect(getTeamSizeForFormat('3v3')).toBe(3)
+    expect(getTeamSizeForFormat('4v4')).toBe(4)
+  })
+})
+
+describe('createEmptyMatchup', () => {
+  test('fills both teams with wildcards sized to the format', () => {
+    expect(createEmptyMatchup('1v1')).toEqual({ team1: [undefined], team2: [undefined] })
+    expect(createEmptyMatchup('2v2')).toEqual({
+      team1: [undefined, undefined],
+      team2: [undefined, undefined],
+    })
+  })
+
+  test('round-trips through encode/decode as an all-wildcard string', () => {
+    for (const format of ['1v1', '2v2', '3v3', '4v4'] as GameFormat[]) {
+      const empty = createEmptyMatchup(format)
+      expect(decodeMatchup(format, encodeMatchup(empty))).toEqual(empty)
+    }
+  })
+})
+
+describe('encodeMatchup', () => {
+  test('encodes races and wildcards joined by a dash', () => {
+    expect(encodeMatchup({ team1: ['p'], team2: ['z'] })).toBe('p-z')
+    expect(encodeMatchup({ team1: [undefined], team2: ['z'] })).toBe('_-z')
+    expect(encodeMatchup({ team1: ['p', 't'], team2: ['z', undefined] })).toBe('pt-z_')
+  })
+})
+
+describe('decodeMatchup', () => {
+  test('returns undefined for a missing string', () => {
+    expect(decodeMatchup('1v1', undefined)).toBeUndefined()
+    expect(decodeMatchup('1v1', makeEncodedMatchupString(''))).toBeUndefined()
+  })
+
+  test('decodes races and wildcards', () => {
+    expect(decodeMatchup('1v1', makeEncodedMatchupString('p-z'))).toEqual({
+      team1: ['p'],
+      team2: ['z'],
+    })
+    expect(decodeMatchup('1v1', makeEncodedMatchupString('_-z'))).toEqual({
+      team1: [undefined],
+      team2: ['z'],
+    })
+    expect(decodeMatchup('2v2', makeEncodedMatchupString('pt-z_'))).toEqual({
+      team1: ['p', 't'],
+      team2: ['z', undefined],
+    })
+  })
+
+  test('returns undefined when there are not exactly two teams', () => {
+    expect(decodeMatchup('1v1', makeEncodedMatchupString('p'))).toBeUndefined()
+    expect(decodeMatchup('1v1', makeEncodedMatchupString('p-z-t'))).toBeUndefined()
+  })
+
+  test('returns undefined when a team length does not match the format', () => {
+    // 1v1 expects one race per team
+    expect(decodeMatchup('1v1', makeEncodedMatchupString('pt-z'))).toBeUndefined()
+    // 2v2 expects two races per team
+    expect(decodeMatchup('2v2', makeEncodedMatchupString('p-z'))).toBeUndefined()
+    expect(decodeMatchup('2v2', makeEncodedMatchupString('ptz-zz'))).toBeUndefined()
+  })
+
+  test('returns undefined for invalid race characters', () => {
+    // 'r' (random) is not a valid assigned race in a matchup
+    expect(decodeMatchup('1v1', makeEncodedMatchupString('r-z'))).toBeUndefined()
+    expect(decodeMatchup('1v1', makeEncodedMatchupString('x-z'))).toBeUndefined()
+    expect(decodeMatchup('1v1', makeEncodedMatchupString('P-z'))).toBeUndefined()
+  })
+
+  test('round-trips arbitrary valid matchups', () => {
+    const cases: Array<[GameFormat, MatchupFilter]> = [
+      ['1v1', { team1: ['p'], team2: ['z'] }],
+      ['1v1', { team1: [undefined], team2: [undefined] }],
+      ['2v2', { team1: ['p', 'z'], team2: ['t', undefined] }],
+      ['3v3', { team1: ['p', undefined, 'z'], team2: ['t', 't', undefined] }],
+    ]
+    for (const [format, matchup] of cases) {
+      expect(decodeMatchup(format, encodeMatchup(matchup))).toEqual(matchup)
+    }
+  })
+})

--- a/common/games/game-filters.ts
+++ b/common/games/game-filters.ts
@@ -1,0 +1,170 @@
+import { TFunction } from 'i18next'
+import { Tagged } from 'type-fest'
+import { AssignedRaceChar } from '../races'
+
+/** Duration filter options. */
+export enum GameDurationFilter {
+  All = 'all',
+  Under10 = 'under10',
+  From10To20 = '10to20',
+  From20To30 = '20to30',
+  Over30 = 'over30',
+}
+
+export const getDurationLabel = (d: GameDurationFilter, t: TFunction): string => {
+  switch (d) {
+    case GameDurationFilter.All:
+      return t('game.filters.duration.all', 'All')
+    case GameDurationFilter.Under10:
+      return t('game.filters.duration.under10', 'Under 10min')
+    case GameDurationFilter.From10To20:
+      return t('game.filters.duration.10to20', '10-20min')
+    case GameDurationFilter.From20To30:
+      return t('game.filters.duration.20to30', '20-30min')
+    case GameDurationFilter.Over30:
+      return t('game.filters.duration.over30', 'Over 30min')
+    default:
+      return d satisfies never
+  }
+}
+
+/** Sort options for game lists. */
+export enum GameSortOption {
+  LatestFirst = 'latest',
+  OldestFirst = 'oldest',
+  ShortestFirst = 'shortest',
+  LongestFirst = 'longest',
+}
+
+export const getSortLabel = (s: GameSortOption, t: TFunction): string => {
+  switch (s) {
+    case GameSortOption.LatestFirst:
+      return t('game.filters.sort.latest', 'Latest first')
+    case GameSortOption.OldestFirst:
+      return t('game.filters.sort.oldest', 'Oldest first')
+    case GameSortOption.ShortestFirst:
+      return t('game.filters.sort.shortest', 'Shortest first')
+    case GameSortOption.LongestFirst:
+      return t('game.filters.sort.longest', 'Longest first')
+    default:
+      return s satisfies never
+  }
+}
+
+/** Game format (team size). */
+export type GameFormat = '1v1' | '2v2' | '3v3' | '4v4'
+
+export const ALL_GAME_FORMATS: ReadonlyArray<GameFormat> = ['1v1', '2v2', '3v3', '4v4']
+
+/**
+ * A URL-friendly encoded matchup string, e.g. `'p_-_z'`, `'pt-tz'`. Uses `_` for wildcard slots
+ * (any race). Distinct from `MatchupString` which is the canonical form without wildcards.
+ */
+export type EncodedMatchupString = Tagged<string, 'EncodedMatchupString'>
+
+/**
+ * Converts a string to a properly typed `EncodedMatchupString`. Prefer better ways of getting a
+ * typed version, such as encoding via `encodeMatchup`. This method should mainly be considered for
+ * testing and internal behavior.
+ */
+export function makeEncodedMatchupString(s: string): EncodedMatchupString {
+  return s as EncodedMatchupString
+}
+
+/** Matchup race filter - undefined means wildcard (any race). */
+export type MatchupRaceSlot = AssignedRaceChar | undefined
+
+/** Team races in a matchup (length = team size). */
+export type TeamRaces = MatchupRaceSlot[]
+
+/** Full matchup filter with both teams. */
+export interface MatchupFilter {
+  team1: TeamRaces
+  team2: TeamRaces
+}
+
+/**
+ * Returns the team size for a given game format.
+ */
+export function getTeamSizeForFormat(format: GameFormat): number {
+  switch (format) {
+    case '1v1':
+      return 1
+    case '2v2':
+      return 2
+    case '3v3':
+      return 3
+    case '4v4':
+      return 4
+    default:
+      return format satisfies never
+  }
+}
+
+/**
+ * Creates an empty matchup filter for a given format with all slots set to undefined (any race).
+ */
+export function createEmptyMatchup(format: GameFormat): MatchupFilter {
+  const teamSize = getTeamSizeForFormat(format)
+  return {
+    team1: Array(teamSize).fill(undefined),
+    team2: Array(teamSize).fill(undefined),
+  }
+}
+
+/**
+ * Encodes a matchup filter to a URL-friendly string.
+ * Format: "ptz-ttz" where each character is a race or '_' for wildcard.
+ */
+export function encodeMatchup(matchup: MatchupFilter): EncodedMatchupString {
+  const encodeTeam = (team: TeamRaces): string => {
+    return team.map(r => r ?? '_').join('')
+  }
+  return makeEncodedMatchupString(`${encodeTeam(matchup.team1)}-${encodeTeam(matchup.team2)}`)
+}
+
+/**
+ * Decodes a matchup string for a given format back to a MatchupFilter.
+ * Returns undefined if the string is invalid or doesn't match the expected format.
+ */
+export function decodeMatchup(
+  format: GameFormat,
+  matchupStr?: EncodedMatchupString,
+): MatchupFilter | undefined {
+  if (!matchupStr) {
+    return undefined
+  }
+
+  const teamSize = getTeamSizeForFormat(format)
+  const parts = matchupStr.split('-')
+  if (parts.length !== 2) {
+    return undefined
+  }
+
+  const decodeTeam = (teamStr: string): TeamRaces | undefined => {
+    if (teamStr.length !== teamSize) {
+      return undefined
+    }
+
+    const races: TeamRaces = []
+    for (const char of teamStr) {
+      if (char === '_') {
+        races.push(undefined)
+      } else if (char === 'p' || char === 't' || char === 'z') {
+        races.push(char)
+      } else {
+        return undefined
+      }
+    }
+    return races
+  }
+
+  const team1 = decodeTeam(parts[0])
+  const team2 = decodeTeam(parts[1])
+
+  if (!team1 || !team2) {
+    return undefined
+  }
+
+  return { team1, team2 }
+}

--- a/common/games/games.ts
+++ b/common/games/games.ts
@@ -12,6 +12,7 @@ import {
 import { SbUser } from '../users/sb-user'
 import { SbUserId } from '../users/sb-user-id'
 import { GameConfig, GameSource } from './configuration'
+import { MatchupString } from './matchups'
 import { GameClientPlayerResult, ReconciledPlayerResult } from './results'
 
 export interface GameRecord {
@@ -24,6 +25,8 @@ export interface GameRecord {
   disputeReviewed: boolean
   gameLength: number | null
   results: [SbUserId, ReconciledPlayerResult][] | null
+  selectedMatchup: MatchupString | null
+  assignedMatchup: MatchupString | null
 }
 
 export type GameRecordJson = Jsonify<GameRecord>
@@ -91,6 +94,8 @@ export function toGameRecordJson(game: GameRecord): GameRecordJson {
     disputeReviewed: game.disputeReviewed,
     gameLength: game.gameLength,
     results: game.results,
+    selectedMatchup: game.selectedMatchup,
+    assignedMatchup: game.assignedMatchup,
   }
 }
 

--- a/common/games/matchups.test.ts
+++ b/common/games/matchups.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, test } from 'vitest'
+import { makeSbUserId } from '../users/sb-user-id'
+import { GameSource } from './configuration'
+import { GameType } from './game-type'
+import { computeMatchupString, expandMatchupFilter, getTeamsFromConfig } from './matchups'
+
+describe('computeMatchupString', () => {
+  test('canonicalizes 1v1 matchups', () => {
+    expect(computeMatchupString([['z'], ['p']])).toBe('p-z')
+    expect(computeMatchupString([['p'], ['z']])).toBe('p-z')
+    expect(computeMatchupString([['t'], ['t']])).toBe('t-t')
+  })
+
+  test('handles random race in selected matchup', () => {
+    expect(computeMatchupString([['r'], ['z']])).toBe('r-z')
+    expect(computeMatchupString([['z'], ['r']])).toBe('r-z')
+  })
+
+  test('canonicalizes 2v2 matchups', () => {
+    expect(
+      computeMatchupString([
+        ['p', 't'],
+        ['t', 'z'],
+      ]),
+    ).toBe('pt-tz')
+    expect(
+      computeMatchupString([
+        ['t', 'z'],
+        ['p', 't'],
+      ]),
+    ).toBe('pt-tz')
+    // Sorts races within team
+    expect(
+      computeMatchupString([
+        ['t', 'p'],
+        ['z', 't'],
+      ]),
+    ).toBe('pt-tz')
+  })
+
+  test('canonicalizes 3v3 matchups', () => {
+    expect(
+      computeMatchupString([
+        ['z', 'p', 't'],
+        ['t', 'z', 'p'],
+      ]),
+    ).toBe('ptz-ptz')
+  })
+
+  test('returns null for invalid inputs', () => {
+    expect(computeMatchupString([])).toBe(null)
+    expect(computeMatchupString([['p']])).toBe(null)
+    expect(computeMatchupString([[], ['p']])).toBe(null)
+    expect(computeMatchupString([['p'], []])).toBe(null)
+  })
+})
+
+describe('getTeamsFromConfig', () => {
+  test('returns teams as-is for multi-team configs', () => {
+    const config = {
+      gameSource: GameSource.Matchmaking as const,
+      gameSourceExtra: { type: 'match2v2' as any },
+      gameType: GameType.Melee,
+      gameSubType: 0,
+      teams: [
+        [
+          { id: makeSbUserId(1), race: 'p' as const, isComputer: false },
+          { id: makeSbUserId(2), race: 't' as const, isComputer: false },
+        ],
+        [
+          { id: makeSbUserId(3), race: 'z' as const, isComputer: false },
+          { id: makeSbUserId(4), race: 'p' as const, isComputer: false },
+        ],
+      ],
+    }
+
+    const result = getTeamsFromConfig(config)
+    expect(result).toBe(config.teams)
+  })
+
+  test('splits 1-team-of-2 into two teams', () => {
+    const p1 = { id: makeSbUserId(1), race: 'p' as const, isComputer: false }
+    const p2 = { id: makeSbUserId(2), race: 'z' as const, isComputer: false }
+    const config = {
+      gameSource: GameSource.Lobby as const,
+      gameType: GameType.Melee,
+      gameSubType: 0,
+      teams: [[p1, p2]],
+    }
+
+    const result = getTeamsFromConfig(config)
+    expect(result).toEqual([[p1], [p2]])
+  })
+
+  test('returns null for Melee with >2 players', () => {
+    const config = {
+      gameSource: GameSource.Lobby as const,
+      gameType: GameType.Melee,
+      gameSubType: 0,
+      teams: [
+        [
+          { id: makeSbUserId(1), race: 'p' as const, isComputer: false },
+          { id: makeSbUserId(2), race: 't' as const, isComputer: false },
+          { id: makeSbUserId(3), race: 'z' as const, isComputer: false },
+        ],
+      ],
+    }
+
+    expect(getTeamsFromConfig(config)).toBe(null)
+  })
+
+  test('returns null for empty teams', () => {
+    const config = {
+      gameSource: GameSource.Lobby as const,
+      gameType: GameType.Melee,
+      gameSubType: 0,
+      teams: [],
+    }
+
+    expect(getTeamsFromConfig(config)).toBe(null)
+  })
+})
+
+describe('expandMatchupFilter', () => {
+  test('returns exact match for fully specified matchup', () => {
+    const result = expandMatchupFilter({
+      team1: ['p'],
+      team2: ['z'],
+    })
+    expect(result).toEqual(['p-z'])
+  })
+
+  test('expands single wildcard', () => {
+    const result = expandMatchupFilter({
+      team1: ['p'],
+      team2: [undefined],
+    })
+    expect(result.sort()).toEqual(['p-p', 'p-t', 'p-z'])
+  })
+
+  test('expands all wildcards for 1v1', () => {
+    const result = expandMatchupFilter({
+      team1: [undefined],
+      team2: [undefined],
+    })
+    // Should have 6 unique canonical matchups: pp, pt, pz, tt, tz, zz
+    expect(result.sort()).toEqual(['p-p', 'p-t', 'p-z', 't-t', 't-z', 'z-z'])
+  })
+
+  test('handles symmetry correctly', () => {
+    // p vs z and z vs p should produce the same canonical string
+    const result1 = expandMatchupFilter({ team1: ['p'], team2: ['z'] })
+    const result2 = expandMatchupFilter({ team1: ['z'], team2: ['p'] })
+    expect(result1).toEqual(result2)
+  })
+
+  test('expands 2v2 matchup with wildcards', () => {
+    const result = expandMatchupFilter({
+      team1: ['p', undefined],
+      team2: ['z', 't'],
+    })
+    // Team1 could be pp, pt, pz; Team2 is tz
+    // Canonicalized: pp-tz, pt-tz, pz-tz
+    expect(result.sort()).toEqual(['pp-tz', 'pt-tz', 'pz-tz'])
+  })
+
+  test('deduplicates symmetric 2v2 matchups', () => {
+    const result = expandMatchupFilter({
+      team1: ['p', 't'],
+      team2: ['p', 't'],
+    })
+    expect(result).toEqual(['pt-pt'])
+  })
+})

--- a/common/games/matchups.test.ts
+++ b/common/games/matchups.test.ts
@@ -75,7 +75,43 @@ describe('getTeamsFromConfig', () => {
     }
 
     const result = getTeamsFromConfig(config)
-    expect(result).toBe(config.teams)
+    expect(result).toEqual(config.teams)
+  })
+
+  test('ignores empty teams in multi-team configs', () => {
+    const config = {
+      gameSource: GameSource.Lobby as const,
+      gameType: GameType.Melee,
+      gameSubType: 0,
+      teams: [
+        [
+          { id: makeSbUserId(1), race: 'p' as const, isComputer: false },
+          { id: makeSbUserId(2), race: 't' as const, isComputer: false },
+        ],
+        [
+          { id: makeSbUserId(3), race: 'z' as const, isComputer: false },
+          { id: makeSbUserId(4), race: 'p' as const, isComputer: false },
+        ],
+        // Empty observer team
+        [],
+      ],
+    }
+
+    expect(getTeamsFromConfig(config)).toEqual([config.teams[0], config.teams[1]])
+  })
+
+  test('splits a single 2-player team when the only other team is empty (melee with observers)', () => {
+    const p1 = { id: makeSbUserId(1), race: 'p' as const, isComputer: false }
+    const p2 = { id: makeSbUserId(2), race: 'z' as const, isComputer: false }
+    const config = {
+      gameSource: GameSource.Lobby as const,
+      gameType: GameType.Melee,
+      gameSubType: 0,
+      // 1v1 melee lobby with an (empty) observer team
+      teams: [[p1, p2], []],
+    }
+
+    expect(getTeamsFromConfig(config)).toEqual([[p1], [p2]])
   })
 
   test('splits 1-team-of-2 into two teams', () => {

--- a/common/games/matchups.ts
+++ b/common/games/matchups.ts
@@ -1,0 +1,111 @@
+import { Tagged } from 'type-fest'
+import { ALL_ASSIGNED_RACE_CHARS, AssignedRaceChar, RaceChar } from '../races'
+import { GameConfig, GameConfigPlayer } from './configuration'
+import { MatchupFilter } from './game-filters'
+
+/** A canonical matchup string, e.g. `'p-z'`, `'pt-tz'`. */
+export type MatchupString = Tagged<string, 'MatchupString'>
+
+/**
+ * Converts a string to a properly typed `MatchupString`. Prefer better ways of getting a typed
+ * version, such as computing it via `computeMatchupString`. This method should mainly be considered
+ * for testing and internal behavior.
+ */
+export function makeMatchupString(s: string): MatchupString {
+  return s as MatchupString
+}
+
+/**
+ * Computes a canonical matchup string from an array of team race arrays.
+ * Races within each team are sorted alphabetically, then teams are sorted lexicographically,
+ * and joined with '-'.
+ *
+ * @example
+ * computeMatchupString([['z'], ['p']]) // => 'p-z'
+ * computeMatchupString([['p', 't'], ['t', 'z']]) // => 'pt-tz'
+ *
+ * @returns the canonical matchup string, or `null` if the input is invalid
+ */
+export function computeMatchupString(teamRaces: RaceChar[][]): MatchupString | null {
+  if (teamRaces.length < 2) {
+    return null
+  }
+
+  for (const team of teamRaces) {
+    if (team.length === 0) {
+      return null
+    }
+  }
+
+  const sortedTeams = teamRaces.map(team => [...team].sort().join(''))
+  sortedTeams.sort()
+
+  return makeMatchupString(sortedTeams.join('-'))
+}
+
+/**
+ * Extracts team arrays from a game config in a way that allows matchup computation.
+ *
+ * - For configs with 2+ team arrays: returns them as-is
+ * - For configs with 1 team array of exactly 2 players: splits into [[p1], [p2]]
+ * - For configs with 1 team array of >2 players: returns `null` (Melee, can't determine teams)
+ */
+export function getTeamsFromConfig(config: GameConfig): GameConfigPlayer[][] | null {
+  if (config.teams.length >= 2) {
+    return config.teams
+  }
+
+  if (config.teams.length === 1) {
+    if (config.teams[0].length === 2) {
+      return [[config.teams[0][0]], [config.teams[0][1]]]
+    }
+    // Melee with >2 players - can't determine teams
+    return null
+  }
+
+  return null
+}
+
+/**
+ * Expands a matchup filter (which may contain `undefined` wildcard slots) into all possible
+ * canonical matchup strings.
+ *
+ * For each team, replaces `undefined` slots with each of 'p', 't', 'z', computes the cartesian
+ * product, canonicalizes each combination, and deduplicates.
+ *
+ * @returns the list of all matching canonical matchup strings
+ */
+export function expandMatchupFilter(matchup: MatchupFilter): MatchupString[] {
+  const expandTeam = (team: (AssignedRaceChar | undefined)[]): AssignedRaceChar[][] => {
+    let combinations: AssignedRaceChar[][] = [[]]
+    for (const slot of team) {
+      const races = slot !== undefined ? [slot] : ALL_ASSIGNED_RACE_CHARS
+      const newCombinations: AssignedRaceChar[][] = []
+      for (const combo of combinations) {
+        for (const race of races) {
+          newCombinations.push([...combo, race])
+        }
+      }
+      combinations = newCombinations
+    }
+    return combinations
+  }
+
+  const team1Combos = expandTeam(matchup.team1)
+  const team2Combos = expandTeam(matchup.team2)
+
+  const seen = new Set<MatchupString>()
+  const result: MatchupString[] = []
+
+  for (const t1 of team1Combos) {
+    for (const t2 of team2Combos) {
+      const matchupStr = computeMatchupString([t1, t2])
+      if (matchupStr && !seen.has(matchupStr)) {
+        seen.add(matchupStr)
+        result.push(matchupStr)
+      }
+    }
+  }
+
+  return result
+}

--- a/common/games/matchups.ts
+++ b/common/games/matchups.ts
@@ -46,18 +46,23 @@ export function computeMatchupString(teamRaces: RaceChar[][]): MatchupString | n
 /**
  * Extracts team arrays from a game config in a way that allows matchup computation.
  *
+ * Empty teams are ignored first: some configs include them (e.g. an observer team in a melee lobby
+ * with observers enabled gets serialized as an empty array). After filtering:
+ *
  * - For configs with 2+ team arrays: returns them as-is
  * - For configs with 1 team array of exactly 2 players: splits into [[p1], [p2]]
  * - For configs with 1 team array of >2 players: returns `null` (Melee, can't determine teams)
  */
 export function getTeamsFromConfig(config: GameConfig): GameConfigPlayer[][] | null {
-  if (config.teams.length >= 2) {
-    return config.teams
+  const teams = config.teams.filter(team => team.length > 0)
+
+  if (teams.length >= 2) {
+    return teams
   }
 
-  if (config.teams.length === 1) {
-    if (config.teams[0].length === 2) {
-      return [[config.teams[0][0]], [config.teams[0][1]]]
+  if (teams.length === 1) {
+    if (teams[0].length === 2) {
+      return [[teams[0][0]], [teams[0][1]]]
     }
     // Melee with >2 players - can't determine teams
     return null

--- a/common/races.ts
+++ b/common/races.ts
@@ -11,6 +11,8 @@ export const ALL_RACE_CHARS: ReadonlyArray<RaceChar> = ['p', 'r', 't', 'z']
  */
 export type AssignedRaceChar = 'p' | 't' | 'z'
 
+export const ALL_ASSIGNED_RACE_CHARS: ReadonlyArray<AssignedRaceChar> = ['p', 't', 'z']
+
 /**
  * A type representing all possible combinations we care about with regards to race statistics. The
  * values at the bottom refer to races that were assigned when the player had "random" selected as

--- a/common/users/user-network.ts
+++ b/common/users/user-network.ts
@@ -1,3 +1,9 @@
+import {
+  EncodedMatchupString,
+  GameDurationFilter,
+  GameFormat,
+  GameSortOption,
+} from '../games/game-filters'
 import { GameRecordJson } from '../games/games'
 import { TranslationLanguage } from '../i18n'
 import { Jsonify } from '../json'
@@ -72,12 +78,24 @@ export interface GetUserProfileResponse {
   seasons: MatchmakingSeasonJson[]
 }
 
-export const SEARCH_MATCH_HISTORY_LIMIT = 40
+export const GET_MATCH_HISTORY_LIMIT = 40
+
+export interface GetMatchHistoryQueryParams {
+  ranked?: boolean
+  custom?: boolean
+  duration?: GameDurationFilter
+  mapName?: string
+  playerName?: string
+  format?: GameFormat
+  matchup?: EncodedMatchupString
+  sort?: GameSortOption
+  offset?: number
+}
 
 /**
- * The response returned when searching the user's match history.
+ * The response returned when getting the user's match history.
  */
-export interface SearchMatchHistoryResponse {
+export interface GetMatchHistoryResponse {
   games: GameRecordJson[]
   maps: MapInfoJson[]
   users: SbUser[]

--- a/migrations/20260212000000_add_matchup_columns.sql
+++ b/migrations/20260212000000_add_matchup_columns.sql
@@ -1,0 +1,153 @@
+ALTER TABLE games ADD COLUMN selected_matchup text;
+ALTER TABLE games ADD COLUMN assigned_matchup text;
+
+CREATE INDEX idx_games_selected_matchup ON games (selected_matchup) WHERE selected_matchup IS NOT NULL;
+CREATE INDEX idx_games_assigned_matchup ON games (assigned_matchup) WHERE assigned_matchup IS NOT NULL;
+
+-- Backfill matchup columns from existing config/results JSONB data
+CREATE OR REPLACE FUNCTION backfill_matchups() RETURNS void AS $$
+DECLARE
+  r RECORD;
+  team_races text[];
+  all_team_strings text[];
+  team_str text;
+  player_race text;
+  player_id int;
+  team jsonb;
+  player jsonb;
+  result_pair jsonb;
+  teams_count int;
+  team0_count int;
+  selected text;
+  assigned text;
+  is_1v1_single_team boolean;
+  has_computers boolean;
+BEGIN
+  FOR r IN SELECT id, config, results FROM games LOOP
+    teams_count := jsonb_array_length(r.config->'teams');
+    selected := NULL;
+    assigned := NULL;
+    is_1v1_single_team := false;
+
+    has_computers := EXISTS (
+      SELECT 1
+      FROM jsonb_array_elements(r.config->'teams') AS t,
+           jsonb_array_elements(t) AS p
+      WHERE (p->>'isComputer')::boolean = true
+    );
+
+    -- Determine if we can compute matchups
+    IF teams_count = 1 THEN
+      team0_count := jsonb_array_length(r.config->'teams'->0);
+      IF team0_count = 2 THEN
+        -- 1v1 stored as single team of 2 - split into two teams
+        is_1v1_single_team := true;
+      ELSE
+        -- Melee with >2 players, can't determine teams
+        CONTINUE;
+      END IF;
+    END IF;
+
+    -- Compute selected_matchup
+    IF is_1v1_single_team THEN
+      -- Split single team into two 1-player teams
+      all_team_strings := ARRAY[
+        (r.config->'teams'->0->0->>'race'),
+        (r.config->'teams'->0->1->>'race')
+      ];
+      -- Sort the team strings
+      SELECT array_agg(s ORDER BY s) INTO all_team_strings FROM unnest(all_team_strings) AS s;
+      selected := array_to_string(all_team_strings, '-');
+    ELSE
+      -- Multiple teams: sort races within each team, collect team strings
+      all_team_strings := ARRAY[]::text[];
+      FOR i IN 0..(teams_count - 1) LOOP
+        team := r.config->'teams'->i;
+        team_races := ARRAY[]::text[];
+        FOR j IN 0..(jsonb_array_length(team) - 1) LOOP
+          team_races := array_append(team_races, team->j->>'race');
+        END LOOP;
+        -- Sort races within the team
+        SELECT array_agg(s ORDER BY s) INTO team_races FROM unnest(team_races) AS s;
+        team_str := array_to_string(team_races, '');
+        all_team_strings := array_append(all_team_strings, team_str);
+      END LOOP;
+      -- Sort team strings lexicographically
+      SELECT array_agg(s ORDER BY s) INTO all_team_strings FROM unnest(all_team_strings) AS s;
+      selected := array_to_string(all_team_strings, '-');
+    END IF;
+
+    -- Compute assigned_matchup (only if results exist and no computer players)
+    IF r.results IS NOT NULL AND NOT has_computers THEN
+      IF is_1v1_single_team THEN
+        -- For 1v1, look up each player's assigned race from results
+        all_team_strings := ARRAY[]::text[];
+        FOR k IN 0..1 LOOP
+          player := r.config->'teams'->0->k;
+          player_id := (player->>'id')::int;
+          player_race := NULL;
+          FOR result_pair IN SELECT jsonb_array_elements(r.results) LOOP
+            IF (result_pair->0)::int = player_id THEN
+              player_race := result_pair->1->>'race';
+              EXIT;
+            END IF;
+          END LOOP;
+          IF player_race IS NULL THEN
+            -- Player not found in results, skip this game
+            all_team_strings := NULL;
+            EXIT;
+          END IF;
+          all_team_strings := array_append(all_team_strings, player_race);
+        END LOOP;
+
+        IF all_team_strings IS NOT NULL THEN
+          SELECT array_agg(s ORDER BY s) INTO all_team_strings FROM unnest(all_team_strings) AS s;
+          assigned := array_to_string(all_team_strings, '-');
+        END IF;
+      ELSE
+        -- Multiple teams
+        all_team_strings := ARRAY[]::text[];
+        FOR i IN 0..(teams_count - 1) LOOP
+          team := r.config->'teams'->i;
+          team_races := ARRAY[]::text[];
+          FOR j IN 0..(jsonb_array_length(team) - 1) LOOP
+            player := team->j;
+            player_id := (player->>'id')::int;
+            player_race := NULL;
+            FOR result_pair IN SELECT jsonb_array_elements(r.results) LOOP
+              IF (result_pair->0)::int = player_id THEN
+                player_race := result_pair->1->>'race';
+                EXIT;
+              END IF;
+            END LOOP;
+            IF player_race IS NULL THEN
+              team_races := NULL;
+              EXIT;
+            END IF;
+            team_races := array_append(team_races, player_race);
+          END LOOP;
+
+          IF team_races IS NULL THEN
+            all_team_strings := NULL;
+            EXIT;
+          END IF;
+
+          SELECT array_agg(s ORDER BY s) INTO team_races FROM unnest(team_races) AS s;
+          team_str := array_to_string(team_races, '');
+          all_team_strings := array_append(all_team_strings, team_str);
+        END LOOP;
+
+        IF all_team_strings IS NOT NULL THEN
+          SELECT array_agg(s ORDER BY s) INTO all_team_strings FROM unnest(all_team_strings) AS s;
+          assigned := array_to_string(all_team_strings, '-');
+        END IF;
+      END IF;
+    END IF;
+
+    UPDATE games SET selected_matchup = selected, assigned_matchup = assigned WHERE id = r.id;
+  END LOOP;
+END;
+$$ LANGUAGE plpgsql;
+
+SELECT backfill_matchups();
+DROP FUNCTION backfill_matchups();

--- a/migrations/20260212000000_add_matchup_columns.sql
+++ b/migrations/20260212000000_add_matchup_columns.sql
@@ -1,153 +1,20 @@
+-- Adds the matchup columns used for filtering games by format/matchup. These are populated going
+-- forward by the application code (selected_matchup at registration, assigned_matchup at result
+-- reconciliation).
+--
+-- NOTE: This migration intentionally only does the (instant) DDL. Adding a nullable column is a
+-- metadata-only change, and the partial indexes are empty at creation time (every row is NULL), so
+-- they build instantly and nothing here holds a long lock on `games`. Backfilling the existing rows
+-- is done separately and out-of-band via tools/backfill-matchups.sql so we don't lock the table for
+-- the (potentially very long) duration of rewriting every row.
+
 ALTER TABLE games ADD COLUMN selected_matchup text;
 ALTER TABLE games ADD COLUMN assigned_matchup text;
 
-CREATE INDEX idx_games_selected_matchup ON games (selected_matchup) WHERE selected_matchup IS NOT NULL;
+-- Only assigned_matchup gets an index: matchup filtering is an equality lookup
+-- (`assigned_matchup = ANY(...)`) which a btree can serve. selected_matchup is only used for format
+-- filtering, which is a regex on team sizes that a plain btree can't serve, so an index on it would
+-- be pure write overhead. If/when a global games page needs to filter by format at scale, that
+-- should get a purpose-built index (e.g. an expression index on the team sizes or a generated
+-- column) rather than this column's raw value.
 CREATE INDEX idx_games_assigned_matchup ON games (assigned_matchup) WHERE assigned_matchup IS NOT NULL;
-
--- Backfill matchup columns from existing config/results JSONB data
-CREATE OR REPLACE FUNCTION backfill_matchups() RETURNS void AS $$
-DECLARE
-  r RECORD;
-  team_races text[];
-  all_team_strings text[];
-  team_str text;
-  player_race text;
-  player_id int;
-  team jsonb;
-  player jsonb;
-  result_pair jsonb;
-  teams_count int;
-  team0_count int;
-  selected text;
-  assigned text;
-  is_1v1_single_team boolean;
-  has_computers boolean;
-BEGIN
-  FOR r IN SELECT id, config, results FROM games LOOP
-    teams_count := jsonb_array_length(r.config->'teams');
-    selected := NULL;
-    assigned := NULL;
-    is_1v1_single_team := false;
-
-    has_computers := EXISTS (
-      SELECT 1
-      FROM jsonb_array_elements(r.config->'teams') AS t,
-           jsonb_array_elements(t) AS p
-      WHERE (p->>'isComputer')::boolean = true
-    );
-
-    -- Determine if we can compute matchups
-    IF teams_count = 1 THEN
-      team0_count := jsonb_array_length(r.config->'teams'->0);
-      IF team0_count = 2 THEN
-        -- 1v1 stored as single team of 2 - split into two teams
-        is_1v1_single_team := true;
-      ELSE
-        -- Melee with >2 players, can't determine teams
-        CONTINUE;
-      END IF;
-    END IF;
-
-    -- Compute selected_matchup
-    IF is_1v1_single_team THEN
-      -- Split single team into two 1-player teams
-      all_team_strings := ARRAY[
-        (r.config->'teams'->0->0->>'race'),
-        (r.config->'teams'->0->1->>'race')
-      ];
-      -- Sort the team strings
-      SELECT array_agg(s ORDER BY s) INTO all_team_strings FROM unnest(all_team_strings) AS s;
-      selected := array_to_string(all_team_strings, '-');
-    ELSE
-      -- Multiple teams: sort races within each team, collect team strings
-      all_team_strings := ARRAY[]::text[];
-      FOR i IN 0..(teams_count - 1) LOOP
-        team := r.config->'teams'->i;
-        team_races := ARRAY[]::text[];
-        FOR j IN 0..(jsonb_array_length(team) - 1) LOOP
-          team_races := array_append(team_races, team->j->>'race');
-        END LOOP;
-        -- Sort races within the team
-        SELECT array_agg(s ORDER BY s) INTO team_races FROM unnest(team_races) AS s;
-        team_str := array_to_string(team_races, '');
-        all_team_strings := array_append(all_team_strings, team_str);
-      END LOOP;
-      -- Sort team strings lexicographically
-      SELECT array_agg(s ORDER BY s) INTO all_team_strings FROM unnest(all_team_strings) AS s;
-      selected := array_to_string(all_team_strings, '-');
-    END IF;
-
-    -- Compute assigned_matchup (only if results exist and no computer players)
-    IF r.results IS NOT NULL AND NOT has_computers THEN
-      IF is_1v1_single_team THEN
-        -- For 1v1, look up each player's assigned race from results
-        all_team_strings := ARRAY[]::text[];
-        FOR k IN 0..1 LOOP
-          player := r.config->'teams'->0->k;
-          player_id := (player->>'id')::int;
-          player_race := NULL;
-          FOR result_pair IN SELECT jsonb_array_elements(r.results) LOOP
-            IF (result_pair->0)::int = player_id THEN
-              player_race := result_pair->1->>'race';
-              EXIT;
-            END IF;
-          END LOOP;
-          IF player_race IS NULL THEN
-            -- Player not found in results, skip this game
-            all_team_strings := NULL;
-            EXIT;
-          END IF;
-          all_team_strings := array_append(all_team_strings, player_race);
-        END LOOP;
-
-        IF all_team_strings IS NOT NULL THEN
-          SELECT array_agg(s ORDER BY s) INTO all_team_strings FROM unnest(all_team_strings) AS s;
-          assigned := array_to_string(all_team_strings, '-');
-        END IF;
-      ELSE
-        -- Multiple teams
-        all_team_strings := ARRAY[]::text[];
-        FOR i IN 0..(teams_count - 1) LOOP
-          team := r.config->'teams'->i;
-          team_races := ARRAY[]::text[];
-          FOR j IN 0..(jsonb_array_length(team) - 1) LOOP
-            player := team->j;
-            player_id := (player->>'id')::int;
-            player_race := NULL;
-            FOR result_pair IN SELECT jsonb_array_elements(r.results) LOOP
-              IF (result_pair->0)::int = player_id THEN
-                player_race := result_pair->1->>'race';
-                EXIT;
-              END IF;
-            END LOOP;
-            IF player_race IS NULL THEN
-              team_races := NULL;
-              EXIT;
-            END IF;
-            team_races := array_append(team_races, player_race);
-          END LOOP;
-
-          IF team_races IS NULL THEN
-            all_team_strings := NULL;
-            EXIT;
-          END IF;
-
-          SELECT array_agg(s ORDER BY s) INTO team_races FROM unnest(team_races) AS s;
-          team_str := array_to_string(team_races, '');
-          all_team_strings := array_append(all_team_strings, team_str);
-        END LOOP;
-
-        IF all_team_strings IS NOT NULL THEN
-          SELECT array_agg(s ORDER BY s) INTO all_team_strings FROM unnest(all_team_strings) AS s;
-          assigned := array_to_string(all_team_strings, '-');
-        END IF;
-      END IF;
-    END IF;
-
-    UPDATE games SET selected_matchup = selected, assigned_matchup = assigned WHERE id = r.id;
-  END LOOP;
-END;
-$$ LANGUAGE plpgsql;
-
-SELECT backfill_matchups();
-DROP FUNCTION backfill_matchups();

--- a/server/lib/games/game-models.ts
+++ b/server/lib/games/game-models.ts
@@ -1,13 +1,26 @@
+import { GameSource } from '../../../common/games/configuration'
+import {
+  GameDurationFilter,
+  GameFormat,
+  GameSortOption,
+  getTeamSizeForFormat,
+  MatchupFilter,
+} from '../../../common/games/game-filters'
 import { GameRecord, GameRouteDebugInfo } from '../../../common/games/games'
+import { expandMatchupFilter, MatchupString } from '../../../common/games/matchups'
 import { ReconciledResults } from '../../../common/games/results'
 import { SbUserId } from '../../../common/users/sb-user-id'
 import db, { DbClient } from '../db'
-import { sql } from '../db/sql'
+import { escapeSearchString } from '../db/escape-search-string'
+import { sql, sqlConcat, sqlRaw } from '../db/sql'
 import { Dbify } from '../db/types'
 
 type DbGameRecord = Dbify<GameRecord>
 
-export type CreateGameRecordData = Pick<GameRecord, 'startTime' | 'mapId' | 'config'>
+export type CreateGameRecordData = Pick<
+  GameRecord,
+  'startTime' | 'mapId' | 'config' | 'selectedMatchup'
+>
 
 function convertFromDb(row: DbGameRecord): GameRecord {
   return {
@@ -20,6 +33,8 @@ function convertFromDb(row: DbGameRecord): GameRecord {
     disputeReviewed: row.dispute_reviewed,
     gameLength: row.game_length,
     results: row.results,
+    selectedMatchup: row.selected_matchup,
+    assignedMatchup: row.assigned_matchup,
   }
 }
 
@@ -29,15 +44,17 @@ function convertFromDb(row: DbGameRecord): GameRecord {
  */
 export async function createGameRecord(
   client: DbClient,
-  { startTime, mapId, config }: CreateGameRecordData,
+  { startTime, mapId, config, selectedMatchup }: CreateGameRecordData,
 ): Promise<string> {
   // TODO(tec27): We could make some type of TransactionClient transformation to enforce this is
   // done in a transaction
   const result = await client.query<{ id: string }>(sql`
     INSERT INTO games (
-      start_time, map_id, config, disputable, dispute_requested, dispute_reviewed, game_length
+      start_time, map_id, config, disputable, dispute_requested, dispute_reviewed, game_length,
+      selected_matchup
     ) VALUES (
-      ${startTime}, ${mapId}, ${config}, FALSE, FALSE, FALSE, NULL
+      ${startTime}, ${mapId}, ${config}, FALSE, FALSE, FALSE, NULL,
+      ${selectedMatchup}
     ) RETURNING id
   `)
 
@@ -52,7 +69,7 @@ export async function getGameRecord(gameId: string): Promise<GameRecord | undefi
   try {
     const result = await client.query<DbGameRecord>(sql`
       SELECT id, start_time, map_id, config, disputable, dispute_requested, dispute_reviewed,
-        game_length, results
+        game_length, results, selected_matchup, assigned_matchup
       FROM games
       WHERE id = ${gameId}`)
     return result.rowCount ? convertFromDb(result.rows[0]) : undefined
@@ -82,6 +99,7 @@ export async function setReconciledResult(
   client: DbClient,
   gameId: string,
   results: ReconciledResults,
+  assignedMatchup: MatchupString | null,
 ): Promise<void> {
   await client.query(sql`
     UPDATE games
@@ -90,7 +108,8 @@ export async function setReconciledResult(
       game_length = ${results.time},
       disputable = ${results.disputed},
       dispute_requested = false,
-      dispute_reviewed = false
+      dispute_reviewed = false,
+      assigned_matchup = ${assignedMatchup}
     WHERE id = ${gameId}
   `)
 }
@@ -160,29 +179,142 @@ export async function getRecentGamesForUser(
 /**
  * Retrieves game information for the match history of a user.
  */
-export async function searchGamesForUser(
-  {
-    userId,
-    limit,
-    offset,
-  }: {
+export async function getGamesForUser(
+  params: {
     userId: SbUserId
     limit: number
     offset: number
+    ranked?: boolean
+    custom?: boolean
+    duration?: GameDurationFilter
+    mapName?: string
+    playerName?: string
+    format?: GameFormat
+    matchup?: MatchupFilter
+    sort?: GameSortOption
   },
   withClient?: DbClient,
 ): Promise<GameRecord[]> {
+  const {
+    userId,
+    limit,
+    offset,
+    ranked,
+    custom,
+    duration,
+    mapName,
+    playerName,
+    format,
+    matchup,
+    sort,
+  } = params
+
   const { client, done } = await db(withClient)
   try {
-    const query = sql`
-      SELECT *
+    const whereClauses = [sql`gu.user_id = ${userId}`]
+    let needMapJoin = false
+
+    if (ranked || custom) {
+      const sourceConditions = []
+      if (ranked) {
+        sourceConditions.push(sql`g.config->>'gameSource' = ${GameSource.Matchmaking}`)
+      }
+      if (custom) {
+        sourceConditions.push(sql`g.config->>'gameSource' = ${GameSource.Lobby}`)
+      }
+      whereClauses.push(sql`(${sqlConcat(' OR ', sourceConditions)})`)
+    }
+
+    if (duration && duration !== GameDurationFilter.All) {
+      switch (duration) {
+        case GameDurationFilter.Under10:
+          whereClauses.push(sql`g.game_length < 600000`)
+          break
+        case GameDurationFilter.From10To20:
+          whereClauses.push(sql`g.game_length >= 600000 AND g.game_length < 1200000`)
+          break
+        case GameDurationFilter.From20To30:
+          whereClauses.push(sql`g.game_length >= 1200000 AND g.game_length < 1800000`)
+          break
+        case GameDurationFilter.Over30:
+          whereClauses.push(sql`g.game_length >= 1800000`)
+          break
+        default:
+          duration satisfies never
+      }
+    }
+
+    if (mapName) {
+      needMapJoin = true
+      whereClauses.push(sql`m.name ILIKE ${'%' + escapeSearchString(mapName) + '%'}`)
+    }
+
+    if (playerName) {
+      whereClauses.push(sql`
+        EXISTS (
+          SELECT 1 FROM games_users gu2
+          INNER JOIN users u ON gu2.user_id = u.id
+          WHERE gu2.game_id = g.id
+          AND u.name ILIKE ${'%' + escapeSearchString(playerName) + '%'}
+        )
+      `)
+    }
+
+    if (format) {
+      const teamSize = getTeamSizeForFormat(format)
+      // Match games with exactly 2 teams where both teams have the expected size
+      whereClauses.push(sql`
+        g.selected_matchup ~ ${`^[prtz]{${teamSize}}-[prtz]{${teamSize}}$`}
+      `)
+    }
+
+    if (format && matchup) {
+      const hasNonUndefinedRace = [...matchup.team1, ...matchup.team2].some(r => r !== undefined)
+
+      if (hasNonUndefinedRace) {
+        const matchupStrings = expandMatchupFilter(matchup)
+        whereClauses.push(sql`g.assigned_matchup = ANY(${matchupStrings})`)
+      }
+    }
+
+    let orderBy = sqlRaw('g.start_time DESC')
+    if (sort) {
+      switch (sort) {
+        case GameSortOption.LatestFirst:
+          orderBy = sqlRaw('g.start_time DESC')
+          break
+        case GameSortOption.OldestFirst:
+          orderBy = sqlRaw('g.start_time ASC')
+          break
+        case GameSortOption.ShortestFirst:
+          orderBy = sqlRaw('g.game_length ASC NULLS LAST')
+          break
+        case GameSortOption.LongestFirst:
+          orderBy = sqlRaw('g.game_length DESC NULLS LAST')
+          break
+        default:
+          sort satisfies never
+      }
+    }
+
+    let query = sql`
+      SELECT g.*
       FROM games_users gu
       INNER JOIN games g ON gu.game_id = g.id
-      WHERE gu.user_id = ${userId}
-      ORDER BY g.start_time DESC
-      LIMIT ${limit}
-      OFFSET ${offset};
     `
+
+    if (needMapJoin) {
+      query = query.append(sql`
+        INNER JOIN uploaded_maps m ON g.map_id = m.id
+      `)
+    }
+
+    query = query.append(sql`
+      WHERE ${sqlConcat(' AND ', whereClauses)}
+      ORDER BY ${orderBy}
+      LIMIT ${limit}
+      OFFSET ${offset}
+    `)
 
     const result = await client.query<DbGameRecord>(query)
 

--- a/server/lib/games/game-models.ts
+++ b/server/lib/games/game-models.ts
@@ -277,20 +277,24 @@ export async function getGamesForUser(
       }
     }
 
-    let orderBy = sqlRaw('g.start_time DESC')
+    // NOTE(2Pac): All of these include `g.id` as a final tiebreaker so the ordering is fully
+    // deterministic. Without it, rows that tie on the leading column (e.g. many unreconciled games
+    // all have a NULL game_length, or games that share a start_time) can be duplicated or skipped
+    // across paginated requests.
+    let orderBy = sqlRaw('g.start_time DESC, g.id DESC')
     if (sort) {
       switch (sort) {
         case GameSortOption.LatestFirst:
-          orderBy = sqlRaw('g.start_time DESC')
+          orderBy = sqlRaw('g.start_time DESC, g.id DESC')
           break
         case GameSortOption.OldestFirst:
-          orderBy = sqlRaw('g.start_time ASC')
+          orderBy = sqlRaw('g.start_time ASC, g.id ASC')
           break
         case GameSortOption.ShortestFirst:
-          orderBy = sqlRaw('g.game_length ASC NULLS LAST')
+          orderBy = sqlRaw('g.game_length ASC NULLS LAST, g.start_time DESC, g.id DESC')
           break
         case GameSortOption.LongestFirst:
-          orderBy = sqlRaw('g.game_length DESC NULLS LAST')
+          orderBy = sqlRaw('g.game_length DESC NULLS LAST, g.start_time DESC, g.id DESC')
           break
         default:
           sort satisfies never

--- a/server/lib/games/game-result-service.ts
+++ b/server/lib/games/game-result-service.ts
@@ -10,6 +10,7 @@ import {
   MatchmakingResultsEvent,
   toGameRecordJson,
 } from '../../../common/games/games'
+import { computeMatchupString, getTeamsFromConfig } from '../../../common/games/matchups'
 import { GameClientPlayerResult, GameResultErrorCode } from '../../../common/games/results'
 import { League, toClientLeagueUserChangeJson, toLeagueJson } from '../../../common/leagues/leagues'
 import {
@@ -524,11 +525,17 @@ export default class GameResultService {
         }
       }
 
+      const hasComputers = gameRecord.config.teams.some(team => team.some(p => p.isComputer))
+      const teams = !hasComputers ? getTeamsFromConfig(gameRecord.config) : null
+      const assignedMatchup = teams
+        ? computeMatchupString(teams.map(team => team.map(p => reconciled.results.get(p.id)!.race)))
+        : null
+
       await Promise.all([
         ...userPromises,
         ...matchmakingDbPromises,
         ...statsUpdatePromises,
-        setReconciledResult(client, gameId, reconciled),
+        setReconciledResult(client, gameId, reconciled, assignedMatchup),
       ])
 
       if (matchmakingRankingChanges.length) {

--- a/server/lib/games/game-result-service.ts
+++ b/server/lib/games/game-result-service.ts
@@ -525,8 +525,15 @@ export default class GameResultService {
         }
       }
 
+      // Only compute an assigned matchup when we actually know every player's assigned race: skip
+      // games with computers (which are excluded from results) and disputed games. A disputed game
+      // can have a player who's missing from every report, in which case reconcileResults falls back
+      // to a fabricated 'p' race (see results.ts) that we don't want to bake into the matchup. This
+      // also keeps us consistent with the backfill, which leaves assigned_matchup NULL in these
+      // cases.
       const hasComputers = gameRecord.config.teams.some(team => team.some(p => p.isComputer))
-      const teams = !hasComputers ? getTeamsFromConfig(gameRecord.config) : null
+      const teams =
+        !hasComputers && !reconciled.disputed ? getTeamsFromConfig(gameRecord.config) : null
       const assignedMatchup = teams
         ? computeMatchupString(teams.map(team => team.map(p => reconciled.results.get(p.id)!.race)))
         : null

--- a/server/lib/games/registration.ts
+++ b/server/lib/games/registration.ts
@@ -1,4 +1,5 @@
 import { GameConfig } from '../../../common/games/configuration'
+import { computeMatchupString, getTeamsFromConfig } from '../../../common/games/matchups'
 import { SbMapId } from '../../../common/maps'
 import transact from '../db/transaction'
 import { createGameUserRecord } from '../models/games-users'
@@ -27,12 +28,22 @@ export async function registerGame(mapId: SbMapId, gameConfig: GameConfig, start
 
   const resultCodes = new Map(humanPlayers.map(p => [p.id, genResultCode()]))
 
+  const teams = getTeamsFromConfig(gameConfig)
+  const selectedMatchup = teams
+    ? computeMatchupString(teams.map(team => team.map(p => p.race)))
+    : null
+
   // NOTE(tec27): the value here makes the linter happy, but this will actually be set in the
   // transaction below
   let gameId = ''
 
   await transact(async client => {
-    gameId = await createGameRecord(client, { startTime, mapId, config: gameConfig })
+    gameId = await createGameRecord(client, {
+      startTime,
+      mapId,
+      config: gameConfig,
+      selectedMatchup,
+    })
     await Promise.all(
       humanPlayers.map(p =>
         createGameUserRecord(client, {

--- a/server/lib/users/user-api.ts
+++ b/server/lib/users/user-api.ts
@@ -11,6 +11,12 @@ import {
   USERNAME_MINLENGTH,
   USERNAME_PATTERN,
 } from '../../../common/constants'
+import {
+  ALL_GAME_FORMATS,
+  decodeMatchup,
+  GameDurationFilter,
+  GameSortOption,
+} from '../../../common/games/game-filters'
 import { toGameRecordJson } from '../../../common/games/games'
 import { ALL_TRANSLATION_LANGUAGES } from '../../../common/i18n'
 import { LadderPlayer } from '../../../common/ladder/ladder'
@@ -47,15 +53,16 @@ import {
   AuthEvent,
   ChangeLanguageRequest,
   ChangeLanguagesResponse,
+  GET_MATCH_HISTORY_LIMIT,
   GetBatchUserInfoResponse,
+  GetMatchHistoryQueryParams,
+  GetMatchHistoryResponse,
   GetUserProfileResponse,
   GetUserRankingHistoryResponse,
   RANDOM_EMAIL_CODE_PATTERN,
   RecoverUsernameRequest,
   RequestPasswordResetRequest,
   ResetPasswordRequest,
-  SEARCH_MATCH_HISTORY_LIMIT,
-  SearchMatchHistoryResponse,
   toBanHistoryEntryJson,
   toUserIpInfoJson,
   toUserRestrictionHistoryJson,
@@ -66,7 +73,7 @@ import ChatService from '../chat/chat-service'
 import { UNIQUE_VIOLATION } from '../db/pg-error-codes'
 import transact from '../db/transaction'
 import isDev from '../env/is-dev'
-import { getRecentGamesForUser, searchGamesForUser } from '../games/game-models'
+import { getGamesForUser, getRecentGamesForUser } from '../games/game-models'
 import { httpApi, httpBeforeAll } from '../http/http-api'
 import { httpBefore, httpDelete, httpGet, httpPost } from '../http/route-decorators'
 import { joiLocale } from '../i18n/locale-validator'
@@ -655,16 +662,23 @@ export class UserApi {
       String(ctx.session?.user?.id ?? ctx.ip),
     ),
   )
-  async searchMatchHistory(ctx: RouterContext): Promise<SearchMatchHistoryResponse> {
+  async getMatchHistory(ctx: RouterContext): Promise<GetMatchHistoryResponse> {
     const {
       params,
-      query: { offset },
+      query: { ranked, custom, duration, mapName, playerName, format, matchup, sort, offset },
     } = validateRequest(ctx, {
       params: Joi.object<{ id: SbUserId }>({
         id: joiUserId().required(),
       }).required(),
-      query: Joi.object<{ q?: string; offset: number }>({
-        q: Joi.string().allow(''),
+      query: Joi.object<GetMatchHistoryQueryParams>({
+        ranked: Joi.boolean(),
+        custom: Joi.boolean(),
+        duration: Joi.string().valid(...Object.values(GameDurationFilter)),
+        mapName: Joi.string().max(100),
+        playerName: Joi.string().max(100),
+        format: Joi.string().valid(...ALL_GAME_FORMATS),
+        matchup: Joi.string().pattern(/^[ptz_]{1,4}-[ptz_]{1,4}$/),
+        sort: Joi.string().valid(...Object.values(GameSortOption)),
         offset: Joi.number().min(0),
       }),
     })
@@ -674,10 +688,20 @@ export class UserApi {
       throw new UserApiError(UserErrorCode.NotFound, 'user not found')
     }
 
-    const games = await searchGamesForUser({
+    const decodedMatchup = matchup && format ? decodeMatchup(format, matchup) : undefined
+
+    const games = await getGamesForUser({
       userId: user.id,
-      limit: SEARCH_MATCH_HISTORY_LIMIT,
-      offset,
+      limit: GET_MATCH_HISTORY_LIMIT,
+      offset: offset ?? 0,
+      ranked,
+      custom,
+      duration,
+      mapName,
+      playerName,
+      format,
+      matchup: decodedMatchup,
+      sort,
     })
     const uniqueUsers = new Set<SbUserId>()
     const uniqueMaps = new Set<SbMapId>()
@@ -701,7 +725,7 @@ export class UserApi {
       games: games.map(g => toGameRecordJson(g)),
       maps: maps.map(m => toMapInfoJson(m)),
       users,
-      hasMoreGames: games.length >= SEARCH_MATCH_HISTORY_LIMIT,
+      hasMoreGames: games.length >= GET_MATCH_HISTORY_LIMIT,
     }
   }
 

--- a/server/public/locales/en/global.json
+++ b/server/public/locales/en/global.json
@@ -325,6 +325,30 @@
     }
   },
   "game": {
+    "filters": {
+      "advanced": "Advanced",
+      "custom": "Custom",
+      "duration": {
+        "10to20": "10-20min",
+        "20to30": "20-30min",
+        "all": "All",
+        "over30": "Over 30min",
+        "under10": "Under 10min"
+      },
+      "format": "Format",
+      "label": "Filters",
+      "mapName": "Map name",
+      "matchup": "Matchup",
+      "playerName": "Player name",
+      "ranked": "Ranked",
+      "sort": {
+        "latest": "Latest first",
+        "longest": "Longest first",
+        "oldest": "Oldest first",
+        "shortest": "Shortest first"
+      },
+      "vs": "vs"
+    },
     "gameSource": {
       "custom": "Custom game",
       "ranked": "Ranked {{matchmakingType}}"

--- a/tools/backfill-matchups.sql
+++ b/tools/backfill-matchups.sql
@@ -1,0 +1,182 @@
+-- Backfills games.selected_matchup / games.assigned_matchup from the historical config/results
+-- JSONB. Run this AFTER the 20260212000000_add_matchup_columns migration has been applied and the
+-- new application code has been deployed.
+--
+-- Why this isn't part of the migration: backfilling (potentially) rewrites every row in `games`,
+-- and we don't want to hold a lock on that table for the whole duration. This processes the table
+-- in id-range batches, committing after each batch so locks are released and normal traffic can
+-- interleave between batches.
+--
+-- It is idempotent and safe to re-run: a row is only written when a freshly computed value actually
+-- differs from what's stored. Running it again after the deploy has settled therefore doubles as a
+-- cheap catch-up pass for any games that were created or reconciled by old code during the deploy
+-- window (which would otherwise keep NULL matchups forever).
+--
+-- Usage (psql, and NOT wrapped in an explicit transaction, so the per-batch COMMITs can take
+-- effect):
+--   \i tools/backfill-matchups.sql               -- installs/updates the procedure
+--   CALL backfill_matchups(dry_run => true);      -- report how many rows *would* change, no writes
+--   CALL backfill_matchups();                     -- run it for real (5000-row batches)
+--   CALL backfill_matchups(batch_size => 20000);  -- larger batches
+--
+-- The procedure is left installed afterwards. Clean it up when you're done with:
+--   DROP PROCEDURE backfill_matchups(int, boolean);
+
+CREATE OR REPLACE PROCEDURE backfill_matchups(batch_size int DEFAULT 5000, dry_run boolean DEFAULT false)
+LANGUAGE plpgsql AS $$
+DECLARE
+  r RECORD;
+  last_id uuid := '00000000-0000-0000-0000-000000000000';
+  batch_last_id uuid;
+  non_empty_teams jsonb[];
+  teams_for_matchup jsonb[];
+  teams_count int;
+  is_1v1_single_team boolean;
+  has_computers boolean;
+  selected text;
+  assigned text;
+  all_team_strings text[];
+  team_races text[];
+  player_race text;
+  player_id int;
+  team jsonb;
+  player jsonb;
+  result_pair jsonb;
+  processed bigint := 0;
+  changed bigint := 0;
+BEGIN
+  LOOP
+    batch_last_id := NULL;
+
+    FOR r IN
+      SELECT id, config, results, selected_matchup, assigned_matchup
+      FROM games
+      WHERE id > last_id
+      ORDER BY id
+      LIMIT batch_size
+    LOOP
+      batch_last_id := r.id;
+      processed := processed + 1;
+
+      selected := NULL;
+      assigned := NULL;
+      is_1v1_single_team := false;
+
+      -- Drop empty teams (e.g. observer teams in melee lobbies serialize as []) before working out
+      -- the real layout. This mirrors getTeamsFromConfig() in common/games/matchups.ts.
+      non_empty_teams := ARRAY(
+        SELECT t
+        FROM jsonb_array_elements(r.config->'teams') AS t
+        WHERE jsonb_array_length(t) > 0
+      );
+      teams_count := coalesce(array_length(non_empty_teams, 1), 0);
+
+      has_computers := EXISTS (
+        SELECT 1
+        FROM unnest(non_empty_teams) AS t,
+             jsonb_array_elements(t) AS p
+        WHERE (p->>'isComputer')::boolean = true
+      );
+
+      IF teams_count = 1 THEN
+        IF jsonb_array_length(non_empty_teams[1]) = 2 THEN
+          -- 1v1 stored as a single team of 2 - split into two single-player teams
+          is_1v1_single_team := true;
+        ELSE
+          -- Melee with != 2 players, can't determine teams; leave matchups NULL
+          teams_count := 0;
+        END IF;
+      END IF;
+
+      IF teams_count >= 2 OR is_1v1_single_team THEN
+        IF is_1v1_single_team THEN
+          teams_for_matchup := ARRAY[
+            jsonb_build_array(non_empty_teams[1]->0),
+            jsonb_build_array(non_empty_teams[1]->1)
+          ];
+        ELSE
+          teams_for_matchup := non_empty_teams;
+        END IF;
+
+        -- selected_matchup: from each player's configured race
+        all_team_strings := ARRAY[]::text[];
+        FOREACH team IN ARRAY teams_for_matchup LOOP
+          team_races := ARRAY[]::text[];
+          FOR j IN 0..(jsonb_array_length(team) - 1) LOOP
+            team_races := array_append(team_races, team->j->>'race');
+          END LOOP;
+          SELECT array_agg(s ORDER BY s) INTO team_races FROM unnest(team_races) AS s;
+          all_team_strings := array_append(all_team_strings, array_to_string(team_races, ''));
+        END LOOP;
+        SELECT array_agg(s ORDER BY s) INTO all_team_strings FROM unnest(all_team_strings) AS s;
+        selected := array_to_string(all_team_strings, '-');
+
+        -- assigned_matchup: from each player's assigned (result) race, only when results exist and
+        -- there are no computer players (computers aren't included in our results). Some legacy rows
+        -- store results as a non-array (e.g. an empty `{}` object), which we treat as "no results".
+        IF jsonb_typeof(r.results) = 'array' AND NOT has_computers THEN
+          all_team_strings := ARRAY[]::text[];
+          FOREACH team IN ARRAY teams_for_matchup LOOP
+            team_races := ARRAY[]::text[];
+            FOR j IN 0..(jsonb_array_length(team) - 1) LOOP
+              player := team->j;
+              player_id := (player->>'id')::int;
+              player_race := NULL;
+              FOR result_pair IN SELECT jsonb_array_elements(r.results) LOOP
+                IF (result_pair->>0)::int = player_id THEN
+                  player_race := result_pair->1->>'race';
+                  EXIT;
+                END IF;
+              END LOOP;
+              IF player_race IS NULL THEN
+                -- Player missing from results, can't compute an assigned matchup for this game
+                team_races := NULL;
+                EXIT;
+              END IF;
+              team_races := array_append(team_races, player_race);
+            END LOOP;
+
+            IF team_races IS NULL THEN
+              all_team_strings := NULL;
+              EXIT;
+            END IF;
+
+            SELECT array_agg(s ORDER BY s) INTO team_races FROM unnest(team_races) AS s;
+            all_team_strings := array_append(all_team_strings, array_to_string(team_races, ''));
+          END LOOP;
+
+          IF all_team_strings IS NOT NULL THEN
+            SELECT array_agg(s ORDER BY s) INTO all_team_strings FROM unnest(all_team_strings) AS s;
+            assigned := array_to_string(all_team_strings, '-');
+          END IF;
+        END IF;
+      END IF;
+
+      IF r.selected_matchup IS DISTINCT FROM selected
+         OR r.assigned_matchup IS DISTINCT FROM assigned THEN
+        changed := changed + 1;
+        IF NOT dry_run THEN
+          UPDATE games
+          SET selected_matchup = selected, assigned_matchup = assigned
+          WHERE id = r.id;
+        END IF;
+      END IF;
+    END LOOP;
+
+    -- No rows came back, we've reached the end of the table.
+    EXIT WHEN batch_last_id IS NULL;
+
+    last_id := batch_last_id;
+    IF NOT dry_run THEN
+      COMMIT;
+      RAISE NOTICE 'backfill_matchups: processed % games (% changed so far)', processed, changed;
+    END IF;
+  END LOOP;
+
+  IF dry_run THEN
+    RAISE NOTICE 'backfill_matchups dry run: % of % games would change', changed, processed;
+  ELSE
+    RAISE NOTICE 'backfill_matchups: done, updated % of % games', changed, processed;
+  END IF;
+END;
+$$;

--- a/tools/backfill-matchups.sql
+++ b/tools/backfill-matchups.sql
@@ -49,7 +49,7 @@ BEGIN
     batch_last_id := NULL;
 
     FOR r IN
-      SELECT id, config, results, selected_matchup, assigned_matchup
+      SELECT id, config, results, disputable, selected_matchup, assigned_matchup
       FROM games
       WHERE id > last_id
       ORDER BY id
@@ -114,7 +114,11 @@ BEGIN
         -- assigned_matchup: from each player's assigned (result) race, only when results exist and
         -- there are no computer players (computers aren't included in our results). Some legacy rows
         -- store results as a non-array (e.g. an empty `{}` object), which we treat as "no results".
-        IF jsonb_typeof(r.results) = 'array' AND NOT has_computers THEN
+        -- Disputed games are skipped too: their results (and thus assigned races) are unreliable,
+        -- and a player missing from the reports gets a fabricated 'p' race baked into the stored
+        -- results. This matches the live reconciliation path, which leaves assigned_matchup NULL for
+        -- disputed games.
+        IF jsonb_typeof(r.results) = 'array' AND NOT has_computers AND NOT r.disputable THEN
           all_team_strings := ARRAY[]::text[];
           FOREACH team IN ARRAY teams_for_matchup LOOP
             team_races := ARRAY[]::text[];


### PR DESCRIPTION
Add filter bar to match history with support for filtering by game type (ranked/custom), format, duration, matchup, map name, and player name, with sorting options. Filter state is persisted in URL search params.

This filter bar is currently used in user's match history, but we'll probably reuse it in our main Games page that shows all (matchmaking) games on the platform, as well as in our League details page where we can show a list of games particular to that league.

This also adds a couple of columns in our games table in DB, selected_matchup and assigned_matchup. Selected matchup is recorded as soon as the game record is created and it uses user's selected race. Additionally, this column is saved for the games including computers as well, and it's this column that is used to filter the games by "format" (e.g. 1v1, 2v2, 3v3, 4v4).

On the other hand, assigned matchup is saved after the game results are reconciled, and it uses user's assigned race (resolves random to actual race the user got in the game). Additionally, this column is *not* saved for games that have any computers in them since computers are not included in our games results (yet). Also, this column is used for filtering games by matchup.

The data for these 2 columns is being backfilled by an SQL function in the latest migration. Also, I'll provide a dry-run version of this function that can be run manually to verify its results before actually making any changes to the DB.

This PR also adds a Filter Chip component from Material Design 3.

And finally, I also renamed "search" match history terminology to "get" match history terminology to be a bit more in line with other places we do similar things.