### PR TITLE
Derive the "pool updated" indicator on the client

### DIFF
--- a/client/matchmaking/find-match-content.tsx
+++ b/client/matchmaking/find-match-content.tsx
@@ -222,9 +222,6 @@ export function FindMatchContent({ type, disabled }: FindMatchContentProps) {
         | Immutable<MatchmakingPreferences>
         | undefined,
   )
-  const mapPoolOutdated = useAppSelector(
-    s => s.matchmakingPreferences.byType.get(type)?.mapPoolOutdated ?? false,
-  )
   const mapPool = useAppSelector(s => s.mapPools.byType.get(type))
   const prefsMapSelections = prefs?.mapSelections
   const mapSelections = useMemo(
@@ -238,6 +235,9 @@ export function FindMatchContent({ type, disabled }: FindMatchContentProps) {
   if (!prefs) {
     return <LoadingDotsArea />
   }
+
+  // Derived from the currently-loaded pool (see find-match.tsx) rather than a connect-time flag.
+  const mapPoolOutdated = !!mapPool && prefs.mapPoolId !== mapPool.id
 
   const data = prefs.data as Immutable<MatchmakingPreferencesData1v1> | undefined
   const race = prefs.race ?? 'r'

--- a/client/matchmaking/find-match.tsx
+++ b/client/matchmaking/find-match.tsx
@@ -1305,7 +1305,9 @@ export function FindMatch() {
   const getSummaryStateForType = (type: MatchmakingType): RowSummaryState => {
     const prefs = matchmakingPreferences.get(type)?.preferences
     const mapPool = mapPools.get(type)
-    const poolChanged = matchmakingPreferences.get(type)?.mapPoolOutdated ?? false
+    // Derived from the currently-loaded pool rather than a connect-time flag, so the badge refreshes
+    // whenever the page (re)fetches the pool — e.g. each time the user opens the Play screen.
+    const poolChanged = !!prefs && !!mapPool && prefs.mapPoolId !== mapPool.id
 
     let race: RaceChar = 'r'
     let useAlternateRace = false

--- a/client/matchmaking/matchmaking-preferences-reducer.ts
+++ b/client/matchmaking/matchmaking-preferences-reducer.ts
@@ -5,7 +5,6 @@ import { immerKeyedReducer } from '../reducers/keyed-reducer'
 
 export interface FetchedMatchmakingPreferences {
   preferences?: MatchmakingPreferences
-  mapPoolOutdated?: boolean
   lastError?: FetchError
 }
 
@@ -19,10 +18,10 @@ const DEFAULT_STATE: Immutable<MatchmakingPreferencesState> = {
 
 export default immerKeyedReducer(DEFAULT_STATE, {
   ['@matchmaking/initPreferences'](state, action) {
-    const { preferences, mapPoolOutdated } = action.payload
+    const { preferences } = action.payload
     const { type } = action.meta
 
-    state.byType.set(type, { preferences, mapPoolOutdated, lastError: undefined })
+    state.byType.set(type, { preferences, lastError: undefined })
   },
 
   ['@matchmaking/updatePreferences'](state, action) {
@@ -37,7 +36,7 @@ export default immerKeyedReducer(DEFAULT_STATE, {
       return
     }
 
-    const { preferences, mapPoolOutdated } = action.payload
-    state.byType.set(type, { preferences, mapPoolOutdated })
+    const { preferences } = action.payload
+    state.byType.set(type, { preferences })
   },
 })

--- a/common/matchmaking.ts
+++ b/common/matchmaking.ts
@@ -851,7 +851,6 @@ export function defaultPreferences<M extends MatchmakingType>(
 
 export interface GetPreferencesResponse {
   preferences: MatchmakingPreferences
-  mapPoolOutdated: boolean
   currentMapPoolId: number
   mapInfos: MapInfoJson[]
 }

--- a/server/lib/matchmaking/matchmaking-preferences-api.ts
+++ b/server/lib/matchmaking/matchmaking-preferences-api.ts
@@ -69,7 +69,6 @@ export class MatchmakingPreferencesApi {
 
     return {
       preferences,
-      mapPoolOutdated: false,
       currentMapPoolId: currentMapPool.id,
       mapInfos,
     }

--- a/server/lib/matchmaking/matchmaking-preferences-service.ts
+++ b/server/lib/matchmaking/matchmaking-preferences-service.ts
@@ -61,8 +61,6 @@ export default class MatchmakingPreferencesService {
                 (await getMatchmakingPreferences(c.userId, matchmakingType)) ??
                 buildDefaultPreferences(matchmakingType, c.userId, currentMapPool)
 
-              const mapPoolOutdated =
-                !!currentMapPool && preferences.mapPoolId !== currentMapPool.id
               const mapInfos = currentMapPool
                 ? (
                     await getMapInfos(
@@ -73,7 +71,6 @@ export default class MatchmakingPreferencesService {
 
               return {
                 preferences,
-                mapPoolOutdated,
                 currentMapPoolId: currentMapPool?.id ?? 1,
                 mapInfos,
               }
@@ -81,7 +78,6 @@ export default class MatchmakingPreferencesService {
               logger.error({ err }, 'error retrieving user matchmaking preferences')
               return {
                 preferences: buildDefaultPreferences(matchmakingType, c.userId, null),
-                mapPoolOutdated: false,
                 currentMapPoolId: 1,
                 mapInfos: [],
               }


### PR DESCRIPTION
Follow-up to #1309.

## Problem

The server computed `mapPoolOutdated` in the preferences subscription, which only runs on connect. A user who leaves the app open wouldn't see the "pool updated" indicator until they reconnected — and map pools roll over on a schedule (no discrete server event), so there's nothing natural to push an update on.

## Change

Derive the indicator on the client instead, comparing the stored `mapPoolId` against the currently-loaded pool. The find page already refetches the pool on mount, so the indicator now refreshes whenever the user opens the Play screen rather than only on reconnect. This drops the server-computed field from `GetPreferencesResponse`, the POST response, and the reducer state — net less code.

## Verification

Single-client run against the real Electron app (`claude-1`):

- Indicator **shows** when the stored `mapPoolId` differs from the freshly-fetched current pool — confirmed against a real mid-session pool rollover, so the badge reflects the live-fetched pool rather than a connect-time snapshot.
- Indicator **clears** on a preference edit (the POST updates the stored pool to current, and the derived value recomputes to false).
- Server boots and serves preferences cleanly with the field removed.

`typecheck` and `lint` pass.

## Note

Concern raised in review about the indicator only clearing on an actual edit is intentionally left as-is: requiring a deliberate change is the safer default for pick modes (auto-clearing on drawer-open would silently keep stale/narrowed selections). An explicit "dismiss" affordance would be the right fix if that ever becomes annoying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)