### PR TITLE
Show "Match found!" in the matchmaking queue bar

### DIFF
--- a/client/matchmaking/devonly/find-match-test.tsx
+++ b/client/matchmaking/devonly/find-match-test.tsx
@@ -205,7 +205,13 @@ const MOCK_MODES: MockModeData[] = [
 
 // ─── Scenario state ───────────────────────────────────────────────────────────
 
-type Scenario = 'idle' | 'in-lobby' | 'some-disabled' | 'searching' | 'multi-searching'
+type Scenario =
+  | 'idle'
+  | 'in-lobby'
+  | 'some-disabled'
+  | 'searching'
+  | 'multi-searching'
+  | 'match-found'
 
 interface MockAvailability {
   nextStartDate?: Date
@@ -215,6 +221,7 @@ interface MockAvailability {
 interface ScenarioState {
   selectedIds: Set<MockModeId>
   isSearching: boolean
+  isMatched: boolean
   inLobby: boolean
   disabledModes: Map<MockModeId, MockAvailability>
 }
@@ -225,6 +232,7 @@ function buildScenario(scenario: Scenario): ScenarioState {
   const base: ScenarioState = {
     selectedIds: new Set(),
     isSearching: false,
+    isMatched: false,
     inLobby: false,
     disabledModes: new Map(),
   }
@@ -259,6 +267,13 @@ function buildScenario(scenario: Scenario): ScenarioState {
         ...base,
         selectedIds: new Set([MatchmakingType.Match1v1, '2v2hunters']),
         isSearching: true,
+      }
+    case 'match-found':
+      return {
+        ...base,
+        selectedIds: new Set([MatchmakingType.Match1v1]),
+        isSearching: true,
+        isMatched: true,
       }
     default:
       return base
@@ -342,6 +357,7 @@ const SCENARIOS: { id: Scenario; label: string }[] = [
   { id: 'some-disabled', label: 'Some disabled' },
   { id: 'searching', label: 'Searching' },
   { id: 'multi-searching', label: 'Multi searching' },
+  { id: 'match-found', label: 'Match found' },
 ]
 
 export function FindMatchListTest() {
@@ -429,7 +445,7 @@ export function FindMatchListTest() {
     handleSetScenario('idle')
   }
 
-  const { selectedIds, isSearching, inLobby, disabledModes } = state
+  const { selectedIds, isSearching, isMatched, inLobby, disabledModes } = state
 
   const drawerModeData = drawerModeId ? (MOCK_MODES.find(m => m.id === drawerModeId) ?? null) : null
   let drawerType: MatchmakingType | null = null
@@ -533,6 +549,7 @@ export function FindMatchListTest() {
         <QueueBar
           selectedChips={selectedChips}
           isSearching={isSearching}
+          isMatched={isMatched}
           elapsedSecs={elapsed}
           disabled={selectedIds.size === 0 || inLobby}
           onFindMatch={handleFindMatch}

--- a/client/matchmaking/find-match.tsx
+++ b/client/matchmaking/find-match.tsx
@@ -32,7 +32,7 @@ import { healthChecked } from '../starcraft/health-checked'
 import { bodySmall, labelMedium, labelSmall, sofiaSans, titleSmall } from '../styles/typography'
 import { cancelFindMatch, findMatch, getCurrentMapPool } from './action-creators'
 import { FindMatchContent } from './find-match-content'
-import { currentSearchInfoAtom, isMatchmakingAtom } from './matchmaking-atoms'
+import { currentSearchInfoAtom, foundMatchAtom, isMatchmakingAtom } from './matchmaking-atoms'
 import { DivisionIcon } from './rank-icon'
 
 // ─── Static mode definitions ─────────────────────────────────────────────────
@@ -1118,6 +1118,7 @@ export interface QueueChipData {
 interface QueueBarProps {
   selectedChips: QueueChipData[]
   isSearching: boolean
+  isMatched: boolean
   elapsedSecs: number
   disabled: boolean
   onFindMatch: () => void
@@ -1127,6 +1128,7 @@ interface QueueBarProps {
 export function QueueBar({
   selectedChips,
   isSearching,
+  isMatched,
   elapsedSecs,
   disabled,
   onFindMatch,
@@ -1138,17 +1140,19 @@ export function QueueBar({
 
   let summaryContent: React.ReactNode
   if (isSearching) {
+    // Once a match is found (the accept dialog is up), the elapsed search time is no longer
+    // meaningful, so we hide it behind a placeholder — mirroring the gameplay activity widget.
     summaryContent = (
       <>
         <QueueSummaryHead>
-          {t(
-            'matchmaking.findMatch.searchingMessage',
-            'Searching for a match — widening MMR range · first match wins the queue',
-          )}
+          {isMatched
+            ? t('matchmaking.findMatch.matchFound', 'Match found!')
+            : t(
+                'matchmaking.findMatch.searchingMessage',
+                'Searching for a match — widening MMR range · first match wins the queue',
+              )}
         </QueueSummaryHead>
-        <SearchingTimer>
-          {mm}:{ss}
-        </SearchingTimer>
+        <SearchingTimer>{isMatched ? '…' : `${mm}:${ss}`}</SearchingTimer>
       </>
     )
   } else if (disabled) {
@@ -1220,6 +1224,7 @@ export function FindMatch() {
   // ─── Searching state (from Jotai atoms) ─────────────────────────────────────
   const isSearching = useAtomValue(isMatchmakingAtom)
   const searchInfo = useAtomValue(currentSearchInfoAtom)
+  const isMatched = !!useAtomValue(foundMatchAtom)
 
   // ─── Redux state ────────────────────────────────────────────────────────────
   const season = useAppSelector(s => s.selfRank.currentSeason)
@@ -1517,6 +1522,7 @@ export function FindMatch() {
         <QueueBar
           selectedChips={selectedChips}
           isSearching={isSearching}
+          isMatched={isMatched}
           elapsedSecs={elapsedSecs}
           disabled={findMatchDisabled}
           onFindMatch={handleFindMatch}

--- a/server/public/locales/en/global.json
+++ b/server/public/locales/en/global.json
@@ -907,6 +907,7 @@
       "inLobbyBanner": "You’re in a lobby — matchmaking is unavailable while in a game lobby.",
       "mapPool": "Map pool",
       "mapSelectionDescription": "Select the maps you would like to play on. Only selected maps will be chosen.",
+      "matchFound": "Match found!",
       "noScheduledWindow": "No scheduled window yet",
       "pickedCount": " / {{limit}} picked",
       "poolUpdated": "Pool updated",


### PR DESCRIPTION
## Summary

When a match is found and the accept dialog is up, the elapsed search time in the queue bar is no longer meaningful. This swaps the searching message + timer for a **"Match found!"** label and a `…` placeholder, mirroring the gameplay activity widget.

The queue bar already stays mounted in this state — `matchFound` sets `foundMatchAtom` without clearing `currentSearchInfoAtom`, so `isMatchmakingAtom` (which drives `isSearching`) remains true. This change just adds an `isMatched` prop derived from `foundMatchAtom` and branches the summary text/timer on it.

Also adds a **"Match found"** scenario to the `find-match` devonly page so this state can be previewed in isolation.

## Verification

- `pnpm typecheck` ✓
- `pnpm lint` ✓
- `pnpm gen-translations` produces exactly the committed `matchFound` key (no stale catalog) ✓
- T1 visual: rendered the new devonly `Match found` scenario — the queue bar shows "MATCH FOUND!" with the `…` placeholder instead of the searching message + timer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)