### PR TITLE
Increase the map thumbnail size in the find match form.

### DIFF
--- a/client/matchmaking/find-match-forms.tsx
+++ b/client/matchmaking/find-match-forms.tsx
@@ -56,7 +56,7 @@ export const OutdatedIndicator = styled.span`
   border-radius: 4px;
 `
 
-export const MAP_THUMB_SIZE_PX = 164
+export const MAP_THUMB_SIZE_PX = 196
 
 export const MapSelections = styled.div`
   margin: 16px 0;


### PR DESCRIPTION
Now that we're showing an actions button in map thumbnails there, we need more space for map title to show without being cut off.