### PR TITLE
Persist matchmaker formation telemetry for matches that fail to start

### DIFF
--- a/docs/USEFUL_QUERIES.md
+++ b/docs/USEFUL_QUERIES.md
@@ -102,7 +102,8 @@ ORDER BY imbalance_bucket;
 A health check on what the matchmaker is actually shipping: how negative the quality scores are (how
 often the adaptive low-population threshold is carrying matches), and how much each penalty term
 (skill spread, win-probability imbalance, latency) contributes on average. Useful before changing any
-of the `WEIGHT_*` constants in `server-rs/src/matchmaking/matchmaker.rs`.
+of the `WEIGHT_*` constants in `server-rs/src/matchmaking/matchmaker.rs`. Scoped to matches that
+actually launched (`game_id IS NOT NULL`); the failed-to-start query below breaks down the rest.
 
 ```sql
 SELECT
@@ -115,6 +116,7 @@ SELECT
   -- max_latency is the estimated one-way latency (ms) of the match's worst pairwise link.
   round(avg(max_latency)::numeric, 2) AS avg_max_latency_ms
 FROM matchmaking_match_formations
+WHERE game_id IS NOT NULL
 GROUP BY matchmaking_type
 ORDER BY matchmaking_type;
 ```
@@ -204,32 +206,77 @@ GROUP BY matchmaking_type
 ORDER BY matchmaking_type;
 ```
 
-## Formed matches that never produced a completed game (failed-to-start proxy)
+## Formed-match start outcomes per mode (launched vs. failed by phase)
 
-A match that the matchmaker formed but that never resulted in a finished game — the players were
-removed from the queue, a game was created, but no results ever came back (failed to load, everyone
-bailed during the draft, etc.). A rising `never_completed_rate` for a mode points at a launch/draft
-problem rather than a matching one. Legacy `games.results` rows can be `{}` instead of an array, so
-the array shape is guarded explicitly.
+Of the matches the matchmaker actually formed, how many launched versus fell apart before the game
+started, broken down by the phase they failed in (`accepting` = ready-up declines/timeouts,
+`drafting` = race draft canceled, `loading` = game failed to load). A rising `failed_to_start_rate`
+for a mode points at a launch/draft problem rather than a matching one; which phase dominates says
+where to look. This is the durable counterpart to the live
+`shieldbattery_matchmaker_match_failed_total{phase=...}` counter.
+
+```sql
+SELECT
+  matchmaking_type,
+  count(*) AS formed,
+  count(*) FILTER (WHERE game_id IS NOT NULL) AS launched,
+  count(*) FILTER (WHERE fail_phase = 'accepting') AS failed_accepting,
+  count(*) FILTER (WHERE fail_phase = 'drafting') AS failed_drafting,
+  count(*) FILTER (WHERE fail_phase = 'loading') AS failed_loading,
+  round(
+    count(*) FILTER (WHERE fail_phase IS NOT NULL)::numeric / greatest(count(*), 1), 3
+  ) AS failed_to_start_rate
+FROM matchmaking_match_formations
+GROUP BY matchmaking_type
+ORDER BY matchmaking_type;
+```
+
+## What kind of matches fail to start (decision inputs of failed vs. launched)
+
+Joins each formed match's outcome back to the matchmaker decision that produced it, so a failed-start
+cohort can be compared to the launched one on the exact quality/win-probability/latency inputs. If, say,
+`loading` failures skew toward a much higher `avg_max_latency_ms` than launched matches, the problem is
+networking rather than the matcher; if failed matches cluster at very negative `avg_quality`, the
+adaptive threshold is forming matches nobody sticks around for.
+
+```sql
+SELECT
+  matchmaking_type,
+  CASE WHEN game_id IS NOT NULL THEN 'launched' ELSE fail_phase END AS outcome,
+  count(*) AS matches,
+  round(avg(quality)::numeric, 1) AS avg_quality,
+  round(avg(abs(0.5 - win_probability))::numeric, 3) AS avg_winprob_imbalance,
+  round(avg(max_latency)::numeric, 1) AS avg_max_latency_ms
+FROM matchmaking_match_formations
+GROUP BY matchmaking_type, outcome
+ORDER BY matchmaking_type, outcome;
+```
+
+## Launched matches that produced no game result
+
+The post-launch counterpart to the failed-to-start query: a match that loaded into a game, but that
+game never recorded a result (it crashed, everyone quit before it counted, etc.). A rising
+`no_result_rate` points at in-game problems rather than the matchmaker or the launch funnel. Scoped to
+launched matches (`game_id IS NOT NULL`); legacy `games.results` rows can be `{}` instead of an array,
+so the array shape is guarded explicitly.
 
 ```sql
 SELECT
   f.matchmaking_type,
-  count(*) AS formed,
+  count(*) AS launched,
   count(*) FILTER (
-    WHERE g.id IS NULL
-       OR jsonb_typeof(g.results) <> 'array'
+    WHERE jsonb_typeof(g.results) <> 'array'
        OR jsonb_array_length(g.results) = 0
-  ) AS never_completed,
+  ) AS no_result,
   round(
     count(*) FILTER (
-      WHERE g.id IS NULL
-         OR jsonb_typeof(g.results) <> 'array'
+      WHERE jsonb_typeof(g.results) <> 'array'
          OR jsonb_array_length(g.results) = 0
     )::numeric / greatest(count(*), 1), 3
-  ) AS never_completed_rate
+  ) AS no_result_rate
 FROM matchmaking_match_formations f
-LEFT JOIN games g ON g.id = f.game_id
+JOIN games g ON g.id = f.game_id
+WHERE f.game_id IS NOT NULL
 GROUP BY f.matchmaking_type
 ORDER BY f.matchmaking_type;
 ```

--- a/migrations/20260628120000_capture_failed_match_formations.sql
+++ b/migrations/20260628120000_capture_failed_match_formations.sql
@@ -28,3 +28,11 @@ ALTER TABLE matchmaking_match_formations
 
 ALTER TABLE matchmaking_match_formations
   ADD CONSTRAINT matchmaking_match_formations_game_id_key UNIQUE (game_id);
+
+-- Enforce the launched XOR failed invariant at the DB level: exactly one of game_id / fail_phase is
+-- set, so a row is either a launched match (joinable to its game) or a failed-to-start match (tagged
+-- with the phase it fell apart in) — never both or neither. Mirrors the TS union that guards the two
+-- insert call sites, and keeps the `outcome` queries honest even if a future caller gets it wrong.
+ALTER TABLE matchmaking_match_formations
+  ADD CONSTRAINT matchmaking_match_formations_outcome_check
+  CHECK (num_nonnulls(game_id, fail_phase) = 1);

--- a/migrations/20260628120000_capture_failed_match_formations.sql
+++ b/migrations/20260628120000_capture_failed_match_formations.sql
@@ -1,0 +1,30 @@
+-- Extend matchmaking_match_formations to also capture matches the matchmaker formed but that *failed
+-- to start* — i.e. fell apart during accept/draft/load and never produced a game. Previously a row
+-- was written only once a match successfully loaded (keyed by game_id), so failed-start cohorts had no
+-- persisted quality/win-probability/rating/latency inputs and couldn't be joined back to the
+-- matchmaker decision that produced them.
+--
+-- A row now represents one formed match's decision, regardless of outcome:
+--   * launched   -> game_id set, fail_phase NULL (joinable to the game's outcome for calibration)
+--   * failed     -> game_id NULL, fail_phase set to the phase it fell apart in
+-- game_id can therefore no longer be the primary key (it's NULL for failures), so a surrogate id takes
+-- over; game_id keeps its games FK + cascade and gains a UNIQUE constraint so there's still at most one
+-- formation per game. Existing rows are all launched matches, so they keep their game_id and get a
+-- NULL fail_phase automatically.
+
+ALTER TABLE matchmaking_match_formations
+  DROP CONSTRAINT matchmaking_match_formations_pkey;
+
+ALTER TABLE matchmaking_match_formations
+  ALTER COLUMN game_id DROP NOT NULL;
+
+ALTER TABLE matchmaking_match_formations
+  ADD COLUMN id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY;
+
+-- NULL for launched matches; otherwise the phase the match fell apart in. Mirrors the `phase` the
+-- matchmaking service tracks (and labels the failure metric with), so the two stay aligned.
+ALTER TABLE matchmaking_match_formations
+  ADD COLUMN fail_phase text CHECK (fail_phase IN ('accepting', 'drafting', 'loading'));
+
+ALTER TABLE matchmaking_match_formations
+  ADD CONSTRAINT matchmaking_match_formations_game_id_key UNIQUE (game_id);

--- a/server/lib/matchmaking/matchmaking-service.test.ts
+++ b/server/lib/matchmaking/matchmaking-service.test.ts
@@ -12,6 +12,7 @@ import {
 import { asMockedFunction } from '../../../common/testing/mocks'
 import { MatchFoundMessage } from '../../../common/typeshare'
 import { makeSbUserId, SbUserId } from '../../../common/users/sb-user-id'
+import { BaseGameLoaderError, GameLoadErrorType } from '../games/game-loader'
 import { GameplayActivityRegistry } from '../games/gameplay-activity-registry'
 import { FakeClock } from '../time/testing/fake-clock'
 import { ClientSocketsGroup } from '../websockets/socket-groups'
@@ -420,6 +421,55 @@ describe('matchmaking/matchmaking-service', () => {
     expect(insertMatchmakingMatchFormation).toHaveBeenCalledTimes(1)
     expect(insertMatchmakingMatchFormation).toHaveBeenCalledWith({
       gameId: GAME_ID,
+      matchmakingType: MatchmakingType.Match1v1,
+      quality: 12.5,
+      skillVariance: 30000,
+      winProbability: 0.42,
+      teamARating: 1500,
+      teamBRating: 1600,
+      maxLatency: 1,
+    })
+  })
+
+  test('records the match formation telemetry for a match that fails to start', async () => {
+    asMockedFunction(getCurrentMapPool).mockResolvedValue({ maps: [MAP_ID] } as any)
+    asMockedFunction(getMapInfos).mockResolvedValue([{ id: MAP_ID } as any])
+    // The game fails to load, so the match falls apart in the 'loading' phase.
+    gameLoader.loadGame.mockResolvedValue(
+      Result.error(new BaseGameLoaderError(GameLoadErrorType.Internal, 'game load failed')),
+    )
+
+    await queuePlayer(USER_A, CLIENT_A)
+    await queuePlayer(USER_B, CLIENT_B)
+
+    redisHandler({
+      type: 'matchFound',
+      data: {
+        mode: MatchmakingType.Match1v1,
+        teamA: [{ id: USER_A, ticket: 'ticket-a' }],
+        teamB: [{ id: USER_B, ticket: 'ticket-b' }],
+        quality: 12.5,
+        skillVariance: 30000,
+        winProbability: 0.42,
+        teamARating: 1500,
+        teamBRating: 1600,
+        maxLatency: 1,
+      },
+    })
+    await vi.advanceTimersByTimeAsync(0)
+
+    // Both players accept; the match then runs through to the (failing) game load.
+    await service.accept(USER_A)
+    await service.accept(USER_B)
+    for (let i = 0; i < 20; i++) {
+      await vi.advanceTimersByTimeAsync(0)
+    }
+
+    // The failed match's formation decision is persisted exactly once, keyed by the phase it fell
+    // apart in (no game id) and carrying the same quality breakdown a launched match would.
+    expect(insertMatchmakingMatchFormation).toHaveBeenCalledTimes(1)
+    expect(insertMatchmakingMatchFormation).toHaveBeenCalledWith({
+      failPhase: 'loading',
       matchmakingType: MatchmakingType.Match1v1,
       quality: 12.5,
       skillVariance: 30000,

--- a/server/lib/matchmaking/matchmaking-service.ts
+++ b/server/lib/matchmaking/matchmaking-service.ts
@@ -64,6 +64,7 @@ import {
   getMatchmakingRating,
   insertMatchmakingCompletion,
   insertMatchmakingMatchFormation,
+  MatchmakingMatchFailPhase,
   MatchmakingRating,
 } from '../matchmaking/models'
 import { RallyPointService } from '../rally-point/rally-point-service'
@@ -110,8 +111,8 @@ interface PlayerQueueData {
 
 /**
  * The matchmaker's quality breakdown for a formed match (from the Rust `matchFound` event), carried
- * on the in-memory match until the game loads so it can be persisted keyed by the resulting game id
- * (see `insertMatchmakingMatchFormation`).
+ * on the in-memory match until it resolves so it can be persisted — keyed by the resulting game id if
+ * it launches, or by the phase it failed in if it doesn't (see `insertMatchmakingMatchFormation`).
  */
 interface MatchFormationTelemetry {
   quality: number
@@ -820,7 +821,7 @@ export class MatchmakingService {
 
   private async runMatch(matchId: string) {
     const match = this.matches.get(matchId)!
-    let phase: 'accepting' | 'drafting' | 'loading' = 'accepting'
+    let phase: MatchmakingMatchFailPhase = 'accepting'
 
     const activeClients = new Map<SbUserId, ClientSocketsGroup>()
 
@@ -876,6 +877,15 @@ export class MatchmakingService {
       // `phase` is the stage the match was in when it threw, so this records *where* formed matches
       // fall apart — `accepting` failures are the ready-up funnel dropouts.
       this.matchFailedMetric.labels(match.type, phase).inc()
+
+      // Persist the formation decision for this failed-to-start match, mirroring the launch path below
+      // so failed cohorts carry the same quality/win-prob/rating/latency inputs (keyed by the phase it
+      // fell apart in, since there's no game id). Best-effort: a failure here must not affect flow.
+      insertMatchmakingMatchFormation({
+        failPhase: phase,
+        matchmakingType: match.type,
+        ...match.formation,
+      }).catch(err => logger.error({ err }, 'error while logging matchmaking match formation'))
 
       const [toKick, toBan, toRequeue] = match.getKicksBansAndRequeues()
 
@@ -1198,8 +1208,8 @@ export class MatchmakingService {
     }
 
     // Record the matchmaker's formation decision keyed by the game it produced, so it can later be
-    // joined to the game's actual outcome for calibration. Best-effort: a failure here must not
-    // affect game flow.
+    // joined to the game's actual outcome for calibration (the failed-to-start counterpart is recorded
+    // in `runMatch`'s catch). Best-effort: a failure here must not affect game flow.
     insertMatchmakingMatchFormation({
       gameId: loadResult.value.gameId,
       matchmakingType: match.type,

--- a/server/lib/matchmaking/matchmaking-service.ts
+++ b/server/lib/matchmaking/matchmaking-service.ts
@@ -866,9 +866,20 @@ export class MatchmakingService {
       await match.runDraft(activeClients, mapInfo)
 
       phase = 'loading'
-      await this.doGameLoad(match, mapInfo)
+      const gameId = await this.doGameLoad(match, mapInfo)
 
       this.matchLaunchedMetric.labels(match.type).inc()
+
+      // Record the matchmaker's formation decision keyed by the game it produced, so it can later be
+      // joined to the game's actual outcome for calibration (the failed-to-start counterpart is
+      // recorded in the catch below). Done here, only once `doGameLoad` has fully succeeded, so the
+      // launch and failure inserts stay mutually exclusive by construction. Best-effort: a failure
+      // here must not affect game flow.
+      insertMatchmakingMatchFormation({
+        gameId,
+        matchmakingType: match.type,
+        ...match.formation,
+      }).catch(err => logger.error({ err }, 'error while logging matchmaking match formation'))
     } catch (err: any) {
       if (!isAbortError(err) && !(err instanceof MatchmakingServiceError)) {
         logger.error({ err }, 'error while processing match')
@@ -1207,15 +1218,6 @@ export class MatchmakingService {
       )
     }
 
-    // Record the matchmaker's formation decision keyed by the game it produced, so it can later be
-    // joined to the game's actual outcome for calibration (the failed-to-start counterpart is recorded
-    // in `runMatch`'s catch). Best-effort: a failure here must not affect game flow.
-    insertMatchmakingMatchFormation({
-      gameId: loadResult.value.gameId,
-      matchmakingType: match.type,
-      ...match.formation,
-    }).catch(err => logger.error({ err }, 'error while logging matchmaking match formation'))
-
     for (const player of match.players()) {
       this.queueEntries.delete(player.id)
     }
@@ -1224,6 +1226,8 @@ export class MatchmakingService {
       // TODO(tec27): Should this be maintained until the client reports game exit instead?
       this.unregisterActivity(client.userId)
     }
+
+    return loadResult.value.gameId
   }
 
   private handleRsMatchEvent(message: PublishedMatchmakingMessage): void {

--- a/server/lib/matchmaking/models.ts
+++ b/server/lib/matchmaking/models.ts
@@ -688,14 +688,21 @@ export async function insertMatchmakingCompletion(
   }
 }
 
+/** The phase a formed match fell apart in when it failed to start. Mirrors the matchmaking service's
+ * own `phase` tracking and the failure metric's `phase` label. */
+export type MatchmakingMatchFailPhase = 'accepting' | 'drafting' | 'loading'
+
 /**
- * The matchmaker's formation decision for a single matchmaking game: the quality score the match
- * formed at, plus the raw (unweighted) inputs that fed it. Keyed by game so it can be joined to the
- * game's actual outcome for calibrating the quality weights. See the `matchmaking_match_formations`
- * migration.
+ * The matchmaker's formation decision for a single formed match: the quality score the match formed
+ * at, plus the raw (unweighted) inputs that fed it. Recorded for every formed match, whether it
+ * launched or failed to start:
+ *   - launched: `gameId` set, so it can be joined to the game's actual outcome for calibrating the
+ *     quality weights.
+ *   - failed to start: `failPhase` set (and no game), so failed cohorts carry the same decision inputs
+ *     and can be analyzed by the phase they fell apart in.
+ * See the `matchmaking_match_formations` migration.
  */
-export interface MatchmakingMatchFormation {
-  gameId: string
+export type MatchmakingMatchFormation = {
   matchmakingType: MatchmakingType
   /** Overall quality score (in seconds of wait) the match formed at. */
   quality: number
@@ -711,11 +718,15 @@ export interface MatchmakingMatchFormation {
    * rally-point server pings (raw latency input to quality).
    */
   maxLatency: number
-}
+} & (
+  | { gameId: string; failPhase?: never }
+  | { gameId?: never; failPhase: MatchmakingMatchFailPhase }
+)
 
 /**
- * Records the matchmaker's formation decision for a game. Best-effort telemetry for calibration; a
- * failure here must not affect the game itself, so callers should not block game flow on it.
+ * Records the matchmaker's formation decision for a formed match (launched or failed-to-start).
+ * Best-effort telemetry for calibration and failure analysis; a failure here must not affect game
+ * flow, so callers should not block on it.
  */
 export async function insertMatchmakingMatchFormation(
   formation: Readonly<MatchmakingMatchFormation>,
@@ -725,12 +736,12 @@ export async function insertMatchmakingMatchFormation(
   try {
     await client.query(sql`
       INSERT INTO matchmaking_match_formations
-        (game_id, matchmaking_type, quality, skill_variance, win_probability,
+        (game_id, fail_phase, matchmaking_type, quality, skill_variance, win_probability,
           team_a_rating, team_b_rating, max_latency)
       VALUES
-        (${formation.gameId}, ${formation.matchmakingType}, ${formation.quality},
-          ${formation.skillVariance}, ${formation.winProbability}, ${formation.teamARating},
-          ${formation.teamBRating}, ${formation.maxLatency})
+        (${formation.gameId ?? null}, ${formation.failPhase ?? null}, ${formation.matchmakingType},
+          ${formation.quality}, ${formation.skillVariance}, ${formation.winProbability},
+          ${formation.teamARating}, ${formation.teamBRating}, ${formation.maxLatency})
     `)
   } finally {
     done()


### PR DESCRIPTION
## Problem

`matchmaking_match_formations` only got a row once a match successfully loaded (it was keyed by a `NOT NULL game_id`). Matches that fell apart during accept / draft / load left no durable record, so:

- failed-start cohorts had **no persisted quality / win-probability / rating / latency**, only the aggregate Prometheus `shieldbattery_matchmaker_match_failed_total{phase}` counter — which can't be joined back to the decision that produced the failure (and is gone after retention).
- the "failed-to-start proxy" query in `USEFUL_QUERIES.md` was **misleading**: because the table only held successfully-loaded matches, it could only ever surface games that loaded but produced no result — never an actual pre-launch failure.

## Change

Record the formation decision for **every** formed match, launched or not:

- **Migration**: `game_id` becomes nullable; a surrogate `id` is the new primary key, while `game_id` keeps its `games` FK + cascade and gains a `UNIQUE` constraint (still at most one formation per game). Failed matches store the phase they fell apart in (`fail_phase`, CHECK'd to `accepting`/`drafting`/`loading`). Existing rows are all launched matches, so they keep their `game_id` and get a `NULL fail_phase`.
- **Service**: the matchmaking service writes a formation row in `runMatch`'s catch, mirroring the launch path, so failed cohorts carry identical decision inputs (keyed by phase since there's no game id).
- **Docs**: replaced the misleading query with a real launch-vs-failure-by-phase breakdown plus a failed-vs-launched decision-input comparison, and added a correctly-scoped "launched but no game result" query. Existing launched-only queries are scoped to `game_id IS NOT NULL`.

## Verification

- `pnpm typecheck`, `pnpm lint`, and the matchmaking-service unit tests (incl. a new failed-to-start formation test) all pass.
- Migration applied against the real dev DB schema inside a rolled-back transaction: DDL applies, failed-start insert works, multiple-null `UNIQUE(game_id)` allowed, bad `fail_phase` rejected by the CHECK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PGFEvxMMVHCoY57RtiX3Tm