### PR TITLE
Fix post-match dialog crash from m.create dropping MotionValue props

### DIFF
--- a/client/matchmaking/post-match-dialog.tsx
+++ b/client/matchmaking/post-match-dialog.tsx
@@ -472,11 +472,7 @@ function RatedUserContent({
             ))}
           </Deltas>
         </IconAndDeltas>
-        <PointsBarView
-          points={points}
-          ref={pointsAnimScope}
-          style={{ '--sb-points-bar-scale': divPercent } as any}
-        />
+        <PointsBarView points={points} divPercent={divPercent} ref={pointsAnimScope} />
       </MatchmakingSide>
       {leagueValues.length > 0 ? (
         <LeagueSide>
@@ -728,19 +724,24 @@ const PointsLabel = styled(m.div)`
 
 interface PointsBarViewProps {
   points: MotionValue<number>
+  divPercent: MotionValue<number>
 }
 
-const PointsBarView = m.create(
-  forwardRef<HTMLDivElement, PointsBarViewProps>(({ points }, ref) => {
+// NOTE: This is a plain `forwardRef` (not `m.create`) on purpose. `PointsBarRoot` and `PointsLabel`
+// are already motion components, so they consume the `divPercent`/`points` MotionValues natively.
+// Wrapping the whole view in `m.create` instead caused motion to strip the `points` MotionValue
+// before it reached this component, crashing on `points.get()`.
+const PointsBarView = forwardRef<HTMLDivElement, PointsBarViewProps>(
+  ({ points, divPercent }, ref) => {
     const roundedPoints = useTransform(() => Math.round(points.get()))
 
     return (
-      <PointsBarRoot ref={ref}>
+      <PointsBarRoot ref={ref} style={{ '--sb-points-bar-scale': divPercent } as any}>
         <PointsBar />
         <PointsLabelMover>
           <PointsLabel>{roundedPoints}</PointsLabel>
         </PointsLabelMover>
       </PointsBarRoot>
     )
-  }),
+  },
 )


### PR DESCRIPTION
## Problem

The post-match results dialog crashed on render (`TypeError: Cannot read properties of undefined (reading 'get')`) for **any completed ranked game**. `PointsBarView` was built with motion's `m.create()` and received its `points` MotionValue as a custom prop; under motion@12 the `m.create` wrapper no longer forwards that prop, so `points.get()` ran on `undefined`.

It's the only `m.create` usage in the client — a latent break from the motion bump that stayed hidden because a *completed ranked game* (the only thing that renders this dialog) is rare in dev. It surfaced while verifying an unrelated change with a real match.

## Fix

`PointsBarView` doesn't need to be a motion component itself — its children (`PointsBarRoot`, `PointsLabel`) are already `styled(m.div)` and consume MotionValues natively. Made it a plain `forwardRef` that takes `points` + `divPercent` as ordinary props and applies `divPercent` directly to the motion-backed `PointsBarRoot`.

## Verification

Rendered the dialog via the devonly post-match page (`/dev/matchmaking/post-match-dialog`, driven through the Electron renderer): the points bar and rating/points now display correctly with no error boundary. typecheck + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)