### PR TITLE
Enforce map overlap for pick modes in the matchmaker

### DIFF
--- a/server-rs/benches/matchmaker.rs
+++ b/server-rs/benches/matchmaker.rs
@@ -16,6 +16,7 @@ fn bench_1v1(c: &mut Criterion) {
                 uncertainty: None,
             },
         )]),
+        map_selections: HashMap::new(),
         latency_bucket: None,
     }) {
         matchmaker.insert_player(player).unwrap();
@@ -36,6 +37,7 @@ fn bench_2v2(c: &mut Criterion) {
                 uncertainty: None,
             },
         )]),
+        map_selections: HashMap::new(),
         latency_bucket: None,
     }) {
         matchmaker.insert_player(player).unwrap();

--- a/server-rs/src/matchmaking/api.rs
+++ b/server-rs/src/matchmaking/api.rs
@@ -15,6 +15,7 @@ use axum::{Json, Router, extract::State, routing::post};
 use base64::Engine as _;
 use base64::prelude::BASE64_STANDARD;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 use uuid::Uuid;
@@ -63,6 +64,10 @@ struct PlayerModeRatingDto {
     mode: MatchmakingType,
     rating: f32,
     uncertainty: Option<f32>,
+    /// Positive map selections for this mode, present only for "pick" modes. Used by the matchmaker
+    /// to require that matched players share at least one map. `None`/absent for veto/fixed modes.
+    #[serde(default)]
+    map_selections: Option<Vec<String>>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -113,6 +118,35 @@ fn lock_matchmaker(
         .unwrap_or_else(|poisoned| poisoned.into_inner())
 }
 
+/// Builds a [`Player`] from the per-mode DTOs received over the wire (or restored from a ticket),
+/// splitting them into the rating map and the positive-map-selection map.
+fn build_player(
+    id: usize,
+    mode_ratings: Vec<PlayerModeRatingDto>,
+    latency_bucket: Option<u8>,
+) -> Player {
+    let mut ratings = HashMap::new();
+    let mut map_selections = HashMap::new();
+    for r in mode_ratings {
+        ratings.insert(
+            r.mode,
+            PlayerModeRating {
+                rating: r.rating,
+                uncertainty: r.uncertainty,
+            },
+        );
+        if let Some(maps) = r.map_selections {
+            map_selections.insert(r.mode, maps);
+        }
+    }
+    Player {
+        id,
+        ratings,
+        map_selections,
+        latency_bucket,
+    }
+}
+
 fn build_ticket(entry: &QueueEntry, process_token: &Uuid, matchmaker_start: Instant) -> String {
     let ticket = QueueTicket {
         id: entry.player.id,
@@ -124,6 +158,7 @@ fn build_ticket(entry: &QueueEntry, process_token: &Uuid, matchmaker_start: Inst
                 mode,
                 rating: r.rating,
                 uncertainty: r.uncertainty,
+                map_selections: entry.player.map_selections.get(&mode).cloned(),
             })
             .collect(),
         latency_bucket: entry.player.latency_bucket,
@@ -282,25 +317,9 @@ async fn insert_player(
     State(state): State<MatchmakingApiState>,
     Json(payload): Json<QueueRequest>,
 ) -> Result<StatusCode, MatchmakerError> {
-    let ratings = payload
-        .mode_ratings
-        .into_iter()
-        .map(|r| {
-            (
-                r.mode,
-                PlayerModeRating {
-                    rating: r.rating,
-                    uncertainty: r.uncertainty,
-                },
-            )
-        })
-        .collect();
+    let player = build_player(payload.id, payload.mode_ratings, payload.latency_bucket);
     let mut matchmaker = lock_matchmaker(&state.matchmaker);
-    matchmaker.insert_player(Player {
-        id: payload.id,
-        ratings,
-        latency_bucket: payload.latency_bucket,
-    })?;
+    matchmaker.insert_player(player)?;
     Ok(StatusCode::NO_CONTENT)
 }
 
@@ -349,23 +368,7 @@ async fn requeue_player(
     let mut matchmaker = lock_matchmaker(&state.matchmaker);
     let queue_time = matchmaker.start() + Duration::from_millis(ticket.queue_time);
     match matchmaker.requeue_player(
-        Player {
-            id: ticket.id,
-            ratings: ticket
-                .mode_ratings
-                .into_iter()
-                .map(|r| {
-                    (
-                        r.mode,
-                        PlayerModeRating {
-                            rating: r.rating,
-                            uncertainty: r.uncertainty,
-                        },
-                    )
-                })
-                .collect(),
-            latency_bucket: ticket.latency_bucket,
-        },
+        build_player(ticket.id, ticket.mode_ratings, ticket.latency_bucket),
         queue_time,
     ) {
         Ok(_) => StatusCode::NO_CONTENT.into_response(),
@@ -415,6 +418,7 @@ mod tests {
                         uncertainty: None,
                     },
                 )]),
+                map_selections: HashMap::new(),
                 latency_bucket: None,
             },
             modes: MatchmakingType::Match1v1.into(),
@@ -430,6 +434,7 @@ mod tests {
                         uncertainty: None,
                     },
                 )]),
+                map_selections: HashMap::new(),
                 latency_bucket: None,
             },
             modes: MatchmakingType::Match1v1.into(),
@@ -445,6 +450,7 @@ mod tests {
                         uncertainty: None,
                     },
                 )]),
+                map_selections: HashMap::new(),
                 latency_bucket: None,
             },
             modes: MatchmakingType::Match1v1.into(),

--- a/server-rs/src/matchmaking/matchmaker.rs
+++ b/server-rs/src/matchmaking/matchmaker.rs
@@ -47,6 +47,11 @@ const ADAPTIVE_COMFORTABLE_MULTIPLIER: usize = 2;
 /// Seconds the quality threshold drops per player below the comfortable queue size.
 const ADAPTIVE_DECAY_PER_MISSING: f32 = 15.0;
 
+/// Identifies a map. Opaque to the matchmaker — only compared for equality when verifying that the
+/// players in a positive-selection mode share at least one map. Matches the string `SbMapId` used
+/// elsewhere in the codebase.
+pub type MapId = String;
+
 #[derive(Debug, Copy, Clone, PartialEq, Default)]
 pub struct PlayerModeRating {
     pub rating: f32,
@@ -61,6 +66,12 @@ pub struct Player {
     /// The set of keys *is* the set of modes the player is queued for: the queue entry's modes are
     /// derived from this map (see `create_entry_and_update_modes`).
     pub ratings: HashMap<MatchmakingType, PlayerModeRating>,
+    /// Per-mode positive map selections, present only for modes that use positive map selection
+    /// ("pick"). When every player in a candidate match carries selections for the mode, the match
+    /// is only formed if they share at least one map (see `find_matches_for_modes`); otherwise no
+    /// map could be chosen and the match would fail downstream. Veto/fixed modes have no entry here
+    /// and are unconstrained.
+    pub map_selections: HashMap<MatchmakingType, Vec<MapId>>,
     /// Latency tier (0 = great, 1 = fine, 2 = noticeable, 3 = bad). None treated as 0.
     pub latency_bucket: Option<u8>,
 }
@@ -176,6 +187,19 @@ fn get_team_rating(team: &[&QueueEntry], mode: MatchmakingType) -> f32 {
 /// side.
 fn get_win_probability(rating_a: f32, rating_b: f32) -> f32 {
     1.0 / (1.0 + 10.0f32.powf((rating_b - rating_a) / 400.0))
+}
+
+/// Returns whether every player's positive map selections share at least one common map. Used to
+/// avoid forming matches for positive-selection ("pick") modes where no single map satisfies
+/// everyone — such a match could not have its map chosen and would fail when it tried to start. An
+/// empty input (no players carry selections) is treated as having overlap, i.e. no constraint.
+fn selections_share_a_map(selections: &[&Vec<MapId>]) -> bool {
+    match selections.split_first() {
+        Some((first, rest)) => first
+            .iter()
+            .any(|map| rest.iter().all(|other| other.contains(map))),
+        None => true,
+    }
 }
 
 impl<T: QueueSelector> Matchmaker<T> {
@@ -320,6 +344,20 @@ impl<T: QueueSelector> Matchmaker<T> {
                 .combinations(mode.total_players())
                 // Calculate match quality
                 .filter_map(|queue_entries| {
+                    // For positive-selection ("pick") modes, every player carries their map
+                    // selections; reject any combination whose players share no map, since the
+                    // match map couldn't be chosen and the match would fail. Veto/fixed modes store
+                    // no selections, so this check is a no-op for them.
+                    let mode_selections: Vec<&Vec<MapId>> = queue_entries
+                        .iter()
+                        .filter_map(|q| q.player.map_selections.get(mode))
+                        .collect();
+                    if mode_selections.len() == queue_entries.len()
+                        && !selections_share_a_map(&mode_selections)
+                    {
+                        return None;
+                    }
+
                     let mut oldest_queue_time = queue_entries[0].queue_time;
                     let mut count = 0;
                     let mut mean = 0.0;
@@ -431,6 +469,7 @@ mod tests {
                     uncertainty: None,
                 },
             )]),
+            map_selections: HashMap::new(),
             latency_bucket: None,
         }
     }
@@ -452,6 +491,7 @@ mod tests {
                     )
                 })
                 .collect(),
+            map_selections: HashMap::new(),
             latency_bucket: None,
         }
     }
@@ -736,6 +776,7 @@ mod tests {
                         uncertainty: None,
                     },
                 )]),
+                map_selections: HashMap::new(),
                 latency_bucket: Some(2),
             })
             .unwrap();
@@ -749,6 +790,7 @@ mod tests {
                         uncertainty: None,
                     },
                 )]),
+                map_selections: HashMap::new(),
                 latency_bucket: Some(2),
             })
             .unwrap();
@@ -817,6 +859,7 @@ mod tests {
                     uncertainty: Some(350.0),
                 },
             )]),
+            map_selections: HashMap::new(),
             latency_bucket: None,
         };
         let certain = Player {
@@ -828,6 +871,7 @@ mod tests {
                     uncertainty: None,
                 },
             )]),
+            map_selections: HashMap::new(),
             latency_bucket: None,
         };
 
@@ -873,6 +917,7 @@ mod tests {
                     },
                 ),
             ]),
+            map_selections: HashMap::new(),
             latency_bucket: None,
         };
         let player_b = Player {
@@ -893,6 +938,7 @@ mod tests {
                     },
                 ),
             ]),
+            map_selections: HashMap::new(),
             latency_bucket: None,
         };
         matchmaker.insert_player(player_a).unwrap();
@@ -912,5 +958,77 @@ mod tests {
                 .iter()
                 .any(|m| m.mode == MatchmakingType::Match1v1Fastest)
         );
+    }
+
+    /// Builds a player queued for a single mode with the given positive map selections.
+    fn make_player_with_maps(
+        id: usize,
+        rating: f32,
+        mode: MatchmakingType,
+        maps: &[&str],
+    ) -> Player {
+        Player {
+            id,
+            ratings: HashMap::from([(
+                mode,
+                PlayerModeRating {
+                    rating,
+                    uncertainty: None,
+                },
+            )]),
+            map_selections: HashMap::from([(
+                mode,
+                maps.iter().map(|m| m.to_string()).collect(),
+            )]),
+            latency_bucket: None,
+        }
+    }
+
+    #[test]
+    fn pick_mode_does_not_match_disjoint_map_selections() {
+        let mut matchmaker = Matchmaker::with_queue_selector(16, TestQueueSelector);
+        matchmaker
+            .insert_player(make_player_with_maps(0, 1000.0, MatchmakingType::Match1v1, &["a"]))
+            .unwrap();
+        matchmaker
+            .insert_player(make_player_with_maps(1, 1000.0, MatchmakingType::Match1v1, &["b"]))
+            .unwrap();
+
+        // Even at the most lenient quality, players who share no map must not be matched (the match
+        // map could not be chosen and the match would fail to start).
+        let result = matchmaker.find_matches_for_modes(
+            &[MatchmakingType::Match1v1],
+            f32::NEG_INFINITY,
+            Instant::now(),
+        );
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn pick_mode_matches_when_selections_share_a_map() {
+        let mut matchmaker = Matchmaker::with_queue_selector(16, TestQueueSelector);
+        matchmaker
+            .insert_player(make_player_with_maps(
+                0,
+                1000.0,
+                MatchmakingType::Match1v1,
+                &["a", "b"],
+            ))
+            .unwrap();
+        matchmaker
+            .insert_player(make_player_with_maps(
+                1,
+                1000.0,
+                MatchmakingType::Match1v1,
+                &["b", "c"],
+            ))
+            .unwrap();
+
+        let result = matchmaker.find_matches_for_modes(
+            &[MatchmakingType::Match1v1],
+            f32::NEG_INFINITY,
+            Instant::now(),
+        );
+        assert_eq!(result.len(), 1);
     }
 }

--- a/server-rs/src/matchmaking/matchmaker.rs
+++ b/server-rs/src/matchmaking/matchmaker.rs
@@ -976,10 +976,7 @@ mod tests {
                     uncertainty: None,
                 },
             )]),
-            map_selections: HashMap::from([(
-                mode,
-                maps.iter().map(|m| m.to_string()).collect(),
-            )]),
+            map_selections: HashMap::from([(mode, maps.iter().map(|m| m.to_string()).collect())]),
             latency_bucket: None,
         }
     }
@@ -988,10 +985,20 @@ mod tests {
     fn pick_mode_does_not_match_disjoint_map_selections() {
         let mut matchmaker = Matchmaker::with_queue_selector(16, TestQueueSelector);
         matchmaker
-            .insert_player(make_player_with_maps(0, 1000.0, MatchmakingType::Match1v1, &["a"]))
+            .insert_player(make_player_with_maps(
+                0,
+                1000.0,
+                MatchmakingType::Match1v1,
+                &["a"],
+            ))
             .unwrap();
         matchmaker
-            .insert_player(make_player_with_maps(1, 1000.0, MatchmakingType::Match1v1, &["b"]))
+            .insert_player(make_player_with_maps(
+                1,
+                1000.0,
+                MatchmakingType::Match1v1,
+                &["b"],
+            ))
             .unwrap();
 
         // Even at the most lenient quality, players who share no map must not be matched (the match

--- a/server/lib/matchmaking/matchmaker-rs-client.ts
+++ b/server/lib/matchmaking/matchmaker-rs-client.ts
@@ -1,4 +1,5 @@
 import got, { HTTPError } from 'got'
+import { SbMapId } from '../../../common/maps'
 import { MatchmakingType } from '../../../common/matchmaking'
 import { urlPath } from '../../../common/urls'
 import { SbUserId } from '../../../common/users/sb-user-id'
@@ -10,6 +11,12 @@ export interface RsModeRating {
   rating: number
   /** Glicko-2 σ (uncertainty). null treated as 0 (fully certain). */
   uncertainty: number | null
+  /**
+   * The player's positive map selections for this mode, for "pick" modes only. The matchmaker uses
+   * these to avoid matching players who share no map (which would produce a match with no playable
+   * map). `null` for veto/fixed modes, which don't constrain matching on maps.
+   */
+  mapSelections: SbMapId[] | null
 }
 
 /** Sent to Rust when adding a player to the queue. */

--- a/server/lib/matchmaking/matchmaking-service.ts
+++ b/server/lib/matchmaking/matchmaking-service.ts
@@ -286,6 +286,16 @@ async function pickMap(
     entities.map(e => e.mapSelections),
   )
 
+  // For "pick" modes the matchmaker only forms matches whose players share a map, so this should be
+  // non-empty; guard anyway (e.g. the map pool changed after the players queued) so we fail with a
+  // clean service error rather than an unexpected throw from randomItem on an empty pool.
+  if (!mapPool.size) {
+    throw new MatchmakingServiceError(
+      MatchmakingServiceErrorCode.InvalidMaps,
+      'No valid map for the match',
+    )
+  }
+
   const chosenMapId = randomItem(Array.from(mapPool))
   const mapInfo = await getMapInfos([chosenMapId])
 
@@ -508,6 +518,12 @@ export class MatchmakingService {
           mode: d.type,
           rating: d.mmr.rating,
           uncertainty: d.mmr.uncertainty,
+          // Only "pick" modes constrain matching on maps; the matchmaker uses these selections to
+          // avoid pairing players who share no map. Veto/fixed modes send null.
+          mapSelections:
+            getMatchmakingModeInfo(d.type).mapSelectionStyle === 'pick'
+              ? d.playerData.mapSelections.slice()
+              : null,
         })),
         latencyBucket: null, // TODO: populate from actual latency data
       })


### PR DESCRIPTION
## What

Fixes a live bug: the Rust matchmaker is **map-blind**, so two players in a positive-selection (`pick`) mode with **disjoint map selections can be matched** (e.g. 1v1 Fastest, pool [A, B], P1 picks A, P2 picks B). `pickMap` then computes an empty map intersection, `randomItem([])` throws, and the match fails *after* both players accepted — silently requeueing them into the same impossible pairing (an effective loop), or making them eat an accept-timeout matchmaking ban.

This is a **regression** from the pre-Rust matchmaker, which enforced `requireOverlappingMaps = !hasVetoes(type)` for positive-selection modes. **1v1 Fastest is affected today.**

## Changes

- **Send map selections to Rust for `pick` modes.** `RsModeRating` / `PlayerModeRatingDto` gain a `mapSelections` field (the player's per-mode selections; `null` for veto/fixed modes). It's carried in the queue request and round-trips through the requeue ticket. `Player` in the matchmaker gains a `map_selections: HashMap<MatchmakingType, Vec<MapId>>`.
- **Enforce overlap when forming matches.** `find_matches_for_modes` rejects any candidate combination whose players share no common map for the mode being evaluated. Only applies when every player carries selections for that mode (i.e. pick modes); veto/fixed store none and are unconstrained.
- **Harden `pickMap`** to fail with a clean `MatchmakingServiceError` on an empty pool (e.g. the map pool changed after queueing) instead of throwing from `randomItem`.

Behavior on no-overlap: the matchmaker simply **doesn't form the match** and the players keep searching (matching the old `requireOverlappingMaps` behavior), per the decision in the last discussion.

## Verification

- `cargo test matchmaking` — 16 pass, incl. new `pick_mode_does_not_match_disjoint_map_selections` and `pick_mode_matches_when_selections_share_a_map`
- `cargo clippy --all-targets --workspace -- -D warnings` — clean
- `pnpm run typecheck` — clean
- `pnpm run test` (server/lib/matchmaking) — 49 pass
- `eslint --fix`, `pnpm gen-translations` — clean / no drift

Note: the `mapSelections` ticket field is `#[serde(default)]`, and tickets are invalidated across a server-rs restart by the process token anyway, so a deploy mid-queue is handled gracefully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)