### PR TITLE
Return Result from the Rust matchmaker client and typeshare its error codes

### DIFF
--- a/common/typeshare.ts
+++ b/common/typeshare.ts
@@ -117,3 +117,21 @@ export type PublishedUserMessage =
         email: string
       }
     }
+
+/**
+ * Error codes the matchmaking HTTP API returns in the `code` field of its JSON error bodies. This
+ * is the single source of truth for the set of codes; it's shared with the Node.js client via
+ * typeshare so both sides agree on the exact strings (rather than the client re-declaring them).
+ */
+export enum RsMatchmakerErrorCode {
+  /** The player is already in the queue. */
+  AlreadyInQueue = 'alreadyInQueue',
+  /** The queue request listed no modes to search for. */
+  NoModesSelected = 'noModesSelected',
+  /** The player was not found in the queue (e.g. cancel/requeue for someone already removed). */
+  NotFound = 'notFound',
+  /** A requeue ticket was malformed and couldn't be decoded. */
+  InvalidTicket = 'invalidTicket',
+  /** A requeue ticket was issued by a previous process — server-rs has restarted since. */
+  StaleTicket = 'staleTicket',
+}

--- a/server-rs/src/matchmaking/api.rs
+++ b/server-rs/src/matchmaking/api.rs
@@ -3,6 +3,7 @@ use crate::matchmaking::matchmaker::{
 };
 use crate::matchmaking::{
     MatchFoundMessage, MatchedPlayer, MatchmakingType, PublishedMatchmakingMessage,
+    RsMatchmakerErrorCode,
 };
 use crate::redis::RedisPool;
 use crate::state::AppState;
@@ -41,7 +42,7 @@ const PUBLISH_RETRY_DELAY: Duration = Duration::from_millis(200);
 
 #[derive(Serialize)]
 struct ApiError {
-    code: &'static str,
+    code: RsMatchmakerErrorCode,
     message: &'static str,
 }
 
@@ -51,14 +52,14 @@ impl IntoResponse for MatchmakerError {
             MatchmakerError::AlreadyInQueue(_) => (
                 StatusCode::CONFLICT,
                 ApiError {
-                    code: "alreadyInQueue",
+                    code: RsMatchmakerErrorCode::AlreadyInQueue,
                     message: "Player is already in the queue",
                 },
             ),
             MatchmakerError::NoModesSelected => (
                 StatusCode::BAD_REQUEST,
                 ApiError {
-                    code: "noModesSelected",
+                    code: RsMatchmakerErrorCode::NoModesSelected,
                     message: "Must queue for at least one mode",
                 },
             ),
@@ -393,7 +394,7 @@ async fn requeue_player(
             return (
                 StatusCode::BAD_REQUEST,
                 Json(ApiError {
-                    code: "invalidTicket",
+                    code: RsMatchmakerErrorCode::InvalidTicket,
                     message: "Ticket is malformed",
                 }),
             )
@@ -406,7 +407,7 @@ async fn requeue_player(
             return (
                 StatusCode::BAD_REQUEST,
                 Json(ApiError {
-                    code: "invalidTicket",
+                    code: RsMatchmakerErrorCode::InvalidTicket,
                     message: "Ticket is malformed",
                 }),
             )
@@ -418,7 +419,7 @@ async fn requeue_player(
         return (
             StatusCode::GONE,
             Json(ApiError {
-                code: "staleTicket",
+                code: RsMatchmakerErrorCode::StaleTicket,
                 message: "Server restarted since ticket was issued",
             }),
         )
@@ -447,7 +448,7 @@ async fn cancel(
         (
             StatusCode::NOT_FOUND,
             Json(ApiError {
-                code: "notFound",
+                code: RsMatchmakerErrorCode::NotFound,
                 message: "Player is not in the queue",
             }),
         )

--- a/server-rs/src/matchmaking/mod.rs
+++ b/server-rs/src/matchmaking/mod.rs
@@ -50,6 +50,25 @@ pub enum PublishedMatchmakingMessage {
     MatchFound(MatchFoundMessage),
 }
 
+/// Error codes the matchmaking HTTP API returns in the `code` field of its JSON error bodies. This
+/// is the single source of truth for the set of codes; it's shared with the Node.js client via
+/// typeshare so both sides agree on the exact strings (rather than the client re-declaring them).
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "camelCase")]
+#[typeshare]
+pub enum RsMatchmakerErrorCode {
+    /// The player is already in the queue.
+    AlreadyInQueue,
+    /// The queue request listed no modes to search for.
+    NoModesSelected,
+    /// The player was not found in the queue (e.g. cancel/requeue for someone already removed).
+    NotFound,
+    /// A requeue ticket was malformed and couldn't be decoded.
+    InvalidTicket,
+    /// A requeue ticket was issued by a previous process — server-rs has restarted since.
+    StaleTicket,
+}
+
 /// All of the matchmaking types that we support. These values match the enum values used in the
 /// database.
 #[typeshare]

--- a/server/lib/matchmaking/matchmaker-rs-client.ts
+++ b/server/lib/matchmaking/matchmaker-rs-client.ts
@@ -1,9 +1,13 @@
 import got, { HTTPError } from 'got'
+import { Result } from 'typescript-result'
 import { SbMapId } from '../../../common/maps'
 import { MatchmakingType } from '../../../common/matchmaking'
+import { RsMatchmakerErrorCode } from '../../../common/typeshare'
 import { urlPath } from '../../../common/urls'
 import { SbUserId } from '../../../common/users/sb-user-id'
 import { serverRsUrl } from '../network/server-rs-requests'
+
+export { RsMatchmakerErrorCode }
 
 /** Per-mode rating sent to Rust when queuing for multiple matchmaking types. */
 export interface RsModeRating {
@@ -38,95 +42,124 @@ export interface RsQueueRequest {
 }
 
 /** Error response body returned by the Rust API on 4xx responses. */
-export interface RsApiError {
+interface RsApiError {
   code: string
   message: string
 }
 
-/** Possible error codes the Rust API returns. */
-export const RS_ERROR_CODES = {
-  alreadyInQueue: 'alreadyInQueue',
-  noModesSelected: 'noModesSelected',
-  notFound: 'notFound',
-  invalidTicket: 'invalidTicket',
-  staleTicket: 'staleTicket',
-} as const
-export type RsErrorCode = (typeof RS_ERROR_CODES)[keyof typeof RS_ERROR_CODES]
+/**
+ * Error codes that originate on this (Node) side of the bridge rather than in a Rust error
+ * response: we couldn't reach server-rs at all, or it returned a code we don't recognize. Kept
+ * separate from the typeshared `RsMatchmakerErrorCode` because Rust never sends these.
+ */
+export enum RsClientErrorCode {
+  /** Couldn't reach the Rust matchmaker at all (connection refused, timeout, DNS failure, …). */
+  ServiceUnavailable = 'serviceUnavailable',
+  /** Rust returned an error response whose `code` we didn't recognize. */
+  Unknown = 'unknown',
+}
 
+/** Every code an `RsMatchmakerError` can carry — one Rust returned, or a client-side one. */
+export type RsErrorCode = RsMatchmakerErrorCode | RsClientErrorCode
+
+const KNOWN_RUST_CODES: ReadonlySet<string> = new Set(Object.values(RsMatchmakerErrorCode))
+
+/** Maps the raw `code` from a Rust error body to a known code, falling back to `Unknown`. */
+function toRsErrorCode(code: string | undefined): RsErrorCode {
+  return code !== undefined && KNOWN_RUST_CODES.has(code)
+    ? (code as RsMatchmakerErrorCode)
+    : RsClientErrorCode.Unknown
+}
+
+/**
+ * A failure talking to the Rust matchmaker. `code` is either a code Rust returned
+ * (`RsMatchmakerErrorCode`) or, when we couldn't reach it / couldn't understand the response, a
+ * client-side `RsClientErrorCode`. Callers branch on `code` rather than `instanceof` checks.
+ */
 export class RsMatchmakerError extends Error {
   constructor(
-    readonly status: number,
-    readonly code: string,
+    readonly code: RsErrorCode,
     message: string,
+    options?: { cause?: unknown },
   ) {
-    super(message)
+    super(message, options)
     this.name = 'RsMatchmakerError'
-  }
-
-  get isStaleTicket() {
-    return this.code === RS_ERROR_CODES.staleTicket
-  }
-
-  get isNotFound() {
-    return this.code === RS_ERROR_CODES.notFound
   }
 }
 
-async function rsRequest(method: 'POST' | 'DELETE', path: string, body?: unknown): Promise<void> {
+/** Converts any error thrown by `got` into a typed `RsMatchmakerError`. */
+function toRsError(err: unknown): RsMatchmakerError {
+  if (err instanceof HTTPError) {
+    let errorBody: RsApiError | undefined
+    try {
+      errorBody = JSON.parse(err.response.body as string) as RsApiError
+    } catch {
+      // Rust returned a non-JSON error body (shouldn't happen in normal operation)
+    }
+    return new RsMatchmakerError(
+      toRsErrorCode(errorBody?.code),
+      errorBody?.message ?? `Rust matchmaker returned ${err.response.statusCode}`,
+      { cause: err },
+    )
+  }
+  // Anything that isn't an HTTP error response means the request never completed — connection
+  // refused, timeout, DNS failure, etc. Collapse them all into `serviceUnavailable` so callers
+  // handle "Rust is unreachable" in exactly one place.
+  return new RsMatchmakerError(
+    RsClientErrorCode.ServiceUnavailable,
+    `Couldn't reach the Rust matchmaker: ${String(err)}`,
+    { cause: err },
+  )
+}
+
+async function rsRequest(
+  method: 'POST' | 'DELETE',
+  path: string,
+  body?: unknown,
+): Promise<Result<void, RsMatchmakerError>> {
   try {
     await got(serverRsUrl(path), {
       method,
       json: body,
       throwHttpErrors: true,
     })
+    return Result.ok()
   } catch (err) {
-    if (err instanceof HTTPError) {
-      let errorBody: RsApiError | undefined
-      try {
-        errorBody = JSON.parse(err.response.body as string) as RsApiError
-      } catch {
-        // Rust returned a non-JSON error body (shouldn't happen in normal operation)
-      }
-      throw new RsMatchmakerError(
-        err.response.statusCode,
-        errorBody?.code ?? 'unknown',
-        errorBody?.message ?? `Rust matchmaker returned ${err.response.statusCode}`,
-      )
-    }
-    throw err
+    return Result.error(toRsError(err))
   }
 }
 
 /** Fetches the current process token from the Rust matchmaker. */
-export async function rsGetProcessToken(): Promise<string> {
-  const response = await got(serverRsUrl('/matchmaker/token')).json<{ processToken: string }>()
-  return response.processToken
-}
-
-/** Adds a player to the Rust matchmaker queue. */
-export async function rsQueuePlayer(request: RsQueueRequest): Promise<void> {
-  await rsRequest('POST', '/matchmaker', request)
-}
-
-/**
- * Removes a player from the Rust matchmaker queue (cancel or disconnect).
- * Silently succeeds if the player is not in the queue (404 is treated as success).
- */
-export async function rsCancelPlayer(id: SbUserId): Promise<void> {
+export async function rsGetProcessToken(): Promise<Result<string, RsMatchmakerError>> {
   try {
-    await rsRequest('DELETE', urlPath`/matchmaker/${id}`)
+    const response = await got(serverRsUrl('/matchmaker/token')).json<{ processToken: string }>()
+    return Result.ok(response.processToken)
   } catch (err) {
-    if (err instanceof RsMatchmakerError && err.isNotFound) {
-      return // Already removed — treat as success
-    }
-    throw err
+    return Result.error(toRsError(err))
   }
 }
 
+/** Adds a player to the Rust matchmaker queue. */
+export function rsQueuePlayer(request: RsQueueRequest): Promise<Result<void, RsMatchmakerError>> {
+  return rsRequest('POST', '/matchmaker', request)
+}
+
 /**
- * Re-queues a player using a ticket from a previously-formed (but failed) match.
- * Throws `RsMatchmakerError` with `isStaleTicket === true` if the Rust service has restarted.
+ * Removes a player from the Rust matchmaker queue (cancel or disconnect). A `notFound` response is
+ * treated as success, since it means the player is already out of the queue.
  */
-export async function rsRequeuePlayer(ticket: string): Promise<void> {
-  await rsRequest('POST', '/matchmaker/requeue', { ticket })
+export async function rsCancelPlayer(id: SbUserId): Promise<Result<void, RsMatchmakerError>> {
+  const result = await rsRequest('DELETE', urlPath`/matchmaker/${id}`)
+  return result.isError() && result.error.code === RsMatchmakerErrorCode.NotFound
+    ? Result.ok()
+    : result
+}
+
+/**
+ * Re-queues a player using a ticket from a previously-formed (but failed) match. Fails with
+ * `code === RsMatchmakerErrorCode.StaleTicket` if the Rust service has restarted since the ticket
+ * was issued.
+ */
+export function rsRequeuePlayer(ticket: string): Promise<Result<void, RsMatchmakerError>> {
+  return rsRequest('POST', '/matchmaker/requeue', { ticket })
 }

--- a/server/lib/matchmaking/matchmaking-service.test.ts
+++ b/server/lib/matchmaking/matchmaking-service.test.ts
@@ -17,18 +17,19 @@ import { FakeClock } from '../time/testing/fake-clock'
 import { ClientSocketsGroup } from '../websockets/socket-groups'
 import { TypedPublisher } from '../websockets/typed-publisher'
 import {
-  RS_ERROR_CODES,
   rsCancelPlayer,
+  RsClientErrorCode,
   rsGetProcessToken,
   RsMatchmakerError,
+  RsMatchmakerErrorCode,
   rsQueuePlayer,
   rsRequeuePlayer,
 } from './matchmaker-rs-client'
 import { MatchmakingService } from './matchmaking-service'
 import { getMatchmakingUserPath } from './matchmaking-socket-paths'
 
-// We only mock the network functions of the Rust client; the error type and codes stay real so
-// `instanceof` / code checks behave like production.
+// We only mock the network functions of the Rust client; the error type and codes stay real so the
+// service's `code` checks behave like production.
 vi.mock('./matchmaker-rs-client', async () => {
   const actual =
     await vi.importActual<typeof import('./matchmaker-rs-client')>('./matchmaker-rs-client')
@@ -206,10 +207,10 @@ describe('matchmaking/matchmaking-service', () => {
     asMockedFunction(getMatchmakingRating).mockImplementation(async (userId: SbUserId) =>
       makeMmr(userId),
     )
-    asMockedFunction(rsQueuePlayer).mockResolvedValue(undefined)
-    asMockedFunction(rsCancelPlayer).mockResolvedValue(undefined)
-    asMockedFunction(rsRequeuePlayer).mockResolvedValue(undefined)
-    asMockedFunction(rsGetProcessToken).mockResolvedValue('token-1')
+    asMockedFunction(rsQueuePlayer).mockResolvedValue(Result.ok())
+    asMockedFunction(rsCancelPlayer).mockResolvedValue(Result.ok())
+    asMockedFunction(rsRequeuePlayer).mockResolvedValue(Result.ok())
+    asMockedFunction(rsGetProcessToken).mockResolvedValue(Result.ok('token-1'))
 
     service = new MatchmakingService(
       publisher as unknown as TypedPublisher<any>,
@@ -235,10 +236,15 @@ describe('matchmaking/matchmaking-service', () => {
 
   test('recovers from an orphaned Rust queue entry by canceling and retrying once', async () => {
     asMockedFunction(rsQueuePlayer)
-      .mockRejectedValueOnce(
-        new RsMatchmakerError(409, RS_ERROR_CODES.alreadyInQueue, 'Player is already in the queue'),
+      .mockResolvedValueOnce(
+        Result.error(
+          new RsMatchmakerError(
+            RsMatchmakerErrorCode.AlreadyInQueue,
+            'Player is already in the queue',
+          ),
+        ),
       )
-      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce(Result.ok())
 
     await queuePlayer(USER_A, CLIENT_A)
 
@@ -249,9 +255,11 @@ describe('matchmaking/matchmaking-service', () => {
   })
 
   test('cancels the Rust queue entry when the token fetch fails after a successful queue', async () => {
-    // The queue starts idle, so the first queuer triggers a token fetch. If that fetch throws after
+    // The queue starts idle, so the first queuer triggers a token fetch. If that fetch fails after
     // the player was already added to the Rust queue, we must cancel them rather than leave a ghost.
-    asMockedFunction(rsGetProcessToken).mockRejectedValueOnce(new Error('boom'))
+    asMockedFunction(rsGetProcessToken).mockResolvedValueOnce(
+      Result.error(new RsMatchmakerError(RsClientErrorCode.ServiceUnavailable, 'boom')),
+    )
 
     await expect(queuePlayer(USER_A, CLIENT_A)).rejects.toThrow('boom')
 
@@ -269,7 +277,7 @@ describe('matchmaking/matchmaking-service', () => {
     await vi.advanceTimersByTimeAsync(5000)
 
     // server-rs restarts while the queue is idle (new process token).
-    asMockedFunction(rsGetProcessToken).mockResolvedValue('token-2')
+    asMockedFunction(rsGetProcessToken).mockResolvedValue(Result.ok('token-2'))
 
     // Player B queues against the new process and the watchdog re-baselines to token-2.
     await queuePlayer(USER_B, CLIENT_B)
@@ -283,7 +291,9 @@ describe('matchmaking/matchmaking-service', () => {
   test('tolerates a single transient token-fetch failure, ejecting only after two in a row', async () => {
     await queuePlayer(USER_A, CLIENT_A)
 
-    asMockedFunction(rsGetProcessToken).mockRejectedValue(new Error('boom'))
+    asMockedFunction(rsGetProcessToken).mockResolvedValue(
+      Result.error(new RsMatchmakerError(RsClientErrorCode.ServiceUnavailable, 'boom')),
+    )
 
     // First failure: do not eject.
     await vi.advanceTimersByTimeAsync(5000)
@@ -299,7 +309,9 @@ describe('matchmaking/matchmaking-service', () => {
   test('a single failure followed by a success resets the failure counter', async () => {
     await queuePlayer(USER_A, CLIENT_A)
 
-    asMockedFunction(rsGetProcessToken).mockRejectedValueOnce(new Error('boom'))
+    asMockedFunction(rsGetProcessToken).mockResolvedValueOnce(
+      Result.error(new RsMatchmakerError(RsClientErrorCode.ServiceUnavailable, 'boom')),
+    )
     await vi.advanceTimersByTimeAsync(5000) // failure 1
     await vi.advanceTimersByTimeAsync(5000) // success, resets counter
 
@@ -360,7 +372,7 @@ describe('matchmaking/matchmaking-service', () => {
     await vi.advanceTimersByTimeAsync(0)
 
     // Both players are now in a match (accept phase). server-rs restarts.
-    asMockedFunction(rsGetProcessToken).mockResolvedValue('token-2')
+    asMockedFunction(rsGetProcessToken).mockResolvedValue(Result.ok('token-2'))
     asMockedFunction(rsCancelPlayer).mockClear()
     await vi.advanceTimersByTimeAsync(5000)
 
@@ -454,10 +466,10 @@ describe('matchmaking/matchmaking-service', () => {
     // queueSoloPlayer. The Rust search loop runs independently, so a match referencing B can arrive
     // as soon as B is in the Rust queue — before queueSoloPlayer finishes. B's queue entry must
     // already exist so handleMatchFound can set its matchId.
-    let resolveBQueue: (() => void) | undefined
+    let resolveBQueue: ((result: Result<void, RsMatchmakerError>) => void) | undefined
     asMockedFunction(rsQueuePlayer).mockImplementationOnce(
       () =>
-        new Promise<void>(resolve => {
+        new Promise<Result<void, RsMatchmakerError>>(resolve => {
           resolveBQueue = resolve
         }),
     )
@@ -486,7 +498,7 @@ describe('matchmaking/matchmaking-service', () => {
     await vi.advanceTimersByTimeAsync(0)
 
     // B's queue call now returns and queueSoloPlayer completes.
-    resolveBQueue!()
+    resolveBQueue!(Result.ok())
     await bQueuePromise
     await vi.advanceTimersByTimeAsync(0)
 

--- a/server/lib/matchmaking/matchmaking-service.ts
+++ b/server/lib/matchmaking/matchmaking-service.ts
@@ -3,6 +3,7 @@ import { nanoid } from 'nanoid'
 import { Counter, exponentialBuckets, Gauge, Histogram } from 'prom-client'
 import { singleton } from 'tsyringe'
 import { ReadonlyDeep } from 'type-fest'
+import { Result } from 'typescript-result'
 import { assertUnreachable } from '../../../common/assert-unreachable'
 import { isAbortError, raceAbort } from '../../../common/async/abort-signals'
 import createDeferred, { Deferred } from '../../../common/async/deferred'
@@ -41,10 +42,10 @@ import { GameplayActivityRegistry } from '../games/gameplay-activity-registry'
 import logger from '../logging/logger'
 import { getMapInfos } from '../maps/map-models'
 import {
-  RS_ERROR_CODES,
   rsCancelPlayer,
   rsGetProcessToken,
   RsMatchmakerError,
+  RsMatchmakerErrorCode,
   rsQueuePlayer,
   RsQueueRequest,
   rsRequeuePlayer,
@@ -559,40 +560,43 @@ export class MatchmakingService {
       registeredId: userId,
     })
 
-    // Queue the player in the Rust matchmaker with per-mode ratings, then fetch the process token
-    // as a baseline for the watchdog. The two requests are sequential so the token is guaranteed
-    // to be from the same server-rs instance that accepted the queue entry.
-    try {
-      await this.queuePlayerInRust({
-        id: userId,
-        modeRatings: typeDataEntries.map(d => ({
-          mode: d.type,
-          rating: d.mmr.rating,
-          uncertainty: d.mmr.uncertainty,
-          // Only "pick" modes constrain matching on maps; the matchmaker uses these selections to
-          // avoid pairing players who share no map. Veto/fixed modes send null.
-          mapSelections:
-            getMatchmakingModeInfo(d.type).mapSelectionStyle === 'pick'
-              ? d.playerData.mapSelections.slice()
-              : null,
-        })),
-        // The matchmaker can't reason about latency from a single player in isolation — the latency
-        // of a match depends on which rally-point server gets chosen, which is a function of *all*
-        // the matched players' pings. So we hand it this client's raw per-server pings and let it
-        // reproduce the route selection per candidate match (see `match_latency` in Rust). We waited
-        // for a ping result above, so these are populated.
-        serverPings: this.rallyPointService.getPingsForClient(clientSockets),
-      })
-      if (this.lastKnownProcessToken === undefined) {
-        this.lastKnownProcessToken = await rsGetProcessToken()
+    // Queue the player in the Rust matchmaker with per-mode ratings, then (for the first queuer)
+    // fetch the process token as a baseline for the watchdog. The two requests are sequential so the
+    // token is guaranteed to be from the same server-rs instance that accepted the queue entry.
+    let result: Result<unknown, RsMatchmakerError> = await this.queuePlayerInRust({
+      id: userId,
+      modeRatings: typeDataEntries.map(d => ({
+        mode: d.type,
+        rating: d.mmr.rating,
+        uncertainty: d.mmr.uncertainty,
+        // Only "pick" modes constrain matching on maps; the matchmaker uses these selections to
+        // avoid pairing players who share no map. Veto/fixed modes send null.
+        mapSelections:
+          getMatchmakingModeInfo(d.type).mapSelectionStyle === 'pick'
+            ? d.playerData.mapSelections.slice()
+            : null,
+      })),
+      // The matchmaker can't reason about latency from a single player in isolation — the latency
+      // of a match depends on which rally-point server gets chosen, which is a function of *all*
+      // the matched players' pings. So we hand it this client's raw per-server pings and let it
+      // reproduce the route selection per candidate match (see `match_latency` in Rust). We waited
+      // for a ping result above, so these are populated.
+      serverPings: this.rallyPointService.getPingsForClient(clientSockets),
+    })
+    if (result.isOk() && this.lastKnownProcessToken === undefined) {
+      const tokenResult = await rsGetProcessToken()
+      if (tokenResult.isOk()) {
+        this.lastKnownProcessToken = tokenResult.value
       }
-    } catch (err) {
+      result = tokenResult
+    }
+    if (result.isError()) {
       this.playerQueueData.delete(userId)
       this.queueEntries.delete(userId)
       // We may have already added the player to the Rust queue (e.g. the token fetch failed after a
       // successful queue); best-effort cancel it so we don't leave a ghost entry behind.
       this.cancelPlayerInRust(userId)
-      throw err
+      throw result.error
     }
 
     this.startProcessTokenWatchdog()
@@ -619,21 +623,23 @@ export class MatchmakingService {
    * — otherwise the player could never re-enter matchmaking until their ghost entry happened to get
    * matched.
    */
-  private async queuePlayerInRust(request: RsQueueRequest): Promise<void> {
-    try {
-      await rsQueuePlayer(request)
-    } catch (err) {
-      if (err instanceof RsMatchmakerError && err.code === RS_ERROR_CODES.alreadyInQueue) {
-        logger.warn(
-          { userId: request.id },
-          'player already in Rust queue — canceling stale entry and retrying',
-        )
-        await rsCancelPlayer(request.id)
-        await rsQueuePlayer(request)
-      } else {
-        throw err
-      }
+  private async queuePlayerInRust(
+    request: RsQueueRequest,
+  ): Promise<Result<void, RsMatchmakerError>> {
+    const result = await rsQueuePlayer(request)
+    if (!(result.isError() && result.error.code === RsMatchmakerErrorCode.AlreadyInQueue)) {
+      return result
     }
+
+    logger.warn(
+      { userId: request.id },
+      'player already in Rust queue — canceling stale entry and retrying',
+    )
+    const cancelResult = await rsCancelPlayer(request.id)
+    if (cancelResult.isError()) {
+      return cancelResult
+    }
+    return await rsQueuePlayer(request)
   }
 
   async cancel(userId: SbUserId): Promise<void> {
@@ -1354,18 +1360,19 @@ export class MatchmakingService {
       return
     }
 
-    let token: string
-    try {
-      token = await rsGetProcessToken()
-    } catch (err) {
+    const tokenResult = await rsGetProcessToken()
+    if (tokenResult.isError()) {
       this.consecutiveTokenFailures += 1
       if (this.consecutiveTokenFailures < MAX_TOKEN_FETCH_FAILURES) {
         // A single failed fetch is usually a transient hiccup — don't eject everyone over it.
-        logger.warn({ err }, 'failed to fetch Rust matchmaker process token — will retry')
+        logger.warn(
+          { err: tokenResult.error },
+          'failed to fetch Rust matchmaker process token — will retry',
+        )
         return
       }
       logger.error(
-        { err },
+        { err: tokenResult.error },
         'failed to fetch Rust matchmaker process token repeatedly — assuming restart',
       )
       this.consecutiveTokenFailures = 0
@@ -1374,6 +1381,7 @@ export class MatchmakingService {
       return
     }
 
+    const token = tokenResult.value
     this.consecutiveTokenFailures = 0
 
     if (this.lastKnownProcessToken !== undefined && token !== this.lastKnownProcessToken) {
@@ -1419,9 +1427,16 @@ export class MatchmakingService {
       // never knew the player), but if we reached here via a false positive — e.g. a stale token
       // baseline — the player really is still queued, and skipping this would leave a ghost entry
       // that fails all their future `find()`s with `alreadyInQueue`.
-      rsCancelPlayer(userId).catch(err => {
-        logger.error({ err, userId }, 'failed to cancel player in Rust matchmaker after restart')
-      })
+      rsCancelPlayer(userId)
+        .then(result => {
+          if (result.isError()) {
+            logger.error(
+              { err: result.error, userId },
+              'failed to cancel player in Rust matchmaker after restart',
+            )
+          }
+        })
+        .catch(swallowNonBuiltins)
     }
   }
 
@@ -1432,11 +1447,15 @@ export class MatchmakingService {
    * surfaces a matchmaking error to the player.
    */
   private requeuePlayerInRust(userId: SbUserId, ticket: string): void {
-    const promise = rsRequeuePlayer(ticket).catch(err => {
-      if (!(err instanceof RsMatchmakerError && err.isStaleTicket)) {
-        logger.error({ err, userId }, 'failed to requeue player in Rust matchmaker')
+    const promise = rsRequeuePlayer(ticket).then(result => {
+      if (result.isError()) {
+        // A stale ticket is the expected signal that server-rs restarted; anything else is a real
+        // failure worth logging. Either way the player can't be requeued, so surface a restart.
+        if (result.error.code !== RsMatchmakerErrorCode.StaleTicket) {
+          logger.error({ err: result.error, userId }, 'failed to requeue player in Rust matchmaker')
+        }
+        this.handleRsRestart([userId])
       }
-      this.handleRsRestart([userId])
     })
     this.pendingRequeues.set(userId, promise)
     promise
@@ -1457,8 +1476,13 @@ export class MatchmakingService {
     const pendingRequeue = this.pendingRequeues.get(userId) ?? Promise.resolve()
     pendingRequeue
       .then(() => rsCancelPlayer(userId))
+      .then(result => {
+        if (result.isError()) {
+          logger.error({ err: result.error, userId }, 'failed to cancel player in Rust matchmaker')
+        }
+      })
       .catch(err => {
-        logger.error({ err, userId }, 'failed to cancel player in Rust matchmaker')
+        logger.error({ err, userId }, 'error canceling player in Rust matchmaker')
       })
   }
 


### PR DESCRIPTION
## Summary

Cleans up the Node↔Rust matchmaking bridge so its error handling is strongly bounded and lives in one place, without changing behavior. This is the first of the small matchmaking-code improvements we discussed (the others — generic Rust↔Node glue, lobby work — are separate).

- **Typeshare the error codes.** Adds a `#[typeshare] RsMatchmakerErrorCode` enum in server-rs and uses it in `api.rs` instead of scattered string literals. The generated enum replaces the hand-maintained `RS_ERROR_CODES` const in `matchmaker-rs-client.ts`, so the two sides can't drift.
- **Return `Result` instead of throwing.** The client functions now return `Promise<Result<void, RsMatchmakerError>>`. Callers branch on `isOk()`/`isError()` and `code`, dropping the `isStaleTicket`/`isNotFound` getters and every `instanceof` check.
- **One place for "Rust unreachable".** All transport failures (connection refused, timeout, DNS, …) collapse into a single `serviceUnavailable` code in `toRsError`. Node-only synthetic codes live in a separate `RsClientErrorCode` enum since Rust never sends them.
- **Flatten `find()`.** Its nested try/catch becomes a linear queue → token → rollback sequence, matching the game-loader's existing `Result` style.

## Scoping notes

- `find()` still throws at its public edge (`throw result.error`); the `Result` boundary is the rs-client. Converting `find`'s signature would ripple into the WS API layer and is out of scope. Behavior is identical to before.
- Dropped the vestigial `status` field on `RsMatchmakerError` (set but never read) and made `RsApiError` internal.

## Verification

- `cargo build` + `cargo clippy --all-targets --workspace -- -D warnings` clean; `cargo fmt` applied
- `pnpm typecheck` clean
- 16/16 `matchmaking-service` tests pass
- `eslint --fix` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VVjx3SveGsE8ggC9CJ4LAA