### PR TITLE
Add `created` to SbUser and stop hand-building user infos

### DIFF
--- a/client/active-game/socket-handlers.ts
+++ b/client/active-game/socket-handlers.ts
@@ -58,6 +58,7 @@ export default function ({
             localUser: {
               id: self!.user.id,
               name: self!.user.name,
+              created: self!.user.created,
             },
             blockedUsers: Array.from(getState().relationships.blocks.keys()),
             serverConfig: {

--- a/client/ladder/devonly/table-test.tsx
+++ b/client/ladder/devonly/table-test.tsx
@@ -70,7 +70,7 @@ for (let i = 0; i < 1000; i++) {
     rZLosses,
     lastPlayedDate,
   })
-  usersById.set(makeSbUserId(i), { id: makeSbUserId(i), name })
+  usersById.set(makeSbUserId(i), { id: makeSbUserId(i), name, created: Date.now() })
 }
 
 PLAYERS.sort((a, b) => b.points - a.points)

--- a/client/replays/action-creators.ts
+++ b/client/replays/action-creators.ts
@@ -39,6 +39,7 @@ async function setGameConfig(
   const localUser: SbUser = {
     id: user?.id ?? makeSbUserId(0),
     name: user?.name ?? 'ShieldBattery User',
+    created: user?.created ?? 0,
   }
 
   return ipcRenderer.invoke('activeGameSetConfig', {

--- a/client/users/user-profile-overlay.tsx
+++ b/client/users/user-profile-overlay.tsx
@@ -218,7 +218,7 @@ export function UserProfileOverlayContents({
   }, [dispatch, userId])
 
   const hasAnyRanks = getRankedTypesByActivity(profile?.ladder ?? {}).length > 0
-  const longFormattedDate = longTimestamp.format(profile?.created)
+  const longFormattedDate = longTimestamp.format(user?.created)
 
   return (
     <PopoverContents>
@@ -257,7 +257,7 @@ export function UserProfileOverlayContents({
               <BodyMedium>
                 {t('users.profileOverlay.joined', {
                   defaultValue: 'Joined {{date}}',
-                  date: joinDateFormat.format(profile.created),
+                  date: joinDateFormat.format(user?.created),
                 })}
               </BodyMedium>
             </Tooltip>

--- a/client/users/user-reducer.ts
+++ b/client/users/user-reducer.ts
@@ -35,7 +35,7 @@ function updateUsers(state: UserState, users: SbUser[]) {
         userState.name = user.name
       }
     } else {
-      state.byId.set(user.id, { id: user.id, name: user.name })
+      state.byId.set(user.id, { id: user.id, name: user.name, created: user.created })
     }
   }
 }
@@ -46,7 +46,7 @@ export default immerKeyedReducer(DEFAULT_STATE, {
       payload: { user },
     } = action
 
-    state.byId.set(user.id, { id: user.id, name: user.name })
+    state.byId.set(user.id, { id: user.id, name: user.name, created: user.created })
   },
 
   ['@chat/loadMessageHistory'](state, action) {

--- a/client/whispers/socket-handlers.ts
+++ b/client/whispers/socket-handlers.ts
@@ -42,7 +42,7 @@ const eventToAction: EventToActionMap = {
         return
       }
 
-      const isBlocked = blocks.has(event.message.from.id)
+      const isBlocked = blocks.has(event.message.from)
       if (!isBlocked) {
         // Notify the main process of the new message, so it can display an appropriate notification
         ipcRenderer.send('chatNewMessage', {
@@ -51,7 +51,7 @@ const eventToAction: EventToActionMap = {
       }
 
       const { from, to } = event.message
-      const target = self.user.id === to.id ? from.id : to.id
+      const target = self.user.id === to ? from : to
       dispatch({
         type: '@whispers/updateMessage',
         payload: event,

--- a/client/whispers/whisper-reducer.ts
+++ b/client/whispers/whisper-reducer.ts
@@ -103,7 +103,7 @@ export default immerKeyedReducer(DEFAULT_STATE, {
     const newMessage = new TextMessageRecord({
       id,
       time,
-      from: from.id,
+      from,
       text,
     })
 
@@ -129,7 +129,7 @@ export default immerKeyedReducer(DEFAULT_STATE, {
         new TextMessageRecord({
           id: msg.id,
           time: msg.time,
-          from: msg.from.id,
+          from: msg.from,
           text: msg.text,
         }),
     )

--- a/common/users/sb-user.ts
+++ b/common/users/sb-user.ts
@@ -11,6 +11,12 @@ export interface SbUser {
   id: SbUserId
   /** The user's display name. */
   name: string
+  /**
+   * When the user's account was created, as a UTC timestamp in milliseconds. Represented as a
+   * number (rather than a `Date`) because `SbUser`s are sent over the wire as-is, without a
+   * `Jsonify` conversion step.
+   */
+  created: number
 }
 
 /** Information about the current user. */
@@ -48,6 +54,7 @@ export function toSelfUserJson(user: SelfUser): SelfUserJson {
   return {
     id: user.id,
     name: user.name,
+    created: user.created,
     loginName: user.loginName,
     email: user.email,
     emailVerified: user.emailVerified,
@@ -65,6 +72,7 @@ export function fromSelfUserJson(userJson: SelfUserJson): SelfUser {
   return {
     id: userJson.id,
     name: userJson.name,
+    created: userJson.created,
     loginName: userJson.loginName,
     email: userJson.email,
     emailVerified: userJson.emailVerified,

--- a/common/users/user-network.ts
+++ b/common/users/user-network.ts
@@ -36,7 +36,6 @@ export const RANDOM_EMAIL_CODE_PATTERN = new RegExp(
  */
 export interface UserProfile {
   userId: SbUserId
-  created: Date
   ladder: Partial<Record<MatchmakingType, LadderPlayer>>
   seasonId: SeasonId
   userStats: UserStats
@@ -47,7 +46,6 @@ export type UserProfileJson = Jsonify<UserProfile>
 export function toUserProfileJson(userProfile: UserProfile): UserProfileJson {
   return {
     userId: userProfile.userId,
-    created: Number(userProfile.created),
     ladder: userProfile.ladder,
     seasonId: userProfile.seasonId,
     userStats: userProfile.userStats,

--- a/common/whispers.ts
+++ b/common/whispers.ts
@@ -11,8 +11,13 @@ export enum WhisperMessageType {
 export interface BaseWhisperMessage {
   id: string
   type: WhisperMessageType
-  from: SbUser
-  to: SbUser
+  /**
+   * The ID of the user that sent the message. Full user info is delivered separately via the
+   * `users` array on the containing event/response.
+   */
+  from: SbUserId
+  /** The ID of the user that received the message. See `from` for where to find full user info. */
+  to: SbUserId
   time: number
 }
 

--- a/server/lib/chat/chat-models.ts
+++ b/server/lib/chat/chat-models.ts
@@ -380,7 +380,6 @@ export type ChatMessageData = TextMessageData | JoinChannelData
 export interface ChatMessage {
   msgId: string
   userId: SbUserId
-  userName: string
   channelId: SbChannelId
   sent: Date
   data: ChatMessageData
@@ -396,18 +395,13 @@ export async function addMessageToChannel<T extends ChatMessageData>(
 ): Promise<ChatMessage & { data: T }> {
   const doIt = async (client: DbClient) => {
     const result = await client.query<DbChatMessage>(sql`
-      WITH ins AS (
-        INSERT INTO channel_messages (user_id, channel_id, sent, data)
-        SELECT ${userId}, ${channelId},
-          CURRENT_TIMESTAMP AT TIME ZONE 'UTC', ${messageData}
-        WHERE EXISTS (
-          SELECT 1 FROM channel_users WHERE user_id = ${userId} AND channel_id = ${channelId}
-        )
-        RETURNING id, user_id, channel_id, sent, data
+      INSERT INTO channel_messages (user_id, channel_id, sent, data)
+      SELECT ${userId}, ${channelId},
+        CURRENT_TIMESTAMP AT TIME ZONE 'UTC', ${messageData}
+      WHERE EXISTS (
+        SELECT 1 FROM channel_users WHERE user_id = ${userId} AND channel_id = ${channelId}
       )
-      SELECT ins.id AS msg_id, users.id AS user_id, users.name AS user_name, ins.channel_id,
-        ins.sent, ins.data
-      FROM ins INNER JOIN users ON ins.user_id = users.id;
+      RETURNING id AS msg_id, user_id, channel_id, sent, data;
     `)
     if (result.rows.length < 1) {
       throw new Error('No rows returned')
@@ -417,7 +411,6 @@ export async function addMessageToChannel<T extends ChatMessageData>(
     return {
       msgId: row.msg_id,
       userId: row.user_id,
-      userName: row.user_name,
       channelId: row.channel_id,
       sent: row.sent,
       data: row.data as T,
@@ -445,8 +438,8 @@ export async function getMessagesForChannel(
 
   let query = sql`
       WITH messages AS (
-        SELECT m.id AS msg_id, u.id AS user_id, u.name AS user_name, m.channel_id, m.sent, m.data
-        FROM channel_messages as m INNER JOIN users as u ON m.user_id = u.id
+        SELECT m.id AS msg_id, m.user_id, m.channel_id, m.sent, m.data
+        FROM channel_messages as m
         WHERE m.channel_id = ${channelId} `
 
   if (beforeDate !== undefined) {
@@ -464,7 +457,6 @@ export async function getMessagesForChannel(
     return result.rows.map(row => ({
       msgId: row.msg_id,
       userId: row.user_id,
-      userName: row.user_name,
       channelId: row.channel_id,
       sent: row.sent,
       data: row.data,

--- a/server/lib/chat/chat-service.test.ts
+++ b/server/lib/chat/chat-service.test.ts
@@ -89,8 +89,8 @@ const mockRestrictionService = {
 } as any as RestrictionService
 
 const { user1, user2 } = vi.hoisted(() => ({
-  user1: { id: 1 as SbUserId, name: 'USER_NAME_1' } as SbUser,
-  user2: { id: 2 as SbUserId, name: 'USER_NAME_2' } as SbUser,
+  user1: { id: 1 as SbUserId, name: 'USER_NAME_1', created: 1577836800000 } as SbUser,
+  user2: { id: 2 as SbUserId, name: 'USER_NAME_2', created: 1577836800000 } as SbUser,
 }))
 
 vi.mock('../users/user-model', () => {
@@ -262,7 +262,6 @@ describe('chat/chat-service', () => {
   const joinUser1ShieldBatteryChannelMessage: FakeDbJoinChannelMessage = {
     msgId: 'MESSAGE_ID',
     userId: user1.id,
-    userName: user1.name,
     channelId: shieldBatteryChannel.id,
     sent: new Date('2023-03-11T00:00:00.000Z'),
     data: {
@@ -272,7 +271,6 @@ describe('chat/chat-service', () => {
   const joinUser1TestChannelMessage: FakeDbJoinChannelMessage = {
     msgId: 'MESSAGE_ID',
     userId: user1.id,
-    userName: user1.name,
     channelId: testChannel.id,
     sent: new Date('2023-03-11T00:00:00.000Z'),
     data: {
@@ -282,7 +280,6 @@ describe('chat/chat-service', () => {
   const joinUser2ShieldBatteryChannelMessage: FakeDbJoinChannelMessage = {
     msgId: 'MESSAGE_ID',
     userId: user2.id,
-    userName: user2.name,
     channelId: shieldBatteryChannel.id,
     sent: new Date('2023-03-11T00:00:00.000Z'),
     data: {
@@ -292,7 +289,6 @@ describe('chat/chat-service', () => {
   const joinUser2TestChannelMessage: FakeDbJoinChannelMessage = {
     msgId: 'MESSAGE_ID',
     userId: user2.id,
-    userName: user2.name,
     channelId: testChannel.id,
     sent: new Date('2023-03-11T00:00:00.000Z'),
     data: {
@@ -371,7 +367,6 @@ describe('chat/chat-service', () => {
     textMessage = {
       msgId: 'MESSAGE_ID',
       userId: user.id,
-      userName: user.name,
       channelId: channel.id,
       sent: new Date('2023-03-11T00:00:00.000Z'),
       data: {
@@ -440,7 +435,7 @@ describe('chat/chat-service', () => {
 
   describe('handleNewUser', () => {
     test('subscribes user to their joined channels', async () => {
-      const user3: SbUser = { id: 3 as SbUserId, name: 'USER_NAME_3' }
+      const user3: SbUser = { id: 3 as SbUserId, name: 'USER_NAME_3', created: 1577836800000 }
       const user3ShieldBatteryChannelEntry = { ...user1ShieldBatteryChannelEntry, userId: user3.id }
       const user3TestChannelEntry = { ...user1TestChannelEntry, userId: user3.id }
 
@@ -1669,7 +1664,6 @@ describe('chat/chat-service', () => {
     const textMessage1: FakeDbTextChannelMessage = {
       msgId: 'MESSAGE_1_ID',
       userId: user1.id,
-      userName: user1.name,
       channelId: testChannel.id,
       sent: new Date('2023-03-11T00:00:00.000Z'),
       data: {
@@ -1680,7 +1674,6 @@ describe('chat/chat-service', () => {
     const textMessage2: FakeDbTextChannelMessage = {
       msgId: 'MESSAGE_2_ID',
       userId: user1.id,
-      userName: user1.name,
       channelId: testChannel.id,
       sent: new Date('2023-03-11T00:00:00.000Z'),
       data: {
@@ -1692,7 +1685,6 @@ describe('chat/chat-service', () => {
     const textMessage3: FakeDbTextChannelMessage = {
       msgId: 'MESSAGE_3_ID',
       userId: user1.id,
-      userName: user1.name,
       channelId: testChannel.id,
       sent: new Date('2023-03-11T00:00:00.000Z'),
       data: {
@@ -1704,7 +1696,6 @@ describe('chat/chat-service', () => {
     const textMessage4: FakeDbTextChannelMessage = {
       msgId: 'MESSAGE_4_ID',
       userId: user1.id,
-      userName: user1.name,
       channelId: testChannel.id,
       sent: new Date('2023-03-11T00:00:00.000Z'),
       data: {
@@ -1827,7 +1818,6 @@ describe('chat/chat-service', () => {
       const message: FakeDbTextChannelMessage = {
         msgId: 'MESSAGE_5_ID',
         userId: user1.id,
-        userName: user1.name,
         channelId: testChannel.id,
         sent: new Date('2023-03-11T00:00:00.000Z'),
         data: {

--- a/server/lib/chat/chat-service.ts
+++ b/server/lib/chat/chat-service.ts
@@ -701,6 +701,8 @@ export default class ChatService {
       mentions: mentionedUserIds.length > 0 ? mentionedUserIds : undefined,
       channelMentions: mentionedChannelIds.length > 0 ? mentionedChannelIds : undefined,
     })
+    // The sender just posted a message, so they're guaranteed to exist
+    const user = (await findUserById(result.userId))!
 
     this.publisher.publish(getChannelPath(channelId), {
       action: 'message2',
@@ -712,10 +714,7 @@ export default class ChatService {
         time: Number(result.sent),
         text: result.data.text,
       },
-      user: {
-        id: result.userId,
-        name: result.userName,
-      },
+      user,
       mentions: userMentions,
       channelMentions: channelMentions.map(c => toBasicChannelInfo(c)),
     })

--- a/server/lib/users/user-api.ts
+++ b/server/lib/users/user-api.ts
@@ -130,7 +130,6 @@ import {
   findUserByName,
   findUsersById,
   isUsernameAvailable,
-  retrieveUserCreatedDate,
   UserUpdatables,
 } from './user-model'
 import { UserRelationshipService } from './user-relationship-service'
@@ -580,7 +579,6 @@ export class UserApi {
     const rankingsPromise = getRankingsForUser(this.redis, user.id, currentSeason.id)
 
     const userStatsPromise = getUserStats(user.id)
-    const createdDatePromise = retrieveUserCreatedDate(user.id)
 
     const NUM_RECENT_GAMES = 6
     const matchHistoryPromise = (async () => {
@@ -610,10 +608,9 @@ export class UserApi {
       }
     })()
 
-    const [userStats, matchHistory, createdDate, ratings, rankings] = await Promise.all([
+    const [userStats, matchHistory, ratings, rankings] = await Promise.all([
       userStatsPromise,
       matchHistoryPromise,
-      createdDatePromise,
       ratingsPromise,
       rankingsPromise,
     ])
@@ -653,7 +650,6 @@ export class UserApi {
       user,
       profile: {
         userId: user.id,
-        created: Number(createdDate),
         ladder,
         seasonId: currentSeason.id,
         userStats,

--- a/server/lib/users/user-model.ts
+++ b/server/lib/users/user-model.ts
@@ -87,6 +87,7 @@ function convertToExternalSelf(userInternal: UserInternal): SelfUser {
   return {
     id: userInternal.id,
     name: userInternal.name,
+    created: Number(userInternal.created),
     loginName: userInternal.loginName,
     email: userInternal.email,
     emailVerified: userInternal.emailVerified,
@@ -108,6 +109,7 @@ function convertToExternal(userInternal: UserInternal): SbUser {
   return {
     id: userInternal.id,
     name: userInternal.name,
+    created: Number(userInternal.created),
   }
 }
 
@@ -491,14 +493,6 @@ export async function findAllUsersWithEmail(email: string): Promise<SbUser[]> {
   } finally {
     done()
   }
-}
-
-// TODO(tec27): Delete this function and make this value part of SbUser (I don't have time to
-// thread this value through everywhere that needs it because a bunch of services try to construct
-// their own SbUsers from just a name and ID :( )
-export async function retrieveUserCreatedDate(userId: SbUserId): Promise<Date> {
-  const user = await internalFindUserById(userId)
-  return user!.created
 }
 
 export async function isUsernameAvailable(

--- a/server/lib/users/user-relationship-service.test.ts
+++ b/server/lib/users/user-relationship-service.test.ts
@@ -386,8 +386,14 @@ describe('users/user-relationship-service', () => {
     )
     connector = new NydusConnector(nydus, sessionLookup)
 
-    client1 = connector.connectClient({ id: makeSbUserId(1), name: 'One' }, 'one')
-    client2 = connector.connectClient({ id: makeSbUserId(2), name: 'Two' }, 'two')
+    client1 = connector.connectClient(
+      { id: makeSbUserId(1), name: 'One', created: 1577836800000 },
+      'one',
+    )
+    client2 = connector.connectClient(
+      { id: makeSbUserId(2), name: 'Two', created: 1577836800000 },
+      'two',
+    )
 
     asMockedFunction(client1.publish).mockClear()
     asMockedFunction(client2.publish).mockClear()
@@ -1038,7 +1044,10 @@ describe('users/user-relationship-service', () => {
       await userRelationshipService.acceptFriendRequest(USER, makeSbUserId(2))
       await userRelationshipService.acceptFriendRequest(USER, makeSbUserId(3))
 
-      const nextClient = connector.connectClient({ id: makeSbUserId(1), name: 'One' }, 'another')
+      const nextClient = connector.connectClient(
+        { id: makeSbUserId(1), name: 'One', created: 1577836800000 },
+        'another',
+      )
       await Promise.resolve()
 
       expect(nextClient.publish).toHaveBeenCalledWith(

--- a/server/lib/whispers/whisper-models.ts
+++ b/server/lib/whispers/whisper-models.ts
@@ -1,5 +1,4 @@
 import { SbChannelId } from '../../../common/chat'
-import { SbUser } from '../../../common/users/sb-user'
 import { SbUserId } from '../../../common/users/sb-user-id'
 import { WhisperMessageType } from '../../../common/whispers'
 import db from '../db'
@@ -84,35 +83,19 @@ type WhisperMessageData = WhisperTextMessageData
 
 export interface WhisperMessage {
   id: string
-  from: SbUser
-  to: SbUser
+  from: SbUserId
+  to: SbUserId
   sent: Date
   data: WhisperMessageData
 }
 
-interface FromUser {
-  fromId: SbUserId
-  fromName: string
-}
-
-interface ToUser {
-  toId: SbUserId
-  toName: string
-}
-
-type DbWhisperMessage = Dbify<WhisperMessage & FromUser & ToUser>
+type DbWhisperMessage = Dbify<WhisperMessage>
 
 function convertMessageFromDb(dbMessage: DbWhisperMessage): WhisperMessage {
   return {
     id: dbMessage.id,
-    from: {
-      id: dbMessage.from_id,
-      name: dbMessage.from_name,
-    },
-    to: {
-      id: dbMessage.to_id,
-      name: dbMessage.to_name,
-    },
+    from: dbMessage.from,
+    to: dbMessage.to,
     sent: dbMessage.sent,
     data: dbMessage.data,
   }
@@ -126,16 +109,10 @@ export async function addMessageToWhisper(
   const { client, done } = await db()
   try {
     const result = await client.query<DbWhisperMessage>(sql`
-      WITH ins AS (
-        INSERT INTO whisper_messages (from_id, to_id, sent, data)
-        VALUES (${fromId}, ${toId},
-          CURRENT_TIMESTAMP AT TIME ZONE 'UTC', ${messageData})
-        RETURNING id, from_id, to_id, sent, data
-      )
-      SELECT ins.id, u_from.id AS from_id, u_from.name AS from_name, u_to.id AS to_id,
-        u_to.name AS to_name, ins.sent, ins.data FROM ins
-      INNER JOIN users AS u_from ON ins.from_id = u_from.id
-      INNER JOIN users AS u_to ON ins.to_id = u_to.id;
+      INSERT INTO whisper_messages (from_id, to_id, sent, data)
+      VALUES (${fromId}, ${toId},
+        CURRENT_TIMESTAMP AT TIME ZONE 'UTC', ${messageData})
+      RETURNING id, from_id AS "from", to_id AS "to", sent, data;
     `)
     if (result.rows.length < 1) {
       throw new Error('No rows returned')
@@ -159,11 +136,8 @@ export async function getMessagesForWhisperSession(
   try {
     const result = await client.query<DbWhisperMessage>(sql`
       WITH messages AS (
-        SELECT m.id, m.from_id AS from_id, u_from.name AS from_name, m.to_id AS to_id,
-          u_to.name AS to_name, m.sent, m.data
+        SELECT m.id, m.from_id AS "from", m.to_id AS "to", m.sent, m.data
         FROM whisper_messages AS m
-        INNER JOIN users AS u_from ON m.from_id = u_from.id
-        INNER JOIN users AS u_to ON m.to_id = u_to.id
         WHERE m.user_low  = ${userLow}::int4
           AND m.user_high = ${userHigh}::int4
           ${beforeDate !== undefined ? sql`AND m.sent < ${beforeDate}` : sql``}


### PR DESCRIPTION
Closes #792.

## What

Moves the account creation date into the core `SbUser` structure and removes it from `UserProfile`. Along the way, cleans up the remaining places that constructed their own `SbUser`s from partial data — the exact thing #792 was blocked on ("a bunch of services try to construct their own SbUsers from just a name and ID").

## Why now

`SbUser` is a required-field interface, so adding a field makes the compiler flag every construction site — there's no silent breakage. Getting the hand-built sites onto the standard "embed an id + ship users via a side-channel array" pattern means the *next* addition to `SbUser` (e.g. a profile image) is a genuine one-liner.

## Changes

**Core**
- `SbUser.created: number` (epoch ms). It's a `number` rather than a `Date` because `SbUser`s are sent over the wire as-is, with no `Jsonify` conversion step and no date reviver in `fetchJson` — a `Date` would arrive as a string while TS claimed `Date`. This matches how the client already consumed `UserProfileJson.created`.
- `convertToExternal`/`convertToExternalSelf` populate it (the underlying `SELECT *` already fetches `created`).
- Deleted `retrieveUserCreatedDate` (tec27's stopgap) and `UserProfile.created`; the profile endpoint drops its extra query.

**Removed hand-built `SbUser` sites**
- **Whispers:** message `from`/`to` are now `SbUserId`s instead of embedded `SbUser`s. The client already only read `.id`, and full user info arrives via the `users` side-channel array. The name-lookup JOINs in the whisper message queries are gone.
- **Live chat sends:** the sender is now resolved via `findUserById` (like the channel-history path) instead of a denormalized `user_name` join column, which is removed from the chat message queries/type.
- **Client:** the two `localUser` constructions (game + replay launch) and the central user store's field-picker now carry `created`.

## Verification

- `pnpm typecheck`, `pnpm lint`, and the full unit suite (864 tests) pass.
- All four changed SQL query patterns (whisper insert/history with `"from"`/`"to"` reserved-word aliases, chat insert `RETURNING`, chat history without the join) were run against the dev DB and return the expected columns; the chat insert was checked inside a rolled-back transaction.

## Out of scope

The GraphQL `type SbUser` (server-rs) is a separate representation and is intentionally left unchanged.