### PR TITLE
Drive the matchmaker from a runtime DB config (foundation)

### DIFF
--- a/migrations/20260627120000_add_matchmaking_config.sql
+++ b/migrations/20260627120000_add_matchmaking_config.sql
@@ -8,7 +8,6 @@
 --   {
 --     "searchIntervalSeconds": <number>,
 --     "maxPlayersExamined": <number>,
---     "populationWindowSeconds": <number>,
 --     "global": { <per-mode knob overrides> },
 --     "perMode": { "<matchmaking_type>": { <per-mode knob overrides> } }
 --   }

--- a/migrations/20260627120000_add_matchmaking_config.sql
+++ b/migrations/20260627120000_add_matchmaking_config.sql
@@ -1,0 +1,27 @@
+-- Runtime-tunable matchmaker configuration, read by server-rs at startup (and, once the admin
+-- mutation lands, re-read when it changes). A single row (id = 1) holds the config as JSONB
+-- containing only the *overrides* an admin has set; any field not present falls back to the
+-- hardcoded defaults in server-rs. So an empty `{}` config — or a missing/unparseable row — means
+-- "use the built-in defaults", and matchmaking can never be bricked by a bad or absent config.
+--
+-- Shape (all fields optional):
+--   {
+--     "searchIntervalSeconds": <number>,
+--     "maxPlayersExamined": <number>,
+--     "populationWindowSeconds": <number>,
+--     "global": { <per-mode knob overrides> },
+--     "perMode": { "<matchmaking_type>": { <per-mode knob overrides> } }
+--   }
+-- where a per-mode knob block is a subset of:
+--   weightRatingVariance, weightWinProb, weightLatency, uncertaintyK, minQuality,
+--   adaptiveComfortableMultiplier, adaptiveDecayPerMissing, populationHalfLifeSeconds
+CREATE TABLE matchmaking_config (
+  id smallint PRIMARY KEY DEFAULT 1 CHECK (id = 1),
+  config jsonb NOT NULL DEFAULT '{}'::jsonb,
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  updated_by integer REFERENCES users (id) ON DELETE SET NULL
+);
+
+-- Seed the singleton "all defaults" row so the server always has a row to read and the admin
+-- mutation always has a row to update.
+INSERT INTO matchmaking_config (id, config) VALUES (1, '{}'::jsonb);

--- a/server-rs/.sqlx/query-f82b44af569bd77c4f638f008542c769e9d34a6ecd22736cf6de1f233a3912ec.json
+++ b/server-rs/.sqlx/query-f82b44af569bd77c4f638f008542c769e9d34a6ecd22736cf6de1f233a3912ec.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT config as \"config: Json<StoredConfig>\" FROM matchmaking_config WHERE id = 1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "config: Json<StoredConfig>",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "f82b44af569bd77c4f638f008542c769e9d34a6ecd22736cf6de1f233a3912ec"
+}

--- a/server-rs/Cargo.lock
+++ b/server-rs/Cargo.lock
@@ -4097,6 +4097,7 @@ dependencies = [
 name = "server"
 version = "0.1.0"
 dependencies = [
+ "arc-swap",
  "async-graphql",
  "async-graphql-axum",
  "async-trait",

--- a/server-rs/Cargo.toml
+++ b/server-rs/Cargo.toml
@@ -21,6 +21,7 @@ name = "matchmaker"
 harness = false
 
 [dependencies]
+arc-swap = "1"
 async-graphql = { version = "7.0", features = [
   "chrono",
   "dataloader",

--- a/server-rs/benches/matchmaker.rs
+++ b/server-rs/benches/matchmaker.rs
@@ -1,12 +1,14 @@
 use std::collections::HashMap;
+use std::sync::Arc;
 use std::time::Instant;
 
 use criterion::{Criterion, black_box, criterion_group, criterion_main};
 use server::matchmaking::MatchmakingType;
+use server::matchmaking::config::MatchmakerConfig;
 use server::matchmaking::matchmaker::{Matchmaker, Player, PlayerModeRating};
 
 fn bench_1v1(c: &mut Criterion) {
-    let mut matchmaker = Matchmaker::new(16);
+    let mut matchmaker = Matchmaker::new(Arc::new(MatchmakerConfig::default()));
     for player in (0..1000).map(|n| Player {
         id: n,
         ratings: HashMap::from([(
@@ -22,12 +24,12 @@ fn bench_1v1(c: &mut Criterion) {
         matchmaker.insert_player(player).unwrap();
     }
     c.bench_function("find_matches_1v1", |b| {
-        b.iter(|| black_box(matchmaker.find_matches(f32::NEG_INFINITY, Instant::now())));
+        b.iter(|| black_box(matchmaker.find_matches(Instant::now())));
     });
 }
 
 fn bench_2v2(c: &mut Criterion) {
-    let mut matchmaker = Matchmaker::new(16);
+    let mut matchmaker = Matchmaker::new(Arc::new(MatchmakerConfig::default()));
     for player in (0..1000).map(|n| Player {
         id: n,
         ratings: HashMap::from([(
@@ -43,7 +45,7 @@ fn bench_2v2(c: &mut Criterion) {
         matchmaker.insert_player(player).unwrap();
     }
     c.bench_function("find_matches_2v2", |b| {
-        b.iter(|| black_box(matchmaker.find_matches(f32::NEG_INFINITY, Instant::now())));
+        b.iter(|| black_box(matchmaker.find_matches(Instant::now())));
     });
 }
 

--- a/server-rs/src/matchmaking/api.rs
+++ b/server-rs/src/matchmaking/api.rs
@@ -1,3 +1,4 @@
+use crate::matchmaking::config::MatchmakerConfig;
 use crate::matchmaking::matchmaker::{
     Match, Matchmaker, Player, PlayerModeRating, QueueEntry, RandomQueueSelector,
 };
@@ -8,6 +9,7 @@ use crate::matchmaking::{
 use crate::redis::RedisPool;
 use crate::state::AppState;
 use crate::users::SbUserId;
+use arc_swap::ArcSwap;
 use axum::extract::Path;
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
@@ -22,14 +24,6 @@ use std::time::{Duration, Instant};
 use uuid::Uuid;
 
 use super::matchmaker::MatchmakerError;
-
-/// Minimum quality score a match must reach before it is published. The matchmaker applies an
-/// adaptive threshold that lowers this automatically when the queue is below a comfortable size,
-/// so matches can still form during low-population periods.
-const MIN_QUALITY: f32 = -30.0;
-
-/// How often the matchmaker searches for new matches.
-const SEARCH_INTERVAL: std::time::Duration = std::time::Duration::from_secs(6);
 
 /// How many times to attempt publishing a formed match to Redis before treating the failure as
 /// fatal. A formed match has already been removed from the queue, so a few quick retries are worth
@@ -121,6 +115,10 @@ type SharedMatchmaker = Arc<Mutex<Matchmaker<RandomQueueSelector>>>;
 #[derive(Clone)]
 struct MatchmakingApiState {
     matchmaker: SharedMatchmaker,
+    /// The live, swappable matchmaker configuration. The search loop reads it each tick and pushes
+    /// it into the matchmaker, so an admin edit (which replaces the pointee — separate change) takes
+    /// effect without a restart.
+    config: Arc<ArcSwap<MatchmakerConfig>>,
     process_token: Uuid,
 }
 
@@ -252,7 +250,9 @@ async fn search_loop(state: MatchmakingApiState, redis_pool: RedisPool) {
     // Capture the epoch once — it never changes for the lifetime of this process.
     let matchmaker_start = lock_matchmaker(&state.matchmaker).start();
 
-    let mut interval = tokio::time::interval(SEARCH_INTERVAL);
+    // The search cadence is read once at startup. The formula/threshold knobs hot-reload each tick
+    // (below), but changing the interval would mean rebuilding this timer, so it takes a restart.
+    let mut interval = tokio::time::interval(state.config.load().search_interval);
     // The first tick fires immediately; skip it so the first real search happens after one interval.
     interval.tick().await;
 
@@ -266,13 +266,15 @@ async fn search_loop(state: MatchmakingApiState, redis_pool: RedisPool) {
         // and have the fresh queue entry incorrectly removed.
         let selected = {
             let mut matchmaker = lock_matchmaker(&state.matchmaker);
+            // Push the latest config into the matchmaker so an admin edit takes effect this tick.
+            matchmaker.set_config(state.config.load_full());
             // Roll the population estimate forward before searching so the adaptive quality threshold
             // reflects recent population rather than the post-drain residual queue size.
             matchmaker.update_population_estimates(tick_start);
             // Sample the per-mode gauges here — after the population roll-forward, before the drain
             // below — so they reflect everyone waiting this tick rather than the unmatched residual.
-            metrics::sample_queue_state(&matchmaker, MIN_QUALITY);
-            let matches = matchmaker.find_matches(MIN_QUALITY, tick_start);
+            metrics::sample_queue_state(&matchmaker);
+            let matches = matchmaker.find_matches(tick_start);
             let selected = deduplicate_matches(matches);
             for m in &selected {
                 for entry in m.team_a.iter().chain(m.team_b.iter()) {
@@ -369,11 +371,15 @@ async fn get_process_token(State(state): State<MatchmakingApiState>) -> Json<Pro
     })
 }
 
-pub fn create_matchmaking_api(redis_pool: RedisPool) -> Router<AppState> {
+pub fn create_matchmaking_api(
+    redis_pool: RedisPool,
+    config: Arc<ArcSwap<MatchmakerConfig>>,
+) -> Router<AppState> {
     metrics::describe_metrics();
 
     let state = MatchmakingApiState {
-        matchmaker: Arc::new(Mutex::new(Matchmaker::new(16))),
+        matchmaker: Arc::new(Mutex::new(Matchmaker::new(config.load_full()))),
+        config,
         process_token: Uuid::new_v4(),
     };
 

--- a/server-rs/src/matchmaking/config.rs
+++ b/server-rs/src/matchmaking/config.rs
@@ -1,0 +1,307 @@
+//! Runtime-tunable matchmaker configuration.
+//!
+//! The matchmaker's tuning knobs (quality-formula weights, the adaptive low-population threshold, and
+//! a few process-level operational settings) live in the `matchmaking_config` table rather than as
+//! compile-time constants, so they can be adjusted without a code change/release. server-rs loads the
+//! row at startup into an [`arc_swap::ArcSwap`] shared with the search loop; the admin GraphQL
+//! mutation (separate change) rewrites the row and reloads the swap.
+//!
+//! The stored JSON holds only *overrides*; anything absent falls back to the [`Default`] impls below,
+//! which mirror the constants the matchmaker shipped with. A missing or unparseable row therefore
+//! yields the built-in defaults, so matchmaking can never be bricked by a bad config. Every value is
+//! also clamped to a sane range on load as a second line of defence against a bad write.
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use serde::Deserialize;
+use sqlx::PgPool;
+use sqlx::types::Json;
+
+use crate::matchmaking::MatchmakingType;
+
+/// Per-mode tuning knobs. Defaults mirror the constants the matchmaker shipped with (see
+/// `matchmaker.rs`). Overridable globally and, sparsely, per mode.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ModeConfig {
+    /// Seconds of wait traded per unit of skill variance.
+    pub weight_rating_variance: f32,
+    /// Seconds of wait traded per unit of win-probability imbalance.
+    pub weight_win_prob: f32,
+    /// Seconds of wait traded per latency turn-rate step.
+    pub weight_latency: f32,
+    /// σ multiplier for the conservative effective rating (rating − k·σ).
+    pub uncertainty_k: f32,
+    /// Base minimum quality (seconds of wait) a match must reach; relaxed adaptively in low pop.
+    pub min_quality: f32,
+    /// Comfortable population = this × `mode.total_players()`; at/above it the full threshold applies.
+    pub adaptive_comfortable_multiplier: usize,
+    /// Seconds the threshold drops per player below the comfortable population.
+    pub adaptive_decay_per_missing: f32,
+    /// Half-life of the smoothed population estimate's EWMA.
+    pub population_half_life: Duration,
+}
+
+impl Default for ModeConfig {
+    fn default() -> Self {
+        Self {
+            weight_rating_variance: 0.005,
+            weight_win_prob: 50.0,
+            weight_latency: 30.0,
+            uncertainty_k: 1.0,
+            min_quality: -30.0,
+            adaptive_comfortable_multiplier: 2,
+            adaptive_decay_per_missing: 15.0,
+            population_half_life: Duration::from_secs(20 * 60),
+        }
+    }
+}
+
+/// The full matchmaker configuration: process-level operational knobs plus the global per-mode
+/// defaults and any (pre-resolved) per-mode overrides.
+#[derive(Debug, Clone)]
+pub struct MatchmakerConfig {
+    /// How often the search loop runs.
+    pub search_interval: Duration,
+    /// Max queue entries the matchmaker examines per mode per tick.
+    pub max_players_examined: usize,
+    global: ModeConfig,
+    /// Fully-resolved config for the modes that carry an override (global merged with the override).
+    /// Modes absent here use `global` directly.
+    per_mode: HashMap<MatchmakingType, ModeConfig>,
+}
+
+impl Default for MatchmakerConfig {
+    fn default() -> Self {
+        Self {
+            search_interval: Duration::from_secs(6),
+            max_players_examined: 16,
+            global: ModeConfig::default(),
+            per_mode: HashMap::new(),
+        }
+    }
+}
+
+impl MatchmakerConfig {
+    /// The resolved config for `mode`: its override if one exists, otherwise the global defaults.
+    pub fn for_mode(&self, mode: MatchmakingType) -> &ModeConfig {
+        self.per_mode.get(&mode).unwrap_or(&self.global)
+    }
+
+    /// Builds a config from an explicit global [`ModeConfig`], with default operational knobs and no
+    /// per-mode overrides. For tests that need a specific knob value.
+    #[cfg(test)]
+    pub(crate) fn from_global(global: ModeConfig) -> Self {
+        Self {
+            global,
+            ..Default::default()
+        }
+    }
+
+    fn from_stored(stored: StoredConfig) -> Self {
+        let global = stored.global.resolve_onto(ModeConfig::default());
+        // Per-mode overrides layer on top of the *resolved global*, so a mode that overrides only one
+        // field inherits the rest of the global config (including its overrides).
+        let per_mode = stored
+            .per_mode
+            .iter()
+            .map(|(mode, over)| (*mode, over.resolve_onto(global)))
+            .collect();
+
+        Self {
+            search_interval: clamp_duration(stored.search_interval_seconds, 1, 60)
+                .unwrap_or(Duration::from_secs(6)),
+            max_players_examined: stored
+                .max_players_examined
+                .map(|v| v.clamp(2, 200) as usize)
+                .unwrap_or(16),
+            global,
+            per_mode,
+        }
+    }
+}
+
+/// Builds a clamped [`Duration`] from optional seconds, or `None` to fall back to a default. Drops
+/// non-finite inputs defensively (standard JSON can't carry NaN/∞, but this keeps `from_secs_f64`
+/// from ever seeing one).
+fn clamp_duration(seconds: Option<f64>, min: u64, max: u64) -> Option<Duration> {
+    seconds
+        .filter(|s| s.is_finite())
+        .map(|s| Duration::from_secs_f64(s.clamp(min as f64, max as f64)))
+}
+
+/// Stored (JSON) form of [`MatchmakerConfig`]: every field optional so the row carries only the
+/// overrides an admin set. Unknown fields are ignored (forward-compatible).
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase", default)]
+struct StoredConfig {
+    search_interval_seconds: Option<f64>,
+    max_players_examined: Option<i64>,
+    global: StoredModeConfig,
+    per_mode: HashMap<MatchmakingType, StoredModeConfig>,
+}
+
+/// Stored (JSON) form of [`ModeConfig`]: a sparse set of knob overrides.
+#[derive(Debug, Default, Clone, Deserialize)]
+#[serde(rename_all = "camelCase", default)]
+struct StoredModeConfig {
+    weight_rating_variance: Option<f32>,
+    weight_win_prob: Option<f32>,
+    weight_latency: Option<f32>,
+    uncertainty_k: Option<f32>,
+    min_quality: Option<f32>,
+    adaptive_comfortable_multiplier: Option<i64>,
+    adaptive_decay_per_missing: Option<f32>,
+    population_half_life_seconds: Option<f64>,
+}
+
+impl StoredModeConfig {
+    /// Resolves this sparse override onto `base`, clamping every field to its valid range.
+    fn resolve_onto(&self, base: ModeConfig) -> ModeConfig {
+        ModeConfig {
+            weight_rating_variance: clamp_f32(
+                self.weight_rating_variance,
+                base.weight_rating_variance,
+                0.0,
+                0.1,
+            ),
+            weight_win_prob: clamp_f32(self.weight_win_prob, base.weight_win_prob, 0.0, 500.0),
+            weight_latency: clamp_f32(self.weight_latency, base.weight_latency, 0.0, 300.0),
+            uncertainty_k: clamp_f32(self.uncertainty_k, base.uncertainty_k, 0.0, 3.0),
+            min_quality: clamp_f32(self.min_quality, base.min_quality, -600.0, 60.0),
+            adaptive_comfortable_multiplier: self
+                .adaptive_comfortable_multiplier
+                .map(|v| v.clamp(1, 10) as usize)
+                .unwrap_or(base.adaptive_comfortable_multiplier),
+            adaptive_decay_per_missing: clamp_f32(
+                self.adaptive_decay_per_missing,
+                base.adaptive_decay_per_missing,
+                0.0,
+                120.0,
+            ),
+            population_half_life: clamp_duration(
+                self.population_half_life_seconds,
+                60,
+                24 * 60 * 60,
+            )
+            .unwrap_or(base.population_half_life),
+        }
+    }
+}
+
+/// Returns `value` (when present and finite) clamped to `[min, max]`, else `base`.
+fn clamp_f32(value: Option<f32>, base: f32, min: f32, max: f32) -> f32 {
+    value
+        .filter(|v| v.is_finite())
+        .unwrap_or(base)
+        .clamp(min, max)
+}
+
+/// Loads the current matchmaker config from the database. Any failure (missing row, unparseable
+/// JSON, DB error) falls back to the built-in defaults and logs — matchmaking must keep running.
+pub async fn load_matchmaker_config(db: &PgPool) -> MatchmakerConfig {
+    match sqlx::query!(
+        r#"SELECT config as "config: Json<StoredConfig>" FROM matchmaking_config WHERE id = 1"#
+    )
+    .fetch_optional(db)
+    .await
+    {
+        Ok(Some(row)) => MatchmakerConfig::from_stored(row.config.0),
+        Ok(None) => {
+            tracing::info!("no matchmaking_config row found; using built-in matchmaker defaults");
+            MatchmakerConfig::default()
+        }
+        Err(e) => {
+            tracing::error!("failed to load matchmaking_config, using built-in defaults: {e:?}");
+            MatchmakerConfig::default()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(json: &str) -> MatchmakerConfig {
+        MatchmakerConfig::from_stored(serde_json::from_str(json).unwrap())
+    }
+
+    #[test]
+    fn empty_config_is_defaults() {
+        let cfg = parse("{}");
+        let defaults = MatchmakerConfig::default();
+        assert_eq!(cfg.max_players_examined, defaults.max_players_examined);
+        assert_eq!(cfg.search_interval, defaults.search_interval);
+        assert_eq!(
+            *cfg.for_mode(MatchmakingType::Match1v1),
+            ModeConfig::default()
+        );
+    }
+
+    #[test]
+    fn unknown_fields_ignored() {
+        let cfg = parse(r#"{"somethingNew": 5, "global": {"alsoNew": true}}"#);
+        assert_eq!(
+            *cfg.for_mode(MatchmakingType::Match1v1),
+            ModeConfig::default()
+        );
+    }
+
+    #[test]
+    fn global_override_applies_to_all_modes() {
+        let cfg = parse(r#"{"global": {"weightWinProb": 75, "minQuality": -45}}"#);
+        for mode in [MatchmakingType::Match1v1, MatchmakingType::Match3v3Bgh] {
+            assert_eq!(cfg.for_mode(mode).weight_win_prob, 75.0);
+            assert_eq!(cfg.for_mode(mode).min_quality, -45.0);
+            // Untouched fields keep their defaults.
+            assert_eq!(cfg.for_mode(mode).weight_latency, 30.0);
+        }
+    }
+
+    #[test]
+    fn per_mode_override_layers_on_global() {
+        let cfg = parse(
+            r#"{"global": {"minQuality": -45}, "perMode": {"3v3bgh": {"adaptiveDecayPerMissing": 25}}}"#,
+        );
+        // 1v1 has no per-mode override: global only.
+        let one = cfg.for_mode(MatchmakingType::Match1v1);
+        assert_eq!(one.min_quality, -45.0);
+        assert_eq!(one.adaptive_decay_per_missing, 15.0);
+        // 3v3bgh inherits the global minQuality and applies its own decay override.
+        let team = cfg.for_mode(MatchmakingType::Match3v3Bgh);
+        assert_eq!(team.min_quality, -45.0);
+        assert_eq!(team.adaptive_decay_per_missing, 25.0);
+    }
+
+    #[test]
+    fn out_of_range_values_are_clamped() {
+        let cfg = parse(
+            r#"{
+                "searchIntervalSeconds": 9000,
+                "maxPlayersExamined": 100000,
+                "global": {"weightWinProb": -10, "uncertaintyK": 999, "minQuality": -100000}
+            }"#,
+        );
+        assert_eq!(cfg.search_interval, Duration::from_secs(60));
+        assert_eq!(cfg.max_players_examined, 200);
+        let m = cfg.for_mode(MatchmakingType::Match1v1);
+        assert_eq!(m.weight_win_prob, 0.0); // clamped up from -10
+        assert_eq!(m.uncertainty_k, 3.0); // clamped down from 999
+        assert_eq!(m.min_quality, -600.0); // clamped up from -100000
+    }
+
+    #[test]
+    fn half_life_seconds_parsed_and_clamped() {
+        let cfg = parse(r#"{"global": {"populationHalfLifeSeconds": 600}}"#);
+        assert_eq!(
+            cfg.for_mode(MatchmakingType::Match1v1).population_half_life,
+            Duration::from_secs(600)
+        );
+        // Below the 60s floor → clamped up.
+        let cfg = parse(r#"{"global": {"populationHalfLifeSeconds": 1}}"#);
+        assert_eq!(
+            cfg.for_mode(MatchmakingType::Match1v1).population_half_life,
+            Duration::from_secs(60)
+        );
+    }
+}

--- a/server-rs/src/matchmaking/config.rs
+++ b/server-rs/src/matchmaking/config.rs
@@ -101,11 +101,20 @@ impl MatchmakerConfig {
     fn from_stored(stored: StoredConfig) -> Self {
         let global = stored.global.resolve_onto(ModeConfig::default());
         // Per-mode overrides layer on top of the *resolved global*, so a mode that overrides only one
-        // field inherits the rest of the global config (including its overrides).
+        // field inherits the rest of the global config (including its overrides). An unrecognized mode
+        // key (e.g. a removed/renamed mode, or one written by a newer server) is dropped with a log
+        // rather than failing the whole parse — losing one mode's override is far better than silently
+        // reverting *every* knob to defaults.
         let per_mode = stored
             .per_mode
             .iter()
-            .map(|(mode, over)| (*mode, over.resolve_onto(global)))
+            .filter_map(|(key, over)| match parse_mode_key(key) {
+                Some(mode) => Some((mode, over.resolve_onto(global))),
+                None => {
+                    tracing::warn!("ignoring matchmaking_config override for unknown mode {key:?}");
+                    None
+                }
+            })
             .collect();
 
         Self {
@@ -138,7 +147,15 @@ struct StoredConfig {
     search_interval_seconds: Option<f64>,
     max_players_examined: Option<i64>,
     global: StoredModeConfig,
-    per_mode: HashMap<MatchmakingType, StoredModeConfig>,
+    // Keyed by the mode's stored string name rather than `MatchmakingType` so an unknown key doesn't
+    // fail the entire deserialize (see `from_stored`); the keys are resolved to modes there.
+    per_mode: HashMap<String, StoredModeConfig>,
+}
+
+/// Parses a stored per-mode key (e.g. `"3v3bgh"`) into a [`MatchmakingType`], or `None` if it doesn't
+/// match a known mode. Uses serde so the accepted names stay in lockstep with the enum's renames.
+fn parse_mode_key(key: &str) -> Option<MatchmakingType> {
+    serde_json::from_value(serde_json::Value::String(key.to_owned())).ok()
 }
 
 /// Stored (JSON) form of [`ModeConfig`]: a sparse set of knob overrides.
@@ -245,6 +262,22 @@ mod tests {
             *cfg.for_mode(MatchmakingType::Match1v1),
             ModeConfig::default()
         );
+    }
+
+    #[test]
+    fn unknown_per_mode_key_dropped_without_losing_the_rest() {
+        // A bogus/renamed mode key must not nuke the whole config: the global override and any valid
+        // per-mode override still apply, the unknown key is simply ignored.
+        let cfg = parse(
+            r#"{
+                "global": {"minQuality": -45},
+                "perMode": {"4v4chaos": {"minQuality": 10}, "3v3bgh": {"weightWinProb": 75}}
+            }"#,
+        );
+        assert_eq!(cfg.for_mode(MatchmakingType::Match1v1).min_quality, -45.0);
+        let team = cfg.for_mode(MatchmakingType::Match3v3Bgh);
+        assert_eq!(team.min_quality, -45.0);
+        assert_eq!(team.weight_win_prob, 75.0);
     }
 
     #[test]

--- a/server-rs/src/matchmaking/matchmaker.rs
+++ b/server-rs/src/matchmaking/matchmaker.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::HashMap,
+    sync::Arc,
     time::{Duration, Instant},
 };
 
@@ -9,6 +10,7 @@ use rand::{Rng, seq::SliceRandom};
 use strum::IntoEnumIterator;
 
 use crate::matchmaking::MatchmakingType;
+use crate::matchmaking::config::MatchmakerConfig;
 
 /*
 Match quality is expressed in seconds of wait time: a positive value means the match is good
@@ -46,52 +48,18 @@ See also Menke's talk for background on this scoring approach:
 https://www.youtube.com/watch?v=Q8BX0nXfPjY
 */
 
-const WEIGHT_RATING_VARIANCE: f32 = 0.005;
-const WEIGHT_WIN_PROB: f32 = 50.0;
-/// Seconds of wait time we'll trade to drop a match's latency by one turn-rate step (one unit of
-/// [`latency_value`]). Latency below the first step (~100ms one-way) plays identically, so this only
-/// bites once a match would force the game onto a slower turn rate / longer input buffer. The
-/// match-formation telemetry records the raw `max_latency` (in ms) so this can be tuned against real
-/// game outcomes.
-const WEIGHT_LATENCY: f32 = 30.0;
-
-/// How many σ below their mean rating a player's effective rating is.
-/// Controls how strongly uncertainty drags down effective rating.
-/// k=1.0 → 68% confidence lower bound. k=2.0 → 95% lower bound.
-const UNCERTAINTY_K: f32 = 1.0;
-
-/// Smoothed population (see [`Matchmaker::update_population_estimates`]) at or above which the full
-/// MIN_QUALITY threshold applies. Below this, the threshold decays by ADAPTIVE_DECAY_PER_MISSING per
-/// missing player. This multiplier is applied to mode.total_players() so it scales with mode size.
-const ADAPTIVE_COMFORTABLE_MULTIPLIER: usize = 2;
-
-/// Seconds the quality threshold drops per player below the comfortable population.
-const ADAPTIVE_DECAY_PER_MISSING: f32 = 15.0;
-
 /// Length of one population-sampling window. At each boundary the window's peak concurrent queue size
 /// is folded into the smoothed per-mode population estimate (see
-/// [`Matchmaker::update_population_estimates`]).
+/// [`Matchmaker::update_population_estimates`]). This sets the sampling granularity only; the EWMA
+/// time constant is the per-mode, runtime-configurable `population_half_life` (see
+/// [`crate::matchmaking::config::ModeConfig`]).
 const POPULATION_WINDOW: Duration = Duration::from_secs(60);
 
-/// Half-life of the population estimate: the time a mode's estimate takes to decay halfway toward a
-/// lower level once the queue goes quiet (and, symmetrically, to climb halfway toward a higher one).
-///
-/// This is the knob that controls how reactive the adaptive threshold is, and it wants to be *long*.
-/// A matched player vanishes from the queue for the length of a game (~15-20 minutes for BW) before
-/// requeueing, so the estimate has to remember the population across at least one game-and-requeue
-/// cycle or it would forget the active player base mid-game and spuriously relax the threshold. A
-/// half-life around a game length also smooths over the multi-minute lulls that are normal even at
-/// peak hours, while still relaxing the threshold over the better part of an hour during a genuinely
-/// dead period. [`POPULATION_WINDOW`] only sets the sampling granularity; this sets the time
-/// constant. (The previous value — inherited verbatim from the old TS matchmaker, where it was an
-/// admittedly arbitrary placeholder — was a ~2.4-minute half-life, far too twitchy.)
-const POPULATION_HALF_LIFE: Duration = Duration::from_secs(20 * 60);
-
-/// Per-window EWMA blend factor derived from [`POPULATION_HALF_LIFE`] and [`POPULATION_WINDOW`]:
+/// Per-window EWMA blend factor for a given half-life and sampling window:
 /// `alpha = 1 - 0.5^(window / half_life)`, i.e. the fraction of a window's peak folded into the
-/// estimate each fold, chosen so the estimate halves over exactly one half-life of idle windows.
-fn population_alpha() -> f32 {
-    1.0 - 0.5_f32.powf(POPULATION_WINDOW.as_secs_f32() / POPULATION_HALF_LIFE.as_secs_f32())
+/// estimate each fold, chosen so the estimate halves over exactly one `half_life` of idle windows.
+fn ewma_alpha(half_life: Duration, window: Duration) -> f32 {
+    1.0 - 0.5_f32.powf(window.as_secs_f32() / half_life.as_secs_f32())
 }
 
 /// Identifies a map. Opaque to the matchmaker — only compared for equality when verifying that the
@@ -128,12 +96,12 @@ pub struct Player {
     pub server_pings: HashMap<u32, f32>,
 }
 
-/// Returns the conservative skill estimate: the player's rating minus k standard deviations.
-/// A player with high uncertainty will have a lower effective rating, meaning they can match
-/// against a wider range of opponents without the quality formula penalizing the match.
-fn effective_rating(player: &Player, mode: MatchmakingType) -> f32 {
+/// Returns the conservative skill estimate: the player's rating minus `uncertainty_k` standard
+/// deviations. A player with high uncertainty will have a lower effective rating, meaning they can
+/// match against a wider range of opponents without the quality formula penalizing the match.
+fn effective_rating(player: &Player, mode: MatchmakingType, uncertainty_k: f32) -> f32 {
     let mode_rating = player.ratings.get(&mode).copied().unwrap_or_default();
-    mode_rating.rating - UNCERTAINTY_K * mode_rating.uncertainty.unwrap_or(0.0)
+    mode_rating.rating - uncertainty_k * mode_rating.uncertainty.unwrap_or(0.0)
 }
 
 /// Estimates the one-way latency (ms) of a candidate match by reproducing the route selection the
@@ -180,7 +148,8 @@ fn match_latency(entries: &[&QueueEntry]) -> Option<f32> {
 }
 
 /// Converts an estimated one-way latency (ms) into the number of turn-rate "steps" it costs — the
-/// form the quality formula actually penalizes (see [`WEIGHT_LATENCY`]). Network latency only changes
+/// form the quality formula actually penalizes (weighted by the configurable `weight_latency`).
+/// Network latency only changes
 /// the play experience in discrete jumps: StarCraft holds a fixed turn rate / input buffer until
 /// latency crosses a threshold, then drops to a slower one. So a 30ms match and a 100ms match are
 /// equivalent, while a 200ms match is meaningfully worse. This reproduces the game's turn-rate
@@ -199,7 +168,10 @@ pub struct QueueEntry {
 #[derive(Debug, Clone)]
 pub struct Matchmaker<T: QueueSelector> {
     start: Instant,
-    max_players_examined: usize,
+    /// Runtime-tunable configuration (weights, adaptive-threshold knobs, max players examined). Read
+    /// fresh on each search tick and replaceable via [`Matchmaker::set_config`] so an admin change
+    /// takes effect without a restart.
+    config: Arc<MatchmakerConfig>,
     queue: Vec<QueueEntry>,
     queue_sizes: HashMap<MatchmakingType, usize>,
     /// Smoothed (EWMA) estimate of how many players have recently been queued for each mode, used to
@@ -290,8 +262,8 @@ impl QueueSelector for RandomQueueSelector {
 }
 
 impl Matchmaker<RandomQueueSelector> {
-    pub fn new(max_players_examined: usize) -> Matchmaker<RandomQueueSelector> {
-        Matchmaker::with_queue_selector(max_players_examined, RandomQueueSelector)
+    pub fn new(config: Arc<MatchmakerConfig>) -> Matchmaker<RandomQueueSelector> {
+        Matchmaker::with_queue_selector(config, RandomQueueSelector)
     }
 }
 
@@ -299,14 +271,14 @@ impl Matchmaker<RandomQueueSelector> {
 /// weight things such that more skilled players influence the resulting rating more than less
 /// skilled ones. Note that this differs from how we determine this in rating change calculations,
 /// because this method would be inflationary there.
-fn get_team_rating(team: &[&QueueEntry], mode: MatchmakingType) -> f32 {
+fn get_team_rating(team: &[&QueueEntry], mode: MatchmakingType, uncertainty_k: f32) -> f32 {
     if team.len() == 1 {
-        effective_rating(&team[0].player, mode)
+        effective_rating(&team[0].player, mode, uncertainty_k)
     } else {
         let sum: f32 = team
             .iter()
             .map(|q| {
-                let r = effective_rating(&q.player, mode);
+                let r = effective_rating(&q.player, mode, uncertainty_k);
                 r * r
             })
             .sum();
@@ -336,11 +308,11 @@ fn selections_share_a_map(selections: &[&Vec<MapId>]) -> bool {
 }
 
 impl<T: QueueSelector> Matchmaker<T> {
-    fn with_queue_selector(max_players_examined: usize, queue_selector: T) -> Matchmaker<T> {
+    fn with_queue_selector(config: Arc<MatchmakerConfig>, queue_selector: T) -> Matchmaker<T> {
         let start = Instant::now();
         Self {
             start,
-            max_players_examined,
+            config,
             queue: Vec::new(),
             queue_sizes: HashMap::new(),
             population_estimate: HashMap::new(),
@@ -348,6 +320,12 @@ impl<T: QueueSelector> Matchmaker<T> {
             population_window_start: start,
             queue_selector,
         }
+    }
+
+    /// Replaces the active configuration (e.g. after an admin edits the matchmaker knobs). Takes
+    /// effect on the next search tick; the queue and population history are untouched.
+    pub fn set_config(&mut self, config: Arc<MatchmakerConfig>) {
+        self.config = config;
     }
 
     /// Returns the instant at which this matchmaker was created. Queue times in serialized tickets
@@ -438,8 +416,8 @@ impl<T: QueueSelector> Matchmaker<T> {
     /// Folds any elapsed sampling windows into the smoothed per-mode population estimate. The search
     /// loop calls this once per tick; for each whole [`POPULATION_WINDOW`] that has passed since the
     /// last fold, that window's peak concurrent queue size is blended into an exponential moving
-    /// average (factor [`population_alpha`], derived from [`POPULATION_HALF_LIFE`]) and the peak is
-    /// reset to the live queue size for the next window.
+    /// average (factor [`ewma_alpha`], derived from each mode's configured `population_half_life`) and
+    /// the peak is reset to the live queue size for the next window.
     ///
     /// Sampling the *window peak* rather than the instantaneous queue size is the whole point: the
     /// matchmaker removes every match it forms each tick, so the instantaneous size sits near the
@@ -447,9 +425,12 @@ impl<T: QueueSelector> Matchmaker<T> {
     /// captures the players who passed through the window, and the EWMA decays toward 0 across idle
     /// windows so the threshold still relaxes during a genuine dead hour.
     pub fn update_population_estimates(&mut self, now: Instant) {
-        let alpha = population_alpha();
         while now.duration_since(self.population_window_start) >= POPULATION_WINDOW {
             for mode in MatchmakingType::iter() {
+                let alpha = ewma_alpha(
+                    self.config.for_mode(mode).population_half_life,
+                    POPULATION_WINDOW,
+                );
                 let peak = self.population_peak.get(&mode).copied().unwrap_or(0) as f32;
                 match self.population_estimate.entry(mode) {
                     std::collections::hash_map::Entry::Occupied(mut e) => {
@@ -485,11 +466,13 @@ impl<T: QueueSelector> Matchmaker<T> {
         self.population_estimate.get(&mode).copied()
     }
 
-    /// The minimum quality a match in `mode` must reach to form right now. Equal to `min_quality`
-    /// when the mode's smoothed population is comfortable, and relaxed by [`ADAPTIVE_DECAY_PER_MISSING`]
-    /// seconds per player below the comfortable population so matches still form when few are around.
-    pub fn effective_min_quality(&self, mode: MatchmakingType, min_quality: f32) -> f32 {
-        let comfortable = (mode.total_players() * ADAPTIVE_COMFORTABLE_MULTIPLIER) as f32;
+    /// The minimum quality a match in `mode` must reach to form right now. Equal to the mode's
+    /// configured `min_quality` when its smoothed population is comfortable, and relaxed by
+    /// `adaptive_decay_per_missing` seconds per player below the comfortable population so matches
+    /// still form when few are around.
+    pub fn effective_min_quality(&self, mode: MatchmakingType) -> f32 {
+        let cfg = self.config.for_mode(mode);
+        let comfortable = (mode.total_players() * cfg.adaptive_comfortable_multiplier) as f32;
         // Until the first window folds (e.g. the first minute after a restart) the smoothed estimate
         // is absent; fall back to the current window's peak so a healthy queue isn't mistaken for zero
         // population and maximally relaxed. Using the peak rather than the live size keeps this
@@ -501,31 +484,26 @@ impl<T: QueueSelector> Matchmaker<T> {
             .or_else(|| self.population_peak.get(&mode).map(|&p| p as f32))
             .unwrap_or(0.0);
         if population < comfortable {
-            min_quality - ADAPTIVE_DECAY_PER_MISSING * (comfortable - population)
+            cfg.min_quality - cfg.adaptive_decay_per_missing * (comfortable - population)
         } else {
-            min_quality
+            cfg.min_quality
         }
     }
 
     /// Finds matches for all modes, returning a Vec the proposed matches. Matches will be returned
     /// ordered by [MatchmakingType] and then the value of that match (so "better" matches will
-    /// appear first). Only matches of at least `min_quality` quality will be returned.
-    pub fn find_matches(&self, min_quality: f32, now: Instant) -> Vec<Match> {
+    /// appear first). Only matches reaching each mode's adaptive minimum quality are returned.
+    pub fn find_matches(&self, now: Instant) -> Vec<Match> {
         let mut modes = MatchmakingType::iter().collect::<Vec<_>>();
         modes.shuffle(&mut rand::rng());
-        self.find_matches_for_modes(&modes, min_quality, now)
+        self.find_matches_for_modes(&modes, now)
     }
 
     /// Finds matches for the given [MatchmakingType]s, returning a Vec of the proposed matches.
     /// Matches will be returned ordered by [MatchmakingType] (in the order given) and then the
-    /// value of that match (so "better" matches will appear first). Only matches of at least
-    /// `min_quality` quality will be returned.
-    pub fn find_matches_for_modes(
-        &self,
-        modes: &[MatchmakingType],
-        min_quality: f32,
-        now: Instant,
-    ) -> Vec<Match> {
+    /// value of that match (so "better" matches will appear first). Only matches reaching each mode's
+    /// adaptive minimum quality (see [`Self::effective_min_quality`]) are returned.
+    pub fn find_matches_for_modes(&self, modes: &[MatchmakingType], now: Instant) -> Vec<Match> {
         let mut matches = Vec::new();
 
         for mode in modes {
@@ -536,7 +514,8 @@ impl<T: QueueSelector> Matchmaker<T> {
                 continue;
             }
 
-            let effective_min = self.effective_min_quality(*mode, min_quality);
+            let mode_cfg = self.config.for_mode(*mode);
+            let effective_min = self.effective_min_quality(*mode);
 
             // Only look at players queued for this mode
             let mode_queue = self.queue.iter().filter(|e| e.modes.contains(*mode));
@@ -544,7 +523,7 @@ impl<T: QueueSelector> Matchmaker<T> {
             // matches we need to examine
             let selected = self
                 .queue_selector
-                .select(mode_queue, self.max_players_examined);
+                .select(mode_queue, self.config.max_players_examined);
 
             let mode_matches = selected
                 .iter()
@@ -586,7 +565,7 @@ impl<T: QueueSelector> Matchmaker<T> {
                         }
                         // Calculate variance with Welford's algorithm over effective ratings
                         count += 1;
-                        let r = effective_rating(&q.player, *mode);
+                        let r = effective_rating(&q.player, *mode, mode_cfg.uncertainty_k);
                         let delta = r - mean;
                         mean += delta / count as f32;
                         m2 += delta * (r - mean);
@@ -610,8 +589,10 @@ impl<T: QueueSelector> Matchmaker<T> {
                                     .copied()
                                     .collect::<Vec<_>>();
 
-                                let rating_a = get_team_rating(&team_a, *mode);
-                                let rating_b = get_team_rating(&team_b, *mode);
+                                let rating_a =
+                                    get_team_rating(&team_a, *mode, mode_cfg.uncertainty_k);
+                                let rating_b =
+                                    get_team_rating(&team_b, *mode, mode_cfg.uncertainty_k);
 
                                 ((rating_a - rating_b).abs(), team_a, team_b)
                             })
@@ -621,15 +602,15 @@ impl<T: QueueSelector> Matchmaker<T> {
                     };
 
                     // Calculate the win probability for team_a vs team_b
-                    let rating_a = get_team_rating(&team_a, *mode);
-                    let rating_b = get_team_rating(&team_b, *mode);
+                    let rating_a = get_team_rating(&team_a, *mode, mode_cfg.uncertainty_k);
+                    let rating_b = get_team_rating(&team_b, *mode, mode_cfg.uncertainty_k);
                     let win_prob = get_win_probability(rating_a, rating_b);
                     let win_prob_diff = (0.5 - win_prob).abs();
 
                     let quality = wait_time.as_secs_f32()
-                        - (WEIGHT_RATING_VARIANCE * variance
-                            + WEIGHT_WIN_PROB * win_prob_diff
-                            + WEIGHT_LATENCY * latency_value(max_latency));
+                        - (mode_cfg.weight_rating_variance * variance
+                            + mode_cfg.weight_win_prob * win_prob_diff
+                            + mode_cfg.weight_latency * latency_value(max_latency));
 
                     // Filter any matches that are too low quality
                     if quality >= effective_min {
@@ -661,8 +642,33 @@ impl<T: QueueSelector> Matchmaker<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::matchmaking::config::ModeConfig;
     use std::collections::HashMap;
     use std::time::Duration;
+
+    /// Built-in defaults (min_quality −30, today's weights). Used by tests that exercise the adaptive
+    /// threshold itself.
+    fn default_config() -> Arc<MatchmakerConfig> {
+        Arc::new(MatchmakerConfig::default())
+    }
+
+    /// A config whose `min_quality` is so low it never blocks a match, so tests can exercise the
+    /// matching/teaming/latency logic without the quality threshold getting in the way (the old
+    /// behaviour of passing `f32::NEG_INFINITY` as the threshold).
+    fn permissive_config() -> Arc<MatchmakerConfig> {
+        Arc::new(MatchmakerConfig::from_global(ModeConfig {
+            min_quality: f32::NEG_INFINITY,
+            ..Default::default()
+        }))
+    }
+
+    /// A config with a specific global `min_quality` and defaults otherwise.
+    fn config_with_min_quality(min_quality: f32) -> Arc<MatchmakerConfig> {
+        Arc::new(MatchmakerConfig::from_global(ModeConfig {
+            min_quality,
+            ..Default::default()
+        }))
+    }
 
     /// A [QueueSelector] that just takes the front `amount` players from the queue.
     pub struct TestQueueSelector;
@@ -716,22 +722,21 @@ mod tests {
 
     #[test]
     fn not_enough_players() {
-        let mut matchmaker = Matchmaker::with_queue_selector(16, TestQueueSelector);
+        let mut matchmaker =
+            Matchmaker::with_queue_selector(permissive_config(), TestQueueSelector);
         matchmaker
             .insert_player(make_player(0, 1000.0, MatchmakingType::Match1v1))
             .unwrap();
 
-        let result = matchmaker.find_matches_for_modes(
-            &[MatchmakingType::Match1v1],
-            f32::NEG_INFINITY,
-            Instant::now(),
-        );
+        let result =
+            matchmaker.find_matches_for_modes(&[MatchmakingType::Match1v1], Instant::now());
         assert!(result.is_empty());
     }
 
     #[test]
     fn exact_number_of_players() {
-        let mut matchmaker = Matchmaker::with_queue_selector(16, TestQueueSelector);
+        let mut matchmaker =
+            Matchmaker::with_queue_selector(permissive_config(), TestQueueSelector);
         matchmaker
             .insert_player(make_player(0, 1000.0, MatchmakingType::Match1v1))
             .unwrap();
@@ -744,11 +749,8 @@ mod tests {
             Some(&2)
         );
 
-        let result = matchmaker.find_matches_for_modes(
-            &[MatchmakingType::Match1v1],
-            f32::NEG_INFINITY,
-            Instant::now(),
-        );
+        let result =
+            matchmaker.find_matches_for_modes(&[MatchmakingType::Match1v1], Instant::now());
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].mode, MatchmakingType::Match1v1);
         assert_eq!(
@@ -771,7 +773,8 @@ mod tests {
 
     #[test]
     fn finds_all_modes_in_order() {
-        let mut matchmaker = Matchmaker::with_queue_selector(16, TestQueueSelector);
+        let mut matchmaker =
+            Matchmaker::with_queue_selector(permissive_config(), TestQueueSelector);
         matchmaker
             .insert_player(make_multi_player(
                 0,
@@ -789,7 +792,6 @@ mod tests {
 
         let result = matchmaker.find_matches_for_modes(
             &[MatchmakingType::Match1v1Fastest, MatchmakingType::Match1v1],
-            f32::NEG_INFINITY,
             Instant::now(),
         );
         assert_eq!(result.len(), 2);
@@ -834,7 +836,8 @@ mod tests {
     #[test]
     fn requeue() {
         let start = Instant::now();
-        let mut matchmaker = Matchmaker::with_queue_selector(16, TestQueueSelector);
+        let mut matchmaker =
+            Matchmaker::with_queue_selector(permissive_config(), TestQueueSelector);
         matchmaker
             .insert_player(make_player(0, 1000.0, MatchmakingType::Match1v1))
             .unwrap();
@@ -847,11 +850,8 @@ mod tests {
             Some(&2)
         );
 
-        let result = matchmaker.find_matches_for_modes(
-            &[MatchmakingType::Match1v1],
-            f32::NEG_INFINITY,
-            Instant::now(),
-        );
+        let result =
+            matchmaker.find_matches_for_modes(&[MatchmakingType::Match1v1], Instant::now());
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].mode, MatchmakingType::Match1v1);
         assert_eq!(
@@ -874,7 +874,8 @@ mod tests {
 
     #[test]
     fn insert_player_new_player_succeeds() {
-        let mut matchmaker = Matchmaker::with_queue_selector(16, TestQueueSelector);
+        let mut matchmaker =
+            Matchmaker::with_queue_selector(permissive_config(), TestQueueSelector);
         let result = matchmaker.insert_player(make_player(0, 1000.0, MatchmakingType::Match1v1));
         assert!(result.is_ok());
         assert_eq!(
@@ -885,7 +886,8 @@ mod tests {
 
     #[test]
     fn insert_player_duplicate_fails() {
-        let mut matchmaker = Matchmaker::with_queue_selector(16, TestQueueSelector);
+        let mut matchmaker =
+            Matchmaker::with_queue_selector(permissive_config(), TestQueueSelector);
         matchmaker
             .insert_player(make_player(0, 1000.0, MatchmakingType::Match1v1))
             .unwrap();
@@ -900,7 +902,8 @@ mod tests {
 
     #[test]
     fn requeue_duplicate_fails() {
-        let mut matchmaker = Matchmaker::with_queue_selector(16, TestQueueSelector);
+        let mut matchmaker =
+            Matchmaker::with_queue_selector(permissive_config(), TestQueueSelector);
         matchmaker
             .insert_player(make_player(0, 1000.0, MatchmakingType::Match1v1))
             .unwrap();
@@ -964,7 +967,7 @@ mod tests {
         // Simulate what api.rs does: take an Instant, convert to millis relative to matchmaker.start
         // (as stored in the ticket), then convert back. The round-trip should not lose more than
         // 1ms of precision.
-        let matchmaker = Matchmaker::with_queue_selector(16, TestQueueSelector);
+        let matchmaker = Matchmaker::with_queue_selector(permissive_config(), TestQueueSelector);
         let original = Instant::now();
         let millis = original.duration_since(matchmaker.start()).as_millis() as u64;
         let recovered = matchmaker.start() + Duration::from_millis(millis);
@@ -1002,7 +1005,8 @@ mod tests {
 
     #[test]
     fn find_matches_with_latency_penalty() {
-        let mut matchmaker = Matchmaker::with_queue_selector(16, TestQueueSelector);
+        let mut matchmaker =
+            Matchmaker::with_queue_selector(config_with_min_quality(-85.0), TestQueueSelector);
         // Both players ping rally-point server 0 at 200ms round-trip. The match's only pair shares
         // that server, so combined = 400ms and estimated one-way latency = 200ms.
         matchmaker
@@ -1034,22 +1038,24 @@ mod tests {
         //
         // min_quality = -85.0 → quality (-90.0) < effective_min (-85.0) → match rejected.
         let result_strict =
-            matchmaker.find_matches_for_modes(&[MatchmakingType::Match1v1], -85.0, Instant::now());
+            matchmaker.find_matches_for_modes(&[MatchmakingType::Match1v1], Instant::now());
         assert!(
             result_strict.is_empty(),
             "expected no match when min_quality (-85.0) exceeds quality (-90.0) at 200ms latency"
         );
 
         // min_quality = -95.0 → quality (-90.0) >= effective_min (-95.0) → match forms.
+        matchmaker.set_config(config_with_min_quality(-95.0));
         let result_lenient =
-            matchmaker.find_matches_for_modes(&[MatchmakingType::Match1v1], -95.0, Instant::now());
+            matchmaker.find_matches_for_modes(&[MatchmakingType::Match1v1], Instant::now());
         assert_eq!(result_lenient.len(), 1);
         assert_eq!(result_lenient[0].max_latency, 200.0);
     }
 
     #[test]
     fn find_matches_no_ping_data_treated_as_zero() {
-        let mut matchmaker = Matchmaker::with_queue_selector(16, TestQueueSelector);
+        let mut matchmaker =
+            Matchmaker::with_queue_selector(permissive_config(), TestQueueSelector);
         matchmaker
             .insert_player(make_player(0, 1000.0, MatchmakingType::Match1v1))
             .unwrap();
@@ -1060,18 +1066,16 @@ mod tests {
         // Defensive: players are required to have pings before queueing, but if a player somehow
         // carries none, latency is unknown and no penalty is applied rather than blocking the match.
         // With equal ratings: variance ≈ 0, win_prob_diff ≈ 0. Quality ≈ 0.
-        let result = matchmaker.find_matches_for_modes(
-            &[MatchmakingType::Match1v1],
-            f32::NEG_INFINITY,
-            Instant::now(),
-        );
+        let result =
+            matchmaker.find_matches_for_modes(&[MatchmakingType::Match1v1], Instant::now());
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].max_latency, 0.0);
     }
 
     #[test]
     fn latency_picks_lowest_combined_server() {
-        let mut matchmaker = Matchmaker::with_queue_selector(16, TestQueueSelector);
+        let mut matchmaker =
+            Matchmaker::with_queue_selector(permissive_config(), TestQueueSelector);
         // Player 0 is closest to server 1, player 1 is closest to server 2, but the cheapest server
         // they *share* is server 0 (combined 80ms → 40ms one-way). The lopsided servers must not be
         // chosen since the other player pings them poorly.
@@ -1090,18 +1094,16 @@ mod tests {
             ))
             .unwrap();
 
-        let result = matchmaker.find_matches_for_modes(
-            &[MatchmakingType::Match1v1],
-            f32::NEG_INFINITY,
-            Instant::now(),
-        );
+        let result =
+            matchmaker.find_matches_for_modes(&[MatchmakingType::Match1v1], Instant::now());
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].max_latency, 40.0);
     }
 
     #[test]
     fn latency_no_shared_server_rejects_match() {
-        let mut matchmaker = Matchmaker::with_queue_selector(16, TestQueueSelector);
+        let mut matchmaker =
+            Matchmaker::with_queue_selector(permissive_config(), TestQueueSelector);
         // Both players have pings, but to disjoint servers. The game loader's `createBestRoute` could
         // not pick a server both can use, so the launch would fail; the matchmaker must not form this
         // match (even at the most lenient quality threshold) rather than repeatedly matching the same
@@ -1121,11 +1123,8 @@ mod tests {
             ))
             .unwrap();
 
-        let result = matchmaker.find_matches_for_modes(
-            &[MatchmakingType::Match1v1],
-            f32::NEG_INFINITY,
-            Instant::now(),
-        );
+        let result =
+            matchmaker.find_matches_for_modes(&[MatchmakingType::Match1v1], Instant::now());
         assert!(
             result.is_empty(),
             "expected no match when players share no pinged rally-point server",
@@ -1134,7 +1133,8 @@ mod tests {
 
     #[test]
     fn latency_unrouteable_pair_rejects_team_match() {
-        let mut matchmaker = Matchmaker::with_queue_selector(16, TestQueueSelector);
+        let mut matchmaker =
+            Matchmaker::with_queue_selector(permissive_config(), TestQueueSelector);
         // A 2v2 where three players share server 0 but player 2 only pinged server 1. Every team
         // split still leaves at least one pair involving player 2 with no shared server, so the match
         // is unrouteable regardless of how teams are formed and must be rejected.
@@ -1167,11 +1167,8 @@ mod tests {
             ))
             .unwrap();
 
-        let result = matchmaker.find_matches_for_modes(
-            &[MatchmakingType::Match2v2],
-            f32::NEG_INFINITY,
-            Instant::now(),
-        );
+        let result =
+            matchmaker.find_matches_for_modes(&[MatchmakingType::Match2v2], Instant::now());
         assert!(
             result.is_empty(),
             "expected no match when a player pair shares no pinged rally-point server",
@@ -1180,7 +1177,8 @@ mod tests {
 
     #[test]
     fn latency_team_mode_uses_worst_pair_across_all_pairs() {
-        let mut matchmaker = Matchmaker::with_queue_selector(16, TestQueueSelector);
+        let mut matchmaker =
+            Matchmaker::with_queue_selector(permissive_config(), TestQueueSelector);
         // A 2v2 has six pairwise links. Three players ping server 0 at 20ms; player 2 pings it at
         // 200ms. The worst link is therefore any pair involving player 2: (20 + 200) / 2 = 110ms.
         // Latency is independent of how the matcher splits the teams — it's the worst pair overall.
@@ -1213,11 +1211,8 @@ mod tests {
             ))
             .unwrap();
 
-        let result = matchmaker.find_matches_for_modes(
-            &[MatchmakingType::Match2v2],
-            f32::NEG_INFINITY,
-            Instant::now(),
-        );
+        let result =
+            matchmaker.find_matches_for_modes(&[MatchmakingType::Match2v2], Instant::now());
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].max_latency, 110.0);
     }
@@ -1257,15 +1252,11 @@ mod tests {
             server_pings: HashMap::new(),
         };
 
-        let mut mm = Matchmaker::with_queue_selector(16, TestQueueSelector);
+        let mut mm = Matchmaker::with_queue_selector(permissive_config(), TestQueueSelector);
         mm.insert_player(uncertain).unwrap();
         mm.insert_player(certain).unwrap();
 
-        let result = mm.find_matches_for_modes(
-            &[MatchmakingType::Match1v1],
-            f32::NEG_INFINITY,
-            Instant::now(),
-        );
+        let result = mm.find_matches_for_modes(&[MatchmakingType::Match1v1], Instant::now());
         assert_eq!(result.len(), 1);
         // Quality is significantly negative at t=0 due to variance penalty from σ=350
         assert!(
@@ -1280,7 +1271,8 @@ mod tests {
         // Player A queued for 1v1 (rating 1500) and Fastest (rating 500)
         // Player B queued for 1v1 (rating 1500) and Fastest (rating 500)
         // They should match in both modes with near-zero quality penalty (equal ratings)
-        let mut matchmaker = Matchmaker::with_queue_selector(16, TestQueueSelector);
+        let mut matchmaker =
+            Matchmaker::with_queue_selector(permissive_config(), TestQueueSelector);
         let player_a = Player {
             id: 0,
             ratings: HashMap::from([
@@ -1329,7 +1321,6 @@ mod tests {
         // Both modes match. With equal ratings in each mode, quality penalty is near zero.
         let result = matchmaker.find_matches_for_modes(
             &[MatchmakingType::Match1v1, MatchmakingType::Match1v1Fastest],
-            f32::NEG_INFINITY,
             Instant::now(),
         );
         assert_eq!(result.len(), 2);
@@ -1365,7 +1356,8 @@ mod tests {
 
     #[test]
     fn pick_mode_does_not_match_disjoint_map_selections() {
-        let mut matchmaker = Matchmaker::with_queue_selector(16, TestQueueSelector);
+        let mut matchmaker =
+            Matchmaker::with_queue_selector(permissive_config(), TestQueueSelector);
         matchmaker
             .insert_player(make_player_with_maps(
                 0,
@@ -1385,17 +1377,15 @@ mod tests {
 
         // Even at the most lenient quality, players who share no map must not be matched (the match
         // map could not be chosen and the match would fail to start).
-        let result = matchmaker.find_matches_for_modes(
-            &[MatchmakingType::Match1v1],
-            f32::NEG_INFINITY,
-            Instant::now(),
-        );
+        let result =
+            matchmaker.find_matches_for_modes(&[MatchmakingType::Match1v1], Instant::now());
         assert!(result.is_empty());
     }
 
     #[test]
     fn pick_mode_matches_when_selections_share_a_map() {
-        let mut matchmaker = Matchmaker::with_queue_selector(16, TestQueueSelector);
+        let mut matchmaker =
+            Matchmaker::with_queue_selector(permissive_config(), TestQueueSelector);
         matchmaker
             .insert_player(make_player_with_maps(
                 0,
@@ -1413,38 +1403,35 @@ mod tests {
             ))
             .unwrap();
 
-        let result = matchmaker.find_matches_for_modes(
-            &[MatchmakingType::Match1v1],
-            f32::NEG_INFINITY,
-            Instant::now(),
-        );
+        let result =
+            matchmaker.find_matches_for_modes(&[MatchmakingType::Match1v1], Instant::now());
         assert_eq!(result.len(), 1);
     }
 
     #[test]
     fn effective_min_relaxes_only_when_smoothed_population_low() {
-        let mut mm = Matchmaker::with_queue_selector(16, TestQueueSelector);
+        let mut mm = Matchmaker::with_queue_selector(default_config(), TestQueueSelector);
         let mode = MatchmakingType::Match1v1; // total_players 2 → comfortable 4
 
         // No population history yet: treated as 0 → maximally relaxed.
-        assert_eq!(mm.effective_min_quality(mode, -30.0), -30.0 - 15.0 * 4.0);
+        assert_eq!(mm.effective_min_quality(mode), -30.0 - 15.0 * 4.0);
 
         // Comfortably populated → no relaxation.
         mm.population_estimate.insert(mode, 10.0);
-        assert_eq!(mm.effective_min_quality(mode, -30.0), -30.0);
+        assert_eq!(mm.effective_min_quality(mode), -30.0);
 
         // Exactly at the comfortable line → no relaxation.
         mm.population_estimate.insert(mode, 4.0);
-        assert_eq!(mm.effective_min_quality(mode, -30.0), -30.0);
+        assert_eq!(mm.effective_min_quality(mode), -30.0);
 
         // Persistently low population → partial relaxation (1 player short of comfortable).
         mm.population_estimate.insert(mode, 3.0);
-        assert_eq!(mm.effective_min_quality(mode, -30.0), -30.0 - 15.0 * 1.0);
+        assert_eq!(mm.effective_min_quality(mode), -30.0 - 15.0 * 1.0);
     }
 
     #[test]
     fn population_falls_back_to_window_peak_before_first_fold() {
-        let mut mm = Matchmaker::with_queue_selector(16, TestQueueSelector);
+        let mut mm = Matchmaker::with_queue_selector(default_config(), TestQueueSelector);
         let mode = MatchmakingType::Match1v1; // comfortable 4
 
         // A healthy queue forms right after a (re)start, before any window has folded — the smoothed
@@ -1453,19 +1440,19 @@ mod tests {
             mm.insert_player(make_player(i, 1500.0, mode)).unwrap();
         }
         assert!(!mm.population_estimate.contains_key(&mode));
-        assert_eq!(mm.effective_min_quality(mode, -30.0), -30.0);
+        assert_eq!(mm.effective_min_quality(mode), -30.0);
 
         // Draining the queue during the warmup window must not relax it either — the peak holds.
         for i in 0..4 {
             mm.remove_player(i);
         }
         assert_eq!(mm.queue_sizes.get(&mode), Some(&2));
-        assert_eq!(mm.effective_min_quality(mode, -30.0), -30.0);
+        assert_eq!(mm.effective_min_quality(mode), -30.0);
     }
 
     #[test]
     fn population_estimate_uses_window_peak_not_instantaneous() {
-        let mut mm = Matchmaker::with_queue_selector(16, TestQueueSelector);
+        let mut mm = Matchmaker::with_queue_selector(default_config(), TestQueueSelector);
         let mode = MatchmakingType::Match1v1; // comfortable 4
         let start = mm.start();
 
@@ -1489,12 +1476,12 @@ mod tests {
         // Despite the instantaneous queue being below comfortable, the smoothed population is still
         // high, so the threshold stays strict. Keying off the instantaneous size — the old bug —
         // would relax it here even though the population is healthy.
-        assert_eq!(mm.effective_min_quality(mode, -30.0), -30.0);
+        assert_eq!(mm.effective_min_quality(mode), -30.0);
     }
 
     #[test]
     fn population_estimate_decays_across_idle_windows() {
-        let mut mm = Matchmaker::with_queue_selector(16, TestQueueSelector);
+        let mut mm = Matchmaker::with_queue_selector(permissive_config(), TestQueueSelector);
         let mode = MatchmakingType::Match1v1;
         let start = mm.start();
 
@@ -1514,8 +1501,12 @@ mod tests {
         assert!((mm.population_estimate[&mode] - 4.0).abs() < 1e-4);
 
         // Subsequent idle windows have peak 0 and decay the estimate by the per-window retention
-        // factor (1 - alpha) each, where alpha is derived from POPULATION_HALF_LIFE.
-        let retention = 1.0 - population_alpha();
+        // factor (1 - alpha) each, where alpha is derived from the mode's population half-life.
+        let retention = 1.0
+            - ewma_alpha(
+                ModeConfig::default().population_half_life,
+                POPULATION_WINDOW,
+            );
         mm.update_population_estimates(start + 3 * POPULATION_WINDOW);
         assert!((mm.population_estimate[&mode] - 4.0 * retention).abs() < 1e-4);
         mm.update_population_estimates(start + 4 * POPULATION_WINDOW);
@@ -1524,15 +1515,16 @@ mod tests {
 
     #[test]
     fn population_half_life_matches_decay() {
-        // One half-life of idle windows should decay the estimate to half. Guards against
-        // POPULATION_HALF_LIFE and POPULATION_WINDOW drifting out of the alpha derivation.
-        let mut mm = Matchmaker::with_queue_selector(16, TestQueueSelector);
+        // One half-life of idle windows should decay the estimate to half. Guards against the
+        // half-life and POPULATION_WINDOW drifting out of the alpha derivation.
+        let mut mm = Matchmaker::with_queue_selector(permissive_config(), TestQueueSelector);
         let mode = MatchmakingType::Match1v1;
+        let half_life = ModeConfig::default().population_half_life;
         let start = mm.start();
 
         mm.population_estimate.insert(mode, 8.0);
         // Park the window start so exactly the windows we fold below have elapsed.
-        let windows = (POPULATION_HALF_LIFE.as_secs() / POPULATION_WINDOW.as_secs()) as u32;
+        let windows = (half_life.as_secs() / POPULATION_WINDOW.as_secs()) as u32;
         for w in 1..=windows {
             mm.update_population_estimates(start + w * POPULATION_WINDOW);
         }

--- a/server-rs/src/matchmaking/metrics.rs
+++ b/server-rs/src/matchmaking/metrics.rs
@@ -97,7 +97,7 @@ pub fn describe_metrics() {
 /// Samples the per-mode queue gauges. Call once per search tick while holding the matchmaker lock,
 /// after the population estimate has been rolled forward and *before* the queue is drained, so the
 /// gauges reflect everyone waiting this tick rather than the post-drain residual.
-pub fn sample_queue_state<T: QueueSelector>(matchmaker: &Matchmaker<T>, min_quality: f32) {
+pub fn sample_queue_state<T: QueueSelector>(matchmaker: &Matchmaker<T>) {
     for mode in MatchmakingType::iter() {
         let label = mode.as_str();
         ::metrics::gauge!(QUEUE_SIZE, "mode" => label).set(matchmaker.queue_size(mode) as f64);
@@ -107,7 +107,7 @@ pub fn sample_queue_state<T: QueueSelector>(matchmaker: &Matchmaker<T>, min_qual
             ::metrics::gauge!(POPULATION_ESTIMATE, "mode" => label).set(estimate as f64);
         }
         ::metrics::gauge!(EFFECTIVE_MIN_QUALITY, "mode" => label)
-            .set(matchmaker.effective_min_quality(mode, min_quality) as f64);
+            .set(matchmaker.effective_min_quality(mode) as f64);
     }
 }
 

--- a/server-rs/src/matchmaking/mod.rs
+++ b/server-rs/src/matchmaking/mod.rs
@@ -7,6 +7,7 @@ use typeshare::typeshare;
 use crate::users::SbUserId;
 
 pub mod api;
+pub mod config;
 pub mod matchmaker;
 mod metrics;
 

--- a/server-rs/src/routes.rs
+++ b/server-rs/src/routes.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 
+use arc_swap::ArcSwap;
 use async_graphql::extensions::Tracing;
 use async_graphql::http::ALL_WEBSOCKET_PROTOCOLS;
 use async_graphql_axum::{GraphQLProtocol, GraphQLRequest, GraphQLResponse, GraphQLWebSocket};
@@ -41,6 +42,7 @@ use crate::graphql::errors::ErrorLoggerExtension;
 use crate::graphql::schema_builder::SchemaBuilderModuleExt;
 use crate::maps::MapsModule;
 use crate::matchmaking::api::create_matchmaking_api;
+use crate::matchmaking::config::load_matchmaker_config;
 use crate::news::NewsModule;
 use crate::redis::RedisPool;
 use crate::schema::{SbSchema, build_schema};
@@ -158,7 +160,12 @@ pub async fn create_app(
         .route("/", get(|| async move { metric_handle.render() }))
         .layer(middleware::from_fn(only_unforwarded_clients));
     let names_router = create_names_api().layer(middleware::from_fn(only_unforwarded_clients));
-    let matchmaker_router = create_matchmaking_api(redis_pool.clone())
+    // Load the runtime matchmaker config from the DB into a swappable handle the search loop reads
+    // each tick. Falls back to built-in defaults if the row is missing/unparseable.
+    let matchmaker_config = Arc::new(ArcSwap::from_pointee(
+        load_matchmaker_config(&db_pool).await,
+    ));
+    let matchmaker_router = create_matchmaking_api(redis_pool.clone(), matchmaker_config)
         .layer(middleware::from_fn(only_unforwarded_clients));
 
     let app_state = AppState {


### PR DESCRIPTION
## What & why

Foundation for runtime-tunable matchmaker knobs: moves the matchmaker's tuning constants
(quality-formula weights, the adaptive-threshold knobs, uncertainty K, population half-life, search
interval, max players examined) out of compile-time `const`s and into a `matchmaking_config` DB row
that server-rs loads at startup, so they can be adjusted without a code change/release.

This is the **plumbing only** — there's no admin UI yet, and the seeded config is empty so every
value equals today's defaults. The admin write path (permission + GraphQL mutation + client page) is
the next PR.

> **Stacked on #1321** (base branch `matchmaker-observability`) — the config refactor touches the
> same matchmaker methods the metrics in #1321 call, so building them together keeps everything
> compiling. I'll retarget this to `master` once #1321 merges.

## Model

- `matchmaking_config`: a singleton (`id = 1`) JSONB row, seeded empty.
- `MatchmakerConfig` / `ModeConfig` with `Default` impls that mirror the former constants.
- The stored JSON holds **only overrides**; absent fields fall back to the defaults. **Global
  defaults + sparse per-mode overrides** (`{ "global": {...}, "perMode": { "3v3bgh": {...} } }`).
- **Can't be bricked:** a missing / unparseable / out-of-range config falls back to defaults, and
  every value is clamped to a sane range on load. Covered by unit tests (empty → defaults, unknown
  fields ignored, global + per-mode layering, clamping).

## Wiring

- Loaded from the DB at boot in `create_app` into an `Arc<ArcSwap<MatchmakerConfig>>`.
- The search loop reads the handle and pushes it into the matchmaker **each tick**, so a future admin
  edit (PR #3) takes effect without a restart. (The search *interval* is read once at boot — changing
  it still needs a restart, since it rebuilds the timer.)
- `POPULATION_WINDOW` stays a constant (sampling granularity); the EWMA time constant is now the
  per-mode, configurable `population_half_life`.

## Verification

- Behaviour-preserving: with the default config, the live `matchmaker_effective_min_quality` gauges
  still read `-90` / `-150` / `-210` for 1v1 / 2v2 / 3v3 — identical to before — confirmed by booting
  server-rs against the seeded row and scraping `/metrics`.
- `cargo clippy --all-targets -- -D warnings` clean, 32 matchmaking tests pass (26 + 6 new config
  tests), `cargo fmt --check` clean. `pnpm sqlx-prepare` offline data committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PGFEvxMMVHCoY57RtiX3Tm
