### PR TITLE
Keep find-match mode selection in Jotai so it survives navigation

### DIFF
--- a/client/matchmaking/find-match.tsx
+++ b/client/matchmaking/find-match.tsx
@@ -1,4 +1,4 @@
-import { useAtomValue } from 'jotai'
+import { useAtomValue, useSetAtom } from 'jotai'
 import { AnimatePresence, m } from 'motion/react'
 import React, { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -44,7 +44,12 @@ import {
 } from '../styles/typography'
 import { cancelFindMatch, findMatch, getCurrentMapPool } from './action-creators'
 import { FindMatchContent } from './find-match-content'
-import { currentSearchInfoAtom, foundMatchAtom, isMatchmakingAtom } from './matchmaking-atoms'
+import {
+  currentSearchInfoAtom,
+  findMatchSelectionAtom,
+  foundMatchAtom,
+  isMatchmakingAtom,
+} from './matchmaking-atoms'
 import { DivisionIcon } from './rank-icon'
 
 // ─── Static mode definitions ─────────────────────────────────────────────────
@@ -1248,10 +1253,11 @@ export function FindMatch() {
 
   // ─── Local state ────────────────────────────────────────────────────────────
   // The mode selection itself isn't stored here: it's derived from the persisted preferences (see
-  // `selectedTypes` below). We only keep an override for when the user changes the selection this
-  // session, so we never duplicate store data into state via a seeding effect.
-  const [selectedTypesOverride, setSelectedTypesOverride] =
-    useState<ReadonlySet<MatchmakingType> | null>(null)
+  // `selectedTypes` below). We only keep an override (in a Jotai atom, so it survives navigating
+  // away and back) for when the user changes the selection this session, so we never duplicate store
+  // data into state via a seeding effect.
+  const sessionSelection = useAtomValue(findMatchSelectionAtom)
+  const setSessionSelection = useSetAtom(findMatchSelectionAtom)
   const [drawerType, setDrawerType] = useState<MatchmakingType | null>(null)
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [elapsedSecs, setElapsedSecs] = useState(0)
@@ -1306,8 +1312,11 @@ export function FindMatch() {
   const persistedSelectedTypes = new Set<MatchmakingType>(
     ALL_MATCHMAKING_TYPES.filter(type => matchmakingPreferences.get(type)?.selected),
   )
-  const selectedTypes: ReadonlySet<MatchmakingType> =
-    selectedTypesOverride ?? persistedSelectedTypes
+  // Only honor the session override if it belongs to the current user (it's a global atom that
+  // outlives a logout), otherwise fall back to this user's persisted selection.
+  const sessionSelectedTypes =
+    sessionSelection?.userId === selfUser.id ? sessionSelection.types : undefined
+  const selectedTypes: ReadonlySet<MatchmakingType> = sessionSelectedTypes ?? persistedSelectedTypes
 
   // While searching, the effective selected types come from Jotai (server-authoritative). When not
   // searching, we filter out any types that are currently disabled: their rows can't be deselected
@@ -1381,7 +1390,7 @@ export function FindMatch() {
     const next = new Set(selectedTypes)
     if (next.has(type)) next.delete(type)
     else next.add(type)
-    setSelectedTypesOverride(next)
+    setSessionSelection({ userId: selfUser.id, types: next })
   }
 
   const handleOpenSettings = (type: MatchmakingType) => {

--- a/client/matchmaking/matchmaking-atoms.ts
+++ b/client/matchmaking/matchmaking-atoms.ts
@@ -1,6 +1,7 @@
 import { atom, Setter } from 'jotai'
 import { MatchmakingType } from '../../common/matchmaking'
 import { RaceChar } from '../../common/races'
+import { SbUserId } from '../../common/users/sb-user-id'
 import { JotaiStore } from '../jotai-store'
 
 export interface MatchmakingSearchInfo {
@@ -13,6 +14,23 @@ export interface MatchmakingSearchInfo {
 export const currentSearchInfoAtom = atom<MatchmakingSearchInfo | undefined>(undefined)
 
 export const isMatchmakingAtom = atom(get => !!get(currentSearchInfoAtom))
+
+export interface FindMatchSelection {
+  /** The user this selection belongs to, so it never bleeds across account switches. */
+  userId: SbUserId
+  /** The matchmaking types the user has checked on the find-match page. */
+  types: ReadonlySet<MatchmakingType>
+}
+
+/**
+ * The find-match mode selection the user has made *this session*, or `undefined` when they haven't
+ * touched it yet (in which case the find-match page falls back to the server-persisted selection
+ * from their most recent search). This lives in Jotai rather than component state so it survives
+ * navigating away from and back to the find-match page mid-session: previously the toggles were kept
+ * in `useState` and lost on unmount, so a queue → navigate → cancel cycle collapsed the selection
+ * (the page fell back to a stale store value, often selecting nothing).
+ */
+export const findMatchSelectionAtom = atom<FindMatchSelection | undefined>(undefined)
 
 export interface FoundMatch {
   matchmakingType: MatchmakingType


### PR DESCRIPTION
## Problem

The find-match page lost the user's mode selection after a queue → navigate away → navigate back → cancel cycle, often leaving **no modes selected** (reported by tec27).

Root cause is client-side: the in-session selection was held in a component `useState` override (`selectedTypesOverride`), layered on top of the server-persisted `selected` flags from the preferences store. That override is discarded when the page unmounts (navigation), so on return the page fell back to the store's `selected` flags — which are only written on connect and never updated when you queue. After cancelling, the selection collapsed to that stale set.

(The server already persists the queued selection — `matchmaking-api.ts` upserts prefs + `setSelectedTypes` on queue — so this is purely about the client not retaining the selection across navigation.)

## Fix

Move the session selection into a Jotai atom (`findMatchSelectionAtom`), the appropriate home for transient feature-local UI state, so it survives navigating away and back within a session. The atom is **keyed by user id** and only honored for the current user, so the global atom can't leak a previous account's selection across a logout/login on the same renderer.

## Verification

- `tsc` clean (full typecheck)
- `eslint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)