### PR TITLE
Support the fixed map-selection style (mode expansion phase 2)

### DIFF
--- a/server/lib/matchmaking/map-selections.test.ts
+++ b/server/lib/matchmaking/map-selections.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+import { makeSbMapId } from '../../../common/maps'
+import { computeMatchMapCandidates } from './map-selections'
+
+const m = makeSbMapId
+const pool = [m('a'), m('b'), m('c'), m('d')]
+
+describe('server/matchmaking/computeMatchMapCandidates', () => {
+  describe('fixed', () => {
+    it('returns the full pool and ignores player selections', () => {
+      expect(computeMatchMapCandidates('fixed', pool, [[m('a')], [m('b')]])).toEqual(new Set(pool))
+    })
+
+    it('returns the (single-map) pool with no selections', () => {
+      expect(computeMatchMapCandidates('fixed', [m('a')], [])).toEqual(new Set([m('a')]))
+    })
+  })
+
+  describe('pick', () => {
+    it('returns the intersection of all players selections', () => {
+      expect(
+        computeMatchMapCandidates('pick', pool, [
+          [m('a'), m('b'), m('c')],
+          [m('b'), m('c'), m('d')],
+        ]),
+      ).toEqual(new Set([m('b'), m('c')]))
+    })
+
+    it('returns an empty set when selections do not overlap', () => {
+      expect(computeMatchMapCandidates('pick', pool, [[m('a')], [m('b')]])).toEqual(new Set())
+    })
+  })
+
+  describe('veto', () => {
+    it('removes vetoed maps from the pool', () => {
+      expect(computeMatchMapCandidates('veto', pool, [[m('a')], [m('b')]])).toEqual(
+        new Set([m('c'), m('d')]),
+      )
+    })
+
+    it('returns the full pool when nothing is vetoed', () => {
+      expect(computeMatchMapCandidates('veto', pool, [[], []])).toEqual(new Set(pool))
+    })
+
+    it('falls back to the least-vetoed maps when the whole pool is vetoed', () => {
+      // `a` is vetoed twice, `b`/`c`/`d` once each — fall back to the least-vetoed (b, c, d).
+      expect(
+        computeMatchMapCandidates('veto', pool, [[m('a'), m('b'), m('c'), m('d')], [m('a')]]),
+      ).toEqual(new Set([m('b'), m('c'), m('d')]))
+    })
+  })
+})

--- a/server/lib/matchmaking/map-selections.ts
+++ b/server/lib/matchmaking/map-selections.ts
@@ -1,6 +1,7 @@
 import { ReadonlyDeep } from 'type-fest'
+import { intersection, subtract } from '../../../common/data-structures/sets'
 import { SbMapId } from '../../../common/maps'
-import { hasVetoes } from '../../../common/matchmaking'
+import { hasVetoes, MapSelectionStyle } from '../../../common/matchmaking'
 import { MatchmakingMapPool } from '../../../common/matchmaking/matchmaking-map-pools'
 
 /**
@@ -13,4 +14,63 @@ export function filterMapSelections(
 ): SbMapId[] {
   const result = selectedMapIds.filter(id => mapPool.maps.includes(id))
   return hasVetoes(mapPool.matchmakingType) ? result.slice(0, mapPool.maxVetoCount) : result
+}
+
+/**
+ * Computes the set of maps a match could be played on, given the mode's map-selection style and each
+ * participating entity's map selections. A single map is then chosen at random from this set.
+ *
+ * - `veto`: each entity's selections are vetoes and are removed from the pool. If every map ends up
+ *   vetoed, fall back to the least-vetoed maps so a match can still form.
+ * - `pick`: each entity's selections are positive picks; the candidates are the intersection of all
+ *   entities' selections (the maps everyone is willing to play).
+ * - `fixed`: players don't choose maps. The match always uses the mode's configured pool regardless
+ *   of player input, so the candidates are the full pool. A true single-map mode simply has a
+ *   one-map pool; this is modeled internally as a pick that's made automatically for the players.
+ */
+export function computeMatchMapCandidates(
+  style: MapSelectionStyle,
+  fullMapPool: ReadonlyArray<SbMapId>,
+  entityMapSelections: ReadonlyArray<ReadonlyArray<SbMapId>>,
+): Set<SbMapId> {
+  if (style === 'fixed') {
+    return new Set(fullMapPool)
+  }
+
+  if (style === 'pick') {
+    let pool = new Set(fullMapPool)
+    for (const selections of entityMapSelections) {
+      pool = intersection(pool, new Set(selections))
+    }
+    return pool
+  }
+
+  // Veto
+  let pool = new Set(fullMapPool)
+  const vetoCount = new Map<SbMapId, number>()
+  for (const selections of entityMapSelections) {
+    pool = subtract(pool, selections)
+    for (const map of selections) {
+      vetoCount.set(map, (vetoCount.get(map) ?? 0) + 1)
+    }
+  }
+
+  if (!pool.size) {
+    // All available maps were vetoed; build a final pool from the least-vetoed maps. We know every
+    // map in the original pool has a veto entry here (the whole pool was vetoed), so the sorted list
+    // is non-empty.
+    const sortedByVetoCount = Array.from(vetoCount.entries()).sort((a, b) => a[1] - b[1])
+    const leastVetoCount = sortedByVetoCount[0][1]
+    let lastElem = 1
+    while (
+      lastElem < sortedByVetoCount.length &&
+      sortedByVetoCount[lastElem][1] <= leastVetoCount
+    ) {
+      lastElem += 1
+    }
+
+    pool = new Set(sortedByVetoCount.slice(0, lastElem).map(e => e[0]))
+  }
+
+  return pool
 }

--- a/server/lib/matchmaking/matchmaking-api.ts
+++ b/server/lib/matchmaking/matchmaking-api.ts
@@ -10,8 +10,8 @@ import {
   DraftProvisionalPickRequest,
   FindMatchRequest,
   GetMatchmakingBanStatusResponse,
+  getMatchmakingModeInfo,
   GetMatchmakingSeasonsResponse,
-  hasVetoes,
   MatchmakingSeasonsServiceErrorCode,
   MatchmakingServiceErrorCode,
   SeasonId,
@@ -157,7 +157,13 @@ export class MatchmakingApi {
         }
 
         const mapSelections = filterMapSelections(currentMapPool, pref.mapSelections)
-        if (!hasVetoes(pref.matchmakingType) && !mapSelections.length) {
+        // Only positive-pick modes require an explicit selection. Veto modes default to the whole
+        // pool when nothing is vetoed, and fixed modes ignore player selections entirely (the map is
+        // chosen automatically), so neither should be rejected for an empty selection.
+        if (
+          getMatchmakingModeInfo(pref.matchmakingType).mapSelectionStyle === 'pick' &&
+          !mapSelections.length
+        ) {
           throw new MatchmakingServiceError(
             MatchmakingServiceErrorCode.InvalidMaps,
             'No maps selected',

--- a/server/lib/matchmaking/matchmaking-service.ts
+++ b/server/lib/matchmaking/matchmaking-service.ts
@@ -8,7 +8,7 @@ import { isAbortError, raceAbort } from '../../../common/async/abort-signals'
 import createDeferred, { Deferred } from '../../../common/async/deferred'
 import swallowNonBuiltins from '../../../common/async/swallow-non-builtins'
 import { timeoutPromise } from '../../../common/async/timeout-promise'
-import { intersection, subtract, union } from '../../../common/data-structures/sets'
+import { subtract, union } from '../../../common/data-structures/sets'
 import {
   GameConfig,
   GameConfigPlayer,
@@ -18,9 +18,9 @@ import {
 import { PlayerInfo } from '../../../common/games/game-launch-config'
 import { GameType } from '../../../common/games/game-type'
 import { createHuman, Slot, SlotType } from '../../../common/lobbies/slot'
-import { MapInfo, SbMapId } from '../../../common/maps'
+import { MapInfo } from '../../../common/maps'
 import {
-  hasVetoes,
+  getMatchmakingModeInfo,
   MATCHMAKING_ACCEPT_MATCH_TIME_MS,
   MatchmakingCompletionType,
   MatchmakingEvent,
@@ -77,6 +77,7 @@ import {
 } from '../websockets/socket-groups'
 import { TypedPublisher } from '../websockets/typed-publisher'
 import { DraftState } from './draft-state'
+import { computeMatchMapCandidates } from './map-selections'
 import { MatchmakingBanService } from './matchmaking-ban-service'
 import { getCurrentMapPool } from './matchmaking-map-pools-models'
 import { MatchmakingSeasonsService } from './matchmaking-seasons'
@@ -279,48 +280,11 @@ async function pickMap(
     )
   }
 
-  const fullMapPool = new Set(currentMapPool.maps)
-  let mapPool = fullMapPool
-  if (hasVetoes(matchmakingType)) {
-    // The algorithm for selecting maps in a veto system is:
-    // 1) All players' map selections are treated as vetoes, and removed from the available map
-    //    pool. We also track how many times each map was vetoed.
-    // 2a) If any maps are remaining, select a random map from the remaining ones
-    // 2b) If no maps are remaining, select a random map from the least vetoed maps
-
-    const vetoCount = new Map<SbMapId, number>()
-    for (const e of entities) {
-      const mapSelections = e.mapSelections
-      mapPool = subtract(mapPool, mapSelections)
-      for (const map of mapSelections) {
-        vetoCount.set(map, (vetoCount.get(map) ?? 0) + 1)
-      }
-    }
-
-    if (!mapPool.size) {
-      // All available maps were vetoed, create a final pool from the least vetoed maps
-      // NOTE(tec27): We know since the whole pool was vetoed, each map in the pool will have an
-      // entry here, even though we didn't initialize the Map directly
-      const sortedByVetoCount = Array.from(vetoCount.entries()).sort((a, b) => a[1] - b[1])
-      const leastVetoCount = sortedByVetoCount[0][1]
-      let lastElem = 1
-      while (
-        lastElem < sortedByVetoCount.length &&
-        sortedByVetoCount[lastElem][1] <= leastVetoCount
-      ) {
-        lastElem += 1
-      }
-
-      mapPool = new Set(sortedByVetoCount.slice(0, lastElem).map(e => e[0]))
-    }
-  } else {
-    // For a positive map selection system, we just intersect all players' map selections to find
-    // the pool
-    for (const e of entities) {
-      const mapSelections = new Set(e.mapSelections)
-      mapPool = intersection(mapPool, mapSelections)
-    }
-  }
+  const mapPool = computeMatchMapCandidates(
+    getMatchmakingModeInfo(matchmakingType).mapSelectionStyle,
+    currentMapPool.maps,
+    entities.map(e => e.mapSelections),
+  )
 
   const chosenMapId = randomItem(Array.from(mapPool))
   const mapInfo = await getMapInfos([chosenMapId])


### PR DESCRIPTION
## What

Phase 2 of the matchmaking mode expansion. Adds server-side support for the `fixed` map-selection style introduced in #1300, so upcoming modes can play on a single auto-selected map the player can't change.

Map selection is now generalized over all three `MapSelectionStyle` values via a pure, unit-tested helper, `computeMatchMapCandidates(style, fullPool, entitySelections)`:
- **veto** — each player's selections are vetoes removed from the pool; falls back to the least-vetoed maps if everything is vetoed.
- **pick** — the intersection of all players' selections (maps everyone is willing to play).
- **fixed** — player selections are ignored; the match always uses the mode's configured pool. A true single-map mode simply has a one-map pool; this is modeled internally as an automatic pick.

`pickMap` now switches on the descriptor's `mapSelectionStyle` instead of the `hasVetoes` boolean, and the `findMatch` validator only requires an explicit map selection for **pick** modes — **veto** and **fixed** both allow an empty selection.

## Scope note

This is **server-only**. The client UI for fixed modes (a read-only map display instead of a veto/pick control) will land with the unified, config-driven settings form in the next phase — there's no `fixed` mode in the enum yet to render, and the current per-mode forms are being replaced anyway, so adding a fixed branch to them now would be throwaway work.

## Why

`fixed` is a known upcoming requirement (e.g. fixed-map variants). Getting the map-selection abstraction right and tested now means adding such a mode later is just a registry entry + a map pool.

## Verification

- `pnpm run typecheck` — clean
- `pnpm run test` (server/lib/matchmaking) — 49 pass, including new `computeMatchMapCandidates` tests covering all three styles (incl. the veto all-vetoed fallback and the new fixed branch); the existing service tests still cover the veto/pick `pickMap` path unchanged
- `eslint --fix` — clean
- `pnpm gen-translations` — no drift (no `t()` changes)

No behavior change for the existing veto/pick modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)