### PR TITLE
fix(security): 2 improvements across 2 files

### DIFF
--- a/app/preload.js
+++ b/app/preload.js
@@ -12,6 +12,9 @@ contextBridge.exposeInMainWorld('SHIELDBATTERY_ELECTRON_API', {
     removeAllListeners: ipcRenderer.removeAllListeners.bind(ipcRenderer),
     removeListener: ipcRenderer.removeListener.bind(ipcRenderer),
   },
-  env: { ...process.env },
+  env: {
+    NODE_ENV: process.env.NODE_ENV,
+    SHIELDBATTERY_HOME: process.env.SHIELDBATTERY_HOME,
+  },
   webUtils,
 })

--- a/client/file-browser/get-files.ts
+++ b/client/file-browser/get-files.ts
@@ -1,3 +1,4 @@
+import path from 'path'
 import { TypedIpcRenderer } from '../../common/ipc'
 import { FileBrowserEntry, FileBrowserEntryType } from './file-browser-types'
 
@@ -19,19 +20,19 @@ export default async function readFolder(folderPath: string): Promise<FileBrowse
       entries.map(async entry => {
         const isFolder = entry.isDirectory
         const [name, extension] = isFolder ? [entry.name, ''] : splitExtension(entry.name)
-        const stats = await ipcRenderer.invoke('fsStat', folderPath + '\\' + entry.name)
-        const path = folderPath + '\\' + entry.name
+        const entryPath = path.join(folderPath, entry.name)
+        const stats = await ipcRenderer.invoke('fsStat', entryPath)
 
         return isFolder
           ? {
               type: FileBrowserEntryType.Folder,
               name,
-              path,
+              path: entryPath,
             }
           : {
               type: FileBrowserEntryType.File,
               name,
-              path,
+              path: entryPath,
               extension: extension.toLowerCase(),
               date: stats?.mtime ?? new Date(0),
             }


### PR DESCRIPTION
## Summary

fix(security): 2 improvements across 2 files

## Problem

**Severity**: `High` | **File**: `app/preload.js:L1`

The preload script exposes the entire `ipcRenderer` object with multiple methods (`invoke`, `send`, `on`, `once`, `removeAllListeners`, `removeListener`) to the renderer process. While the code comments mention this is intentional to limit API surface, the `on` and `once` methods can be used to register arbitrary event listeners, potentially leading to event listener leaks or unexpected behavior. More critically, the `env` object exposes all environment variables (`{ ...process.env }`), which could leak sensitive information like API keys, tokens, or system paths to the renderer process.

## Solution

1. Remove `env: { ...process.env }` entirely or explicitly whitelist only the environment variables needed by the renderer. 2. Consider wrapping `ipcRenderer.on` and `ipcRenderer.once` with additional validation or rate limiting to prevent event listener exhaustion. 3. Use a more restricted channel-based IPC pattern instead of exposing raw `ipcRenderer` methods.

## Changes

- `app/preload.js` (modified)
- `client/file-browser/get-files.ts` (modified)