### PR TITLE
Add data-driven matchmaking mode descriptor (mode expansion phase 1)

### DIFF
--- a/common/matchmaking.test.ts
+++ b/common/matchmaking.test.ts
@@ -123,12 +123,14 @@ describe('common/matchmaking', () => {
       expect(isSoloType(MatchmakingType.Match2v2)).toBe(false)
     })
 
-    it('returns default labels without a t function', () => {
-      expect(matchmakingTypeToLabel(MatchmakingType.Match1v1, undefined as any)).toBe('1v1')
-      expect(matchmakingTypeToLabel(MatchmakingType.Match1v1Fastest, undefined as any)).toBe(
+    it('renders the English label from the i18n default value', () => {
+      // A `t` that returns the default value (its second arg), like i18next with no translation loaded.
+      const useDefault = ((_key: string, defaultValue: string) => defaultValue) as any
+      expect(matchmakingTypeToLabel(MatchmakingType.Match1v1, useDefault)).toBe('1v1')
+      expect(matchmakingTypeToLabel(MatchmakingType.Match1v1Fastest, useDefault)).toBe(
         '1v1 Fastest',
       )
-      expect(matchmakingTypeToLabel(MatchmakingType.Match2v2, undefined as any)).toBe('2v2')
+      expect(matchmakingTypeToLabel(MatchmakingType.Match2v2, useDefault)).toBe('2v2')
     })
 
     it('looks up labels by the expected i18n keys (kept extractable for i18next-parser)', () => {

--- a/common/matchmaking.test.ts
+++ b/common/matchmaking.test.ts
@@ -131,6 +131,16 @@ describe('common/matchmaking', () => {
       expect(matchmakingTypeToLabel(MatchmakingType.Match2v2, undefined as any)).toBe('2v2')
     })
 
+    it('looks up labels by the expected i18n keys (kept extractable for i18next-parser)', () => {
+      // A `t` that echoes its key so we assert the exact key each mode resolves to.
+      const echoKey = ((key: string) => key) as any
+      expect(matchmakingTypeToLabel(MatchmakingType.Match1v1, echoKey)).toBe('matchmaking.type.1v1')
+      expect(matchmakingTypeToLabel(MatchmakingType.Match1v1Fastest, echoKey)).toBe(
+        'matchmaking.type.1v1fastest',
+      )
+      expect(matchmakingTypeToLabel(MatchmakingType.Match2v2, echoKey)).toBe('matchmaking.type.2v2')
+    })
+
     it('provides alternate-race default data only for solo modes', () => {
       expect(defaultPreferenceData(MatchmakingType.Match1v1)).toEqual({
         useAlternateRace: false,

--- a/common/matchmaking.test.ts
+++ b/common/matchmaking.test.ts
@@ -1,5 +1,16 @@
 import { describe, expect, it } from 'vitest'
-import { MatchmakingDivision, pointsToMatchmakingDivisionAndBounds } from './matchmaking'
+import {
+  ALL_MATCHMAKING_TYPES,
+  defaultPreferenceData,
+  hasVetoes,
+  isSoloType,
+  MATCHMAKING_MODES,
+  MatchmakingDivision,
+  MatchmakingType,
+  matchmakingTypeToLabel,
+  pointsToMatchmakingDivisionAndBounds,
+  TEAM_SIZES,
+} from './matchmaking'
 
 describe('common/matchmaking', () => {
   describe('pointsToMatchmakingDivisionAndBounds', () => {
@@ -83,6 +94,53 @@ describe('common/matchmaking', () => {
         6560 + 0.6 * 2400,
         6800 + 2400,
       ])
+    })
+  })
+
+  describe('mode descriptors', () => {
+    it('has an entry for every matchmaking type, keyed correctly', () => {
+      for (const type of ALL_MATCHMAKING_TYPES) {
+        expect(MATCHMAKING_MODES[type]).toBeDefined()
+        expect(MATCHMAKING_MODES[type].type).toBe(type)
+      }
+    })
+
+    it('derives TEAM_SIZES from the registry', () => {
+      expect(TEAM_SIZES[MatchmakingType.Match1v1]).toBe(1)
+      expect(TEAM_SIZES[MatchmakingType.Match1v1Fastest]).toBe(1)
+      expect(TEAM_SIZES[MatchmakingType.Match2v2]).toBe(2)
+    })
+
+    it('derives hasVetoes from map selection style', () => {
+      expect(hasVetoes(MatchmakingType.Match1v1)).toBe(true)
+      expect(hasVetoes(MatchmakingType.Match2v2)).toBe(true)
+      expect(hasVetoes(MatchmakingType.Match1v1Fastest)).toBe(false)
+    })
+
+    it('derives isSoloType from team size', () => {
+      expect(isSoloType(MatchmakingType.Match1v1)).toBe(true)
+      expect(isSoloType(MatchmakingType.Match1v1Fastest)).toBe(true)
+      expect(isSoloType(MatchmakingType.Match2v2)).toBe(false)
+    })
+
+    it('returns default labels without a t function', () => {
+      expect(matchmakingTypeToLabel(MatchmakingType.Match1v1, undefined as any)).toBe('1v1')
+      expect(matchmakingTypeToLabel(MatchmakingType.Match1v1Fastest, undefined as any)).toBe(
+        '1v1 Fastest',
+      )
+      expect(matchmakingTypeToLabel(MatchmakingType.Match2v2, undefined as any)).toBe('2v2')
+    })
+
+    it('provides alternate-race default data only for solo modes', () => {
+      expect(defaultPreferenceData(MatchmakingType.Match1v1)).toEqual({
+        useAlternateRace: false,
+        alternateRace: 'z',
+      })
+      expect(defaultPreferenceData(MatchmakingType.Match1v1Fastest)).toEqual({
+        useAlternateRace: false,
+        alternateRace: 'z',
+      })
+      expect(defaultPreferenceData(MatchmakingType.Match2v2)).toEqual({})
     })
   })
 })

--- a/common/matchmaking.ts
+++ b/common/matchmaking.ts
@@ -61,8 +61,6 @@ export interface MatchmakingModeInfo {
    * extractor, which (with `keepRemoved: false`) would drop the key from the catalog.
    */
   label: (t: TFunction) => string
-  /** English label for contexts without a `t` function. */
-  defaultLabel: string
 }
 
 /**
@@ -79,7 +77,6 @@ export const MATCHMAKING_MODES = {
     mapSelectionStyle: 'veto',
     supportsAlternateRace: true,
     label: t => t('matchmaking.type.1v1', '1v1'),
-    defaultLabel: '1v1',
   },
   [MatchmakingType.Match1v1Fastest]: {
     type: MatchmakingType.Match1v1Fastest,
@@ -89,7 +86,6 @@ export const MATCHMAKING_MODES = {
     mapSelectionStyle: 'pick',
     supportsAlternateRace: true,
     label: t => t('matchmaking.type.1v1fastest', '1v1 Fastest'),
-    defaultLabel: '1v1 Fastest',
   },
   [MatchmakingType.Match2v2]: {
     type: MatchmakingType.Match2v2,
@@ -99,7 +95,6 @@ export const MATCHMAKING_MODES = {
     mapSelectionStyle: 'veto',
     supportsAlternateRace: false,
     label: t => t('matchmaking.type.2v2', '2v2'),
-    defaultLabel: '2v2',
   },
 } satisfies Record<MatchmakingType, MatchmakingModeInfo>
 
@@ -109,8 +104,7 @@ export function getMatchmakingModeInfo(type: MatchmakingType): MatchmakingModeIn
 }
 
 export function matchmakingTypeToLabel(type: MatchmakingType, t: TFunction): string {
-  const mode = MATCHMAKING_MODES[type]
-  return t ? mode.label(t) : mode.defaultLabel
+  return MATCHMAKING_MODES[type].label(t)
 }
 
 /**

--- a/common/matchmaking.ts
+++ b/common/matchmaking.ts
@@ -55,9 +55,13 @@ export interface MatchmakingModeInfo {
   mapSelectionStyle: MapSelectionStyle
   /** Whether players can pick an alternate race for mirror matchups (1v1-style modes only). */
   supportsAlternateRace: boolean
-  /** i18n key for the mode's display label. */
-  labelKey: string
-  /** Fallback English label; also used when no `t` function is available. */
+  /**
+   * Returns the mode's localized display label. Written as an inline `t()` call with a string-literal
+   * key so i18next-parser can statically extract it — a dynamic `t(key)` is invisible to the
+   * extractor, which (with `keepRemoved: false`) would drop the key from the catalog.
+   */
+  label: (t: TFunction) => string
+  /** English label for contexts without a `t` function. */
   defaultLabel: string
 }
 
@@ -74,7 +78,7 @@ export const MATCHMAKING_MODES = {
     teamSize: 1,
     mapSelectionStyle: 'veto',
     supportsAlternateRace: true,
-    labelKey: 'matchmaking.type.1v1',
+    label: t => t('matchmaking.type.1v1', '1v1'),
     defaultLabel: '1v1',
   },
   [MatchmakingType.Match1v1Fastest]: {
@@ -84,7 +88,7 @@ export const MATCHMAKING_MODES = {
     teamSize: 1,
     mapSelectionStyle: 'pick',
     supportsAlternateRace: true,
-    labelKey: 'matchmaking.type.1v1fastest',
+    label: t => t('matchmaking.type.1v1fastest', '1v1 Fastest'),
     defaultLabel: '1v1 Fastest',
   },
   [MatchmakingType.Match2v2]: {
@@ -94,7 +98,7 @@ export const MATCHMAKING_MODES = {
     teamSize: 2,
     mapSelectionStyle: 'veto',
     supportsAlternateRace: false,
-    labelKey: 'matchmaking.type.2v2',
+    label: t => t('matchmaking.type.2v2', '2v2'),
     defaultLabel: '2v2',
   },
 } satisfies Record<MatchmakingType, MatchmakingModeInfo>
@@ -105,8 +109,8 @@ export function getMatchmakingModeInfo(type: MatchmakingType): MatchmakingModeIn
 }
 
 export function matchmakingTypeToLabel(type: MatchmakingType, t: TFunction): string {
-  const { labelKey, defaultLabel } = MATCHMAKING_MODES[type]
-  return t ? t(labelKey, defaultLabel) : defaultLabel
+  const mode = MATCHMAKING_MODES[type]
+  return t ? mode.label(t) : mode.defaultLabel
 }
 
 /**

--- a/common/matchmaking.ts
+++ b/common/matchmaking.ts
@@ -20,17 +20,93 @@ export { MatchmakingType }
 
 export const ALL_MATCHMAKING_TYPES: ReadonlyArray<MatchmakingType> = Object.values(MatchmakingType)
 
+/** The team-size family a mode belongs to. The primary axis for grouping modes in the UI. */
+export type MatchmakingFormat = '1v1' | '2v2' | '3v3'
+
+/** The ruleset/map family of a mode within a format. */
+export type MatchmakingVariant = 'standard' | 'hunters' | 'bgh' | 'fastest'
+
+/**
+ * How players choose maps for a mode:
+ * - `veto`: players veto maps they don't want to play; the match map is chosen from what remains.
+ * - `pick`: players positively select maps they're willing to play; the match map is chosen from the
+ *   intersection of all players' selections.
+ * - `fixed`: the mode always plays a single map. The selection is made automatically and players
+ *   can't change it (handled internally like a `pick` with one forced map).
+ */
+export type MapSelectionStyle = 'veto' | 'pick' | 'fixed'
+
+/**
+ * Static, data-driven description of a matchmaking mode. This is the single source of truth for the
+ * per-mode properties that were previously hardcoded in `switch (MatchmakingType)` statements
+ * scattered across the codebase. UI and server code should read from here (and iterate
+ * `MATCHMAKING_MODES`) rather than switching on `MatchmakingType`, so that adding a mode is mostly a
+ * matter of adding an entry to the registry.
+ */
+export interface MatchmakingModeInfo {
+  type: MatchmakingType
+  /** Team-size family; the primary grouping axis in the UI. */
+  format: MatchmakingFormat
+  /** Ruleset/map family within the format. */
+  variant: MatchmakingVariant
+  /** Number of players per team. */
+  teamSize: number
+  /** How maps are chosen for this mode. */
+  mapSelectionStyle: MapSelectionStyle
+  /** Whether players can pick an alternate race for mirror matchups (1v1-style modes only). */
+  supportsAlternateRace: boolean
+  /** i18n key for the mode's display label. */
+  labelKey: string
+  /** Fallback English label; also used when no `t` function is available. */
+  defaultLabel: string
+}
+
+/**
+ * The registry of all matchmaking modes, keyed by `MatchmakingType`. The `satisfies` clause forces an
+ * entry for every `MatchmakingType`, so adding a value to the enum is a compile error until the new
+ * mode is described here.
+ */
+export const MATCHMAKING_MODES = {
+  [MatchmakingType.Match1v1]: {
+    type: MatchmakingType.Match1v1,
+    format: '1v1',
+    variant: 'standard',
+    teamSize: 1,
+    mapSelectionStyle: 'veto',
+    supportsAlternateRace: true,
+    labelKey: 'matchmaking.type.1v1',
+    defaultLabel: '1v1',
+  },
+  [MatchmakingType.Match1v1Fastest]: {
+    type: MatchmakingType.Match1v1Fastest,
+    format: '1v1',
+    variant: 'fastest',
+    teamSize: 1,
+    mapSelectionStyle: 'pick',
+    supportsAlternateRace: true,
+    labelKey: 'matchmaking.type.1v1fastest',
+    defaultLabel: '1v1 Fastest',
+  },
+  [MatchmakingType.Match2v2]: {
+    type: MatchmakingType.Match2v2,
+    format: '2v2',
+    variant: 'standard',
+    teamSize: 2,
+    mapSelectionStyle: 'veto',
+    supportsAlternateRace: false,
+    labelKey: 'matchmaking.type.2v2',
+    defaultLabel: '2v2',
+  },
+} satisfies Record<MatchmakingType, MatchmakingModeInfo>
+
+/** Returns the static mode descriptor for a given `MatchmakingType`. */
+export function getMatchmakingModeInfo(type: MatchmakingType): MatchmakingModeInfo {
+  return MATCHMAKING_MODES[type]
+}
+
 export function matchmakingTypeToLabel(type: MatchmakingType, t: TFunction): string {
-  switch (type) {
-    case MatchmakingType.Match1v1:
-      return t ? t('matchmaking.type.1v1', '1v1') : '1v1'
-    case MatchmakingType.Match1v1Fastest:
-      return t ? t('matchmaking.type.1v1fastest', '1v1 Fastest') : '1v1 Fastest'
-    case MatchmakingType.Match2v2:
-      return t ? t('matchmaking.type.2v2', '2v2') : '2v2'
-    default:
-      return assertUnreachable(type)
-  }
+  const { labelKey, defaultLabel } = MATCHMAKING_MODES[type]
+  return t ? t(labelKey, defaultLabel) : defaultLabel
 }
 
 /**
@@ -38,15 +114,15 @@ export function matchmakingTypeToLabel(type: MatchmakingType, t: TFunction): str
  * e.g. select the maps you want to play on).
  */
 export function hasVetoes(type: MatchmakingType): boolean {
-  return type !== MatchmakingType.Match1v1Fastest
+  return MATCHMAKING_MODES[type].mapSelectionStyle === 'veto'
 }
 
 /**
- * Returns whether the matchmaking type is a 1v1 mode (which we have different division handling
- * for).
+ * Returns whether the matchmaking type is a solo (one player per team) mode, which we have different
+ * division handling for.
  */
 export function isSoloType(type: MatchmakingType): boolean {
-  return type === MatchmakingType.Match1v1 || type === MatchmakingType.Match1v1Fastest
+  return MATCHMAKING_MODES[type].teamSize === 1
 }
 
 /**
@@ -508,13 +584,12 @@ export function getTotalBonusPoolForSeason(
 }
 
 /**
- * A Record of MatchmakingType -> the size of a team within a match.
+ * A Record of MatchmakingType -> the size of a team within a match. Derived from
+ * `MATCHMAKING_MODES`, which is the source of truth for team sizes.
  */
-export const TEAM_SIZES: Readonly<Record<MatchmakingType, number>> = {
-  [MatchmakingType.Match1v1]: 1,
-  [MatchmakingType.Match1v1Fastest]: 1,
-  [MatchmakingType.Match2v2]: 2,
-}
+export const TEAM_SIZES: Readonly<Record<MatchmakingType, number>> = Object.fromEntries(
+  ALL_MATCHMAKING_TYPES.map(type => [type, MATCHMAKING_MODES[type].teamSize]),
+) as Record<MatchmakingType, number>
 
 export function isValidMatchmakingType(type: string) {
   return Object.values(MatchmakingType).includes(type as MatchmakingType)
@@ -733,18 +808,9 @@ export type PreferenceData = MatchmakingPreferences['data']
 export function defaultPreferenceData<M extends MatchmakingType>(
   matchmakingType: M,
 ): MatchmakingPreferencesOfType<M>['data'] {
-  switch (matchmakingType) {
-    case MatchmakingType.Match1v1:
-    case MatchmakingType.Match1v1Fastest:
-      return {
-        useAlternateRace: false,
-        alternateRace: 'z',
-      }
-    case MatchmakingType.Match2v2:
-      return {}
-    default:
-      return assertUnreachable(matchmakingType)
-  }
+  return MATCHMAKING_MODES[matchmakingType].supportsAlternateRace
+    ? { useAlternateRace: false, alternateRace: 'z' }
+    : {}
 }
 
 export function defaultPreferences<M extends MatchmakingType>(


### PR DESCRIPTION
## What

First step of expanding matchmaking to support many more modes (2v2/3v3 × Hunters/BGH/Fastest, etc.) without the per-mode `switch (MatchmakingType)` sprawl getting unmanageable.

Introduces **`MATCHMAKING_MODES`** in `common/matchmaking.ts` — a registry keyed by `MatchmakingType` (`MatchmakingModeInfo`) that describes each mode's `format`, `variant`, `teamSize`, `mapSelectionStyle`, `supportsAlternateRace`, and label. This is the single source of truth that the previously-scattered per-type helpers now read from, so adding a mode becomes mostly a matter of adding a registry entry. The `satisfies Record<MatchmakingType, MatchmakingModeInfo>` clause forces an entry for every mode — adding an enum value is a compile error until it's described.

Supporting types added: `MatchmakingFormat` (`1v1 | 2v2 | 3v3`), `MatchmakingVariant` (`standard | hunters | bgh | fastest`), and `MapSelectionStyle` (`veto | pick | fixed`). The new `fixed` style (one auto-selected map, no UI) is defined here and will be consumed in the next PR.

Refactored to derive from the registry, with **no behavior change** for the existing three modes:
- `matchmakingTypeToLabel`
- `hasVetoes` → `mapSelectionStyle === 'veto'`
- `isSoloType` → `teamSize === 1`
- `TEAM_SIZES` (now derived from the registry)
- `defaultPreferenceData` → driven by `supportsAlternateRace`

## Why

This is phase 1 of a larger, incremental plan (one reviewable PR at a time). Later PRs build on this descriptor: `fixed`-map plumbing, a unified config-driven settings form, format-first ladder/profile/admin UI to avoid clutter at 9+ modes, then the modes themselves.

## Verification

- `pnpm run typecheck` — clean
- `pnpm run test` (matchmaking + ladder suites) — pass, plus added unit tests for the descriptor and the helpers derived from it
- `eslint --fix` — clean

No runtime behavior changes; this is a pure refactor + new data/types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)