### PR TITLE
Fix web client dev server hang on bundle requests

### DIFF
--- a/server/lib/webpack/middleware.ts
+++ b/server/lib/webpack/middleware.ts
@@ -34,30 +34,32 @@ export function webpackMiddleware({
     }
     ;(res as any).getReadyReadableStreamState = () => 'open'
 
-    let hadData = false
     await new Promise((resolve, reject) => {
+      // webpack-dev-middleware ends a successful response purely through these pseudo-API hooks
+      // (it doesn't call the `next` callback below in that case), so we have to resolve here once
+      // the body has been handed off.
       ;(res as any).stream = (stream: any) => {
         ctx.body = stream
-        hadData = true
+        resolve(undefined)
       }
       ;(res as any).send = (data: any) => {
         ctx.body = data
-        hadData = true
+        resolve(undefined)
       }
-      ;(res as any).finish = (data: any) => {
-        ctx.body = data
-        hadData = true
+      ;(res as any).finish = (data?: any) => {
+        if (data !== undefined) {
+          ctx.body = data
+        }
+        resolve(undefined)
       }
 
       middleware(req, res, (err?: Error) => {
+        // We only reach here on fallthrough (unaccepted method / 404 / file not found), i.e. when
+        // the middleware didn't serve a response itself, so defer to the next Koa middleware.
         if (err) {
           reject(err)
         } else {
-          if (!hadData) {
-            resolve(next())
-          } else {
-            resolve(undefined)
-          }
+          resolve(next())
         }
       }).catch((err: Error) => {
         reject(err)


### PR DESCRIPTION
## Problem

Loading the web client at `http://localhost:5555` in dev hangs indefinitely. The request for `/scripts/client.js` never completes (`responseTime` ~120s, aborted) even though webpack logs a clean compile, so the SPA root (`<div id="app">`) stays empty. The Electron app works fine.

## Root cause

The Koa adapter for `webpack-dev-middleware` (`server/lib/webpack/middleware.ts`) fakes a pseudo-`res` API (`res.stream`/`res.send`/`res.finish`) and `await`s a Promise that was **only resolved inside the `middleware(req, res, next)` callback**.

`webpack-dev-middleware@8` ends a *successful* serve purely through those pseudo hooks (`utils.js` `pipe()` → `res.stream(stream)`) and **never calls the `next` callback** on success — it only calls `next` on fallthrough (unaccepted method / 404 / file not found, via `goNext`). So on every real bundle serve the Promise never settled, and the Koa middleware awaited forever → hang.

The Electron renderer dev server (`:5566`, `electron-dev-server.js`) was unaffected because it uses **Express** directly, so wdm sees a native `res`, falls back to `bufferOrStream.pipe(res)` / native `res.send`, and never touches the deadlocking Koa Promise.

## Fix

Resolve the Promise inside the `stream`/`send`/`finish` hooks (where the body is handed off), and treat the `next` callback purely as the fallthrough path.

## Verification

- `GET /scripts/client.js` → **200, 28.5 MB, ~1.5s** (was hanging ~120s / aborting); repeated requests ~20ms, no intermittent hang.
- Browser at `:5555` now mounts the full home page into `#app` (was empty).
- ESLint clean on the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)