### PR TITLE
Compute matchmaker latency from rally-point pings

### DIFF
--- a/client/matchmaking/action-creators.ts
+++ b/client/matchmaking/action-creators.ts
@@ -90,6 +90,13 @@ export function findMatch(
               'You must select at least one map in the settings for each chosen matchmaking type.',
             )
             break
+          case MatchmakingServiceErrorCode.PingMeasurementFailed:
+            message = i18n.t(
+              'matchmaking.findMatch.errors.pingMeasurementFailed',
+              "Couldn't measure your connection to the game servers. Please check your connection " +
+                'and try again.',
+            )
+            break
           default:
             logger.error(
               `Unhandled error code while queueing for matchmaking as a solo player: ${err.code}`,

--- a/common/matchmaking.ts
+++ b/common/matchmaking.ts
@@ -1169,6 +1169,11 @@ export enum MatchmakingServiceErrorCode {
   InvalidMaps = 'invalidMaps',
   MatchAlreadyStarting = 'matchAlreadyStarting',
   MatchmakingDisabled = 'matchmakingDisabled',
+  /**
+   * The client couldn't measure its rally-point pings in time, so the matchmaker has no latency
+   * estimate to find a match with.
+   */
+  PingMeasurementFailed = 'pingMeasurementFailed',
   NotInQueue = 'notInQueue',
   NoActiveMatch = 'noActiveMatch',
   TooManyPlayers = 'tooManyPlayers',

--- a/common/typeshare.ts
+++ b/common/typeshare.ts
@@ -52,7 +52,10 @@ export interface MatchFoundMessage {
   /** Effective team ratings used to compute `win_probability`. */
   teamARating: number
   teamBRating: number
-  /** Highest latency bucket among the matched players (raw latency input to `quality`). */
+  /**
+   * Estimated one-way latency (ms) of the match's worst pairwise link, computed from the
+   * players' rally-point server pings (raw latency input to `quality`).
+   */
   maxLatency: number
 }
 

--- a/docs/USEFUL_QUERIES.md
+++ b/docs/USEFUL_QUERIES.md
@@ -112,8 +112,45 @@ SELECT
   round((percentile_cont(0.5) WITHIN GROUP (ORDER BY quality))::numeric, 1) AS median_quality,
   round(avg(skill_variance)::numeric, 0) AS avg_skill_variance,
   round(avg(abs(0.5 - win_probability))::numeric, 3) AS avg_winprob_imbalance,
-  round(avg(max_latency)::numeric, 2) AS avg_max_latency
+  -- max_latency is the estimated one-way latency (ms) of the match's worst pairwise link.
+  round(avg(max_latency)::numeric, 2) AS avg_max_latency_ms
 FROM matchmaking_match_formations
+GROUP BY matchmaking_type
+ORDER BY matchmaking_type;
+```
+
+## Predicted vs. actual match latency
+
+Validates the latency input to the quality formula before trusting `WEIGHT_LATENCY`. The matcher
+estimates a match's latency at *queue time* from each player's rally-point pings (stored as
+`match_formations.max_latency`, the worst pairwise one-way link). When the game actually launches, the
+game loader re-picks routes from *fresh* pings and records the real per-pair latency in `games.routes`
+— so the worst actual route latency is the ground truth for what the matcher predicted. A small
+`avg_bias_ms` / `median_abs_error_ms` means the queue-time estimate is trustworthy and the latency
+weight can be tuned against it; a large error means pings drift too much between queue and launch for
+the term to be reliable.
+
+```sql
+WITH paired AS (
+  SELECT
+    f.matchmaking_type,
+    f.max_latency AS predicted_ms,
+    -- Worst actual one-way link, mirroring how max_latency takes the max across pairs.
+    (SELECT max((r->>'latency')::real) FROM unnest(g.routes) AS r) AS actual_ms
+  FROM matchmaking_match_formations f
+  JOIN games g ON g.id = f.game_id
+  WHERE g.routes IS NOT NULL AND array_length(g.routes, 1) > 0
+)
+SELECT
+  matchmaking_type,
+  count(*) AS games,
+  round(avg(predicted_ms)::numeric, 1) AS avg_predicted_ms,
+  round(avg(actual_ms)::numeric, 1) AS avg_actual_ms,
+  -- Signed: positive means the game ended up laggier than the matcher predicted.
+  round(avg(actual_ms - predicted_ms)::numeric, 1) AS avg_bias_ms,
+  round((percentile_cont(0.5)
+    WITHIN GROUP (ORDER BY abs(actual_ms - predicted_ms)))::numeric, 1) AS median_abs_error_ms
+FROM paired
 GROUP BY matchmaking_type
 ORDER BY matchmaking_type;
 ```

--- a/server-rs/benches/matchmaker.rs
+++ b/server-rs/benches/matchmaker.rs
@@ -17,7 +17,7 @@ fn bench_1v1(c: &mut Criterion) {
             },
         )]),
         map_selections: HashMap::new(),
-        latency_bucket: None,
+        server_pings: HashMap::new(),
     }) {
         matchmaker.insert_player(player).unwrap();
     }
@@ -38,7 +38,7 @@ fn bench_2v2(c: &mut Criterion) {
             },
         )]),
         map_selections: HashMap::new(),
-        latency_bucket: None,
+        server_pings: HashMap::new(),
     }) {
         matchmaker.insert_player(player).unwrap();
     }

--- a/server-rs/src/matchmaking/api.rs
+++ b/server-rs/src/matchmaking/api.rs
@@ -88,8 +88,9 @@ struct QueueRequest {
     mode_ratings: Vec<PlayerModeRatingDto>,
     /// The player's most recent round-trip pings (ms) to each rally-point server, as
     /// `[server_id, ping]` pairs. Used to estimate a candidate match's latency (see
-    /// [`crate::matchmaking::matchmaker::match_latency`]). May be empty if the client hasn't
-    /// measured any pings yet.
+    /// [`crate::matchmaking::matchmaker::match_latency`]). The Node.js side waits for the client to
+    /// measure its pings before enqueuing, so this is normally populated; an empty list is tolerated
+    /// and yields no latency penalty.
     #[serde(default)]
     server_pings: Vec<(u32, f32)>,
 }

--- a/server-rs/src/matchmaking/api.rs
+++ b/server-rs/src/matchmaking/api.rs
@@ -86,7 +86,12 @@ struct QueueRequest {
     /// Per-mode ratings. One entry per queued mode; the set of modes the player queues for is
     /// derived from these entries.
     mode_ratings: Vec<PlayerModeRatingDto>,
-    latency_bucket: Option<u8>,
+    /// The player's most recent round-trip pings (ms) to each rally-point server, as
+    /// `[server_id, ping]` pairs. Used to estimate a candidate match's latency (see
+    /// [`crate::matchmaking::matchmaker::match_latency`]). May be empty if the client hasn't
+    /// measured any pings yet.
+    #[serde(default)]
+    server_pings: Vec<(u32, f32)>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -103,7 +108,9 @@ struct QueueTicket {
     /// modes) on requeue.
     mode_ratings: Vec<PlayerModeRatingDto>,
     queue_time: u64,
-    latency_bucket: Option<u8>,
+    /// Per-server pings preserved from queue time, as `[server_id, ping]` pairs. Reused as-is on
+    /// requeue rather than re-measured (a requeue is rare and the pings are still a good estimate).
+    server_pings: Vec<(u32, f32)>,
     process_token: Uuid,
 }
 
@@ -132,7 +139,7 @@ fn lock_matchmaker(
 fn build_player(
     id: usize,
     mode_ratings: Vec<PlayerModeRatingDto>,
-    latency_bucket: Option<u8>,
+    server_pings: Vec<(u32, f32)>,
 ) -> Player {
     let mut ratings = HashMap::new();
     let mut map_selections = HashMap::new();
@@ -152,7 +159,7 @@ fn build_player(
         id,
         ratings,
         map_selections,
-        latency_bucket,
+        server_pings: server_pings.into_iter().collect(),
     }
 }
 
@@ -170,7 +177,12 @@ fn build_ticket(entry: &QueueEntry, process_token: &Uuid, matchmaker_start: Inst
                 map_selections: entry.player.map_selections.get(&mode).cloned(),
             })
             .collect(),
-        latency_bucket: entry.player.latency_bucket,
+        server_pings: entry
+            .player
+            .server_pings
+            .iter()
+            .map(|(&server, &ping)| (server, ping))
+            .collect(),
         queue_time: entry
             .queue_time
             .duration_since(matchmaker_start)
@@ -364,7 +376,7 @@ async fn insert_player(
     State(state): State<MatchmakingApiState>,
     Json(payload): Json<QueueRequest>,
 ) -> Result<StatusCode, MatchmakerError> {
-    let player = build_player(payload.id, payload.mode_ratings, payload.latency_bucket);
+    let player = build_player(payload.id, payload.mode_ratings, payload.server_pings);
     let mut matchmaker = lock_matchmaker(&state.matchmaker);
     matchmaker.insert_player(player)?;
     Ok(StatusCode::NO_CONTENT)
@@ -415,7 +427,7 @@ async fn requeue_player(
     let mut matchmaker = lock_matchmaker(&state.matchmaker);
     let queue_time = matchmaker.start() + Duration::from_millis(ticket.queue_time);
     match matchmaker.requeue_player(
-        build_player(ticket.id, ticket.mode_ratings, ticket.latency_bucket),
+        build_player(ticket.id, ticket.mode_ratings, ticket.server_pings),
         queue_time,
     ) {
         Ok(_) => StatusCode::NO_CONTENT.into_response(),
@@ -466,7 +478,7 @@ mod tests {
                     },
                 )]),
                 map_selections: HashMap::new(),
-                latency_bucket: None,
+                server_pings: HashMap::new(),
             },
             modes: MatchmakingType::Match1v1.into(),
         };
@@ -482,7 +494,7 @@ mod tests {
                     },
                 )]),
                 map_selections: HashMap::new(),
-                latency_bucket: None,
+                server_pings: HashMap::new(),
             },
             modes: MatchmakingType::Match1v1.into(),
         };
@@ -498,7 +510,7 @@ mod tests {
                     },
                 )]),
                 map_selections: HashMap::new(),
-                latency_bucket: None,
+                server_pings: HashMap::new(),
             },
             modes: MatchmakingType::Match1v1.into(),
         };

--- a/server-rs/src/matchmaking/matchmaker.rs
+++ b/server-rs/src/matchmaking/matchmaker.rs
@@ -11,15 +11,20 @@ use crate::matchmaking::MatchmakingType;
 Match quality is expressed in seconds of wait time: a positive value means the match is good
 enough to form right now, a negative value means it needs more wait time to become acceptable.
 
-    quality = wait_time − (W_var * skill_variance + W_prob * win_prob_diff + W_lat * max_latency)
+    quality = wait_time − (W_var * skill_variance + W_prob * win_prob_diff
+                           + W_lat * latency_value(max_latency))
 
 Where:
     - W_var  = "How many seconds I would wait for a 1-unit improvement in skill variance"
     - W_prob = "How many seconds I would wait for a 1-unit improvement in win-probability balance"
-    - W_lat  = "How many seconds I would wait for a 1-millisecond improvement in estimated latency"
+    - W_lat  = "How many seconds I would wait to drop a match's latency by one turn-rate step"
 
 `max_latency` is the estimated one-way latency (in milliseconds) of the candidate match's worst
-pairwise link, derived from each player's rally-point server pings (see [`match_latency`]).
+pairwise link, derived from each player's rally-point server pings (see [`match_latency`]). Latency
+only changes the play experience in discrete jumps — the game holds a fixed turn rate / input buffer
+until latency crosses a threshold, so anything under ~100ms one-way plays identically. The quality
+formula therefore penalizes `latency_value(max_latency)` (a count of turn-rate steps) rather than
+raw milliseconds (see [`latency_value`]).
 
 Skill variance is computed over each player's *effective rating* (rating − k*σ), so newly-placed
 players with high uncertainty contribute less variance and match more freely until their rating
@@ -35,12 +40,12 @@ https://www.youtube.com/watch?v=Q8BX0nXfPjY
 
 const WEIGHT_RATING_VARIANCE: f32 = 0.005;
 const WEIGHT_WIN_PROB: f32 = 50.0;
-/// Seconds of wait time we'll trade for a 1ms improvement in a match's estimated one-way latency.
-/// Deliberately gentle: at this value latency only re-orders otherwise-viable matches (preferring
-/// lower-latency pairings) rather than blocking distant players from ever matching. The true value
-/// is a calibration target — the match-formation telemetry records the raw `max_latency` so it can
-/// be tuned against real game outcomes.
-const WEIGHT_LATENCY: f32 = 0.1;
+/// Seconds of wait time we'll trade to drop a match's latency by one turn-rate step (one unit of
+/// [`latency_value`]). Latency below the first step (~100ms one-way) plays identically, so this only
+/// bites once a match would force the game onto a slower turn rate / longer input buffer. The
+/// match-formation telemetry records the raw `max_latency` (in ms) so this can be tuned against real
+/// game outcomes.
+const WEIGHT_LATENCY: f32 = 30.0;
 
 /// How many σ below their mean rating a player's effective rating is.
 /// Controls how strongly uncertainty drags down effective rating.
@@ -83,8 +88,9 @@ pub struct Player {
     /// Most recently reported round-trip ping (ms) from this player to each rally-point server,
     /// keyed by server id. The matchmaker uses these to estimate a candidate match's latency by
     /// reproducing the route selection the game server performs at launch (see [`match_latency`]).
-    /// Empty if the player hasn't reported any pings yet, in which case any match involving them
-    /// carries no latency penalty.
+    /// Players are required to have measured their pings before queueing (the Node.js side waits for
+    /// a ping result before enqueuing), so this is normally non-empty; a player carrying no pings
+    /// contributes no latency information and matches involving them are not penalized.
     pub server_pings: HashMap<u32, f32>,
 }
 
@@ -103,9 +109,10 @@ fn effective_rating(player: &Player, mode: MatchmakingType) -> f32 {
 /// is `combined / 2`. A lockstep game is bottlenecked by its slowest link, so the match's latency
 /// is the maximum across all pairs.
 ///
-/// Pairs that share no commonly-pinged server are skipped — their latency is unknown, not infinite
-/// — and a match where no pair has any shared ping data yields 0, so we never penalize a match we
-/// have no data for (preserving the original "unknown latency == no penalty" behavior).
+/// Players measure their pings before queueing, so every player normally carries ping data. A pair
+/// can still fail to share a commonly-pinged server (each reached a disjoint subset of servers); such
+/// pairs are skipped rather than treated as infinite latency, and a match with no shared data at all
+/// yields 0.
 fn match_latency(entries: &[&QueueEntry]) -> f32 {
     let mut worst = 0.0f32;
     for (i, a) in entries.iter().enumerate() {
@@ -122,6 +129,16 @@ fn match_latency(entries: &[&QueueEntry]) -> f32 {
         }
     }
     worst
+}
+
+/// Converts an estimated one-way latency (ms) into the number of turn-rate "steps" it costs — the
+/// form the quality formula actually penalizes (see [`WEIGHT_LATENCY`]). Network latency only changes
+/// the play experience in discrete jumps: StarCraft holds a fixed turn rate / input buffer until
+/// latency crosses a threshold, then drops to a slower one. So a 30ms match and a 100ms match are
+/// equivalent, while a 200ms match is meaningfully worse. This reproduces the game's turn-rate
+/// selection (`ceil(latency * 0.9 / 30)`), clamped so the first ~100ms one-way costs nothing (0).
+fn latency_value(latency_ms: f32) -> f32 {
+    (latency_ms * 0.9 / 30.0).ceil().max(3.0) - 3.0
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -167,8 +184,10 @@ pub struct Match {
     /// Effective team ratings (see [`get_team_rating`]) used to compute `win_probability`.
     pub team_a_rating: f32,
     pub team_b_rating: f32,
-    /// Estimated one-way latency (ms) of the match's worst pairwise link (see [`match_latency`]) —
-    /// the raw latency input to the quality score, before `WEIGHT_LATENCY` is applied.
+    /// Estimated one-way latency (ms) of the match's worst pairwise link (see [`match_latency`]).
+    /// Recorded in raw milliseconds for calibration (it joins against the launch-time route latency
+    /// in `games.routes`); the quality score itself penalizes `latency_value(max_latency)` weighted
+    /// by `WEIGHT_LATENCY`, not these raw ms.
     pub max_latency: f32,
 }
 
@@ -469,7 +488,7 @@ impl<T: QueueSelector> Matchmaker<T> {
                     let quality = wait_time.as_secs_f32()
                         - (WEIGHT_RATING_VARIANCE * variance
                             + WEIGHT_WIN_PROB * win_prob_diff
-                            + WEIGHT_LATENCY * max_latency);
+                            + WEIGHT_LATENCY * latency_value(max_latency));
 
                     // Filter any matches that are too low quality
                     if quality >= effective_min {
@@ -830,48 +849,59 @@ mod tests {
     }
 
     #[test]
+    fn latency_value_buckets_by_turn_rate_step() {
+        // Latency only matters once it crosses a turn-rate threshold: everything up to ~100ms one-way
+        // is free (value 0), then each ~33ms step above that adds one unit.
+        assert_eq!(latency_value(0.0), 0.0);
+        assert_eq!(latency_value(90.0), 0.0);
+        assert_eq!(latency_value(110.0), 1.0);
+        assert_eq!(latency_value(160.0), 2.0);
+        assert_eq!(latency_value(250.0), 5.0);
+    }
+
+    #[test]
     fn find_matches_with_latency_penalty() {
         let mut matchmaker = Matchmaker::with_queue_selector(16, TestQueueSelector);
-        // Both players ping rally-point server 0 at 100ms round-trip. The match's only pair shares
-        // that server, so combined = 200ms and estimated one-way latency = 100ms.
+        // Both players ping rally-point server 0 at 200ms round-trip. The match's only pair shares
+        // that server, so combined = 400ms and estimated one-way latency = 200ms.
         matchmaker
             .insert_player(make_player_with_pings(
                 0,
                 MatchmakingType::Match1v1,
-                &[(0, 100.0)],
+                &[(0, 200.0)],
             ))
             .unwrap();
         matchmaker
             .insert_player(make_player_with_pings(
                 1,
                 MatchmakingType::Match1v1,
-                &[(0, 100.0)],
+                &[(0, 200.0)],
             ))
             .unwrap();
 
         // At t=0 with no wait time: quality = 0 - (variance_penalty + win_prob_penalty + latency_penalty)
         // With equal ratings: variance ≈ 0, win_prob_diff ≈ 0.
-        // max_latency = 100ms (one-way). WEIGHT_LATENCY = 0.1. Latency penalty = 0.1 * 100 = 10.0.
-        // Quality ≈ 0 - 10.0 = -10.0.
+        // max_latency = 200ms (one-way). latency_value(200) = 3, WEIGHT_LATENCY = 30.0, so the
+        // latency penalty = 30.0 * 3 = 90.0. Quality ≈ 0 - 90.0 = -90.0.
         //
         // The adaptive threshold: with 2 players in queue and comfortable_size=4 (2 * 2),
         // effective_min = min_quality - ADAPTIVE_DECAY_PER_MISSING * 2
         //               = min_quality - 15.0 * 2 = min_quality - 30.0.
         //
-        // To ensure effective_min > -10.0, we need min_quality > 20.0. Use 25.0:
-        // effective_min = 25.0 - 30.0 = -5.0 > -10.0 → match rejected.
+        // To ensure effective_min > -90.0, we need min_quality > -60.0. Use -55.0:
+        // effective_min = -55.0 - 30.0 = -85.0 > -90.0 → match rejected.
         let result_strict =
-            matchmaker.find_matches_for_modes(&[MatchmakingType::Match1v1], 25.0, Instant::now());
+            matchmaker.find_matches_for_modes(&[MatchmakingType::Match1v1], -55.0, Instant::now());
         assert!(
             result_strict.is_empty(),
-            "expected no match when effective_min (-5.0) exceeds quality (-10.0) at 100ms latency"
+            "expected no match when effective_min (-85.0) exceeds quality (-90.0) at 200ms latency"
         );
 
-        // With min_quality = -15.0: effective_min = -15.0 - 30.0 = -45.0 < -10.0 → match forms.
+        // With min_quality = -65.0: effective_min = -65.0 - 30.0 = -95.0 < -90.0 → match forms.
         let result_lenient =
-            matchmaker.find_matches_for_modes(&[MatchmakingType::Match1v1], -15.0, Instant::now());
+            matchmaker.find_matches_for_modes(&[MatchmakingType::Match1v1], -65.0, Instant::now());
         assert_eq!(result_lenient.len(), 1);
-        assert_eq!(result_lenient[0].max_latency, 100.0);
+        assert_eq!(result_lenient[0].max_latency, 200.0);
     }
 
     #[test]
@@ -884,7 +914,8 @@ mod tests {
             .insert_player(make_player(1, 1000.0, MatchmakingType::Match1v1))
             .unwrap();
 
-        // Neither player has reported pings — latency is unknown, so no penalty is applied.
+        // Defensive: players are required to have pings before queueing, but if a player somehow
+        // carries none, latency is unknown and no penalty is applied rather than blocking the match.
         // With equal ratings: variance ≈ 0, win_prob_diff ≈ 0. Quality ≈ 0.
         let result = matchmaker.find_matches_for_modes(
             &[MatchmakingType::Match1v1],

--- a/server-rs/src/matchmaking/matchmaker.rs
+++ b/server-rs/src/matchmaking/matchmaker.rs
@@ -16,7 +16,10 @@ enough to form right now, a negative value means it needs more wait time to beco
 Where:
     - W_var  = "How many seconds I would wait for a 1-unit improvement in skill variance"
     - W_prob = "How many seconds I would wait for a 1-unit improvement in win-probability balance"
-    - W_lat  = "How many seconds I would wait for a 1-unit improvement in latency bucket"
+    - W_lat  = "How many seconds I would wait for a 1-millisecond improvement in estimated latency"
+
+`max_latency` is the estimated one-way latency (in milliseconds) of the candidate match's worst
+pairwise link, derived from each player's rally-point server pings (see [`match_latency`]).
 
 Skill variance is computed over each player's *effective rating* (rating − k*σ), so newly-placed
 players with high uncertainty contribute less variance and match more freely until their rating
@@ -32,7 +35,12 @@ https://www.youtube.com/watch?v=Q8BX0nXfPjY
 
 const WEIGHT_RATING_VARIANCE: f32 = 0.005;
 const WEIGHT_WIN_PROB: f32 = 50.0;
-const WEIGHT_LATENCY: f32 = 5.0;
+/// Seconds of wait time we'll trade for a 1ms improvement in a match's estimated one-way latency.
+/// Deliberately gentle: at this value latency only re-orders otherwise-viable matches (preferring
+/// lower-latency pairings) rather than blocking distant players from ever matching. The true value
+/// is a calibration target — the match-formation telemetry records the raw `max_latency` so it can
+/// be tuned against real game outcomes.
+const WEIGHT_LATENCY: f32 = 0.1;
 
 /// How many σ below their mean rating a player's effective rating is.
 /// Controls how strongly uncertainty drags down effective rating.
@@ -72,8 +80,12 @@ pub struct Player {
     /// map could be chosen and the match would fail downstream. Veto/fixed modes have no entry here
     /// and are unconstrained.
     pub map_selections: HashMap<MatchmakingType, Vec<MapId>>,
-    /// Latency tier (0 = great, 1 = fine, 2 = noticeable, 3 = bad). None treated as 0.
-    pub latency_bucket: Option<u8>,
+    /// Most recently reported round-trip ping (ms) from this player to each rally-point server,
+    /// keyed by server id. The matchmaker uses these to estimate a candidate match's latency by
+    /// reproducing the route selection the game server performs at launch (see [`match_latency`]).
+    /// Empty if the player hasn't reported any pings yet, in which case any match involving them
+    /// carries no latency penalty.
+    pub server_pings: HashMap<u32, f32>,
 }
 
 /// Returns the conservative skill estimate: the player's rating minus k standard deviations.
@@ -82,6 +94,34 @@ pub struct Player {
 fn effective_rating(player: &Player, mode: MatchmakingType) -> f32 {
     let mode_rating = player.ratings.get(&mode).copied().unwrap_or_default();
     mode_rating.rating - UNCERTAINTY_K * mode_rating.uncertainty.unwrap_or(0.0)
+}
+
+/// Estimates the one-way latency (ms) of a candidate match by reproducing the route selection the
+/// game server performs at launch. The game meshes players with one rally-point route per pair,
+/// choosing for each pair the server that minimizes their combined round-trip ping (see
+/// `RallyPointService::createBestRoute` on the Node.js side); that pair's estimated one-way latency
+/// is `combined / 2`. A lockstep game is bottlenecked by its slowest link, so the match's latency
+/// is the maximum across all pairs.
+///
+/// Pairs that share no commonly-pinged server are skipped — their latency is unknown, not infinite
+/// — and a match where no pair has any shared ping data yields 0, so we never penalize a match we
+/// have no data for (preserving the original "unknown latency == no penalty" behavior).
+fn match_latency(entries: &[&QueueEntry]) -> f32 {
+    let mut worst = 0.0f32;
+    for (i, a) in entries.iter().enumerate() {
+        let a_pings = &a.player.server_pings;
+        for b in &entries[i + 1..] {
+            let b_pings = &b.player.server_pings;
+            let best_combined = a_pings
+                .iter()
+                .filter_map(|(server, &ping_a)| b_pings.get(server).map(|&ping_b| ping_a + ping_b))
+                .fold(f32::INFINITY, f32::min);
+            if best_combined.is_finite() {
+                worst = worst.max(best_combined / 2.0);
+            }
+        }
+    }
+    worst
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -127,8 +167,8 @@ pub struct Match {
     /// Effective team ratings (see [`get_team_rating`]) used to compute `win_probability`.
     pub team_a_rating: f32,
     pub team_b_rating: f32,
-    /// Highest latency bucket among the matched players — the raw latency input to the quality
-    /// score, before `WEIGHT_LATENCY` is applied.
+    /// Estimated one-way latency (ms) of the match's worst pairwise link (see [`match_latency`]) —
+    /// the raw latency input to the quality score, before `WEIGHT_LATENCY` is applied.
     pub max_latency: f32,
 }
 
@@ -425,10 +465,7 @@ impl<T: QueueSelector> Matchmaker<T> {
                     let win_prob = get_win_probability(rating_a, rating_b);
                     let win_prob_diff = (0.5 - win_prob).abs();
 
-                    let max_latency = queue_entries
-                        .iter()
-                        .map(|q| q.player.latency_bucket.unwrap_or(0) as f32)
-                        .fold(0.0f32, f32::max);
+                    let max_latency = match_latency(&queue_entries);
                     let quality = wait_time.as_secs_f32()
                         - (WEIGHT_RATING_VARIANCE * variance
                             + WEIGHT_WIN_PROB * win_prob_diff
@@ -491,7 +528,7 @@ mod tests {
                 },
             )]),
             map_selections: HashMap::new(),
-            latency_bucket: None,
+            server_pings: HashMap::new(),
         }
     }
 
@@ -513,7 +550,7 @@ mod tests {
                 })
                 .collect(),
             map_selections: HashMap::new(),
-            latency_bucket: None,
+            server_pings: HashMap::new(),
         }
     }
 
@@ -784,41 +821,37 @@ mod tests {
         );
     }
 
+    /// Builds a player rated for `mode` with the given round-trip pings (`[server_id, ping_ms]`).
+    fn make_player_with_pings(id: usize, mode: MatchmakingType, pings: &[(u32, f32)]) -> Player {
+        Player {
+            server_pings: pings.iter().copied().collect(),
+            ..make_player(id, 1000.0, mode)
+        }
+    }
+
     #[test]
     fn find_matches_with_latency_penalty() {
         let mut matchmaker = Matchmaker::with_queue_selector(16, TestQueueSelector);
+        // Both players ping rally-point server 0 at 100ms round-trip. The match's only pair shares
+        // that server, so combined = 200ms and estimated one-way latency = 100ms.
         matchmaker
-            .insert_player(Player {
-                id: 0,
-                ratings: HashMap::from([(
-                    MatchmakingType::Match1v1,
-                    PlayerModeRating {
-                        rating: 1000.0,
-                        uncertainty: None,
-                    },
-                )]),
-                map_selections: HashMap::new(),
-                latency_bucket: Some(2),
-            })
+            .insert_player(make_player_with_pings(
+                0,
+                MatchmakingType::Match1v1,
+                &[(0, 100.0)],
+            ))
             .unwrap();
         matchmaker
-            .insert_player(Player {
-                id: 1,
-                ratings: HashMap::from([(
-                    MatchmakingType::Match1v1,
-                    PlayerModeRating {
-                        rating: 1000.0,
-                        uncertainty: None,
-                    },
-                )]),
-                map_selections: HashMap::new(),
-                latency_bucket: Some(2),
-            })
+            .insert_player(make_player_with_pings(
+                1,
+                MatchmakingType::Match1v1,
+                &[(0, 100.0)],
+            ))
             .unwrap();
 
         // At t=0 with no wait time: quality = 0 - (variance_penalty + win_prob_penalty + latency_penalty)
         // With equal ratings: variance ≈ 0, win_prob_diff ≈ 0.
-        // max_latency_bucket = 2. WEIGHT_LATENCY = 5.0. Latency penalty = 5.0 * 2 = 10.0.
+        // max_latency = 100ms (one-way). WEIGHT_LATENCY = 0.1. Latency penalty = 0.1 * 100 = 10.0.
         // Quality ≈ 0 - 10.0 = -10.0.
         //
         // The adaptive threshold: with 2 players in queue and comfortable_size=4 (2 * 2),
@@ -831,17 +864,18 @@ mod tests {
             matchmaker.find_matches_for_modes(&[MatchmakingType::Match1v1], 25.0, Instant::now());
         assert!(
             result_strict.is_empty(),
-            "expected no match when effective_min (-5.0) exceeds quality (-10.0) with latency bucket 2"
+            "expected no match when effective_min (-5.0) exceeds quality (-10.0) at 100ms latency"
         );
 
         // With min_quality = -15.0: effective_min = -15.0 - 30.0 = -45.0 < -10.0 → match forms.
         let result_lenient =
             matchmaker.find_matches_for_modes(&[MatchmakingType::Match1v1], -15.0, Instant::now());
         assert_eq!(result_lenient.len(), 1);
+        assert_eq!(result_lenient[0].max_latency, 100.0);
     }
 
     #[test]
-    fn find_matches_no_latency_bucket_treated_as_zero() {
+    fn find_matches_no_ping_data_treated_as_zero() {
         let mut matchmaker = Matchmaker::with_queue_selector(16, TestQueueSelector);
         matchmaker
             .insert_player(make_player(0, 1000.0, MatchmakingType::Match1v1))
@@ -850,15 +884,118 @@ mod tests {
             .insert_player(make_player(1, 1000.0, MatchmakingType::Match1v1))
             .unwrap();
 
-        // Both players have no latency data — treated as bucket 0, penalty = 0.
-        // With equal ratings: variance ≈ 0, win_prob_diff ≈ 0.
-        // Quality ≈ 0. Should appear at min_quality = f32::NEG_INFINITY.
+        // Neither player has reported pings — latency is unknown, so no penalty is applied.
+        // With equal ratings: variance ≈ 0, win_prob_diff ≈ 0. Quality ≈ 0.
         let result = matchmaker.find_matches_for_modes(
             &[MatchmakingType::Match1v1],
             f32::NEG_INFINITY,
             Instant::now(),
         );
         assert_eq!(result.len(), 1);
+        assert_eq!(result[0].max_latency, 0.0);
+    }
+
+    #[test]
+    fn latency_picks_lowest_combined_server() {
+        let mut matchmaker = Matchmaker::with_queue_selector(16, TestQueueSelector);
+        // Player 0 is closest to server 1, player 1 is closest to server 2, but the cheapest server
+        // they *share* is server 0 (combined 80ms → 40ms one-way). The lopsided servers must not be
+        // chosen since the other player pings them poorly.
+        matchmaker
+            .insert_player(make_player_with_pings(
+                0,
+                MatchmakingType::Match1v1,
+                &[(0, 40.0), (1, 10.0), (2, 500.0)],
+            ))
+            .unwrap();
+        matchmaker
+            .insert_player(make_player_with_pings(
+                1,
+                MatchmakingType::Match1v1,
+                &[(0, 40.0), (1, 500.0), (2, 10.0)],
+            ))
+            .unwrap();
+
+        let result = matchmaker.find_matches_for_modes(
+            &[MatchmakingType::Match1v1],
+            f32::NEG_INFINITY,
+            Instant::now(),
+        );
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].max_latency, 40.0);
+    }
+
+    #[test]
+    fn latency_no_shared_server_has_no_penalty() {
+        let mut matchmaker = Matchmaker::with_queue_selector(16, TestQueueSelector);
+        // The players have pings, but to disjoint servers — no route can be estimated, so latency is
+        // treated as unknown (0) rather than infinite.
+        matchmaker
+            .insert_player(make_player_with_pings(
+                0,
+                MatchmakingType::Match1v1,
+                &[(1, 20.0)],
+            ))
+            .unwrap();
+        matchmaker
+            .insert_player(make_player_with_pings(
+                1,
+                MatchmakingType::Match1v1,
+                &[(2, 20.0)],
+            ))
+            .unwrap();
+
+        let result = matchmaker.find_matches_for_modes(
+            &[MatchmakingType::Match1v1],
+            f32::NEG_INFINITY,
+            Instant::now(),
+        );
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].max_latency, 0.0);
+    }
+
+    #[test]
+    fn latency_team_mode_uses_worst_pair_across_all_pairs() {
+        let mut matchmaker = Matchmaker::with_queue_selector(16, TestQueueSelector);
+        // A 2v2 has six pairwise links. Three players ping server 0 at 20ms; player 2 pings it at
+        // 200ms. The worst link is therefore any pair involving player 2: (20 + 200) / 2 = 110ms.
+        // Latency is independent of how the matcher splits the teams — it's the worst pair overall.
+        matchmaker
+            .insert_player(make_player_with_pings(
+                0,
+                MatchmakingType::Match2v2,
+                &[(0, 20.0)],
+            ))
+            .unwrap();
+        matchmaker
+            .insert_player(make_player_with_pings(
+                1,
+                MatchmakingType::Match2v2,
+                &[(0, 20.0)],
+            ))
+            .unwrap();
+        matchmaker
+            .insert_player(make_player_with_pings(
+                2,
+                MatchmakingType::Match2v2,
+                &[(0, 200.0)],
+            ))
+            .unwrap();
+        matchmaker
+            .insert_player(make_player_with_pings(
+                3,
+                MatchmakingType::Match2v2,
+                &[(0, 20.0)],
+            ))
+            .unwrap();
+
+        let result = matchmaker.find_matches_for_modes(
+            &[MatchmakingType::Match2v2],
+            f32::NEG_INFINITY,
+            Instant::now(),
+        );
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].max_latency, 110.0);
     }
 
     #[test]
@@ -881,7 +1018,7 @@ mod tests {
                 },
             )]),
             map_selections: HashMap::new(),
-            latency_bucket: None,
+            server_pings: HashMap::new(),
         };
         let certain = Player {
             id: 1,
@@ -893,7 +1030,7 @@ mod tests {
                 },
             )]),
             map_selections: HashMap::new(),
-            latency_bucket: None,
+            server_pings: HashMap::new(),
         };
 
         let mut mm = Matchmaker::with_queue_selector(16, TestQueueSelector);
@@ -939,7 +1076,7 @@ mod tests {
                 ),
             ]),
             map_selections: HashMap::new(),
-            latency_bucket: None,
+            server_pings: HashMap::new(),
         };
         let player_b = Player {
             id: 1,
@@ -960,7 +1097,7 @@ mod tests {
                 ),
             ]),
             map_selections: HashMap::new(),
-            latency_bucket: None,
+            server_pings: HashMap::new(),
         };
         matchmaker.insert_player(player_a).unwrap();
         matchmaker.insert_player(player_b).unwrap();
@@ -998,7 +1135,7 @@ mod tests {
                 },
             )]),
             map_selections: HashMap::from([(mode, maps.iter().map(|m| m.to_string()).collect())]),
-            latency_bucket: None,
+            server_pings: HashMap::new(),
         }
     }
 

--- a/server-rs/src/matchmaking/mod.rs
+++ b/server-rs/src/matchmaking/mod.rs
@@ -37,7 +37,8 @@ pub struct MatchFoundMessage {
     /// Effective team ratings used to compute `win_probability`.
     pub team_a_rating: f32,
     pub team_b_rating: f32,
-    /// Highest latency bucket among the matched players (raw latency input to `quality`).
+    /// Estimated one-way latency (ms) of the match's worst pairwise link, computed from the
+    /// players' rally-point server pings (raw latency input to `quality`).
     pub max_latency: f32,
 }
 

--- a/server/lib/matchmaking/matchmaker-rs-client.ts
+++ b/server/lib/matchmaking/matchmaker-rs-client.ts
@@ -31,8 +31,8 @@ export interface RsQueueRequest {
    * The player's most recent round-trip pings (ms) to each rally-point server, as
    * `[serverId, ping]` pairs. The matchmaker estimates a candidate match's latency from these by
    * reproducing the route selection done at game launch (it picks, per pair, the server minimizing
-   * their combined ping). May be empty if the client hasn't reported any pings yet, in which case
-   * the match carries no latency penalty.
+   * their combined ping). The service waits for a ping result before queueing, so this is normally
+   * populated; an empty list is tolerated and yields no latency penalty.
    */
   serverPings: Array<[serverId: number, ping: number]>
 }

--- a/server/lib/matchmaking/matchmaker-rs-client.ts
+++ b/server/lib/matchmaking/matchmaker-rs-client.ts
@@ -27,7 +27,14 @@ export interface RsQueueRequest {
    * entries, so there must be exactly one per type the player is queuing for.
    */
   modeRatings: RsModeRating[]
-  latencyBucket: number | null
+  /**
+   * The player's most recent round-trip pings (ms) to each rally-point server, as
+   * `[serverId, ping]` pairs. The matchmaker estimates a candidate match's latency from these by
+   * reproducing the route selection done at game launch (it picks, per pair, the server minimizing
+   * their combined ping). May be empty if the client hasn't reported any pings yet, in which case
+   * the match carries no latency penalty.
+   */
+  serverPings: Array<[serverId: number, ping: number]>
 }
 
 /** Error response body returned by the Rust API on 4xx responses. */

--- a/server/lib/matchmaking/matchmaking-api.ts
+++ b/server/lib/matchmaking/matchmaking-api.ts
@@ -72,6 +72,7 @@ const convertMatchmakingServiceErrors = makeErrorConverterMiddleware(err => {
     case MatchmakingServiceErrorCode.InvalidClient:
     case MatchmakingServiceErrorCode.TooManyPlayers:
     case MatchmakingServiceErrorCode.InvalidDraftPick:
+    case MatchmakingServiceErrorCode.PingMeasurementFailed:
       throw asHttpError(400, err)
     case MatchmakingServiceErrorCode.MatchmakingDisabled:
     case MatchmakingServiceErrorCode.UserBanned:

--- a/server/lib/matchmaking/matchmaking-service.test.ts
+++ b/server/lib/matchmaking/matchmaking-service.test.ts
@@ -1,6 +1,7 @@
 import { register } from 'prom-client'
 import { Result } from 'typescript-result'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import createDeferred from '../../../common/async/deferred'
 import { makeSbMapId, SbMapId } from '../../../common/maps'
 import {
   MatchmakingCompletionType,
@@ -110,7 +111,10 @@ describe('matchmaking/matchmaking-service', () => {
   let banUser: ReturnType<typeof vi.fn>
   let clientSockets: Map<SbUserId, ClientSocketsGroup>
   let gameLoader: { loadGame: ReturnType<typeof vi.fn> }
-  let rallyPointService: { getPingsForClient: ReturnType<typeof vi.fn> }
+  let rallyPointService: {
+    getPingsForClient: ReturnType<typeof vi.fn>
+    waitForPingResult: ReturnType<typeof vi.fn>
+  }
   let redisHandler: (event: { type: 'matchFound'; data: MatchFoundMessage }) => void
 
   function createFakeClient(userId: SbUserId, clientId: string): ClientSocketsGroup {
@@ -192,7 +196,11 @@ describe('matchmaking/matchmaking-service', () => {
       }),
     }
     // Defaults to "no pings reported yet"; individual tests override to exercise latency capture.
-    rallyPointService = { getPingsForClient: vi.fn().mockReturnValue([]) }
+    // `waitForPingResult` resolves immediately by default so queueing isn't gated in most tests.
+    rallyPointService = {
+      getPingsForClient: vi.fn().mockReturnValue([]),
+      waitForPingResult: vi.fn().mockResolvedValue(undefined),
+    }
 
     asMockedFunction(getMatchmakingRating).mockImplementation(async (userId: SbUserId) =>
       makeMmr(userId),
@@ -528,6 +536,27 @@ describe('matchmaking/matchmaking-service', () => {
     expect(rallyPointService.getPingsForClient).toHaveBeenCalledWith(clientSockets.get(USER_A))
     const request = asMockedFunction(rsQueuePlayer).mock.calls[0][0]
     expect(request.serverPings).toEqual(pings)
+  })
+
+  test('waits for the client to measure its pings before queueing', async () => {
+    // Latency is now a match-finding factor, so a player must have measured their rally-point pings
+    // before they're put in the queue. Hold the ping result and verify the player isn't queued in
+    // Rust until it resolves.
+    const pingDeferred = createDeferred<void>()
+    rallyPointService.waitForPingResult.mockReturnValue(pingDeferred)
+
+    const queued = queuePlayer(USER_A, CLIENT_A)
+    // Flush the microtask chain up to the (still-pending) ping wait. rsQueuePlayer can't fire while
+    // the ping result is outstanding, so this assertion holds regardless of how far we've flushed.
+    for (let i = 0; i < 20; i++) {
+      await Promise.resolve()
+    }
+    expect(rallyPointService.waitForPingResult).toHaveBeenCalledWith(clientSockets.get(USER_A))
+    expect(rsQueuePlayer).not.toHaveBeenCalled()
+
+    pingDeferred.resolve()
+    await queued
+    expect(rsQueuePlayer).toHaveBeenCalledTimes(1)
   })
 
   test('matching in one mode abandons the others without recording their completions', async () => {

--- a/server/lib/matchmaking/matchmaking-service.test.ts
+++ b/server/lib/matchmaking/matchmaking-service.test.ts
@@ -6,6 +6,7 @@ import { makeSbMapId, SbMapId } from '../../../common/maps'
 import {
   MatchmakingCompletionType,
   MatchmakingPreferences,
+  MatchmakingServiceErrorCode,
   MatchmakingType,
 } from '../../../common/matchmaking'
 import { asMockedFunction } from '../../../common/testing/mocks'
@@ -557,6 +558,26 @@ describe('matchmaking/matchmaking-service', () => {
     pingDeferred.resolve()
     await queued
     expect(rsQueuePlayer).toHaveBeenCalledTimes(1)
+  })
+
+  test('fails with a clear error if the client never measures its pings', async () => {
+    // If a client can't reach any rally-point server its pings never arrive. The wait must be
+    // bounded so the player isn't left registered as an active gameplay client with no queue entry
+    // and no error — they should get a clear failure and be released from the activity registry.
+    rallyPointService.waitForPingResult.mockReturnValue(createDeferred<void>())
+
+    const queued = queuePlayer(USER_A, CLIENT_A).then(
+      () => undefined,
+      err => err,
+    )
+    // Let the pre-timeout work run, then trip the ping-result timeout.
+    await vi.advanceTimersByTimeAsync(11 * 1000)
+
+    const err = await queued
+    expect(err?.code).toBe(MatchmakingServiceErrorCode.PingMeasurementFailed)
+    expect(rsQueuePlayer).not.toHaveBeenCalled()
+    // Released from the registry so the player can retry rather than being stuck "in a game".
+    expect(activityRegistry.getClientForUser(USER_A)).toBeUndefined()
   })
 
   test('matching in one mode abandons the others without recording their completions', async () => {

--- a/server/lib/matchmaking/matchmaking-service.test.ts
+++ b/server/lib/matchmaking/matchmaking-service.test.ts
@@ -110,6 +110,7 @@ describe('matchmaking/matchmaking-service', () => {
   let banUser: ReturnType<typeof vi.fn>
   let clientSockets: Map<SbUserId, ClientSocketsGroup>
   let gameLoader: { loadGame: ReturnType<typeof vi.fn> }
+  let rallyPointService: { getPingsForClient: ReturnType<typeof vi.fn> }
   let redisHandler: (event: { type: 'matchFound'; data: MatchFoundMessage }) => void
 
   function createFakeClient(userId: SbUserId, clientId: string): ClientSocketsGroup {
@@ -190,6 +191,8 @@ describe('matchmaking/matchmaking-service', () => {
         redisHandler = handler
       }),
     }
+    // Defaults to "no pings reported yet"; individual tests override to exercise latency capture.
+    rallyPointService = { getPingsForClient: vi.fn().mockReturnValue([]) }
 
     asMockedFunction(getMatchmakingRating).mockImplementation(async (userId: SbUserId) =>
       makeMmr(userId),
@@ -212,6 +215,7 @@ describe('matchmaking/matchmaking-service', () => {
       matchmakingBanService as any,
       restrictionService as any,
       redisSubscriber as any,
+      rallyPointService as any,
     )
   })
 
@@ -506,6 +510,24 @@ describe('matchmaking/matchmaking-service', () => {
     const byMode = new Map((requested?.values ?? []).map(v => [v.labels.matchmaking_type, v.value]))
     expect(byMode.get(MatchmakingType.Match1v1)).toBe(1)
     expect(byMode.get(MatchmakingType.Match1v1Fastest)).toBe(1)
+  })
+
+  test("forwards the client's rally-point pings to the matchmaker so it can estimate latency", async () => {
+    // Latency is a property of a match, not a player, so the matchmaker can't compute it from one
+    // player alone — we hand it this client's per-server pings and let it derive a candidate match's
+    // latency by reproducing route selection. Verify those pings are read from the rally-point
+    // service for the queuing client and passed straight through.
+    const pings: Array<[number, number]> = [
+      [1, 24],
+      [2, 80],
+    ]
+    rallyPointService.getPingsForClient.mockReturnValue(pings)
+
+    await queuePlayer(USER_A, CLIENT_A)
+
+    expect(rallyPointService.getPingsForClient).toHaveBeenCalledWith(clientSockets.get(USER_A))
+    const request = asMockedFunction(rsQueuePlayer).mock.calls[0][0]
+    expect(request.serverPings).toEqual(pings)
   })
 
   test('matching in one mode abandons the others without recording their completions', async () => {

--- a/server/lib/matchmaking/matchmaking-service.ts
+++ b/server/lib/matchmaking/matchmaking-service.ts
@@ -6,6 +6,7 @@ import { ReadonlyDeep } from 'type-fest'
 import { assertUnreachable } from '../../../common/assert-unreachable'
 import { isAbortError, raceAbort } from '../../../common/async/abort-signals'
 import createDeferred, { Deferred } from '../../../common/async/deferred'
+import rejectOnTimeout from '../../../common/async/reject-on-timeout'
 import swallowNonBuiltins from '../../../common/async/swallow-non-builtins'
 import { timeoutPromise } from '../../../common/async/timeout-promise'
 import { subtract, union } from '../../../common/data-structures/sets'
@@ -281,6 +282,12 @@ interface QueueEntry {
 // messages back and forth from clients
 const ACCEPT_MATCH_LATENCY = 2000
 
+// How long to wait for a queuing client to report its rally-point pings before giving up. The client
+// kicks off measurement when the player hits "find match" and it normally completes in well under a
+// second; this is just a safety net so a client that can't reach *any* rally-point server gets a
+// clear error instead of hanging in the queue forever (see `queueSoloPlayer`).
+const PING_RESULT_TIMEOUT_MS = 10 * 1000
+
 /**
  * Selects a map for the given players and matchmaking type, based on the players' stored
  * matchmaking preferences and the current map pool.
@@ -514,8 +521,24 @@ export class MatchmakingService {
       }),
     )
 
-    // Don't enter the queue until the client has reported its rally-point pings (see above).
-    await pingResultPromise
+    // Don't enter the queue until the client has reported its rally-point pings (see above). Bound
+    // the wait: if the client can't reach any rally-point server its pings never arrive and this
+    // promise would otherwise never resolve, leaving the player registered as an active gameplay
+    // client with no queue entry. Time out into a clear error instead so `find`'s catch unregisters
+    // them and the client surfaces the failure.
+    try {
+      await rejectOnTimeout(
+        pingResultPromise,
+        PING_RESULT_TIMEOUT_MS,
+        'timed out waiting for rally-point pings',
+      )
+    } catch (err) {
+      throw new MatchmakingServiceError(
+        MatchmakingServiceErrorCode.PingMeasurementFailed,
+        "Couldn't measure your connection to the game servers, please try again",
+        { cause: err },
+      )
+    }
 
     // Store the full player data and queue entry for use when the match event arrives from Rust.
     // Both must be set *before* queuing in Rust: the Rust search loop runs independently, so a

--- a/server/lib/matchmaking/matchmaking-service.ts
+++ b/server/lib/matchmaking/matchmaking-service.ts
@@ -64,6 +64,7 @@ import {
   insertMatchmakingMatchFormation,
   MatchmakingRating,
 } from '../matchmaking/models'
+import { RallyPointService } from '../rally-point/rally-point-service'
 import { RedisSubscriber } from '../redis/redis'
 import { Clock } from '../time/clock'
 import { monotonicNow } from '../time/monotonic-now'
@@ -420,6 +421,7 @@ export class MatchmakingService {
     private matchmakingBanService: MatchmakingBanService,
     private restrictionService: RestrictionService,
     private redisSubscriber: RedisSubscriber,
+    private rallyPointService: RallyPointService,
   ) {
     this.userSocketsManager.on('newUser', userSockets => {
       userSockets.subscribe<MatchmakingEvent>(getMatchmakingUserPath(userSockets.userId), () => {
@@ -541,7 +543,12 @@ export class MatchmakingService {
               ? d.playerData.mapSelections.slice()
               : null,
         })),
-        latencyBucket: null, // TODO: populate from actual latency data
+        // The matchmaker can't reason about latency from a single player in isolation — the latency
+        // of a match depends on which rally-point server gets chosen, which is a function of *all*
+        // the matched players' pings. So we hand it this client's raw per-server pings and let it
+        // reproduce the route selection per candidate match (see `match_latency` in Rust). Empty if
+        // the client hasn't measured any pings yet.
+        serverPings: this.rallyPointService.getPingsForClient(clientSockets),
       })
       if (this.lastKnownProcessToken === undefined) {
         this.lastKnownProcessToken = await rsGetProcessToken()

--- a/server/lib/matchmaking/matchmaking-service.ts
+++ b/server/lib/matchmaking/matchmaking-service.ts
@@ -491,6 +491,13 @@ export class MatchmakingService {
     const clientSockets = this.getClientSocketsOrFail(userId, clientId)
     const season = await this.matchmakingSeasonsService.getCurrentSeason()
 
+    // Latency is now an input to match-finding: the matchmaker estimates a candidate match's latency
+    // from the players' rally-point pings (see `serverPings` below), so we don't enqueue a player
+    // until their client has actually measured those pings. Measuring is quick and the client kicks
+    // it off when the player hits "find match", so this normally resolves right away; run it
+    // alongside the MMR loads rather than serially.
+    const pingResultPromise = this.rallyPointService.waitForPingResult(clientSockets)
+
     // Load MMR for all queued types in parallel
     const typeDataEntries = await Promise.all(
       allPreferences.map(async pref => {
@@ -506,6 +513,9 @@ export class MatchmakingService {
         return { type, race, mmr, playerData }
       }),
     )
+
+    // Don't enter the queue until the client has reported its rally-point pings (see above).
+    await pingResultPromise
 
     // Store the full player data and queue entry for use when the match event arrives from Rust.
     // Both must be set *before* queuing in Rust: the Rust search loop runs independently, so a
@@ -546,8 +556,8 @@ export class MatchmakingService {
         // The matchmaker can't reason about latency from a single player in isolation — the latency
         // of a match depends on which rally-point server gets chosen, which is a function of *all*
         // the matched players' pings. So we hand it this client's raw per-server pings and let it
-        // reproduce the route selection per candidate match (see `match_latency` in Rust). Empty if
-        // the client hasn't measured any pings yet.
+        // reproduce the route selection per candidate match (see `match_latency` in Rust). We waited
+        // for a ping result above, so these are populated.
         serverPings: this.rallyPointService.getPingsForClient(clientSockets),
       })
       if (this.lastKnownProcessToken === undefined) {

--- a/server/lib/matchmaking/models.ts
+++ b/server/lib/matchmaking/models.ts
@@ -706,7 +706,10 @@ export interface MatchmakingMatchFormation {
   /** Effective team ratings used to compute `winProbability`. */
   teamARating: number
   teamBRating: number
-  /** Highest latency bucket among the matched players (raw latency input to quality). */
+  /**
+   * Estimated one-way latency (ms) of the match's worst pairwise link, computed from the players'
+   * rally-point server pings (raw latency input to quality).
+   */
   maxLatency: number
 }
 

--- a/server/lib/rally-point/rally-point-service.ts
+++ b/server/lib/rally-point/rally-point-service.ts
@@ -263,6 +263,17 @@ export class RallyPointService {
   }
 
   /**
+   * Returns the client's most recently reported pings (round-trip ms) to each rally-point server,
+   * as `[serverId, ping]` pairs. Empty if the client hasn't reported any pings yet. These are the
+   * same values `createBestRoute` uses to pick a server, so the matchmaker can feed them to the
+   * Rust matchmaker to estimate the latency a candidate match would actually have.
+   */
+  getPingsForClient(client: ClientSocketsGroup): Array<[serverId: number, ping: number]> {
+    const pingMap = this.clientPings.get(client)
+    return pingMap ? Array.from(pingMap) : []
+  }
+
+  /**
    * Returns a promise that resolves when the specified client has at least one reported ping result
    * for a rally-point server.
    */

--- a/server/public/locales/en/global.json
+++ b/server/public/locales/en/global.json
@@ -902,6 +902,7 @@
         "dialogTitle": "Error searching for a match",
         "invalidMaps": "You must select at least one map in the settings for each chosen matchmaking type.",
         "matchmakingDisabled": "Matchmaking is currently disabled",
+        "pingMeasurementFailed": "Couldn't measure your connection to the game servers. Please check your connection and try again.",
         "searchAgainError": "There was a problem searching for a match",
         "somethingWentWrong": "Something went wrong :(",
         "userOffline": "Your connection to the server was interrupted, please reconnect and try again."


### PR DESCRIPTION
## Why

The matchmaker's quality formula penalizes a match by `WEIGHT_LATENCY * max_latency`, but the input was a per-player `latency_bucket` that the Node side always sent as `null` — so the term was inert. It also couldn't be made to work as designed: **latency isn't a property of a single player.** A game's latency depends on which rally-point relay gets chosen, and that's picked per *pair* by minimizing the players' combined pings (`RallyPointService.createBestRoute`). Two players who each ping their local servers great can still only share a far-away server once matched together.

This was flagged in review on the telemetry PR (#1316): *"you need to pass the pings from the rally-point servers and then calculate the server that would be chosen for a particular match."*

## What

Replace the bucket with the raw signal and move the computation into the matchmaker:

- **`Player.server_pings`** (round-trip ms per rally-point server) replaces `latency_bucket`. Node reads them from the new `RallyPointService.getPingsForClient` at queue time and passes them through; they're preserved in the requeue ticket.
- **`match_latency`** reproduces launch-time route selection: for each pair pick the server with the lowest combined ping, take that pair's one-way latency (`combined / 2`), and use the max across pairs (a lockstep game is bottlenecked by its slowest link). For 1v1 this is exactly the server that would be chosen.
- **`WEIGHT_LATENCY`** switches from per-bucket to per-ms (`0.1`, deliberately gentle: it re-orders viable matches rather than blocking distant players from matching). The `max_latency` telemetry now records real estimated ms — the calibration target this work is about.

## Tier 3 (latency half)

The telemetry PR deferred *"Tier 3 (live latency buckets + sampled queue snapshots)"*. The capture half is now done (`max_latency` is a real estimate instead of always-zero), so this also adds the **analysis** half: a **"predicted vs. actual match latency"** calibration query that joins the matchmaker's queue-time estimate against the launch-time route latency already stored in `games.routes` (same one-way-ms units, same per-pair selection), so `WEIGHT_LATENCY` can be tuned from data. The unrelated "sampled queue snapshots" half stays in the backlog.

## Verification

- `cargo fmt` / `cargo clippy --all-targets --workspace -D warnings` clean; 19 Rust matchmaking tests pass (rewrote the two bucket tests as ping-based; added `latency_picks_lowest_combined_server`, `latency_no_shared_server_has_no_penalty`, and a 2v2 `latency_team_mode_uses_worst_pair_across_all_pairs`).
- The calibration example's `pg_validate()` still passes, confirming the prototype scorer reproduces the production matcher with the new latency math.
- `tsc` + `eslint` clean; 14 TS service tests pass (added one asserting pings are read from the rally-point service and forwarded).
- **Live integration:** drove the running Rust matchmaker over HTTP with two players whose crafted multi-server pings made server 1 (combined 120 → one-way 60ms) the right pick over server 2 (which player B individually prefers). The published `matchFound` carried `"maxLatency":60.0` exactly, and the requeue ticket round-tripped `serverPings` — proving per-pair selection through the real serde/search-loop/Redis path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)