### PR TITLE
Avoid per-type DB query fan-out when persisting queued matchmaking prefs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -217,6 +217,7 @@ export class LobbyApi {
 - **DI (tsyringe):** `@singleton()`, `@inject()` (rarely needed: `delay(() => Dep)` for circular deps)
 - **Sockets:** `ClientSocketsManager`, `UserSocketsManager` with `.subscribe(path)`
 - **Database:** `withDbClient()`, `transact()` for transactions; use `Dbify<T>` from `server/lib/db/types.ts` for query result types (converts camelCase interfaces to snake_case DB columns)
+- **Avoid per-item DB query fan-out:** Don't run a separate query per element of a collection (e.g. `Promise.all(items.map(i => dbQuery(i)))` or a `for` loop that opens a new client each iteration). Each query grabs its own pool connection, so a large/variable collection can exhaust the pool and starve unrelated requests. Prefer a single set-based statement (e.g. a multi-row upsert with `sqlConcat`, or `WHERE id = ANY(...)`); if you must issue them one at a time, share a single connection via `withDbClient`/`transact` and `withClient`.
 - **Models organization:** Functions that update a table belong in that table's models file, not the new feature's models
 - **Redis:** Session storage, pub/sub between server and server-rs
 - **Errors:** `CodedError` with `makeErrorConverterMiddleware()` for HTTP mapping

--- a/server/lib/matchmaking/matchmaking-api.ts
+++ b/server/lib/matchmaking/matchmaking-api.ts
@@ -19,6 +19,8 @@ import {
   toMatchmakingSeasonJson,
 } from '../../../common/matchmaking'
 import { ALL_RACE_CHARS } from '../../../common/races'
+import { withDbClient } from '../db'
+import transact from '../db/transaction'
 import { makeErrorConverterMiddleware } from '../errors/coded-error'
 import { asHttpError } from '../errors/error-with-payload'
 import { httpApi, httpBeforeAll } from '../http/http-api'
@@ -150,9 +152,13 @@ export class MatchmakingApi {
       )
     }
 
-    const processedPreferences = await Promise.all(
-      preferences.map(async pref => {
-        const currentMapPool = await getCurrentMapPool(pref.matchmakingType)
+    // Validate and normalize each type's preferences against its current map pool. We do this on a
+    // single shared connection rather than fanning out one query per type, which could grab more
+    // pool connections than we have and starve other work.
+    const processedPreferences = await withDbClient(async client => {
+      const processed: typeof preferences = []
+      for (const pref of preferences) {
+        const currentMapPool = await getCurrentMapPool(pref.matchmakingType, client)
         if (!currentMapPool) {
           throw new MatchmakingServiceError(
             MatchmakingServiceErrorCode.InvalidMapPool,
@@ -174,9 +180,10 @@ export class MatchmakingApi {
           )
         }
 
-        return { ...pref, mapSelections }
-      }),
-    )
+        processed.push({ ...pref, mapSelections })
+      }
+      return processed
+    })
 
     await this.matchmakingService.find(
       ctx.session!.user.id,
@@ -191,16 +198,19 @@ export class MatchmakingApi {
     // "pool updated" indicator keeps working for users who queue without reviewing a new pool. A
     // failure here shouldn't fail an already-successful queue.
     try {
-      await Promise.all(
-        preferences.map(pref => this.matchmakingPreferencesService.upsertPreferences(pref)),
-      )
-      // Remember which modes were queued (clearing the rest) so the find-match page can restore this
-      // selection next session and across devices without the user re-checking each mode. Runs after
-      // the upserts so the queued types' rows are guaranteed to exist.
-      await this.matchmakingPreferencesService.setSelectedTypes(
-        ctx.session!.user.id,
-        preferences.map(pref => pref.matchmakingType),
-      )
+      await transact(async client => {
+        // A single bulk upsert (rather than one query per type) so a many-type queue doesn't grab a
+        // pool connection per type.
+        await this.matchmakingPreferencesService.upsertManyPreferences(preferences, client)
+        // Remember which modes were queued (clearing the rest) so the find-match page can restore
+        // this selection next session and across devices without the user re-checking each mode.
+        // Runs after the upserts so the queued types' rows are guaranteed to exist.
+        await this.matchmakingPreferencesService.setSelectedTypes(
+          ctx.session!.user.id,
+          preferences.map(pref => pref.matchmakingType),
+          client,
+        )
+      })
     } catch (err) {
       logger.error({ err }, 'error saving matchmaking preferences after queueing')
     }

--- a/server/lib/matchmaking/matchmaking-preferences-model.ts
+++ b/server/lib/matchmaking/matchmaking-preferences-model.ts
@@ -5,8 +5,8 @@ import {
   PartialMatchmakingPreferences,
 } from '../../../common/matchmaking'
 import { SbUserId } from '../../../common/users/sb-user-id'
-import db from '../db'
-import { sql } from '../db/sql'
+import db, { DbClient } from '../db'
+import { sql, sqlConcat } from '../db/sql'
 import { Dbify } from '../db/types'
 
 type DbMatchmakingPreferences = Dbify<MatchmakingPreferences> & { selected: boolean }
@@ -74,6 +74,44 @@ export async function upsertMatchmakingPreferences({
 }
 
 /**
+ * Upserts a batch of *complete* matchmaking preferences in a single statement. Unlike
+ * `upsertMatchmakingPreferences` (which merges partial updates with the previous values), this
+ * overwrites every column, so callers must pass full preferences — as the queue path does. Used to
+ * persist all of a user's queued types at once without fanning out one query (and thus one pool
+ * connection) per type. Pass `withClient` to run inside an existing transaction.
+ */
+export async function upsertManyMatchmakingPreferences(
+  preferences: ReadonlyArray<MatchmakingPreferences>,
+  withClient?: DbClient,
+): Promise<void> {
+  if (!preferences.length) {
+    return
+  }
+
+  const { client, done } = await db(withClient)
+  try {
+    const rows = preferences.map(
+      p =>
+        sql`(${p.userId}, ${p.matchmakingType}, ${p.race}, ${p.mapPoolId}, ${p.mapSelections},
+          ${p.data})`,
+    )
+    await client.query(sql`
+      INSERT INTO matchmaking_preferences AS mp
+        (user_id, matchmaking_type, race, map_pool_id, map_selections, data)
+      VALUES ${sqlConcat(', ', rows)}
+      ON CONFLICT (user_id, matchmaking_type)
+      DO UPDATE SET
+        race = EXCLUDED.race,
+        map_pool_id = EXCLUDED.map_pool_id,
+        map_selections = EXCLUDED.map_selections,
+        data = EXCLUDED.data;
+    `)
+  } finally {
+    done()
+  }
+}
+
+/**
  * Retrieve the latest `MatchmakingPreferences` for a user for a particular matchmaking type, or
  * `null` if they haven't set any yet.
  */
@@ -103,8 +141,9 @@ export async function getMatchmakingPreferences(
 export async function setSelectedMatchmakingTypes(
   userId: SbUserId,
   selectedTypes: ReadonlyArray<MatchmakingType>,
+  withClient?: DbClient,
 ): Promise<void> {
-  const { client, done } = await db()
+  const { client, done } = await db(withClient)
   try {
     await client.query(sql`
       UPDATE matchmaking_preferences

--- a/server/lib/matchmaking/matchmaking-preferences-service.ts
+++ b/server/lib/matchmaking/matchmaking-preferences-service.ts
@@ -11,6 +11,7 @@ import {
 } from '../../../common/matchmaking'
 import { MatchmakingMapPool } from '../../../common/matchmaking/matchmaking-map-pools'
 import { SbUserId } from '../../../common/users/sb-user-id'
+import { DbClient } from '../db'
 import logger from '../logging/logger'
 import { getMapInfos } from '../maps/map-models'
 import { ClientSocketsManager } from '../websockets/socket-groups'
@@ -18,6 +19,7 @@ import { getCurrentMapPool } from './matchmaking-map-pools-models'
 import {
   getMatchmakingPreferences,
   setSelectedMatchmakingTypes,
+  upsertManyMatchmakingPreferences,
   upsertMatchmakingPreferences,
 } from './matchmaking-preferences-model'
 
@@ -104,11 +106,25 @@ export default class MatchmakingPreferencesService {
   }
 
   /**
+   * Upserts a batch of complete preferences in a single statement (see
+   * `upsertManyMatchmakingPreferences`). Used by the queue path to persist every queued type at once
+   * without a per-type query fan-out. Pass `withClient` to run inside a transaction.
+   */
+  upsertManyPreferences(preferences: ReadonlyArray<MatchmakingPreferences>, withClient?: DbClient) {
+    return upsertManyMatchmakingPreferences(preferences, withClient)
+  }
+
+  /**
    * Marks exactly the given matchmaking types as the user's current selection (clearing the flag on
    * the rest), so the find-match page can restore which modes they want to queue across sessions and
-   * devices. Callers should upsert the queued types' preferences first so their rows exist.
+   * devices. Callers should upsert the queued types' preferences first so their rows exist. Pass
+   * `withClient` to run inside a transaction.
    */
-  setSelectedTypes(userId: SbUserId, selectedTypes: ReadonlyArray<MatchmakingType>) {
-    return setSelectedMatchmakingTypes(userId, selectedTypes)
+  setSelectedTypes(
+    userId: SbUserId,
+    selectedTypes: ReadonlyArray<MatchmakingType>,
+    withClient?: DbClient,
+  ) {
+    return setSelectedMatchmakingTypes(userId, selectedTypes, withClient)
   }
 }


### PR DESCRIPTION
## Background

In the matchmaking queue path (`MatchmakingApi.findMatch`), preferences were persisted with `Promise.all(preferences.map(pref => upsertPreferences(pref)))`, and map pools were validated with a similar per-type `Promise.all(map(...))`. Each of those calls grabs its own connection from the pool, so a many-type queue fires a burst of concurrent connections.

This is fine at today's bounded matchmaking-type count, but it's the fan-out pattern that can exhaust the connection pool and starve unrelated requests once the count is large/variable — so worth fixing now and, more importantly, documenting so it isn't reintroduced.

## Changes

- **Bulk upsert:** new `upsertManyMatchmakingPreferences` model fn — a single multi-row upsert built with `sqlConcat`. Because the queue path always sends *complete* preferences, it overwrites every column from `EXCLUDED` (vs. the partial-merge `upsertMatchmakingPreferences` used by the settings editor, which is unchanged).
- **One connection, atomic:** the bulk upsert + `setSelectedTypes` now run inside a single `transact`, threading the client through (both model fns gained an optional `withClient`).
- **Validation reads:** the per-type `getCurrentMapPool` validation loop now runs on a single shared connection via `withDbClient` instead of fanning out. Same per-type validation and error behavior (`InvalidMapPool` / `InvalidMaps`).
- **AGENTS.md:** added a guideline against per-item DB query fan-out.

Behavior is otherwise preserved: we still persist the raw client-sent preferences (not the pool-filtered version) so the "pool updated" indicator keeps working, and persistence failures still don't fail an already-successful queue.

## Verification

- `tsc` clean (full typecheck)
- `eslint` clean
- `vitest run server/lib/matchmaking` — 54 passed
- DB-level behavior of the new bulk statement is exercised by the queue path in the Playwright integration tests (CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)