### PR TITLE
Always provide matchmaking preferences (synthesize defaults + persist on find)

### DIFF
--- a/client/games/action-creators.ts
+++ b/client/games/action-creators.ts
@@ -118,8 +118,9 @@ export function searchAgainFromGame(gameConfig: ReadonlyDeep<GameConfig>): Thunk
     } = getState()
     const prefs = byType.get(matchmakingType)?.preferences
 
-    if (!prefs || !('matchmakingType' in prefs)) {
-      // TODO(tec27): Request them?
+    if (!prefs) {
+      // The preferences subscription seeds defaults for every type on connect, so this only happens
+      // if we haven't received that event yet.
       externalShowSnackbar(
         i18n.t(
           'matchmaking.findMatch.errors.searchAgainError',
@@ -130,7 +131,7 @@ export function searchAgainFromGame(gameConfig: ReadonlyDeep<GameConfig>): Thunk
       return
     }
 
-    // prefs is narrowed above but TS can't infer through Immutable union, so we cast
+    // TS can't infer the mutable element type through the Immutable store union, so we cast
     const typedPrefs = prefs as Immutable<MatchmakingPreferences>
 
     dispatch(

--- a/client/matchmaking/actions.ts
+++ b/client/matchmaking/actions.ts
@@ -44,11 +44,12 @@ export interface GetCurrentMapPoolFailure extends BaseFetchFailure<'@matchmaking
 
 /**
  * Initialize the user's matchmaking preferences when they connect to the application. If they don't
- * have any preferences saved yet, the default values will be used.
+ * have any preferences saved yet, the server synthesizes defaults, so this always carries a full
+ * preferences object.
  */
 export interface InitPreferences {
   type: '@matchmaking/initPreferences'
-  payload: GetPreferencesResponse | Record<string, undefined>
+  payload: GetPreferencesResponse
   meta: { type: MatchmakingType }
 }
 

--- a/client/matchmaking/devonly/find-match-test.tsx
+++ b/client/matchmaking/devonly/find-match-test.tsx
@@ -535,7 +535,6 @@ export function FindMatchListTest() {
           isSearching={isSearching}
           elapsedSecs={elapsed}
           disabled={selectedIds.size === 0 || inLobby}
-          waitingForMapPool={false}
           onFindMatch={handleFindMatch}
           onCancel={handleCancel}
         />

--- a/client/matchmaking/find-match-content.tsx
+++ b/client/matchmaking/find-match-content.tsx
@@ -220,14 +220,13 @@ export function FindMatchContent({ type, disabled }: FindMatchContentProps) {
     s =>
       s.matchmakingPreferences.byType.get(type)?.preferences as
         | Immutable<MatchmakingPreferences>
-        | Record<string, never>
         | undefined,
   )
   const mapPoolOutdated = useAppSelector(
     s => s.matchmakingPreferences.byType.get(type)?.mapPoolOutdated ?? false,
   )
   const mapPool = useAppSelector(s => s.mapPools.byType.get(type))
-  const prefsMapSelections = prefs && 'mapSelections' in prefs ? prefs.mapSelections : undefined
+  const prefsMapSelections = prefs?.mapSelections
   const mapSelections = useMemo(
     () => (prefsMapSelections ?? []).filter(id => !mapPool || mapPool.maps.includes(id)),
     [prefsMapSelections, mapPool],
@@ -240,9 +239,8 @@ export function FindMatchContent({ type, disabled }: FindMatchContentProps) {
     return <LoadingDotsArea />
   }
 
-  const data =
-    'data' in prefs ? (prefs.data as Immutable<MatchmakingPreferencesData1v1>) : undefined
-  const race = 'race' in prefs ? (prefs.race ?? 'r') : 'r'
+  const data = prefs.data as Immutable<MatchmakingPreferencesData1v1> | undefined
+  const race = prefs.race ?? 'r'
 
   return (
     <FindMatchForm

--- a/client/matchmaking/find-match.tsx
+++ b/client/matchmaking/find-match.tsx
@@ -6,10 +6,8 @@ import styled, { css, keyframes } from 'styled-components'
 import { ladderPlayerToMatchmakingDivision } from '../../common/ladder/ladder'
 import {
   ALL_MATCHMAKING_TYPES,
-  defaultPreferences,
   getMatchmakingModeInfo,
   getTotalBonusPoolForSeason,
-  hasVetoes,
   MapSelectionStyle,
   MatchmakingDivision,
   matchmakingDivisionToLabel,
@@ -1122,8 +1120,6 @@ interface QueueBarProps {
   isSearching: boolean
   elapsedSecs: number
   disabled: boolean
-  /** A selected type's map pool is still loading, so Find is temporarily disabled. */
-  waitingForMapPool: boolean
   onFindMatch: () => void
   onCancel: () => void
 }
@@ -1133,7 +1129,6 @@ export function QueueBar({
   isSearching,
   elapsedSecs,
   disabled,
-  waitingForMapPool,
   onFindMatch,
   onCancel,
 }: QueueBarProps) {
@@ -1155,13 +1150,6 @@ export function QueueBar({
           {mm}:{ss}
         </SearchingTimer>
       </>
-    )
-  } else if (waitingForMapPool) {
-    summaryContent = (
-      <QueueEmptyHint>
-        <MaterialIcon icon='info' size={18} />
-        {t('matchmaking.findMatch.loadingMapPool', 'Loading map pool…')}
-      </QueueEmptyHint>
     )
   } else if (disabled) {
     summaryContent = (
@@ -1299,21 +1287,6 @@ export function FindMatch() {
     ? new Set(searchInfo?.searchedTypes.keys() ?? [])
     : new Set(Array.from(selectedTypes).filter(isTypeEnabled))
 
-  // Whether we can build a valid queue request for a type yet. For a user who never configured the
-  // type the server sends `{}` prefs and handleFindMatch falls back to defaults — and pick (no-veto)
-  // modes default their map selection from the current map pool, which is fetched async on mount.
-  // Until that pool arrives we'd send an empty selection that the server rejects with InvalidMaps, so
-  // treat such a type as not-yet-ready and keep Find disabled (with a loading hint) rather than
-  // letting a fast click produce a spurious error.
-  const isTypeReadyToQueue = (type: MatchmakingType): boolean => {
-    const prefs = matchmakingPreferences.get(type)?.preferences
-    if (prefs && 'matchmakingType' in prefs) return true
-    return hasVetoes(type) || mapPools.get(type) !== undefined
-  }
-
-  const isWaitingForMapPool =
-    !isSearching && Array.from(effectiveSelectedTypes).some(type => !isTypeReadyToQueue(type))
-
   const getStatsForType = (type: MatchmakingType): RowStats => {
     const player = selfRankByType.get(type)
     if (!player || !season) {
@@ -1339,18 +1312,17 @@ export function FindMatch() {
     let alternateRace: AssignedRaceChar = 'z'
     let mapSelectionCount = 0
 
-    if (prefs && 'race' in prefs) {
-      race = (prefs as MatchmakingPreferences).race ?? 'r'
-      mapSelectionCount = (prefs as MatchmakingPreferences).mapSelections?.length ?? 0
+    if (prefs) {
+      race = prefs.race ?? 'r'
+      mapSelectionCount = prefs.mapSelections?.length ?? 0
       if (
         (type === MatchmakingType.Match1v1 || type === MatchmakingType.Match1v1Fastest) &&
         race !== 'r'
       ) {
-        const data1v1 = (
-          prefs as MatchmakingPreferences & {
-            data: { useAlternateRace?: boolean; alternateRace?: AssignedRaceChar }
-          }
-        ).data
+        const data1v1 = prefs.data as {
+          useAlternateRace?: boolean
+          alternateRace?: AssignedRaceChar
+        }
         useAlternateRace = data1v1?.useAlternateRace ?? false
         alternateRace = data1v1?.alternateRace ?? 'z'
       }
@@ -1367,11 +1339,8 @@ export function FindMatch() {
     }
   }
 
-  const getRaceForType = (type: MatchmakingType): RaceChar => {
-    const prefs = matchmakingPreferences.get(type)?.preferences
-    if (prefs && 'race' in prefs) return (prefs as MatchmakingPreferences).race ?? 'r'
-    return 'r'
-  }
+  const getRaceForType = (type: MatchmakingType): RaceChar =>
+    matchmakingPreferences.get(type)?.preferences?.race ?? 'r'
 
   // ─── Handlers ───────────────────────────────────────────────────────────────
 
@@ -1391,28 +1360,17 @@ export function FindMatch() {
   }
 
   const handleFindMatch = healthChecked(() => {
-    // isWaitingForMapPool guards the Enter-key path too, which bypasses the (disabled) Find button.
-    if (inLobby || isSubmitting || isWaitingForMapPool || effectiveSelectedTypes.size === 0) return
+    if (inLobby || isSubmitting || effectiveSelectedTypes.size === 0) return
 
     const allPrefs: MatchmakingPreferences[] = []
     for (const type of effectiveSelectedTypes) {
       const prefs = matchmakingPreferences.get(type)?.preferences
-      if (prefs && 'matchmakingType' in prefs) {
-        allPrefs.push(prefs as MatchmakingPreferences)
-      } else {
-        // The user has never saved preferences for this type, so the server sends `{}`. Fall back
-        // to defaults (random race, current map pool) so they can still queue — otherwise the Find
-        // match button would silently do nothing for a fresh account.
-        const pool = mapPools.get(type)
-        const defaults = defaultPreferences(type, selfUser.id, pool?.id ?? 1)
-        if (!hasVetoes(type)) {
-          // Pick modes (e.g. 1v1 Fastest) require at least one selected map; the server rejects an
-          // empty selection with InvalidMaps. Default to the entire pool ("happy to play any of
-          // these") so a fresh user who never opened the settings drawer can still queue.
-          defaults.mapSelections = pool ? [...pool.maps] : []
-        }
-        allPrefs.push(defaults as MatchmakingPreferences)
+      if (!prefs) {
+        // The preferences subscription seeds defaults for every type on connect, so this is
+        // effectively unreachable past app startup; bail rather than silently queueing a subset.
+        return
       }
+      allPrefs.push(prefs as MatchmakingPreferences)
     }
     if (allPrefs.length === 0) return
 
@@ -1481,8 +1439,7 @@ export function FindMatch() {
         race: getRaceForType(type),
       }))
 
-  const findMatchDisabled =
-    effectiveSelectedTypes.size === 0 || inLobby || isSubmitting || isWaitingForMapPool
+  const findMatchDisabled = effectiveSelectedTypes.size === 0 || inLobby || isSubmitting
 
   return (
     <PageRoot>
@@ -1560,7 +1517,6 @@ export function FindMatch() {
           isSearching={isSearching}
           elapsedSecs={elapsedSecs}
           disabled={findMatchDisabled}
-          waitingForMapPool={isWaitingForMapPool}
           onFindMatch={handleFindMatch}
           onCancel={handleCancel}
         />

--- a/client/matchmaking/matchmaking-preferences-reducer.ts
+++ b/client/matchmaking/matchmaking-preferences-reducer.ts
@@ -4,7 +4,7 @@ import { FetchError } from '../network/fetch-errors'
 import { immerKeyedReducer } from '../reducers/keyed-reducer'
 
 export interface FetchedMatchmakingPreferences {
-  preferences?: MatchmakingPreferences | Record<string, never>
+  preferences?: MatchmakingPreferences
   mapPoolOutdated?: boolean
   lastError?: FetchError
 }
@@ -22,11 +22,7 @@ export default immerKeyedReducer(DEFAULT_STATE, {
     const { preferences, mapPoolOutdated } = action.payload
     const { type } = action.meta
 
-    if (preferences) {
-      state.byType.set(type, { preferences, mapPoolOutdated, lastError: undefined })
-    } else {
-      state.byType.delete(type)
-    }
+    state.byType.set(type, { preferences, mapPoolOutdated, lastError: undefined })
   },
 
   ['@matchmaking/updatePreferences'](state, action) {

--- a/client/matchmaking/socket-handlers.ts
+++ b/client/matchmaking/socket-handlers.ts
@@ -261,7 +261,7 @@ export default function registerModule({ siteSocket }: { siteSocket: NydusClient
 
   siteSocket.registerRoute(
     '/matchmakingPreferences/:userId/:matchmakingType',
-    (route: RouteInfo, event: GetPreferencesResponse | Record<string, undefined>) => {
+    (route: RouteInfo, event: GetPreferencesResponse) => {
       const type = route.params.matchmakingType as MatchmakingType
 
       dispatch((_, getState) => {

--- a/common/matchmaking.ts
+++ b/common/matchmaking.ts
@@ -850,7 +850,7 @@ export function defaultPreferences<M extends MatchmakingType>(
 }
 
 export interface GetPreferencesResponse {
-  preferences: MatchmakingPreferences | Record<string, never>
+  preferences: MatchmakingPreferences
   mapPoolOutdated: boolean
   currentMapPoolId: number
   mapInfos: MapInfoJson[]

--- a/server/lib/matchmaking/matchmaking-api.ts
+++ b/server/lib/matchmaking/matchmaking-api.ts
@@ -23,6 +23,7 @@ import { makeErrorConverterMiddleware } from '../errors/coded-error'
 import { asHttpError } from '../errors/error-with-payload'
 import { httpApi, httpBeforeAll } from '../http/http-api'
 import { httpBefore, httpDelete, httpGet, httpPost } from '../http/route-decorators'
+import logger from '../logging/logger'
 import { checkAllPermissions } from '../permissions/check-permissions'
 import ensureLoggedIn from '../session/ensure-logged-in'
 import createThrottle from '../throttle/create-throttle'
@@ -33,6 +34,7 @@ import { validateRequest } from '../validation/joi-validator'
 import { filterMapSelections } from './map-selections'
 import { MatchmakingBanService } from './matchmaking-ban-service'
 import { getCurrentMapPool } from './matchmaking-map-pools-models'
+import MatchmakingPreferencesService from './matchmaking-preferences-service'
 import { MatchmakingSeasonsService, MatchmakingSeasonsServiceError } from './matchmaking-seasons'
 import { MatchmakingService } from './matchmaking-service'
 import { MatchmakingServiceError } from './matchmaking-service-error'
@@ -112,6 +114,7 @@ export class MatchmakingApi {
     private userIdManager: UserIdentifierManager,
     private matchmakingSeasonsService: MatchmakingSeasonsService,
     private matchmakingBanService: MatchmakingBanService,
+    private matchmakingPreferencesService: MatchmakingPreferencesService,
   ) {}
 
   @httpPost('/find')
@@ -180,6 +183,19 @@ export class MatchmakingApi {
       identifiers,
       processedPreferences,
     )
+
+    // Persist the preferences used for this search so they're pre-filled next session and usable for
+    // "search again" without the user having to open the settings drawer first. We store what the
+    // client sent (preserving their `mapPoolId`) rather than the pool-filtered version, so the
+    // "pool updated" indicator keeps working for users who queue without reviewing a new pool. A
+    // failure here shouldn't fail an already-successful queue.
+    try {
+      await Promise.all(
+        preferences.map(pref => this.matchmakingPreferencesService.upsertPreferences(pref)),
+      )
+    } catch (err) {
+      logger.error({ err }, 'error saving matchmaking preferences after queueing')
+    }
   }
 
   @httpDelete('/find')

--- a/server/lib/matchmaking/matchmaking-preferences-service.ts
+++ b/server/lib/matchmaking/matchmaking-preferences-service.ts
@@ -2,11 +2,14 @@ import { singleton } from 'tsyringe'
 import { toMapInfoJson } from '../../../common/maps'
 import {
   ALL_MATCHMAKING_TYPES,
+  defaultPreferences,
+  getMatchmakingModeInfo,
   GetPreferencesResponse,
   MatchmakingPreferences,
   MatchmakingType,
   PartialMatchmakingPreferences,
 } from '../../../common/matchmaking'
+import { MatchmakingMapPool } from '../../../common/matchmaking/matchmaking-map-pools'
 import { SbUserId } from '../../../common/users/sb-user-id'
 import logger from '../logging/logger'
 import { getMapInfos } from '../maps/map-models'
@@ -24,6 +27,24 @@ export function getMatchmakingPreferencesPath(
   return `/matchmakingPreferences/${userId}/${matchmakingType}`
 }
 
+/**
+ * Builds the preferences we hand back for a user who hasn't saved any for this type yet. Pick modes
+ * need a non-empty map selection to be queueable (the matchmaker rejects an empty selection), so we
+ * default them to the entire current pool ("happy to play any of these"); veto and fixed modes
+ * default to an empty selection.
+ */
+function buildDefaultPreferences(
+  matchmakingType: MatchmakingType,
+  userId: SbUserId,
+  currentMapPool: MatchmakingMapPool | null,
+): MatchmakingPreferences {
+  const prefs = defaultPreferences(matchmakingType, userId, currentMapPool?.id ?? 1)
+  if (currentMapPool && getMatchmakingModeInfo(matchmakingType).mapSelectionStyle === 'pick') {
+    prefs.mapSelections = [...currentMapPool.maps]
+  }
+  return prefs
+}
+
 @singleton()
 export default class MatchmakingPreferencesService {
   constructor(private clientSocketsManager: ClientSocketsManager) {
@@ -33,21 +54,20 @@ export default class MatchmakingPreferencesService {
           getMatchmakingPreferencesPath(c.userId, matchmakingType),
           async () => {
             try {
-              // Undefined means the user doesn't have any matchmaking preferences saved yet. We
-              // send an empty object instead of `undefined` so the client knows their preferences
-              // have been initialized and aren't simply missing.
-              const preferences: MatchmakingPreferences | Record<string, never> =
-                (await getMatchmakingPreferences(c.userId, matchmakingType)) ?? {}
-              const mapSelections = preferences.mapSelections ?? []
               const currentMapPool = await getCurrentMapPool(matchmakingType)
+              // If the user has never saved preferences for this type, we synthesize defaults rather
+              // than signalling "missing", so every read site can rely on a full preferences object.
+              const preferences =
+                (await getMatchmakingPreferences(c.userId, matchmakingType)) ??
+                buildDefaultPreferences(matchmakingType, c.userId, currentMapPool)
 
               const mapPoolOutdated =
-                !!currentMapPool &&
-                'mapPoolId' in preferences &&
-                preferences.mapPoolId !== currentMapPool.id
+                !!currentMapPool && preferences.mapPoolId !== currentMapPool.id
               const mapInfos = currentMapPool
                 ? (
-                    await getMapInfos(mapSelections.filter(m => currentMapPool.maps.includes(m)))
+                    await getMapInfos(
+                      preferences.mapSelections.filter(m => currentMapPool.maps.includes(m)),
+                    )
                   ).map(m => toMapInfoJson(m))
                 : []
 
@@ -60,7 +80,7 @@ export default class MatchmakingPreferencesService {
             } catch (err) {
               logger.error({ err }, 'error retrieving user matchmaking preferences')
               return {
-                preferences: {},
+                preferences: buildDefaultPreferences(matchmakingType, c.userId, null),
                 mapPoolOutdated: false,
                 currentMapPoolId: 1,
                 mapInfos: [],

--- a/server/public/locales/en/global.json
+++ b/server/public/locales/en/global.json
@@ -905,7 +905,6 @@
       "fixedMapDescription": "This mode is always played on a fixed map.",
       "goToLobby": "Go to lobby",
       "inLobbyBanner": "You’re in a lobby — matchmaking is unavailable while in a game lobby.",
-      "loadingMapPool": "Loading map pool…",
       "mapPool": "Map pool",
       "mapSelectionDescription": "Select the maps you would like to play on. Only selected maps will be chosen.",
       "noScheduledWindow": "No scheduled window yet",


### PR DESCRIPTION
## Problem

The matchmaking preferences subscription sent an empty-object sentinel (`{}`) when a user had never saved preferences for a type, forcing every read site to guard against it and reconstruct defaults client-side. The find path also never persisted preferences, so:

- Queueing from the main screen (the common path now that multiple types can be selected) saved nothing — the server kept sending `{}` every session.
- **"Search again" was broken** for never-configured accounts (`searchAgainFromGame` bailed because the store held `{}` with no `matchmakingType`).
- Pick modes (1v1 Fastest) needed special client-side handling to fill the whole pool before queueing, since an empty selection is rejected with `InvalidMaps`.

## Change

- The preferences subscription now **synthesizes full defaults** instead of `{}`, filling the whole current pool for `pick` modes so they're queueable out of the box.
- The find handler **persists the preferences used for a search**, storing what the client sent (preserving their `mapPoolId`, so the "pool updated" indicator still works for someone who queues without reviewing a changed pool).
- With preferences always present, the scattered `{}` guards, the client-side default reconstruction in `handleFindMatch`, and the map-pool readiness gating (`isWaitingForMapPool`) are removed. Net negative diff.

## Verification

Single-client run against the real Electron app (`claude-1`):

- Fresh account (no `1v1fastest` row) selects 1v1 Fastest and queues → **SEARCHING**, no `InvalidMaps`; a new prefs row is persisted with the current pool + full map selection.
- "Search again" precondition restored — the store now always carries full prefs with `matchmakingType`.
- Queueing an outdated mode preserves the stale `mapPoolId` (nudge survives), and the "pool updated" indicator shows/clears as expected.

`typecheck`, `lint`, `gen-translations`, and matchmaking unit tests all pass.

## Not in scope

A follow-up will derive the "pool updated" indicator on the client so it refreshes on navigation rather than only on reconnect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)