### PR TITLE
Tolerate legacy empty-object game results in server-rs

### DIFF
--- a/server-rs/.sqlx/query-1b1e9601db57d62cba100678383e7b413e7b398e9259b55b76138686293fa4af.json
+++ b/server-rs/.sqlx/query-1b1e9601db57d62cba100678383e7b413e7b398e9259b55b76138686293fa4af.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n            SELECT id, start_time, map_id as \"map_id: _\", config as \"config: _\",\n                disputable, dispute_requested, dispute_reviewed,\n                game_length, results as \"results: _\", routes as \"routes: _\"\n            FROM games\n            WHERE\n                game_length IS NULL\n                AND start_time < now() - interval '2 minutes'\n                AND start_time > now() - interval '1 hour'\n                AND config->>'gameSource' = 'MATCHMAKING'\n            ORDER BY start_time DESC\n            LIMIT 10\n            ",
+  "query": "\n            SELECT id, start_time, map_id as \"map_id: _\", config as \"config: _\",\n                disputable, dispute_requested, dispute_reviewed,\n                game_length,\n                -- Some legacy rows store `results` as an empty object `{}` instead of an array (or\n                -- null); coerce any non-array value to NULL so it decodes as `None` rather than\n                -- erroring (\"invalid type: map, expected a sequence\"). Matches the Node guard in\n                -- game-models.ts.\n                (CASE WHEN jsonb_typeof(results) = 'array' THEN results END) as \"results: _\",\n                routes as \"routes: _\"\n            FROM games WHERE id = ANY($1)\n            ",
   "describe": {
     "columns": [
       {
@@ -95,12 +95,7 @@
         "ordinal": 8,
         "name": "results: _",
         "type_info": "Jsonb",
-        "origin": {
-          "Table": {
-            "table": "games",
-            "name": "results"
-          }
-        }
+        "origin": "Expression"
       },
       {
         "ordinal": 9,
@@ -115,7 +110,9 @@
       }
     ],
     "parameters": {
-      "Left": []
+      "Left": [
+        "UuidArray"
+      ]
     },
     "nullable": [
       false,
@@ -126,9 +123,9 @@
       false,
       false,
       true,
-      true,
+      null,
       true
     ]
   },
-  "hash": "b93a30dc19f570feaeced2cfded96f180e7db730011ab3403d66a5e172274e74"
+  "hash": "1b1e9601db57d62cba100678383e7b413e7b398e9259b55b76138686293fa4af"
 }

--- a/server-rs/.sqlx/query-ae05d13478bf12c3f55f7e75e749f641038c30e1db8658e652be50af3575667c.json
+++ b/server-rs/.sqlx/query-ae05d13478bf12c3f55f7e75e749f641038c30e1db8658e652be50af3575667c.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n            SELECT id, start_time, map_id as \"map_id: _\", config as \"config: _\",\n                disputable, dispute_requested, dispute_reviewed,\n                game_length, results as \"results: _\", routes as \"routes: _\"\n            FROM games WHERE id = ANY($1)\n            ",
+  "query": "\n            SELECT id, start_time, map_id as \"map_id: _\", config as \"config: _\",\n                disputable, dispute_requested, dispute_reviewed,\n                game_length,\n                -- Some legacy rows store `results` as an empty object `{}` instead of an array (or\n                -- null); coerce any non-array value to NULL so it decodes as `None` rather than\n                -- erroring (\"invalid type: map, expected a sequence\"). Matches the Node guard in\n                -- game-models.ts.\n                (CASE WHEN jsonb_typeof(results) = 'array' THEN results END) as \"results: _\",\n                routes as \"routes: _\"\n            FROM games\n            WHERE\n                game_length IS NULL\n                AND start_time < now() - interval '2 minutes'\n                AND start_time > now() - interval '1 hour'\n                AND config->>'gameSource' = 'MATCHMAKING'\n            ORDER BY start_time DESC\n            LIMIT 10\n            ",
   "describe": {
     "columns": [
       {
@@ -95,12 +95,7 @@
         "ordinal": 8,
         "name": "results: _",
         "type_info": "Jsonb",
-        "origin": {
-          "Table": {
-            "table": "games",
-            "name": "results"
-          }
-        }
+        "origin": "Expression"
       },
       {
         "ordinal": 9,
@@ -115,9 +110,7 @@
       }
     ],
     "parameters": {
-      "Left": [
-        "UuidArray"
-      ]
+      "Left": []
     },
     "nullable": [
       false,
@@ -128,9 +121,9 @@
       false,
       false,
       true,
-      true,
+      null,
       true
     ]
   },
-  "hash": "b4595494e9514d5cd783dc8f3051428b4f1655e0de06ef27bb8dc377ea53579e"
+  "hash": "ae05d13478bf12c3f55f7e75e749f641038c30e1db8658e652be50af3575667c"
 }

--- a/server-rs/src/games.rs
+++ b/server-rs/src/games.rs
@@ -408,7 +408,13 @@ impl GamesRepo {
             r#"
             SELECT id, start_time, map_id as "map_id: _", config as "config: _",
                 disputable, dispute_requested, dispute_reviewed,
-                game_length, results as "results: _", routes as "routes: _"
+                game_length,
+                -- Some legacy rows store `results` as an empty object `{}` instead of an array (or
+                -- null); coerce any non-array value to NULL so it decodes as `None` rather than
+                -- erroring ("invalid type: map, expected a sequence"). Matches the Node guard in
+                -- game-models.ts.
+                (CASE WHEN jsonb_typeof(results) = 'array' THEN results END) as "results: _",
+                routes as "routes: _"
             FROM games
             WHERE
                 game_length IS NULL
@@ -448,7 +454,13 @@ impl Loader<Uuid> for GamesLoader {
             r#"
             SELECT id, start_time, map_id as "map_id: _", config as "config: _",
                 disputable, dispute_requested, dispute_reviewed,
-                game_length, results as "results: _", routes as "routes: _"
+                game_length,
+                -- Some legacy rows store `results` as an empty object `{}` instead of an array (or
+                -- null); coerce any non-array value to NULL so it decodes as `None` rather than
+                -- erroring ("invalid type: map, expected a sequence"). Matches the Node guard in
+                -- game-models.ts.
+                (CASE WHEN jsonb_typeof(results) = 'array' THEN results END) as "results: _",
+                routes as "routes: _"
             FROM games WHERE id = ANY($1)
             "#,
             keys


### PR DESCRIPTION
## What

Some legacy `games` rows store `results` as an empty object `{}` instead of an array (or null). The server-rs `Game` queries (`GamesLoader` + `load_live_games`) decode `results` as a JSON array, so loading such a game fails with *"invalid type: map, expected a sequence"*.

This surfaces on the **admin game-report detail page**: a report on a legacy game shows a null `game` field ("Game record not available", and no View-game / Refund-points buttons) even though the game exists. It also breaks any other GraphQL query that loads such a game.

## Fix

Guard both queries with `CASE WHEN jsonb_typeof(results) = 'array' THEN results END`, so any non-array `results` decodes as `None`. This matches the existing Node-side guard in `game-models.ts` (`Array.isArray(row.results) ? row.results : null`).

## Verification

Live against a real legacy game (`019ec0bd…`, whose `results` is `{}`): before, `gameReport { game { id } }` errored on the `game` field; after, it returns the game with `results: null`. `sqlx prepare`, `clippy -D warnings`, and `cargo fmt` all green.

Independent of the open game-reporting stack (#1337/#1338) — this is a general `Game`-type fix off master.