### PR TITLE
Add app→game block sync and a blocked-users settings page

### DIFF
--- a/app/game/active-game-manager.ts
+++ b/app/game/active-game-manager.ts
@@ -273,6 +273,7 @@ export class ActiveGameManager extends EventEmitter<ActiveGameManagerEvents> {
       : undefined
 
     this.emit('gameCommand', id, 'localUser', config.localUser)
+    this.emit('gameCommand', id, 'blockedUsers', config.blockedUsers)
     this.emit('gameCommand', id, 'serverConfig', config.serverConfig)
     this.emit('gameCommand', id, 'settings', {
       local,

--- a/client/active-game/socket-handlers.ts
+++ b/client/active-game/socket-handlers.ts
@@ -12,6 +12,7 @@ import logger from '../logging/logger'
 import { fetchJson } from '../network/fetch'
 import { isFetchError } from '../network/fetch-errors'
 import { makeServerUrl } from '../network/server-url'
+import { getRelationshipsIfNeeded } from '../social/action-creators'
 import { updateActiveGame } from './wait-for-active-game'
 
 type EventToActionMap = {
@@ -52,17 +53,34 @@ export default function ({
           })
         }
 
-        const config: GameLaunchConfig = {
-          localUser: {
-            id: self!.user.id,
-            name: self!.user.name,
-          },
-          serverConfig: {
-            serverUrl: makeServerUrl(''),
-          },
-          setup,
+        const buildAndSend = () => {
+          const config: GameLaunchConfig = {
+            localUser: {
+              id: self!.user.id,
+              name: self!.user.name,
+            },
+            blockedUsers: Array.from(getState().relationships.blocks.keys()),
+            serverConfig: {
+              serverUrl: makeServerUrl(''),
+            },
+            setup,
+          }
+          ipcRenderer.invoke('activeGameSetConfig', config)?.catch(swallowNonBuiltins)
         }
-        ipcRenderer.invoke('activeGameSetConfig', config)?.catch(swallowNonBuiltins)
+
+        // The game needs the block list to hide blocked players' in-game chat. Relationship state
+        // is cleared on every reconnect, so make sure it's loaded before launching (falling back to
+        // whatever's cached rather than blocking the launch if the request fails).
+        if (getState().relationships.loaded) {
+          buildAndSend()
+        } else {
+          dispatch(
+            getRelationshipsIfNeeded({
+              onSuccess: buildAndSend,
+              onError: () => buildAndSend(),
+            }),
+          )
+        }
       }
     },
     setRoutes(_, { routes, gameId }) {

--- a/client/active-game/socket-handlers.ts
+++ b/client/active-game/socket-handlers.ts
@@ -15,6 +15,12 @@ import { makeServerUrl } from '../network/server-url'
 import { getRelationshipsIfNeeded } from '../social/action-creators'
 import { updateActiveGame } from './wait-for-active-game'
 
+/**
+ * How long to wait for the relationships (block list) fetch before launching a game anyway with
+ * whatever's cached. Keeps a slow/hung request from stalling the game-launch path.
+ */
+const RELATIONSHIPS_LAUNCH_TIMEOUT_MS = 5000
+
 type EventToActionMap = {
   [E in GameLoaderEvent['type']]: (
     gameId: string,
@@ -69,13 +75,18 @@ export default function ({
         }
 
         // The game needs the block list to hide blocked players' in-game chat. Relationship state
-        // is cleared on every reconnect, so make sure it's loaded before launching (falling back to
-        // whatever's cached rather than blocking the launch if the request fails).
+        // is cleared on every reconnect, so make sure it's loaded before launching. We cap the wait
+        // with a timeout and fall back to whatever's cached rather than stalling the launch behind a
+        // slow/hung request — worst case the game just launches without the latest block list.
+        // `callbackOnAbort` is required so the timeout still triggers the fallback (abortableThunk
+        // otherwise swallows both callbacks once the signal aborts).
         if (getState().relationships.loaded) {
           buildAndSend()
         } else {
           dispatch(
             getRelationshipsIfNeeded({
+              signal: AbortSignal.timeout(RELATIONSHIPS_LAUNCH_TIMEOUT_MS),
+              callbackOnAbort: true,
               onSuccess: buildAndSend,
               onError: () => buildAndSend(),
             }),

--- a/client/active-game/socket-handlers.ts
+++ b/client/active-game/socket-handlers.ts
@@ -12,14 +12,8 @@ import logger from '../logging/logger'
 import { fetchJson } from '../network/fetch'
 import { isFetchError } from '../network/fetch-errors'
 import { makeServerUrl } from '../network/server-url'
-import { getRelationshipsIfNeeded } from '../social/action-creators'
+import { ensureRelationshipsLoaded } from '../social/action-creators'
 import { updateActiveGame } from './wait-for-active-game'
-
-/**
- * How long to wait for the relationships (block list) fetch before launching a game anyway with
- * whatever's cached. Keeps a slow/hung request from stalling the game-launch path.
- */
-const RELATIONSHIPS_LAUNCH_TIMEOUT_MS = 5000
 
 type EventToActionMap = {
   [E in GameLoaderEvent['type']]: (
@@ -74,24 +68,10 @@ export default function ({
           ipcRenderer.invoke('activeGameSetConfig', config)?.catch(swallowNonBuiltins)
         }
 
-        // The game needs the block list to hide blocked players' in-game chat. Relationship state
-        // is cleared on every reconnect, so make sure it's loaded before launching. We cap the wait
-        // with a timeout and fall back to whatever's cached rather than stalling the launch behind a
-        // slow/hung request — worst case the game just launches without the latest block list.
-        // `callbackOnAbort` is required so the timeout still triggers the fallback (abortableThunk
-        // otherwise swallows both callbacks once the signal aborts).
-        if (getState().relationships.loaded) {
-          buildAndSend()
-        } else {
-          dispatch(
-            getRelationshipsIfNeeded({
-              signal: AbortSignal.timeout(RELATIONSHIPS_LAUNCH_TIMEOUT_MS),
-              callbackOnAbort: true,
-              onSuccess: buildAndSend,
-              onError: () => buildAndSend(),
-            }),
-          )
-        }
+        // The game needs the block list to hide blocked players' in-game chat, and relationship
+        // state is cleared on every reconnect, so make sure it's loaded before launching (falling
+        // back to whatever's cached rather than stalling the launch).
+        dispatch(ensureRelationshipsLoaded(buildAndSend))
       }
     },
     setRoutes(_, { routes, gameId }) {

--- a/client/replays/action-creators.ts
+++ b/client/replays/action-creators.ts
@@ -15,6 +15,7 @@ import logger from '../logging/logger'
 import { abortableThunk, RequestHandlingSpec } from '../network/abortable-thunk'
 import { fetchRaw } from '../network/fetch'
 import { makeServerUrl } from '../network/server-url'
+import { ensureRelationshipsLoaded } from '../social/action-creators'
 import { healthChecked } from '../starcraft/health-checked'
 
 const ipcRenderer = new TypedIpcRenderer()
@@ -73,38 +74,46 @@ export function startReplay({
   name?: string
 }): ThunkAction {
   return healthChecked((dispatch, getState) => {
-    const {
-      auth: { self },
-    } = getState()
+    // Relationship state (the block list) resets on reconnect, so ensure it's loaded before reading
+    // it — otherwise a replay launched right after a reconnect would hide nothing. Consistent with
+    // the game-launch path in active-game/socket-handlers.ts.
+    dispatch(
+      ensureRelationshipsLoaded(() => {
+        const {
+          auth: { self },
+          relationships,
+        } = getState()
 
-    // TODO(2Pac): Use the game loader on the server to register watching a replay, so we can show
-    // to other people (like their friends) when a user is watching a replay.
-    const blockedUsers = Array.from(getState().relationships.blocks.keys())
-    setGameConfig({ path, name }, self?.user, blockedUsers).then(
-      gameId => {
-        if (gameId) {
-          dispatch(openDialog({ type: DialogType.ReplayLoad, initData: { gameId } }))
-          // NOTE(tec27): This is just to give time for the dialog to open/run its effects to start
-          // waiting for this game to launch to avoid a race here. This is pretty dumb and should
-          // probably be handled in a different way.
-          setTimeout(() => {
-            setGameRoutes(gameId)
-          }, 250)
-        }
-      },
-      err => {
-        logger.error(`Error starting replay file [${path}]: ${err?.stack ?? err}`)
-        dispatch(
-          openSimpleDialog(
-            i18n.t('replays.loading.initFailureTitle', 'Error loading replay'),
-            i18n.t(
-              'replays.loading.initFailureBody',
-              'The selected replay could not be loaded. It may either be corrupt, or was created ' +
-                'by a version of StarCraft newer than is currently supported.',
-            ),
-          ),
+        // TODO(2Pac): Use the game loader on the server to register watching a replay, so we can
+        // show to other people (like their friends) when a user is watching a replay.
+        const blockedUsers = Array.from(relationships.blocks.keys())
+        setGameConfig({ path, name }, self?.user, blockedUsers).then(
+          gameId => {
+            if (gameId) {
+              dispatch(openDialog({ type: DialogType.ReplayLoad, initData: { gameId } }))
+              // NOTE(tec27): This is just to give time for the dialog to open/run its effects to
+              // start waiting for this game to launch to avoid a race here. This is pretty dumb and
+              // should probably be handled in a different way.
+              setTimeout(() => {
+                setGameRoutes(gameId)
+              }, 250)
+            }
+          },
+          err => {
+            logger.error(`Error starting replay file [${path}]: ${err?.stack ?? err}`)
+            dispatch(
+              openSimpleDialog(
+                i18n.t('replays.loading.initFailureTitle', 'Error loading replay'),
+                i18n.t(
+                  'replays.loading.initFailureBody',
+                  'The selected replay could not be loaded. It may either be corrupt, or was ' +
+                    'created by a version of StarCraft newer than is currently supported.',
+                ),
+              ),
+            )
+          },
         )
-      },
+      }),
     )
   })
 }

--- a/client/replays/action-creators.ts
+++ b/client/replays/action-creators.ts
@@ -6,7 +6,7 @@ import { GameReplayInfo } from '../../common/games/games'
 import { TypedIpcRenderer } from '../../common/ipc'
 import { SlotType } from '../../common/lobbies/slot'
 import { SbUser, SelfUserJson } from '../../common/users/sb-user'
-import { makeSbUserId } from '../../common/users/sb-user-id'
+import { makeSbUserId, SbUserId } from '../../common/users/sb-user-id'
 import { openDialog, openSimpleDialog } from '../dialogs/action-creators'
 import { DialogType } from '../dialogs/dialog-type'
 import { ThunkAction } from '../dispatch-registry'
@@ -19,7 +19,11 @@ import { healthChecked } from '../starcraft/health-checked'
 
 const ipcRenderer = new TypedIpcRenderer()
 
-async function setGameConfig(replay: { name: string; path: string }, user?: SelfUserJson) {
+async function setGameConfig(
+  replay: { name: string; path: string },
+  user?: SelfUserJson,
+  blockedUsers: SbUserId[] = [],
+) {
   const player: PlayerInfo = {
     type: SlotType.Human,
     typeId: 6,
@@ -38,6 +42,7 @@ async function setGameConfig(replay: { name: string; path: string }, user?: Self
 
   return ipcRenderer.invoke('activeGameSetConfig', {
     localUser,
+    blockedUsers,
     serverConfig: {
       serverUrl: makeServerUrl(''),
     },
@@ -74,7 +79,8 @@ export function startReplay({
 
     // TODO(2Pac): Use the game loader on the server to register watching a replay, so we can show
     // to other people (like their friends) when a user is watching a replay.
-    setGameConfig({ path, name }, self?.user).then(
+    const blockedUsers = Array.from(getState().relationships.blocks.keys())
+    setGameConfig({ path, name }, self?.user, blockedUsers).then(
       gameId => {
         if (gameId) {
           dispatch(openDialog({ type: DialogType.ReplayLoad, initData: { gameId } }))

--- a/client/settings/settings-page.ts
+++ b/client/settings/settings-page.ts
@@ -1,5 +1,6 @@
 export enum UserSettingsPage {
   Account = 'UserAccount',
+  Social = 'UserSocial',
   Language = 'UserLanguage',
 }
 

--- a/client/settings/settings.tsx
+++ b/client/settings/settings.tsx
@@ -44,6 +44,7 @@ import {
 } from './settings-page'
 import { AccountSettings } from './user/account-settings'
 import { UserLanguageSettings } from './user/language-settings'
+import { UserSocialSettings } from './user/social-settings'
 
 const ESCAPE = 'Escape'
 
@@ -142,7 +143,9 @@ function Settings({
       transition={transition}>
       <NavContainer>
         <NavSectionTitle>{t('settings.user.title', 'User')}</NavSectionTitle>
-        {(isLoggedIn ? [UserSettingsPage.Account] : []).map(getNavEntriesMapper())}
+        {(isLoggedIn ? [UserSettingsPage.Account, UserSettingsPage.Social] : []).map(
+          getNavEntriesMapper(),
+        )}
         {[UserSettingsPage.Language].map(getNavEntriesMapper())}
 
         {IS_ELECTRON ? (
@@ -215,6 +218,8 @@ function SettingsPageDisplay({ page }: { page: SettingsPage }) {
   switch (page) {
     case UserSettingsPage.Account:
       return <AccountSettings />
+    case UserSettingsPage.Social:
+      return <UserSocialSettings />
     case UserSettingsPage.Language:
       return <UserLanguageSettings />
   }
@@ -248,6 +253,9 @@ function getSettingsPageTitle({ page, t }: { page: SettingsPage; t: TFunction })
   switch (page) {
     case UserSettingsPage.Account:
       title = t('settings.user.account.label', 'Account')
+      break
+    case UserSettingsPage.Social:
+      title = t('settings.user.social.title', 'Social')
       break
     case UserSettingsPage.Language:
       title = t('settings.user.language.title', 'Language')

--- a/client/settings/user/social-settings.tsx
+++ b/client/settings/user/social-settings.tsx
@@ -1,0 +1,174 @@
+import { useTranslation } from 'react-i18next'
+import styled from 'styled-components'
+import { MAX_BLOCKS } from '../../../common/users/relationships'
+import { SbUserId } from '../../../common/users/sb-user-id'
+import { ConnectedAvatar } from '../../avatars/avatar'
+import { MaterialIcon } from '../../icons/material/material-icon'
+import { IconButton } from '../../material/button'
+import { useAppDispatch, useAppSelector } from '../../redux-hooks'
+import { useSnackbarController } from '../../snackbars/snackbar-overlay'
+import { unblockUser } from '../../social/action-creators'
+import { useRelationshipsLoader } from '../../social/friends-list'
+import { userRelationshipErrorToString } from '../../social/relationship-errors'
+import { bodyLarge, labelLarge, singleLine, titleLarge, titleSmall } from '../../styles/typography'
+import { areUserEntriesEqual, useUserEntriesSelector } from '../../users/user-entries'
+
+const Root = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+`
+
+const SectionHeader = styled.div`
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 16px;
+`
+
+const HeaderTitle = styled.div`
+  ${titleLarge};
+`
+
+const BlockCount = styled.div`
+  ${labelLarge};
+  ${singleLine};
+  color: var(--theme-on-surface-variant);
+`
+
+const Description = styled.div`
+  ${bodyLarge};
+  margin-bottom: 8px;
+  color: var(--theme-on-surface-variant);
+`
+
+const BlockList = styled.div`
+  display: flex;
+  flex-direction: column;
+`
+
+const EmptyList = styled.div`
+  ${bodyLarge};
+  padding: 32px 0 48px;
+
+  color: var(--theme-on-surface-variant);
+  text-align: center;
+`
+
+const BlockedUserRoot = styled.div`
+  height: 56px;
+  padding: 4px 8px;
+
+  display: flex;
+  align-items: center;
+  gap: 16px;
+
+  border-radius: 4px;
+
+  &:hover {
+    background-color: rgb(from var(--theme-on-surface) r g b / 0.08);
+  }
+`
+
+const StyledAvatar = styled(ConnectedAvatar)`
+  width: 40px;
+  height: 40px;
+  flex-shrink: 0;
+`
+
+const BlockedUserName = styled.div`
+  ${titleSmall};
+  ${singleLine};
+  flex-grow: 1;
+`
+
+const LoadingName = styled.div`
+  flex-grow: 1;
+  max-width: 96px;
+  height: 20px;
+
+  background-color: var(--theme-skeleton);
+  border-radius: 4px;
+`
+
+export function UserSocialSettings() {
+  const { t } = useTranslation()
+  useRelationshipsLoader()
+
+  const blocks = useAppSelector(s => s.relationships.blocks)
+  const blockedEntries = useAppSelector(useUserEntriesSelector(blocks), areUserEntriesEqual)
+
+  return (
+    <Root>
+      <SectionHeader>
+        <HeaderTitle>{t('settings.user.social.blockedUsers.title', 'Blocked users')}</HeaderTitle>
+        <BlockCount>
+          {t('settings.user.social.blockedUsers.count', {
+            defaultValue: '{{blocked}} / {{max}}',
+            blocked: blocks.size,
+            max: MAX_BLOCKS,
+          })}
+        </BlockCount>
+      </SectionHeader>
+      <Description>
+        {t(
+          'settings.user.social.blockedUsers.description',
+          "You won't see messages from blocked users in chat or in games, and they can't send you " +
+            'friend requests.',
+        )}
+      </Description>
+      {blockedEntries.length === 0 ? (
+        <EmptyList>
+          {t('settings.user.social.blockedUsers.empty', "You haven't blocked anyone.")}
+        </EmptyList>
+      ) : (
+        <BlockList>
+          {blockedEntries.map(([userId, username]) => (
+            <BlockedUserEntry key={userId} userId={userId} username={username} />
+          ))}
+        </BlockList>
+      )}
+    </Root>
+  )
+}
+
+function BlockedUserEntry({ userId, username }: { userId: SbUserId; username?: string }) {
+  const { t } = useTranslation()
+  const dispatch = useAppDispatch()
+  const snackbarController = useSnackbarController()
+
+  return (
+    <BlockedUserRoot>
+      <StyledAvatar userId={userId} />
+      {username ? (
+        <BlockedUserName>{username}</BlockedUserName>
+      ) : (
+        <LoadingName aria-label={t('common.loading.username', 'Username loading…')} />
+      )}
+      <IconButton
+        icon={<MaterialIcon icon='person_remove' />}
+        title={t('common.actions.unblock', 'Unblock')}
+        onClick={() => {
+          dispatch(
+            unblockUser(userId, {
+              onSuccess: () => {
+                snackbarController.showSnackbar(
+                  t('users.contextMenu.userUnblocked', 'User unblocked'),
+                )
+              },
+              onError: err => {
+                snackbarController.showSnackbar(
+                  userRelationshipErrorToString(
+                    err,
+                    t('users.errors.friendsList.errorUnblockingUser', 'Error unblocking user'),
+                    t,
+                  ),
+                )
+              },
+            }),
+          )
+        }}
+      />
+    </BlockedUserRoot>
+  )
+}

--- a/client/social/action-creators.ts
+++ b/client/social/action-creators.ts
@@ -23,6 +23,38 @@ export function getRelationshipsIfNeeded(spec: RequestHandlingSpec): ThunkAction
   })
 }
 
+/**
+ * How long to wait for relationships (the block list) to load before proceeding with whatever's
+ * cached. Keeps a slow/hung request from stalling a game or replay launch.
+ */
+const RELATIONSHIPS_LOAD_TIMEOUT_MS = 5000
+
+/**
+ * Ensures relationship state (including the block list) has been loaded, then runs `onReady`.
+ *
+ * Relationship state resets on every reconnect, so the game/replay launch paths use this to send an
+ * up-to-date block list. If it isn't loaded yet, the load is bounded by a timeout and `onReady` runs
+ * with whatever's cached on success, error, or timeout — the launch is never blocked behind a
+ * slow/hung request. `callbackOnAbort` is required so the timeout still triggers `onReady`
+ * (abortableThunk otherwise skips both callbacks once the signal aborts).
+ */
+export function ensureRelationshipsLoaded(onReady: () => void): ThunkAction {
+  return (dispatch, getState) => {
+    if (getState().relationships.loaded) {
+      onReady()
+    } else {
+      dispatch(
+        getRelationshipsIfNeeded({
+          signal: AbortSignal.timeout(RELATIONSHIPS_LOAD_TIMEOUT_MS),
+          callbackOnAbort: true,
+          onSuccess: onReady,
+          onError: () => onReady(),
+        }),
+      )
+    }
+  }
+}
+
 export function sendFriendRequest(toId: SbUserId, spec: RequestHandlingSpec): ThunkAction {
   return abortableThunk(spec, async () => {
     await fetchJson<void>(apiUrl`users/${toId}/relationships/friend-requests`, {

--- a/client/social/friends-list.tsx
+++ b/client/social/friends-list.tsx
@@ -17,6 +17,7 @@ import { useNavigationTracker } from '../navigation/navigation-tracker'
 import { useUserLocalStorageValue } from '../react/state-hooks'
 import { useAppDispatch, useAppSelector } from '../redux-hooks'
 import { openSettings } from '../settings/action-creators'
+import { UserSettingsPage } from '../settings/settings-page'
 import { DURATION_LONG } from '../snackbars/snackbar-durations'
 import { useSnackbarController } from '../snackbars/snackbar-overlay'
 import { styledWithAttrs } from '../styles/styled-with-attrs'
@@ -137,8 +138,7 @@ export function FriendsList() {
             activeTab={activeTab}
             onChange={tab => {
               if (tab === FriendsListTab.Settings) {
-                // TODO(tec27): Open to the correct part of settings once it's there
-                dispatch(openSettings())
+                dispatch(openSettings(UserSettingsPage.Social))
                 onNavigation()
                 return
               }

--- a/common/games/game-launch-config.ts
+++ b/common/games/game-launch-config.ts
@@ -99,6 +99,11 @@ export interface GameSetup {
 export interface GameLaunchConfig {
   /** The user currently logged into the application and playing the game. */
   localUser: SbUser
+  /**
+   * The SbUserIds the local user has blocked. Their chat messages are hidden in-game (matching the
+   * app's behavior in chat/whispers).
+   */
+  blockedUsers: SbUserId[]
   /** Setup for this specific server. */
   serverConfig: {
     /** The URL of the server, so that the game client can communicate with it as necessary. */

--- a/game/src/app_socket.rs
+++ b/game/src/app_socket.rs
@@ -163,6 +163,13 @@ fn handle_app_message(text: String) -> Result<MessageResult, HandleMessageError>
             let user = serde_json::from_value(payload).context(("Invalid local user", &*text))?;
             Ok(MessageResult::Game(GameStateMessage::SetLocalUser(user)))
         }
+        "blockedUsers" => {
+            let blocked_users =
+                serde_json::from_value(payload).context(("Invalid blocked users", &*text))?;
+            Ok(MessageResult::Game(GameStateMessage::SetBlockedUsers(
+                blocked_users,
+            )))
+        }
         "serverConfig" => {
             let config =
                 serde_json::from_value(payload).context(("Invalid server config", &*text))?;

--- a/game/src/bw_scr.rs
+++ b/game/src/bw_scr.rs
@@ -2762,11 +2762,14 @@ impl BwScr {
         &self,
         players: &[JoinedPlayer],
         local_user_id: SbUserId,
+        blocked_users: &[SbUserId],
         is_chat_restricted: bool,
     ) {
         let mut chat_manager = self.chat_manager.lock();
         chat_manager.set_players(players);
+        // Must be set before the blocked players so the local user can't end up blocked.
         chat_manager.set_local_player_info(local_user_id, is_chat_restricted);
+        chat_manager.set_blocked_players(blocked_users);
     }
 
     pub fn snet_next_turn_sequence_number(&self) -> u16 {

--- a/game/src/bw_scr/chat.rs
+++ b/game/src/bw_scr/chat.rs
@@ -43,6 +43,18 @@ impl ChatManager {
         debug!("ChatManager initialized with players: {:?}", self.players);
     }
 
+    /// Replaces the set of players blocked on ShieldBattery. Should be called after
+    /// [`Self::set_local_player_info`] so the local user is never blocked.
+    pub fn set_blocked_players(&mut self, player_ids: &[SbUserId]) {
+        self.blocked_players.clear();
+        self.blocked_players.extend(
+            player_ids
+                .iter()
+                .filter(|&&id| self.local_user_id != Some(id)),
+        );
+        debug!("ChatManager blocked players: {:?}", self.blocked_players);
+    }
+
     pub fn add_blocked_player(&mut self, player_id: SbUserId) {
         if self.local_user_id == Some(player_id) {
             // Don't allow blocking yourself

--- a/game/src/game_state.rs
+++ b/game/src/game_state.rs
@@ -65,6 +65,9 @@ enum InitState {
 
 struct IncompleteInit {
     local_user: Option<SbUser>,
+    /// SbUserIds the local user has blocked; their in-game chat is hidden. Not required for init,
+    /// so it defaults to empty if the app never sends it.
+    blocked_users: Vec<SbUserId>,
     server_config: Option<ServerConfig>,
     settings_set: bool,
     routes_set: bool,
@@ -91,6 +94,7 @@ impl IncompleteInit {
         Ok(InitInProgress::new(
             info.clone(),
             self.local_user.take().unwrap(),
+            mem::take(&mut self.blocked_users),
             self.server_config.take().unwrap(),
         ))
     }
@@ -101,6 +105,7 @@ pub enum GameStateMessage {
     SetSettings(Settings),
     SetRoutes(Vec<Route>),
     SetLocalUser(SbUser),
+    SetBlockedUsers(Vec<SbUserId>),
     SetServerConfig(ServerConfig),
     SetupGame(Box<GameSetupInfo>),
     StartWhenReady,
@@ -186,6 +191,14 @@ impl GameState {
             state.local_user = Some(user);
         } else {
             error!("Received local user after game was started");
+        }
+    }
+
+    fn set_blocked_users(&mut self, users: Vec<SbUserId>) {
+        if let InitState::WaitingForInput(ref mut state) = self.init_state {
+            state.blocked_users = users;
+        } else {
+            error!("Received blocked users after game was started");
         }
     }
 
@@ -566,6 +579,9 @@ impl GameState {
             SetLocalUser(user) => {
                 self.set_local_user(user);
             }
+            SetBlockedUsers(users) => {
+                self.set_blocked_users(users);
+            }
             SetRoutes(routes) => {
                 return self.set_routes(routes).boxed();
             }
@@ -709,6 +725,7 @@ impl GameState {
                     get_bw().init_chat_manager(
                         &state.joined_players,
                         state.local_user.id,
+                        &state.blocked_users,
                         state.setup_info.is_chat_restricted.unwrap_or_default(),
                     );
 
@@ -998,6 +1015,7 @@ async fn send_replay(
 struct InitInProgress {
     setup_info: Arc<GameSetupInfo>,
     local_user: SbUser,
+    blocked_users: Vec<SbUserId>,
     server_config: ServerConfig,
 
     all_players_joined: AwaitableTaskState<Result<(), GameInitError>>,
@@ -1024,6 +1042,7 @@ impl InitInProgress {
     fn new(
         setup_info: Arc<GameSetupInfo>,
         local_user: SbUser,
+        blocked_users: Vec<SbUserId>,
         server_config: ServerConfig,
     ) -> InitInProgress {
         let is_host = setup_info
@@ -1051,6 +1070,7 @@ impl InitInProgress {
         let mut result = InitInProgress {
             setup_info,
             local_user,
+            blocked_users,
             server_config,
 
             all_players_joined: AwaitableTaskState::Incomplete(Vec::new()),
@@ -1670,6 +1690,7 @@ pub async fn create_future(
     let mut game_state = GameState {
         init_state: InitState::WaitingForInput(IncompleteInit {
             local_user: None,
+            blocked_users: Vec::new(),
             server_config: None,
             routes_set: false,
             settings_set: false,

--- a/game/src/game_state.rs
+++ b/game/src/game_state.rs
@@ -709,16 +709,24 @@ impl GameState {
             }
             PlayersRandomized(new_mapping) => {
                 if let InitState::Started(ref mut state) = self.init_state {
-                    for player in &mut state.joined_players {
-                        let old_id = player.player_id;
-                        player.player_id = new_mapping
-                            .get(player.storm_id.0 as usize)
-                            .and_then(|&id| id);
-                        if old_id.is_some() != player.player_id.is_some() {
-                            warn!(
-                                "Player {} lost/gained player id after randomization: {:?} -> {:?}",
-                                player.name, old_id, player.player_id,
-                            );
+                    if state.setup_info.is_replay() {
+                        // Replays don't go through the normal lobby join flow that populates
+                        // joined_players (the launch config only carries the local viewer), so
+                        // rebuild it here from the SB user ids recorded in the replay's Sbat
+                        // section. This is what lets the chat manager hide blocked players' chat.
+                        state.joined_players = build_replay_joined_players();
+                    } else {
+                        for player in &mut state.joined_players {
+                            let old_id = player.player_id;
+                            player.player_id = new_mapping
+                                .get(player.storm_id.0 as usize)
+                                .and_then(|&id| id);
+                            if old_id.is_some() != player.player_id.is_some() {
+                                warn!(
+                                    "Player {} lost/gained player id after randomization: {:?} -> {:?}",
+                                    player.name, old_id, player.player_id,
+                                );
+                            }
                         }
                     }
 
@@ -1603,6 +1611,50 @@ unsafe fn setup_slots(
             }
         }
     }
+}
+
+/// Builds the joined-player list for a replay from the SB user ids recorded in its Sbat section,
+/// so the chat manager can hide blocked players' chat. Unlike a live game, a replay never populates
+/// `joined_players` through the lobby join flow — but the replay records each player's SB user id
+/// keyed by BW player id, which is exactly the id the chat manager matches incoming chat against.
+///
+/// Note we deliberately don't use the storm player list here: in a replay the only storm player is
+/// the local viewer, not the recorded players. `user_ids` is indexed by BW player id (and covers
+/// only the 8 playing slots), so we map it straight across — observers and empty slots (which have
+/// a 0 user id) are skipped and won't have their chat hidden.
+///
+/// Returns an empty list for replays without the Sbat section (e.g. non-ShieldBattery replays), in
+/// which case no chat is hidden.
+fn build_replay_joined_players() -> Vec<JoinedPlayer> {
+    let Some(replay_data) = game_thread::sbat_replay_data() else {
+        return Vec::new();
+    };
+    let players = unsafe { get_bw().players() };
+    let joined_players = replay_data
+        .user_ids
+        .iter()
+        .enumerate()
+        .filter_map(|(player_id, &sb_user_id)| {
+            if sb_user_id.0 == 0 {
+                return None;
+            }
+            // The BW player array is indexed by BW player id too, so it lines up with user_ids.
+            let name = unsafe {
+                CStr::from_ptr((*players.add(player_id)).name.as_ptr() as *const i8)
+                    .to_str()
+                    .unwrap_or("")
+                    .to_string()
+            };
+            Some(JoinedPlayer {
+                name,
+                storm_id: StormPlayerId(player_id as u8),
+                player_id: Some(BwPlayerId(player_id as u8)),
+                sb_user_id,
+            })
+        })
+        .collect::<Vec<_>>();
+    debug!("Built replay joined players: {joined_players:?}");
+    joined_players
 }
 
 unsafe fn storm_player_names(bw: &BwScr) -> Vec<Option<String>> {

--- a/game/src/replay.rs
+++ b/game/src/replay.rs
@@ -5,7 +5,7 @@ use std::io;
 use byteorder::{LE, ReadBytesExt, WriteBytesExt};
 use libc::c_void;
 
-use crate::app_messages::GameSetupInfo;
+use crate::app_messages::{GameSetupInfo, SbUserId};
 use crate::bw::Bw;
 use crate::bw::players::BwPlayerId;
 use crate::bw_scr::BwScr;
@@ -29,6 +29,9 @@ pub const GAME_LOGIC_VERSION: u16 = 0x3;
 pub struct SbatReplayData {
     pub team_game_main_players: [u8; 4],
     pub starting_races: [u8; 0xc],
+    /// ShieldBattery user ids of the players, indexed by BW player id (i.e. `user_ids[player_id]`
+    /// is that player's user id). Non-human/empty slots are `0`.
+    pub user_ids: [SbUserId; 8],
     pub game_logic_version: u16,
 }
 
@@ -174,6 +177,29 @@ fn test_write_uuid() {
     );
 }
 
+#[test]
+fn test_parse_user_ids() {
+    // Section payload as written by `add_shieldbattery_data` (offsets are relative to the payload,
+    // i.e. after the 8-byte section id/length header).
+    let mut data = vec![0u8; 0x58];
+    (&mut data[0x0..]).write_u16::<LE>(1).unwrap(); // format_version
+    data[0x16..0x1a].copy_from_slice(&[1, 2, 3, 4]); // team_game_main_players
+    // user_ids[8] at 0x36, one u32 each. Only the first two slots are "human".
+    let user_ids = [111u32, 222, 0, 0, 0, 0, 0, 0];
+    let mut out = &mut data[0x36..0x56];
+    for &id in &user_ids {
+        out.write_u32::<LE>(id).unwrap();
+    }
+    (&mut data[0x56..])
+        .write_u16::<LE>(GAME_LOGIC_VERSION)
+        .unwrap();
+
+    let parsed = parse_shieldbattery_data(&data).unwrap();
+    assert_eq!(parsed.team_game_main_players, [1, 2, 3, 4]);
+    assert_eq!(parsed.game_logic_version, GAME_LOGIC_VERSION);
+    assert_eq!(parsed.user_ids.map(|id| id.0), user_ids);
+}
+
 pub fn parse_shieldbattery_data(data: &[u8]) -> Option<SbatReplayData> {
     let format = (&data[0..]).read_u16::<LE>().ok()?;
     if format > 1 {
@@ -181,6 +207,11 @@ pub fn parse_shieldbattery_data(data: &[u8]) -> Option<SbatReplayData> {
     }
     let team_game_main_players = data.get(0x16..)?.get(..4)?;
     let starting_races = data.get(0x1a..)?.get(..0xc)?;
+    let mut user_id_bytes = data.get(0x36..)?.get(..0x20)?;
+    let mut user_ids = [SbUserId(0); 8];
+    for out in user_ids.iter_mut() {
+        *out = SbUserId(user_id_bytes.read_u32::<LE>().ok()?);
+    }
     let game_logic_version = if format == 1 {
         data.get(0x56..)?.read_u16::<LE>().ok()?
     } else {
@@ -189,6 +220,7 @@ pub fn parse_shieldbattery_data(data: &[u8]) -> Option<SbatReplayData> {
     Some(SbatReplayData {
         team_game_main_players: team_game_main_players.try_into().ok()?,
         starting_races: starting_races.try_into().ok()?,
+        user_ids,
         game_logic_version,
     })
 }

--- a/server/public/locales/en/global.json
+++ b/server/public/locales/en/global.json
@@ -1348,6 +1348,15 @@
         "selectLanguage": "Select a language",
         "title": "Language"
       },
+      "social": {
+        "blockedUsers": {
+          "count": "{{blocked}} / {{max}}",
+          "description": "You won't see messages from blocked users in chat or in games, and they can't send you friend requests.",
+          "empty": "You haven't blocked anyone.",
+          "title": "Blocked users"
+        },
+        "title": "Social"
+      },
       "title": "User"
     }
   },


### PR DESCRIPTION
## What

Two related pieces of user-blocking work:

1. **App→game block sync (one-way).** The game DLL already had a `ChatManager.blocked_players` set that `handle_message` checks to hide chat — but nothing ever populated it (the methods were dead code). This feeds the local user's block list into the game so blocked players' in-game chat is now hidden, matching the app's behavior in chat/whispers.
2. **Blocked-users settings page.** There was no way to see who you've blocked. The Friends sidebar's "Social settings" tab just opened generic settings with a `TODO`. This adds a real "Social" page under User settings.

## How

**Block sync:** renderer adds `blockedUsers` to `GameLaunchConfig` (reading `relationships.blocks`, loading relationships first if they haven't been since the last reconnect) → app forwards a `blockedUsers` game command → `app_socket.rs` parses it → threaded through `game_state.rs` init → fed to `ChatManager` via `init_chat_manager` at the players-randomized step (after the local user is set, so you can't end up blocking yourself). Replay launches pass the block list too.

**UI:** new `client/settings/user/social-settings.tsx` (`UserSocialSettings`) lists blocked users (avatar + name + unblock, with an X/150 count and empty state), reusing `useUserEntriesSelector` / `useRelationshipsLoader` / `unblockUser`. The Friends sidebar's "Social settings" tab now opens directly to it.

## Out of scope

No in-game `/block` command (no game→app→server write-back) and no mid-game live block updates — the list is sent once at game setup.

## Testing

- `pnpm typecheck`, `pnpm lint`, `pnpm gen-translations`, `cargo fmt` + `cargo clippy` (game) all clean.
- **Social page** driven end-to-end in the app: block appears with name/avatar + count, unblock works with live update, and the previously-dead sidebar "Social settings" button now routes here.
- **In-game** verified with a rebuilt DLL + a real SC:R game (blocker vs computer): the DLL log shows the blocked user's `SbUserId` loaded into `ChatManager.blocked_players` at game start, confirming the renderer→app→DLL pipeline. The final on-screen hide is the pre-existing `handle_message` path shared with `/mute`.