### PR TITLE
Capture matchmaker formation telemetry for calibration

### DIFF
--- a/common/matchmaking.ts
+++ b/common/matchmaking.ts
@@ -1152,6 +1152,12 @@ export interface MatchmakingCompletion {
   completionType: MatchmakingCompletionType
   searchTimeMillis: number
   completionTime: Date
+  /**
+   * The user's rating in this matchmaking type at the time they queued. Lets queue-health analysis
+   * (search/cancel times, abandonment) be sliced by skill band. `undefined` for historical rows
+   * recorded before this was captured.
+   */
+  rating?: number
 }
 
 export enum MatchmakingServiceErrorCode {

--- a/common/typeshare.ts
+++ b/common/typeshare.ts
@@ -43,7 +43,17 @@ export interface MatchFoundMessage {
   mode: MatchmakingType
   teamA: MatchedPlayer[]
   teamB: MatchedPlayer[]
+  /** Overall match-quality score (in seconds of wait) the match formed at. */
   quality: number
+  /** Variance of the matched players' effective ratings (raw skill-spread input to `quality`). */
+  skillVariance: number
+  /** Win probability of team A vs team B (0.5 == perfectly balanced). */
+  winProbability: number
+  /** Effective team ratings used to compute `win_probability`. */
+  teamARating: number
+  teamBRating: number
+  /** Highest latency bucket among the matched players (raw latency input to `quality`). */
+  maxLatency: number
 }
 
 export interface SbPermissions {

--- a/docs/USEFUL_QUERIES.md
+++ b/docs/USEFUL_QUERIES.md
@@ -18,6 +18,132 @@ FROM matchmaking_completions
 GROUP BY matchmaking_type;
 ```
 
+# Matchmaker calibration
+
+These queries are for evaluating how well the matchmaker's predictions and quality formula hold up
+against real outcomes, so weight/formula changes can be made from data rather than guesswork. The
+first two run on data we've always had (`matchmaking_rating_changes.probability`); the rest depend on
+the `matchmaking_match_formations` table and `matchmaking_completions.rating`, which are only
+populated for games/searches that happened **after** that migration, so they'll be empty until enough
+new data accumulates.
+
+## Rating prediction reliability (predicted vs. actual win rate)
+
+Buckets every per-player, per-game predicted win probability and compares the average prediction in
+each bucket to the actual win rate. A well-calibrated model has `predicted_win_rate ≈
+actual_win_rate` in every row. Systematic gaps (e.g. favorites winning more/less than predicted) mean
+the rating→win-probability mapping needs tuning. Note each 1v1 game contributes two rows (one per
+player, with complementary probabilities); team games contribute one row per player.
+
+```sql
+SELECT
+  width_bucket(probability, 0, 1, 10) AS bucket,
+  round(min(probability)::numeric, 3) AS min_p,
+  round(max(probability)::numeric, 3) AS max_p,
+  count(*) AS predictions,
+  round(avg(probability)::numeric, 4) AS predicted_win_rate,
+  round(avg((outcome = 'win')::int)::numeric, 4) AS actual_win_rate
+FROM matchmaking_rating_changes
+-- Optionally restrict to one mode, e.g.:  WHERE matchmaking_type = '1v1'
+GROUP BY bucket
+ORDER BY bucket;
+```
+
+## Prediction accuracy score (Brier score + log loss) per mode
+
+Single-number summaries of prediction quality per mode, useful for tracking calibration over time or
+comparing modes. Lower is better for both. A Brier score of 0.25 / log loss of ~0.693 is what you'd
+get from always predicting 0.5 (no skill information), so values meaningfully below that mean the
+ratings carry real predictive signal.
+
+```sql
+SELECT
+  matchmaking_type,
+  count(*) AS predictions,
+  round(avg(power(probability - (outcome = 'win')::int, 2))::numeric, 4) AS brier_score,
+  round(avg(
+    -1 * (
+      (outcome = 'win')::int * ln(greatest(probability, 1e-15)) +
+      (1 - (outcome = 'win')::int) * ln(greatest(1 - probability, 1e-15))
+    )
+  )::numeric, 4) AS log_loss
+FROM matchmaking_rating_changes
+GROUP BY matchmaking_type
+ORDER BY matchmaking_type;
+```
+
+## Match balance vs. game length (does "balanced" produce closer games?)
+
+Tests the core assumption behind the quality formula: that matches the matchmaker considers balanced
+actually play out as longer, closer games. Buckets formed matches by how far their predicted win
+probability was from a 50/50 split and shows the median game length per bucket. If the formula is
+working, more-balanced matches (lower `avg_imbalance`) should trend toward longer median games.
+Because game length is heavily mode-dependent (Fastest/BGH games are short by nature), filter to a
+single mode for a meaningful comparison.
+
+```sql
+SELECT
+  width_bucket(abs(0.5 - f.win_probability), 0, 0.5, 5) AS imbalance_bucket,
+  count(*) AS games,
+  round(avg(abs(0.5 - f.win_probability))::numeric, 3) AS avg_imbalance,
+  round(
+    ((percentile_cont(0.5) WITHIN GROUP (ORDER BY g.game_length)) / 60000.0)::numeric, 1
+  ) AS median_minutes
+FROM matchmaking_match_formations f
+JOIN games g ON g.id = f.game_id
+WHERE g.game_length IS NOT NULL
+  AND f.matchmaking_type = '1v1'
+GROUP BY imbalance_bucket
+ORDER BY imbalance_bucket;
+```
+
+## Distribution of formed-match quality and its components
+
+A health check on what the matchmaker is actually shipping: how negative the quality scores are (how
+often the adaptive low-population threshold is carrying matches), and how much each penalty term
+(skill spread, win-probability imbalance, latency) contributes on average. Useful before changing any
+of the `WEIGHT_*` constants in `server-rs/src/matchmaking/matchmaker.rs`.
+
+```sql
+SELECT
+  matchmaking_type,
+  count(*) AS matches,
+  round(avg(quality)::numeric, 1) AS avg_quality,
+  round((percentile_cont(0.5) WITHIN GROUP (ORDER BY quality))::numeric, 1) AS median_quality,
+  round(avg(skill_variance)::numeric, 0) AS avg_skill_variance,
+  round(avg(abs(0.5 - win_probability))::numeric, 3) AS avg_winprob_imbalance,
+  round(avg(max_latency)::numeric, 2) AS avg_max_latency
+FROM matchmaking_match_formations
+GROUP BY matchmaking_type
+ORDER BY matchmaking_type;
+```
+
+## Queue health by skill band (search time + abandonment rate)
+
+Uses the rating captured at queue time to show where matchmaking is painful: which skill bands wait
+longest and give up most often. High `abandon_rate` or `median_found_secs` in a band points to a
+population/quality-threshold problem for that band rather than the matchmaker overall.
+
+```sql
+SELECT
+  matchmaking_type,
+  width_bucket(rating, 1000, 2500, 6) AS rating_band,
+  count(*) FILTER (WHERE completion_type = 'found') AS found,
+  count(*) FILTER (WHERE completion_type IN ('cancel', 'disconnect')) AS abandoned,
+  round(
+    count(*) FILTER (WHERE completion_type IN ('cancel', 'disconnect'))::numeric /
+      greatest(count(*), 1), 3
+  ) AS abandon_rate,
+  round(
+    (percentile_cont(0.5) WITHIN GROUP (ORDER BY search_time_millis)
+      FILTER (WHERE completion_type = 'found') / 1000.0)::numeric, 1
+  ) AS median_found_secs
+FROM matchmaking_completions
+WHERE rating IS NOT NULL
+GROUP BY matchmaking_type, rating_band
+ORDER BY matchmaking_type, rating_band;
+```
+
 ## Recent game rally-point routes + estimated latency, 1 route per row
 
 Change the first common table expression to select the game entries you care about.

--- a/migrations/20260625120000_add_matchmaking_match_formations.sql
+++ b/migrations/20260625120000_add_matchmaking_match_formations.sql
@@ -1,0 +1,33 @@
+-- Captures the matchmaker's own decision for each matchmaking game: the quality score the match
+-- formed at, plus the raw inputs that fed that score (skill variance, win probability, per-team
+-- effective ratings, max latency bucket). Keyed by game_id so the formation decision can be joined
+-- to the game's actual outcome (length, result) for calibrating the quality weights against real
+-- games. Populated going forward by the matchmaking service when a match successfully loads.
+--
+-- We store the raw, unweighted inputs (not the pre-weighted penalty terms) so the weights can be
+-- re-derived later without losing information if they change. game_id is the PK (one formation per
+-- game) with a cascading FK so a deleted/failed game doesn't leave an orphan row.
+--
+-- Also adds `rating` to matchmaking_completions: the player's rating in that mode at queue time, so
+-- queue health (search/cancel times, abandonment) can be sliced by skill band without reconstructing
+-- the player's (mutating) rating after the fact. Nullable since historical rows have no value.
+
+CREATE TABLE matchmaking_match_formations (
+  game_id uuid NOT NULL PRIMARY KEY REFERENCES games (id) ON DELETE CASCADE,
+  matchmaking_type matchmaking_type NOT NULL,
+  -- Overall quality score (in seconds of wait) the match formed at.
+  quality real NOT NULL,
+  -- Variance of the matched players' effective ratings (raw skill-spread input to quality).
+  skill_variance real NOT NULL,
+  -- Win probability of team A vs team B from the matchmaker's logistic (0.5 == balanced).
+  win_probability real NOT NULL,
+  -- Effective team ratings used to compute win_probability.
+  team_a_rating real NOT NULL,
+  team_b_rating real NOT NULL,
+  -- Highest latency bucket among the matched players (raw latency input to quality).
+  max_latency real NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE matchmaking_completions
+  ADD COLUMN rating real;

--- a/server-rs/src/matchmaking/api.rs
+++ b/server-rs/src/matchmaking/api.rs
@@ -276,6 +276,11 @@ async fn search_loop(state: MatchmakingApiState, redis_pool: RedisPool) {
                 team_a: m.team_a.iter().map(make_matched_player).collect(),
                 team_b: m.team_b.iter().map(make_matched_player).collect(),
                 quality: m.quality,
+                skill_variance: m.skill_variance,
+                win_probability: m.win_probability,
+                team_a_rating: m.team_a_rating,
+                team_b_rating: m.team_b_rating,
+                max_latency: m.max_latency,
             });
 
             publish_match_or_exit(&redis_pool, event).await;
@@ -506,12 +511,22 @@ mod tests {
                 team_a: vec![player0.clone()],
                 team_b: vec![player1],
                 quality: 10.0,
+                skill_variance: 0.0,
+                win_probability: 0.5,
+                team_a_rating: 1000.0,
+                team_b_rating: 1000.0,
+                max_latency: 0.0,
             },
             Match {
                 mode: MatchmakingType::Match1v1,
                 team_a: vec![player0],
                 team_b: vec![player2],
                 quality: 5.0,
+                skill_variance: 0.0,
+                win_probability: 0.5,
+                team_a_rating: 1000.0,
+                team_b_rating: 1000.0,
+                max_latency: 0.0,
             },
         ];
 

--- a/server-rs/src/matchmaking/matchmaker.rs
+++ b/server-rs/src/matchmaking/matchmaker.rs
@@ -114,6 +114,19 @@ pub struct Match {
     pub team_a: Vec<QueueEntry>,
     pub team_b: Vec<QueueEntry>,
     pub quality: f32,
+    /// Variance of the matched players' effective ratings — the raw skill-spread input to the
+    /// quality score, before `WEIGHT_RATING_VARIANCE` is applied. Persisted as match-formation
+    /// telemetry so the weights can later be calibrated against real game outcomes.
+    pub skill_variance: f32,
+    /// Win probability of team A vs team B from the matchmaker's own logistic (no uncertainty
+    /// term). 0.5 means a perfectly balanced match.
+    pub win_probability: f32,
+    /// Effective team ratings (see [`get_team_rating`]) used to compute `win_probability`.
+    pub team_a_rating: f32,
+    pub team_b_rating: f32,
+    /// Highest latency bucket among the matched players — the raw latency input to the quality
+    /// score, before `WEIGHT_LATENCY` is applied.
+    pub max_latency: f32,
 }
 
 pub trait QueueSelector {
@@ -425,6 +438,11 @@ impl<T: QueueSelector> Matchmaker<T> {
                             team_a: team_a.into_iter().cloned().collect(),
                             team_b: team_b.into_iter().cloned().collect(),
                             quality,
+                            skill_variance: variance,
+                            win_probability: win_prob,
+                            team_a_rating: rating_a,
+                            team_b_rating: rating_b,
+                            max_latency,
                         })
                     } else {
                         None

--- a/server-rs/src/matchmaking/matchmaker.rs
+++ b/server-rs/src/matchmaking/matchmaker.rs
@@ -118,8 +118,11 @@ pub struct Match {
     /// quality score, before `WEIGHT_RATING_VARIANCE` is applied. Persisted as match-formation
     /// telemetry so the weights can later be calibrated against real game outcomes.
     pub skill_variance: f32,
-    /// Win probability of team A vs team B from the matchmaker's own logistic (no uncertainty
-    /// term). 0.5 means a perfectly balanced match.
+    /// Win probability of team A vs team B from the matchmaker's logistic, computed over effective
+    /// (uncertainty-discounted) ratings — see [`get_team_rating`]/[`effective_rating`]. Uncertainty
+    /// is folded in via the effective rating rather than a separate σ-weight, so this differs from
+    /// the Glicko-2 rating update's σ-weighted expected score (the comparison this telemetry
+    /// enables). 0.5 means a perfectly balanced match.
     pub win_probability: f32,
     /// Effective team ratings (see [`get_team_rating`]) used to compute `win_probability`.
     pub team_a_rating: f32,

--- a/server-rs/src/matchmaking/mod.rs
+++ b/server-rs/src/matchmaking/mod.rs
@@ -28,7 +28,17 @@ pub struct MatchFoundMessage {
     pub mode: MatchmakingType,
     pub team_a: Vec<MatchedPlayer>,
     pub team_b: Vec<MatchedPlayer>,
+    /// Overall match-quality score (in seconds of wait) the match formed at.
     pub quality: f32,
+    /// Variance of the matched players' effective ratings (raw skill-spread input to `quality`).
+    pub skill_variance: f32,
+    /// Win probability of team A vs team B (0.5 == perfectly balanced).
+    pub win_probability: f32,
+    /// Effective team ratings used to compute `win_probability`.
+    pub team_a_rating: f32,
+    pub team_b_rating: f32,
+    /// Highest latency bucket among the matched players (raw latency input to `quality`).
+    pub max_latency: f32,
 }
 
 /// Messages published to the Redis `"matchmaking"` channel.

--- a/server/lib/games/game-loader.ts
+++ b/server/lib/games/game-loader.ts
@@ -134,12 +134,18 @@ function createRoutes(players: ISet<Slot>): Promise<RouteResult[]> {
   )
 }
 
+/** Resolved value of a successful `GameLoader.loadGame`. */
+export interface GameLoadResult {
+  /** The ID of the game record that was created and successfully loaded. */
+  gameId: string
+}
+
 const createLoadingData = Record({
   gameSource: GameSource.Lobby,
   players: ISet<Slot>(),
   finishedPlayers: ISet<SbUserId>(),
   abortController: null as unknown as AbortController,
-  deferred: null as unknown as Deferred<Result<void, GameLoaderError>>,
+  deferred: null as unknown as Deferred<Result<GameLoadResult, GameLoaderError>>,
   signal: null as unknown as AbortSignal,
 })
 
@@ -313,8 +319,8 @@ export class GameLoader {
     gameConfig,
     ratings,
     signal,
-  }: GameLoadRequest): AsyncResult<void, GameLoaderError> {
-    const gameLoaded = createDeferred<Result<void, GameLoaderError>>()
+  }: GameLoadRequest): AsyncResult<GameLoadResult, GameLoaderError> {
+    const gameLoaded = createDeferred<Result<GameLoadResult, GameLoaderError>>()
 
     this.gameLoadRequestsTotalMetric.labels(gameConfig.gameSource).inc()
 
@@ -437,7 +443,7 @@ export class GameLoader {
 
       this.recentlyLoadedGames.add(gameId)
       this.loadingGames = this.loadingGames.delete(gameId)
-      loadingData.deferred.resolve(Result.ok())
+      loadingData.deferred.resolve(Result.ok({ gameId }))
 
       setTimeout(() => {
         this.recentlyLoadedGames.delete(gameId)

--- a/server/lib/matchmaking/matchmaking-service.test.ts
+++ b/server/lib/matchmaking/matchmaking-service.test.ts
@@ -1,4 +1,5 @@
 import { register } from 'prom-client'
+import { Result } from 'typescript-result'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { makeSbMapId, SbMapId } from '../../../common/maps'
 import {
@@ -57,7 +58,11 @@ vi.mock('../maps/map-models', async () => ({
 
 import { getMapInfos } from '../maps/map-models'
 import { getCurrentMapPool } from './matchmaking-map-pools-models'
-import { getMatchmakingRating, insertMatchmakingCompletion } from './models'
+import {
+  getMatchmakingRating,
+  insertMatchmakingCompletion,
+  insertMatchmakingMatchFormation,
+} from './models'
 
 const MAP_ID: SbMapId = makeSbMapId('1')
 const SEASON = { id: 1, startDate: new Date(0), name: 'test', resetMmr: false } as any
@@ -66,6 +71,7 @@ const USER_A = makeSbUserId(1)
 const USER_B = makeSbUserId(2)
 const CLIENT_A = 'CLIENT_A'
 const CLIENT_B = 'CLIENT_B'
+const GAME_ID = 'game-1'
 
 function makePreferences(): MatchmakingPreferences {
   return {
@@ -103,6 +109,7 @@ describe('matchmaking/matchmaking-service', () => {
   let activityRegistry: GameplayActivityRegistry
   let banUser: ReturnType<typeof vi.fn>
   let clientSockets: Map<SbUserId, ClientSocketsGroup>
+  let gameLoader: { loadGame: ReturnType<typeof vi.fn> }
   let redisHandler: (event: { type: 'matchFound'; data: MatchFoundMessage }) => void
 
   function createFakeClient(userId: SbUserId, clientId: string): ClientSocketsGroup {
@@ -165,6 +172,9 @@ describe('matchmaking/matchmaking-service', () => {
       [USER_A, createFakeClient(USER_A, CLIENT_A)],
       [USER_B, createFakeClient(USER_B, CLIENT_B)],
     ])
+    // Defaults to a never-resolving load so tests that only exercise earlier phases (accept, etc.)
+    // behave as before; tests that need a completed load override this with a resolved result.
+    gameLoader = { loadGame: vi.fn().mockReturnValue(new Promise<never>(() => {})) }
 
     const userSocketsManager = { on: vi.fn(), getById: vi.fn() }
     const clientSocketsManager = {
@@ -195,7 +205,7 @@ describe('matchmaking/matchmaking-service', () => {
       clientSocketsManager as any,
       matchmakingStatus as any,
       activityRegistry,
-      {} as any,
+      gameLoader as any,
       matchmakingSeasonsService as any,
       clock,
       userIdentifierManager as any,
@@ -346,6 +356,53 @@ describe('matchmaking/matchmaking-service', () => {
     expect(errorPublishedFor(USER_B)).toBe(false)
     expect(banUser).not.toHaveBeenCalled()
     expect(rsCancelPlayer).not.toHaveBeenCalled()
+  })
+
+  test('records the match formation telemetry keyed by the loaded game id', async () => {
+    asMockedFunction(getCurrentMapPool).mockResolvedValue({ maps: [MAP_ID] } as any)
+    asMockedFunction(getMapInfos).mockResolvedValue([{ id: MAP_ID } as any])
+    gameLoader.loadGame.mockResolvedValue(Result.ok({ gameId: GAME_ID }))
+
+    await queuePlayer(USER_A, CLIENT_A)
+    await queuePlayer(USER_B, CLIENT_B)
+
+    redisHandler({
+      type: 'matchFound',
+      data: {
+        mode: MatchmakingType.Match1v1,
+        teamA: [{ id: USER_A, ticket: 'ticket-a' }],
+        teamB: [{ id: USER_B, ticket: 'ticket-b' }],
+        quality: 12.5,
+        skillVariance: 30000,
+        winProbability: 0.42,
+        teamARating: 1500,
+        teamBRating: 1600,
+        maxLatency: 1,
+      },
+    })
+    await vi.advanceTimersByTimeAsync(0)
+
+    // Both players accept, so the match runs through map selection and a successful game load.
+    await service.accept(USER_A)
+    await service.accept(USER_B)
+    // Drain the runMatch promise chain (accept -> pickMap -> draft -> doGameLoad -> loadGame).
+    for (let i = 0; i < 20; i++) {
+      await vi.advanceTimersByTimeAsync(0)
+    }
+
+    // The matchmaker's formation decision is persisted exactly once, keyed by the game it produced
+    // and carrying the quality breakdown from the matchFound event verbatim.
+    expect(insertMatchmakingMatchFormation).toHaveBeenCalledTimes(1)
+    expect(insertMatchmakingMatchFormation).toHaveBeenCalledWith({
+      gameId: GAME_ID,
+      matchmakingType: MatchmakingType.Match1v1,
+      quality: 12.5,
+      skillVariance: 30000,
+      winProbability: 0.42,
+      teamARating: 1500,
+      teamBRating: 1600,
+      maxLatency: 1,
+    })
   })
 
   test('counts a found match once, not once per matched player', async () => {

--- a/server/lib/matchmaking/matchmaking-service.test.ts
+++ b/server/lib/matchmaking/matchmaking-service.test.ts
@@ -42,6 +42,7 @@ vi.mock('./models', () => ({
   getMatchmakingRating: vi.fn(),
   createInitialMatchmakingRating: vi.fn(),
   insertMatchmakingCompletion: vi.fn().mockResolvedValue(undefined),
+  insertMatchmakingMatchFormation: vi.fn().mockResolvedValue(undefined),
 }))
 
 vi.mock('./matchmaking-map-pools-models', async () => ({
@@ -296,6 +297,11 @@ describe('matchmaking/matchmaking-service', () => {
         teamA: [{ id: USER_A, ticket: 'ticket-a' }],
         teamB: [{ id: USER_B, ticket: 'ticket-b' }],
         quality: 1,
+        skillVariance: 0,
+        winProbability: 0.5,
+        teamARating: 1500,
+        teamBRating: 1500,
+        maxLatency: 0,
       },
     })
     await vi.advanceTimersByTimeAsync(0)
@@ -321,6 +327,11 @@ describe('matchmaking/matchmaking-service', () => {
         teamA: [{ id: USER_A, ticket: 'ticket-a' }],
         teamB: [{ id: USER_B, ticket: 'ticket-b' }],
         quality: 1,
+        skillVariance: 0,
+        winProbability: 0.5,
+        teamARating: 1500,
+        teamBRating: 1500,
+        maxLatency: 0,
       },
     })
     await vi.advanceTimersByTimeAsync(0)
@@ -348,6 +359,11 @@ describe('matchmaking/matchmaking-service', () => {
         teamA: [{ id: USER_A, ticket: 'ticket-a' }],
         teamB: [{ id: USER_B, ticket: 'ticket-b' }],
         quality: 1,
+        skillVariance: 0,
+        winProbability: 0.5,
+        teamARating: 1500,
+        teamBRating: 1500,
+        maxLatency: 0,
       },
     })
     await vi.advanceTimersByTimeAsync(0)
@@ -390,6 +406,11 @@ describe('matchmaking/matchmaking-service', () => {
         teamA: [{ id: USER_A, ticket: 'ticket-a' }],
         teamB: [{ id: USER_B, ticket: 'ticket-b' }],
         quality: 1,
+        skillVariance: 0,
+        winProbability: 0.5,
+        teamARating: 1500,
+        teamBRating: 1500,
+        maxLatency: 0,
       },
     })
     await vi.advanceTimersByTimeAsync(0)
@@ -448,6 +469,11 @@ describe('matchmaking/matchmaking-service', () => {
         teamA: [{ id: USER_A, ticket: 'ticket-a' }],
         teamB: [{ id: USER_B, ticket: 'ticket-b' }],
         quality: 1,
+        skillVariance: 0,
+        winProbability: 0.5,
+        teamARating: 1500,
+        teamBRating: 1500,
+        maxLatency: 0,
       },
     })
     await vi.advanceTimersByTimeAsync(0)

--- a/server/lib/matchmaking/matchmaking-service.ts
+++ b/server/lib/matchmaking/matchmaking-service.ts
@@ -61,6 +61,7 @@ import {
   createInitialMatchmakingRating,
   getMatchmakingRating,
   insertMatchmakingCompletion,
+  insertMatchmakingMatchFormation,
   MatchmakingRating,
 } from '../matchmaking/models'
 import { RedisSubscriber } from '../redis/redis'
@@ -104,6 +105,20 @@ interface PlayerQueueData {
   queuedAt: number
 }
 
+/**
+ * The matchmaker's quality breakdown for a formed match (from the Rust `matchFound` event), carried
+ * on the in-memory match until the game loads so it can be persisted keyed by the resulting game id
+ * (see `insertMatchmakingMatchFormation`).
+ */
+interface MatchFormationTelemetry {
+  quality: number
+  skillVariance: number
+  winProbability: number
+  teamARating: number
+  teamBRating: number
+  maxLatency: number
+}
+
 class Match {
   private acceptTimeStart: number
   private acceptPromises = new Map<SbUserId, Deferred<void>>()
@@ -120,6 +135,7 @@ class Match {
     readonly id: string,
     readonly type: MatchmakingType,
     readonly teams: Immutable<MatchmakingEntity[][]>,
+    readonly formation: MatchFormationTelemetry,
     private publisher: TypedPublisher<ReadonlyDeep<MatchmakingEvent>>,
   ) {
     for (const entities of teams) {
@@ -1117,6 +1133,15 @@ export class MatchmakingService {
       )
     }
 
+    // Record the matchmaker's formation decision keyed by the game it produced, so it can later be
+    // joined to the game's actual outcome for calibration. Best-effort: a failure here must not
+    // affect game flow.
+    insertMatchmakingMatchFormation({
+      gameId: loadResult.value.gameId,
+      matchmakingType: match.type,
+      ...match.formation,
+    }).catch(err => logger.error({ err }, 'error while logging matchmaking match formation'))
+
     for (const player of match.players()) {
       this.queueEntries.delete(player.id)
     }
@@ -1203,7 +1228,20 @@ export class MatchmakingService {
       this.requeueTickets.set(userId, entry.ticket)
     }
 
-    const matchInfo = new Match(nanoid(), event.mode, [teamA, teamB], this.publisher)
+    const matchInfo = new Match(
+      nanoid(),
+      event.mode,
+      [teamA, teamB],
+      {
+        quality: event.quality,
+        skillVariance: event.skillVariance,
+        winProbability: event.winProbability,
+        teamARating: event.teamARating,
+        teamBRating: event.teamBRating,
+        maxLatency: event.maxLatency,
+      },
+      this.publisher,
+    )
     this.matches.set(matchInfo.id, matchInfo)
 
     for (const entities of [teamA, teamB]) {
@@ -1230,6 +1268,7 @@ export class MatchmakingService {
             completionType: MatchmakingCompletionType.Found,
             searchTimeMillis,
             completionTime,
+            rating: data?.types.get(event.mode)?.playerData.rating,
           }).catch(err => logger.error({ err }, 'error while logging matchmaking completion'))
         }
 
@@ -1418,13 +1457,14 @@ export class MatchmakingService {
             ? MatchmakingCompletionType.Disconnect
             : MatchmakingCompletionType.Cancel
 
-          for (const [type] of data.types) {
+          for (const [type, typeData] of data.types) {
             insertMatchmakingCompletion({
               userId: client.userId,
               matchmakingType: type,
               completionType,
               searchTimeMillis,
               completionTime,
+              rating: typeData.playerData.rating,
             }).catch(err => logger.error({ err }, 'error while logging matchmaking completion'))
 
             this.matchSearchTimeMetric

--- a/server/lib/matchmaking/models.ts
+++ b/server/lib/matchmaking/models.ts
@@ -661,26 +661,74 @@ function fromDbMatchmakingCompletion(
     completionType: result.completion_type,
     searchTimeMillis: result.search_time_millis,
     completionTime: result.completion_time,
+    rating: result.rating ?? undefined,
   }
 }
 
 export async function insertMatchmakingCompletion(
   completion: Omit<MatchmakingCompletion, 'id'>,
 ): Promise<MatchmakingCompletion> {
-  const { userId, matchmakingType, completionType, searchTimeMillis, completionTime } = completion
+  const { userId, matchmakingType, completionType, searchTimeMillis, completionTime, rating } =
+    completion
 
   const { client, done } = await db()
   try {
     const result = await client.query<DbMatchmakingCompletion>(sql`
       INSERT INTO matchmaking_completions
-        (user_id, matchmaking_type, completion_type, search_time_millis, completion_time)
+        (user_id, matchmaking_type, completion_type, search_time_millis, completion_time, rating)
       VALUES
         (${userId}, ${matchmakingType}, ${completionType}, ${Math.round(searchTimeMillis)},
-          ${completionTime})
+          ${completionTime}, ${rating ?? null})
       RETURNING *
     `)
 
     return fromDbMatchmakingCompletion(result.rows[0])
+  } finally {
+    done()
+  }
+}
+
+/**
+ * The matchmaker's formation decision for a single matchmaking game: the quality score the match
+ * formed at, plus the raw (unweighted) inputs that fed it. Keyed by game so it can be joined to the
+ * game's actual outcome for calibrating the quality weights. See the `matchmaking_match_formations`
+ * migration.
+ */
+export interface MatchmakingMatchFormation {
+  gameId: string
+  matchmakingType: MatchmakingType
+  /** Overall quality score (in seconds of wait) the match formed at. */
+  quality: number
+  /** Variance of the matched players' effective ratings (raw skill-spread input to quality). */
+  skillVariance: number
+  /** Win probability of team A vs team B from the matchmaker's logistic (0.5 == balanced). */
+  winProbability: number
+  /** Effective team ratings used to compute `winProbability`. */
+  teamARating: number
+  teamBRating: number
+  /** Highest latency bucket among the matched players (raw latency input to quality). */
+  maxLatency: number
+}
+
+/**
+ * Records the matchmaker's formation decision for a game. Best-effort telemetry for calibration; a
+ * failure here must not affect the game itself, so callers should not block game flow on it.
+ */
+export async function insertMatchmakingMatchFormation(
+  formation: Readonly<MatchmakingMatchFormation>,
+  withClient?: DbClient,
+): Promise<void> {
+  const { client, done } = await db(withClient)
+  try {
+    await client.query(sql`
+      INSERT INTO matchmaking_match_formations
+        (game_id, matchmaking_type, quality, skill_variance, win_probability,
+          team_a_rating, team_b_rating, max_latency)
+      VALUES
+        (${formation.gameId}, ${formation.matchmakingType}, ${formation.quality},
+          ${formation.skillVariance}, ${formation.winProbability}, ${formation.teamARating},
+          ${formation.teamBRating}, ${formation.maxLatency})
+    `)
   } finally {
     done()
   }


### PR DESCRIPTION
## Why

We collect the rating *inputs* and the rating-change *outputs*, but never the matchmaker's own decision — when a match forms, the Rust matcher computes its quality breakdown (skill variance, win-probability balance, latency) and throws it away. That makes it impossible to tune the quality weights against real outcomes, and the one prediction we do store (`matchmaking_rating_changes.probability`) is the Glicko-2 update's σ-weighted score, *not* the logistic the matcher actually decides on.

This PR implements **Tier 1** (capture the decision) and **Tier 2** (calibration queries on existing data). Tier 3 (live latency buckets + sampled queue snapshots) stays in the backlog.

## Tier 1 — capture the decision

- The Rust matcher's `Match` now carries the raw quality inputs it already computes — `skill_variance`, `win_probability` (the matcher's own logistic over effective, uncertainty-discounted ratings), `team_a_rating`/`team_b_rating`, `max_latency` — alongside `quality`, and publishes them in `MatchFoundMessage`.
- New **`matchmaking_match_formations`** table, keyed by `game_id` (FK → `games`, `ON DELETE CASCADE`), stores those raw *unweighted* inputs so the `WEIGHT_*` constants can be re-derived later. Written when a match successfully loads — best-effort, never blocks game flow.
- `GameLoader.loadGame` now resolves with `{ gameId }` so the matchmaking service can key the formation row to the game it produced (the lobby caller ignores the value).
- `matchmaking_completions` gains a nullable **`rating`** column, populated at queue time, so queue health is sliceable by skill band.

## Tier 2 — calibration queries on existing data

New **Matchmaker calibration** section in `docs/USEFUL_QUERIES.md`:
1. Rating prediction reliability (predicted vs. actual win rate) — *existing data*
2. Brier score + log loss per mode — *existing data*
3. Match balance vs. game length — *new table*
4. Formed-match quality distribution — *new table*
5. Queue health by skill band — *new column*

Queries 1–2 already show signal on historical data (1v1 Brier 0.22 / log loss 0.61 vs. the 0.25 / 0.69 no-information baseline).

## Verification

- `cargo fmt` clean, `cargo clippy --all-targets -D warnings` clean, 16/16 server-rs matchmaking tests pass
- `tsc` passes, `eslint --fix` clean, 61/61 matchmaking + games JS tests pass (incl. a new test asserting the formation insert fires with the right game id and values)
- Migration applied to the dev DB; table/FK/column shape verified
- All five calibration queries executed against the DB

## Follow-up

We now store two predicted win probabilities — the Glicko-2 σ-weighted one (`rating_changes.probability`) and the matcher's own effective-rating logistic (`match_formations.win_probability`). Running query #1 against each will show which is better calibrated, directly informing whether the matcher should adopt the σ-weighted formula.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
