### PR TITLE
Recover stranded players when a formed match fails to publish

### DIFF
--- a/server-rs/src/matchmaking/api.rs
+++ b/server-rs/src/matchmaking/api.rs
@@ -30,6 +30,15 @@ const MIN_QUALITY: f32 = -30.0;
 /// How often the matchmaker searches for new matches.
 const SEARCH_INTERVAL: std::time::Duration = std::time::Duration::from_secs(6);
 
+/// How many times to attempt publishing a formed match to Redis before treating the failure as
+/// fatal. A formed match has already been removed from the queue, so a few quick retries are worth
+/// it to ride out a transient Redis blip before resorting to the process exit in
+/// [publish_match_or_exit].
+const MAX_PUBLISH_ATTEMPTS: u32 = 3;
+
+/// Delay between the publish attempts counted by [MAX_PUBLISH_ATTEMPTS].
+const PUBLISH_RETRY_DELAY: Duration = Duration::from_millis(200);
+
 #[derive(Serialize)]
 struct ApiError {
     code: &'static str,
@@ -269,18 +278,48 @@ async fn search_loop(state: MatchmakingApiState, redis_pool: RedisPool) {
                 quality: m.quality,
             });
 
-            if let Err(e) = redis_pool.publish(event).await {
-                tracing::error!("Failed to publish match event to Redis: {e:?}");
-                // The match is already removed from the Rust queue but was never delivered to
-                // Node.js. Affected players will appear stuck: they believe they're still
-                // searching but are no longer in the queue. This is an unresolved gap — Phase 3
-                // must define a recovery path. One option: treat a Redis publish error as fatal
-                // and restart the process so the process fingerprint changes; Node.js then detects
-                // the restart via the stale-ticket path and surfaces "matchmaking failed" to the
-                // affected players.
+            publish_match_or_exit(&redis_pool, event).await;
+        }
+    }
+}
+
+/// Publishes a formed-match event to Redis, retrying briefly before giving up. If every attempt
+/// fails, the match is irrecoverably lost: its players were already removed from the queue (so the
+/// search loop won't re-form their match) but Node.js never learned of the match, so they would
+/// believe they are still searching forever.
+///
+/// Rather than strand them, we exit the process. The `restart: unless-stopped` policy brings
+/// server-rs back with a fresh `process_token`, which the Node.js watchdog detects (token change,
+/// or the unreachable window during the restart) and uses to eject — and surface a failure to —
+/// every searching player, including the ones from this lost match. They can then immediately
+/// requeue. This is drastic, but a persistent inability to reach Redis means matchmaking can't
+/// function anyway, and a clean restart is the only way to restore consistency between the Rust
+/// queue and Node.js.
+///
+/// NOTE: this must exit the *process*, not panic. A panic here is caught by [supervise_search_loop]
+/// and only restarts the search task within the same process, leaving `process_token` unchanged —
+/// so the watchdog would never fire and the stranded players would stay stranded.
+async fn publish_match_or_exit(redis_pool: &RedisPool, event: PublishedMatchmakingMessage) {
+    for attempt in 1..=MAX_PUBLISH_ATTEMPTS {
+        match redis_pool.publish(event.clone()).await {
+            Ok(()) => return,
+            Err(e) => {
+                tracing::error!(
+                    "Failed to publish match event to Redis \
+                     (attempt {attempt}/{MAX_PUBLISH_ATTEMPTS}): {e:?}"
+                );
+                if attempt < MAX_PUBLISH_ATTEMPTS {
+                    tokio::time::sleep(PUBLISH_RETRY_DELAY).await;
+                }
             }
         }
     }
+
+    tracing::error!(
+        "Exhausted all attempts to publish a formed match to Redis; exiting so the process \
+         restarts with a fresh token and stranded players are ejected by the Node.js watchdog."
+    );
+    std::process::exit(1);
 }
 
 #[derive(Serialize)]

--- a/server-rs/src/matchmaking/api.rs
+++ b/server-rs/src/matchmaking/api.rs
@@ -319,6 +319,9 @@ async fn publish_match_or_exit(redis_pool: &RedisPool, event: PublishedMatchmaki
         "Exhausted all attempts to publish a formed match to Redis; exiting so the process \
          restarts with a fresh token and stranded players are ejected by the Node.js watchdog."
     );
+    // std::process::exit skips the periodic/Drop-based Datadog flush, so force the log above out to
+    // Datadog (stdout already has it synchronously) before terminating.
+    crate::telemetry::flush_datadog_logs().await;
     std::process::exit(1);
 }
 

--- a/server-rs/src/telemetry/datadog.rs
+++ b/server-rs/src/telemetry/datadog.rs
@@ -26,23 +26,37 @@ const MAX_RETRIES: u8 = 3;
 /// so a brief pause ensures a log emitted immediately before the flush is actually in the queue.
 const FLUSH_DRAIN_GRACE: Duration = Duration::from_millis(250);
 
+/// Hard upper bound on how long [flush_datadog_logs] will spend trying to send. The ingestor's HTTP
+/// client has no request timeout, so without this an unreachable Datadog (likely in the same
+/// outage that triggered the flush) could block for OS-level TCP timeouts and delay the very
+/// process exit the caller is racing to reach.
+const FLUSH_TIMEOUT: Duration = Duration::from_secs(2);
+
 /// A clone of the running ingestor, stashed so a fatal shutdown path can force a synchronous flush
 /// of buffered logs before the process exits. The clone shares the underlying queue and HTTP client
 /// (both `Arc`-backed), so flushing through it drains the same buffer the layer is filling. `None`
 /// when Datadog logging isn't configured.
 static INGESTOR: OnceLock<DatadogIngestor> = OnceLock::new();
 
-/// Forces a best-effort, synchronous flush of any buffered Datadog logs. Intended for fatal paths
-/// that call [`std::process::exit`], which skips both the periodic flush and the Drop-based flush,
-/// so a log emitted just before exiting would otherwise never reach Datadog (it still reaches
-/// stdout synchronously). No-op when Datadog logging isn't configured.
+/// Forces a best-effort, synchronous flush of any buffered Datadog logs, bounded by
+/// [FLUSH_TIMEOUT]. Intended for fatal paths that call [`std::process::exit`], which skips both the
+/// periodic flush and the Drop-based flush, so a log emitted just before exiting would otherwise
+/// never reach Datadog (it still reaches stdout synchronously). No-op when Datadog logging isn't
+/// configured.
 pub async fn flush_datadog_logs() {
     let Some(ingestor) = INGESTOR.get() else {
         return;
     };
     // Let the ingestor thread move any logs still sitting in the channel into its queue first.
     tokio::time::sleep(FLUSH_DRAIN_GRACE).await;
-    ingestor.flush().await;
+    // Bounded: this is best-effort and runs on a time-sensitive shutdown path, so we'd rather lose
+    // the log than hang the exit if Datadog is unreachable.
+    if tokio::time::timeout(FLUSH_TIMEOUT, ingestor.flush())
+        .await
+        .is_err()
+    {
+        tracing::warn!("Timed out flushing Datadog logs before exit");
+    }
 }
 
 #[allow(dead_code)]

--- a/server-rs/src/telemetry/datadog.rs
+++ b/server-rs/src/telemetry/datadog.rs
@@ -1,5 +1,5 @@
 use std::collections::VecDeque;
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 
 use chrono::{DateTime, Utc};
@@ -20,6 +20,30 @@ const TAGS: &str = "version:0.1.0";
 const MAX_BATCH_SIZE: usize = 1000;
 const MAX_BATCH_DURATION: Duration = Duration::from_secs(5);
 const MAX_RETRIES: u8 = 3;
+
+/// How long [flush_datadog_logs] waits for the ingestor thread to drain the log channel into its
+/// queue before forcing a send. Logging is asynchronous (`on_event` -> channel -> thread -> queue),
+/// so a brief pause ensures a log emitted immediately before the flush is actually in the queue.
+const FLUSH_DRAIN_GRACE: Duration = Duration::from_millis(250);
+
+/// A clone of the running ingestor, stashed so a fatal shutdown path can force a synchronous flush
+/// of buffered logs before the process exits. The clone shares the underlying queue and HTTP client
+/// (both `Arc`-backed), so flushing through it drains the same buffer the layer is filling. `None`
+/// when Datadog logging isn't configured.
+static INGESTOR: OnceLock<DatadogIngestor> = OnceLock::new();
+
+/// Forces a best-effort, synchronous flush of any buffered Datadog logs. Intended for fatal paths
+/// that call [`std::process::exit`], which skips both the periodic flush and the Drop-based flush,
+/// so a log emitted just before exiting would otherwise never reach Datadog (it still reaches
+/// stdout synchronously). No-op when Datadog logging isn't configured.
+pub async fn flush_datadog_logs() {
+    let Some(ingestor) = INGESTOR.get() else {
+        return;
+    };
+    // Let the ingestor thread move any logs still sitting in the channel into its queue first.
+    tokio::time::sleep(FLUSH_DRAIN_GRACE).await;
+    ingestor.flush().await;
+}
 
 #[allow(dead_code)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
@@ -101,6 +125,9 @@ pub struct DatadogLogLayer {
 impl DatadogLogLayer {
     pub fn new(options: DatadogOptions) -> Self {
         let ingestor = DatadogIngestor::new(options);
+        // Stash a clone (sharing the same queue + client) so a fatal shutdown can force a flush.
+        // Ignore the error if it's already set — only one layer is ever created per process.
+        let _ = INGESTOR.set(ingestor.clone());
 
         let (tx, mut rx) = unbounded_channel();
         let handle = std::thread::Builder::new()

--- a/server-rs/src/telemetry/mod.rs
+++ b/server-rs/src/telemetry/mod.rs
@@ -16,6 +16,8 @@ use crate::telemetry::datadog::{DatadogLogLayer, DatadogOptions};
 
 mod datadog;
 
+pub use datadog::flush_datadog_logs;
+
 /// Initialize a subscriber for tracing events. Note that [env_filter] will apply to *all* layers
 /// (e.g. anything it filters out will not be sent to Datadog or stdout).
 pub fn init_subscriber<Sink>(


### PR DESCRIPTION
## Problem

When the Rust matchmaker forms a match it removes those players from the queue while still holding the lock, *before* publishing the `MatchFound` event to Redis. If that publish failed, the players were gone from the Rust queue but Node.js never learned of the match — they'd believe they were still searching forever, with no recovery path. The previous code just logged the error and moved on; an inline comment flagged it as an unresolved "Phase 3" gap.

## Fix

Add `publish_match_or_exit` in `server-rs/src/matchmaking/api.rs`:

- Retries the publish (3× / 200ms) to ride out a transient Redis blip.
- If every attempt fails, logs a fatal error and `std::process::exit(1)`s.

The `restart: unless-stopped` policy on the `server_rs` container brings the process back with a fresh `process_token`. The **existing** Node.js watchdog (`checkProcessToken` → `handleRsRestart` in `matchmaking-service.ts`) detects the token change (or the unreachable window during restart) and ejects every searching player — including the ones from the lost match, who are still `getSearchingPlayerIds()` since `handleMatchFound` never ran for them — with a `matchmakingServiceError` so they can requeue.

### Why exit, not panic

This must exit the **process**, not panic. A panic here is caught by `supervise_search_loop` and only restarts the search task *within the same process*, leaving `process_token` unchanged — so the watchdog would never fire and the players would stay stranded. There's a `NOTE` in the code making this explicit.

## Verification

- `cargo fmt` + `cargo clippy --all-targets --workspace -- -D warnings` clean
- All 16 matchmaking Rust tests pass
- Traced the Node-side recovery end-to-end (watchdog is started on queue, baseline token captured, stranded searchers ejected)

**Not exercised:** a live Redis-down-mid-match-formation scenario (hard to stage; repo convention skips API-level fault tests). The retry/exit logic is simple and the Node recovery path it relies on is pre-existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)