### PR TITLE
Fix map thumbnail actions and dialog layering in find-match settings drawer

### DIFF
--- a/client/matchmaking/find-match-forms.tsx
+++ b/client/matchmaking/find-match-forms.tsx
@@ -301,7 +301,10 @@ export function FixedMapDisplay({
   return (
     <MapSelections className={className}>
       {mapPool.maps.map(id => (
-        <SelectableMapContainer key={id} $disabled={true}>
+        // No `onClick`, so there's no selection/veto behavior here, but the thumbnail's own
+        // actions (preview, favorite, map details) should still work, so the container isn't
+        // marked as disabled.
+        <SelectableMapContainer key={id}>
           <ReduxMapThumbnail
             mapId={id}
             showInfoLayer={true}

--- a/client/matchmaking/find-match.tsx
+++ b/client/matchmaking/find-match.tsx
@@ -25,6 +25,7 @@ import { getInstantaneousSelfRank } from '../ladder/action-creators'
 import { RaceIcon } from '../lobbies/race-icon'
 import { FilledButton, TextButton } from '../material/button'
 import { CheckBox } from '../material/check-box'
+import { zIndexSettings } from '../material/zindex'
 import { push } from '../navigation/routing'
 import { useNow } from '../react/date-hooks'
 import { useAppDispatch, useAppSelector } from '../redux-hooks'
@@ -899,7 +900,7 @@ const DrawerScrim = styled(m.div)`
   position: fixed;
   inset: var(--sb-system-bar-height, 0) 0 0;
   background: rgba(0, 0, 0, 0.55);
-  z-index: 100;
+  z-index: ${zIndexSettings - 1};
 `
 
 const DrawerPanel = styled(m.aside)`
@@ -912,7 +913,7 @@ const DrawerPanel = styled(m.aside)`
   background: var(--theme-container);
   border-right: 1px solid color-mix(in srgb, var(--theme-on-surface) 10%, transparent);
   box-shadow: 12px 0 48px rgba(0, 0, 0, 0.5);
-  z-index: 101;
+  z-index: ${zIndexSettings};
   display: flex;
   flex-direction: column;
   overflow: hidden;


### PR DESCRIPTION
## Summary

Two related bugs in the matchmaking find-match settings drawer, both around the map thumbnails shown for fixed-map modes:

1. **Thumbnail actions were disabled in fixed-map mode.** `FixedMapDisplay` wrapped each thumbnail in a `SelectableMapContainer` marked `$disabled`, which applies `pointer-events: none`. That `$disabled` flag exists to disable the *selection/veto* click overlay — but `FixedMapDisplay` never passes an `onClick`, so the overlay isn't rendered and there's nothing to disable. The only effect was breaking the thumbnail's own action buttons (preview/zoom, favorite, map-details menu). Removed the flag.

2. **The map preview dialog rendered behind the drawer.** The drawer hardcoded `z-index: 100` (scrim) / `101` (panel), putting the panel at/above `zIndexDialog` (100). A dialog opened from inside the drawer therefore appeared behind it. Switched both layers to the shared `zIndexSettings` constant (panel `99`, scrim `98`), so dialogs layer on top — matching how the global settings overlay already sits below dialogs.

## Testing

- `pnpm run typecheck` passes
- Layering and thumbnail actions confirmed manually in the app

🤖 Generated with [Claude Code](https://claude.com/claude-code)