### PR TITLE
Add a news post authoring UI to the admin panel

### DIFF
--- a/client/admin/admin-news.test.ts
+++ b/client/admin/admin-news.test.ts
@@ -1,0 +1,281 @@
+import { describe, expect, test } from 'vitest'
+import {
+  changedFieldLabels,
+  createPublishedAt,
+  getPostStatus,
+  NewsEditorModel,
+  NewsPostEdit,
+  PUBLISH_MODE_DRAFT,
+  PUBLISH_MODE_NOW,
+  PUBLISH_MODE_SCHEDULE,
+  publishedAtUpdate,
+  toDateTimeLocalString,
+} from './admin-news'
+
+describe('getPostStatus', () => {
+  test('returns draft for a null publishedAt', () => {
+    expect(getPostStatus(null, Date.now())).toEqual({ kind: 'draft' })
+  })
+
+  test('returns draft for an undefined publishedAt', () => {
+    expect(getPostStatus(undefined, Date.now())).toEqual({ kind: 'draft' })
+  })
+
+  test('returns scheduled for a publishedAt in the future', () => {
+    const now = Date.UTC(2026, 0, 1)
+    const publishedAt = new Date(now + 60_000).toISOString()
+
+    expect(getPostStatus(publishedAt, now)).toEqual({
+      kind: 'scheduled',
+      date: new Date(publishedAt),
+    })
+  })
+
+  test('returns published for a publishedAt in the past', () => {
+    const now = Date.UTC(2026, 0, 1)
+    const publishedAt = new Date(now - 60_000).toISOString()
+
+    expect(getPostStatus(publishedAt, now)).toEqual({
+      kind: 'published',
+      date: new Date(publishedAt),
+    })
+  })
+
+  test('returns published for a publishedAt exactly equal to now', () => {
+    const now = Date.UTC(2026, 0, 1)
+    const publishedAt = new Date(now).toISOString()
+
+    expect(getPostStatus(publishedAt, now)).toEqual({
+      kind: 'published',
+      date: new Date(publishedAt),
+    })
+  })
+})
+
+describe('toDateTimeLocalString', () => {
+  test('formats a date with zero-padded components', () => {
+    const date = new Date(2026, 0, 5, 9, 3)
+
+    expect(toDateTimeLocalString(date)).toBe('2026-01-05T09:03')
+  })
+
+  test('pads single-digit month and day', () => {
+    const date = new Date(2026, 8, 1, 0, 0)
+
+    expect(toDateTimeLocalString(date)).toBe('2026-09-01T00:00')
+  })
+
+  test('does not pad four-digit years or double-digit components', () => {
+    const date = new Date(2026, 11, 25, 23, 59)
+
+    expect(toDateTimeLocalString(date)).toBe('2026-12-25T23:59')
+  })
+})
+
+describe('createPublishedAt', () => {
+  const baseModel: NewsEditorModel = {
+    title: 'Title',
+    summary: 'Summary',
+    content: 'Content',
+    publishMode: PUBLISH_MODE_DRAFT,
+    scheduledAt: '',
+  }
+
+  test('returns undefined for draft mode', () => {
+    expect(createPublishedAt({ ...baseModel, publishMode: PUBLISH_MODE_DRAFT })).toBeUndefined()
+  })
+
+  test('returns the ISO string of the scheduled date for schedule mode', () => {
+    const scheduledAt = toDateTimeLocalString(new Date(2026, 5, 15, 10, 30))
+
+    expect(
+      createPublishedAt({ ...baseModel, publishMode: PUBLISH_MODE_SCHEDULE, scheduledAt }),
+    ).toBe(new Date(scheduledAt).toISOString())
+  })
+
+  test('returns a parseable ISO string for publish-now mode', () => {
+    const result = createPublishedAt({ ...baseModel, publishMode: PUBLISH_MODE_NOW })
+
+    expect(result).toBeDefined()
+    expect(new Date(result!).toISOString()).toBe(result)
+  })
+})
+
+describe('publishedAtUpdate', () => {
+  const baseModel: NewsEditorModel = {
+    title: 'Title',
+    summary: 'Summary',
+    content: 'Content',
+    publishMode: PUBLISH_MODE_DRAFT,
+    scheduledAt: '',
+  }
+
+  test('draft mode with an originally unpublished post makes no change', () => {
+    const model: NewsEditorModel = { ...baseModel, publishMode: PUBLISH_MODE_DRAFT }
+
+    expect(publishedAtUpdate(model, null)).toBeUndefined()
+  })
+
+  test('draft mode with an originally published post explicitly unpublishes', () => {
+    const model: NewsEditorModel = { ...baseModel, publishMode: PUBLISH_MODE_DRAFT }
+    const original = new Date(2026, 0, 1).toISOString()
+
+    expect(publishedAtUpdate(model, original)).toEqual({ value: null })
+  })
+
+  test('now mode always re-dates the post, even if already published', () => {
+    const model: NewsEditorModel = { ...baseModel, publishMode: PUBLISH_MODE_NOW }
+    const original = new Date(2026, 0, 1).toISOString()
+
+    const result = publishedAtUpdate(model, original)
+
+    expect(result).toBeDefined()
+    expect(result!.value).not.toBeNull()
+    expect(new Date(result!.value!).toISOString()).toBe(result!.value)
+  })
+
+  test('schedule mode makes no change when the target minute matches the original', () => {
+    const scheduledAt = toDateTimeLocalString(new Date(2026, 5, 15, 10, 30))
+    const original = new Date(2026, 5, 15, 10, 30, 45, 123).toISOString()
+    const model: NewsEditorModel = {
+      ...baseModel,
+      publishMode: PUBLISH_MODE_SCHEDULE,
+      scheduledAt,
+    }
+
+    expect(publishedAtUpdate(model, original)).toBeUndefined()
+  })
+
+  test('schedule mode updates when the target minute differs from the original', () => {
+    const scheduledAt = toDateTimeLocalString(new Date(2026, 5, 15, 10, 30))
+    const original = new Date(2026, 5, 15, 10, 31).toISOString()
+    const model: NewsEditorModel = {
+      ...baseModel,
+      publishMode: PUBLISH_MODE_SCHEDULE,
+      scheduledAt,
+    }
+
+    expect(publishedAtUpdate(model, original)).toEqual({
+      value: new Date(scheduledAt).toISOString(),
+    })
+  })
+
+  test('schedule mode updates when the post was originally unpublished', () => {
+    const scheduledAt = toDateTimeLocalString(new Date(2026, 5, 15, 10, 30))
+    const model: NewsEditorModel = {
+      ...baseModel,
+      publishMode: PUBLISH_MODE_SCHEDULE,
+      scheduledAt,
+    }
+
+    expect(publishedAtUpdate(model, null)).toEqual({
+      value: new Date(scheduledAt).toISOString(),
+    })
+  })
+})
+
+describe('changedFieldLabels', () => {
+  const t = ((_key: string, def: string) => def) as Parameters<typeof changedFieldLabels>[2]
+
+  const baseEdit: NewsPostEdit = {
+    title: 'Title',
+    summary: 'Summary',
+    content: 'Content',
+    publishedAt: null,
+    coverImagePath: null,
+    editedAt: new Date(2026, 0, 1).toISOString(),
+    editor: null,
+  }
+
+  test('returns no labels for the creation entry (no older revision)', () => {
+    expect(changedFieldLabels(baseEdit, undefined, t)).toEqual([])
+  })
+
+  test('returns no labels when nothing changed', () => {
+    expect(changedFieldLabels({ ...baseEdit }, { ...baseEdit }, t)).toEqual([])
+  })
+
+  test('reports a changed title', () => {
+    const edit = { ...baseEdit, title: 'New title' }
+
+    expect(changedFieldLabels(edit, baseEdit, t)).toEqual(['Title'])
+  })
+
+  test('reports a changed summary', () => {
+    const edit = { ...baseEdit, summary: 'New summary' }
+
+    expect(changedFieldLabels(edit, baseEdit, t)).toEqual(['Summary'])
+  })
+
+  test('reports changed content', () => {
+    const edit = { ...baseEdit, content: 'New content' }
+
+    expect(changedFieldLabels(edit, baseEdit, t)).toEqual(['Content'])
+  })
+
+  test('reports a changed publish date', () => {
+    const older = { ...baseEdit, publishedAt: new Date(2026, 0, 1).toISOString() }
+    const edit = { ...baseEdit, publishedAt: new Date(2026, 0, 2).toISOString() }
+
+    expect(changedFieldLabels(edit, older, t)).toEqual(['Publish date'])
+  })
+
+  test('does not report a publish date change when both are null', () => {
+    expect(
+      changedFieldLabels({ ...baseEdit, publishedAt: null }, { ...baseEdit, publishedAt: null }, t),
+    ).toEqual([])
+  })
+
+  test('reports a publish date change from null to a value', () => {
+    const edit = { ...baseEdit, publishedAt: new Date(2026, 0, 1).toISOString() }
+
+    expect(changedFieldLabels(edit, baseEdit, t)).toEqual(['Publish date'])
+  })
+
+  test('reports a changed cover image', () => {
+    const older = { ...baseEdit, coverImagePath: '/covers/old.png' }
+    const edit = { ...baseEdit, coverImagePath: '/covers/new.png' }
+
+    expect(changedFieldLabels(edit, older, t)).toEqual(['Cover image'])
+  })
+
+  test('does not report a cover image change when both are null', () => {
+    expect(
+      changedFieldLabels(
+        { ...baseEdit, coverImagePath: null },
+        { ...baseEdit, coverImagePath: null },
+        t,
+      ),
+    ).toEqual([])
+  })
+
+  test('reports a cover image change from null to a value', () => {
+    const edit = { ...baseEdit, coverImagePath: '/covers/new.png' }
+
+    expect(changedFieldLabels(edit, baseEdit, t)).toEqual(['Cover image'])
+  })
+
+  test('reports all changed fields, in field order', () => {
+    const older = {
+      ...baseEdit,
+      publishedAt: new Date(2026, 0, 1).toISOString(),
+      coverImagePath: '/covers/old.png',
+    }
+    const edit = {
+      ...baseEdit,
+      title: 'New title',
+      summary: 'New summary',
+      content: 'New content',
+      publishedAt: new Date(2026, 0, 2).toISOString(),
+      coverImagePath: '/covers/new.png',
+    }
+
+    expect(changedFieldLabels(edit, older, t)).toEqual([
+      'Title',
+      'Summary',
+      'Content',
+      'Publish date',
+      'Cover image',
+    ])
+  })
+})

--- a/client/admin/admin-news.tsx
+++ b/client/admin/admin-news.tsx
@@ -124,9 +124,9 @@ const NewsDeletePostMutation = graphql(/* GraphQL */ `
 
 const PAGE_SIZE = 20
 
-const PUBLISH_MODE_DRAFT = 'draft'
-const PUBLISH_MODE_NOW = 'now'
-const PUBLISH_MODE_SCHEDULE = 'schedule'
+export const PUBLISH_MODE_DRAFT = 'draft'
+export const PUBLISH_MODE_NOW = 'now'
+export const PUBLISH_MODE_SCHEDULE = 'schedule'
 type PublishMode =
   | typeof PUBLISH_MODE_DRAFT
   | typeof PUBLISH_MODE_NOW
@@ -138,7 +138,7 @@ type PostStatus =
   | { kind: 'published'; date: Date }
 
 /** Classifies a post's publish state given the current time (`now`, in millis). */
-function getPostStatus(publishedAt: string | null | undefined, now: number): PostStatus {
+export function getPostStatus(publishedAt: string | null | undefined, now: number): PostStatus {
   if (!publishedAt) {
     return { kind: 'draft' }
   }
@@ -147,7 +147,7 @@ function getPostStatus(publishedAt: string | null | undefined, now: number): Pos
 }
 
 /** Formats a `Date` for a `datetime-local` input value (`YYYY-MM-DDTHH:mm`, local time). */
-function toDateTimeLocalString(date: Date): string {
+export function toDateTimeLocalString(date: Date): string {
   const pad = (n: number) => String(n).padStart(2, '0')
   return (
     `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}` +
@@ -686,7 +686,7 @@ function AdminNewsEdit({ params: { id } }: { params: { id: string } }) {
 
 type EditablePost = NonNullable<ResultOf<typeof AdminNewsPostQuery>['newsPost']>
 
-interface NewsEditorModel {
+export interface NewsEditorModel {
   title: string
   summary: string
   content: string
@@ -745,7 +745,7 @@ const SaveRow = styled.div`
 `
 
 /** Computes the `publishedAt` value for a newly-created post (undefined leaves it a draft). */
-function createPublishedAt(model: NewsEditorModel): string | undefined {
+export function createPublishedAt(model: NewsEditorModel): string | undefined {
   switch (model.publishMode) {
     case PUBLISH_MODE_DRAFT:
       return undefined
@@ -762,7 +762,7 @@ function createPublishedAt(model: NewsEditorModel): string | undefined {
  * Computes the `publishedAt` change to send in an update, or `undefined` if the publish state is
  * unchanged (so we omit the field and leave it alone). A returned `{ value: null }` unpublishes.
  */
-function publishedAtUpdate(
+export function publishedAtUpdate(
   model: NewsEditorModel,
   originalPublishedAt: string | null,
 ): { value: string | null } | undefined {
@@ -1031,10 +1031,12 @@ const HistoryEntryChanges = styled.div`
   ${bodyMedium};
 `
 
-type NewsPostEdit = NonNullable<ResultOf<typeof AdminNewsHistoryQuery>['newsPost']>['edits'][number]
+export type NewsPostEdit = NonNullable<
+  ResultOf<typeof AdminNewsHistoryQuery>['newsPost']
+>['edits'][number]
 
 /** Field labels that changed between an edit and the next-older revision. */
-function changedFieldLabels(
+export function changedFieldLabels(
   edit: NewsPostEdit,
   older: NewsPostEdit | undefined,
   t: ReturnType<typeof useTranslation>['t'],

--- a/client/admin/admin-news.tsx
+++ b/client/admin/admin-news.tsx
@@ -1,0 +1,1181 @@
+import { ResultOf } from '@graphql-typed-document-node/core'
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import styled from 'styled-components'
+import { useMutation, useQuery } from 'urql'
+import { Route, Switch } from 'wouter'
+import swallowNonBuiltins from '../../common/async/swallow-non-builtins'
+import { urlPath } from '../../common/urls'
+import { useSelfUser } from '../auth/auth-utils'
+import { useForm, useFormCallbacks, ValidatorMap } from '../forms/form-hook'
+import { required } from '../forms/validators'
+import { graphql } from '../gql'
+import { NewsPostCreation, NewsPostUpdates } from '../gql/graphql'
+import { longTimestamp } from '../i18n/date-formats'
+import { MaterialIcon } from '../icons/material/material-icon'
+import { Markdown } from '../markdown/markdown'
+import { FilledButton, IconButton, OutlinedButton, TextButton } from '../material/button'
+import { DateTimeTextField } from '../material/datetime-text-field'
+import { RadioButton, RadioGroup } from '../material/radio'
+import { TextField } from '../material/text-field'
+import { push } from '../navigation/routing'
+import { LoadingDotsArea } from '../progress/dots'
+import { useNow } from '../react/date-hooks'
+import { useSnackbarController } from '../snackbars/snackbar-overlay'
+import { CenteredContentContainer } from '../styles/centered-container'
+import { ContainerLevel, containerStyles } from '../styles/colors'
+import {
+  bodyLarge,
+  bodyMedium,
+  labelMedium,
+  singleLine,
+  titleLarge,
+  titleMedium,
+} from '../styles/typography'
+import { ConnectedUsername } from '../users/connected-username'
+
+const AdminNewsListQuery = graphql(/* GraphQL */ `
+  query AdminNewsList($first: Int, $after: String) {
+    newsPosts(includeUnpublished: true, first: $first, after: $after) {
+      edges {
+        node {
+          id
+          title
+          summary
+          publishedAt
+          updatedAt
+          author {
+            id
+            name
+          }
+        }
+      }
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+    }
+  }
+`)
+
+const AdminNewsPostQuery = graphql(/* GraphQL */ `
+  query AdminNewsPost($id: UUID!) {
+    newsPost(id: $id) {
+      id
+      title
+      summary
+      content
+      publishedAt
+      author {
+        id
+        name
+      }
+    }
+  }
+`)
+
+const AdminNewsHistoryQuery = graphql(/* GraphQL */ `
+  query AdminNewsHistory($id: UUID!) {
+    newsPost(id: $id) {
+      id
+      title
+      edits {
+        title
+        summary
+        content
+        publishedAt
+        coverImagePath
+        editedAt
+        editor {
+          id
+          name
+        }
+        author {
+          id
+          name
+        }
+      }
+    }
+  }
+`)
+
+const NewsCreatePostMutation = graphql(/* GraphQL */ `
+  mutation NewsCreatePost($post: NewsPostCreation!) {
+    newsCreatePost(post: $post) {
+      id
+    }
+  }
+`)
+
+const NewsUpdatePostMutation = graphql(/* GraphQL */ `
+  mutation NewsUpdatePost($id: UUID!, $updates: NewsPostUpdates!) {
+    newsUpdatePost(id: $id, updates: $updates) {
+      id
+      title
+      summary
+      content
+      publishedAt
+      updatedAt
+    }
+  }
+`)
+
+const NewsDeletePostMutation = graphql(/* GraphQL */ `
+  mutation NewsDeletePost($id: UUID!) {
+    newsDeletePost(id: $id)
+  }
+`)
+
+const PAGE_SIZE = 20
+
+const PUBLISH_MODE_DRAFT = 'draft'
+const PUBLISH_MODE_NOW = 'now'
+const PUBLISH_MODE_SCHEDULE = 'schedule'
+type PublishMode =
+  | typeof PUBLISH_MODE_DRAFT
+  | typeof PUBLISH_MODE_NOW
+  | typeof PUBLISH_MODE_SCHEDULE
+
+type PostStatus =
+  | { kind: 'draft' }
+  | { kind: 'scheduled'; date: Date }
+  | { kind: 'published'; date: Date }
+
+/** Classifies a post's publish state given the current time (`now`, in millis). */
+function getPostStatus(publishedAt: string | null | undefined, now: number): PostStatus {
+  if (!publishedAt) {
+    return { kind: 'draft' }
+  }
+  const date = new Date(publishedAt)
+  return date.getTime() > now ? { kind: 'scheduled', date } : { kind: 'published', date }
+}
+
+/** Formats a `Date` for a `datetime-local` input value (`YYYY-MM-DDTHH:mm`, local time). */
+function toDateTimeLocalString(date: Date): string {
+  const pad = (n: number) => String(n).padStart(2, '0')
+  return (
+    `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}` +
+    `T${pad(date.getHours())}:${pad(date.getMinutes())}`
+  )
+}
+
+export function AdminNews() {
+  return (
+    <Switch>
+      <Route path='/admin/news/new' component={AdminNewsCreate} />
+      <Route path='/admin/news/:id/history' component={AdminNewsHistory} />
+      <Route path='/admin/news/:id' component={AdminNewsEdit} />
+      <Route component={AdminNewsList} />
+    </Switch>
+  )
+}
+
+const Root = styled.div`
+  padding-block: 24px;
+
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+`
+
+const HeaderRow = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+`
+
+const Title = styled.div`
+  ${titleLarge};
+`
+
+const HeaderActions = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+`
+
+const ErrorText = styled.div`
+  ${bodyLarge};
+  color: var(--theme-error);
+`
+
+const NotFoundText = styled.div`
+  ${bodyLarge};
+  color: var(--theme-on-surface-variant);
+`
+
+const ListTable = styled.div`
+  display: flex;
+  flex-direction: column;
+
+  border: 1px solid var(--theme-outline-variant);
+  border-radius: 4px;
+`
+
+const ListHeaderRow = styled.div`
+  ${labelMedium};
+
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 8px 12px;
+
+  color: var(--theme-on-surface-variant);
+  border-bottom: 1px solid var(--theme-outline-variant);
+`
+
+const RowRoot = styled.div`
+  min-height: 60px;
+  padding: 8px 12px;
+
+  display: flex;
+  align-items: center;
+  gap: 16px;
+
+  &:not(:last-child) {
+    border-bottom: 1px solid var(--theme-outline-variant);
+  }
+
+  &:hover {
+    background-color: rgba(255, 255, 255, 0.04);
+  }
+`
+
+const TitleCell = styled.div`
+  flex: 1 1 auto;
+  min-width: 0;
+
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+`
+
+const TitleText = styled.div`
+  ${titleMedium};
+  ${singleLine};
+`
+
+const SummaryText = styled.div`
+  ${bodyMedium};
+  ${singleLine};
+  color: var(--theme-on-surface-variant);
+`
+
+const StatusCell = styled.div`
+  flex: 0 0 auto;
+  width: 176px;
+`
+
+const AuthorCell = styled.div`
+  ${bodyMedium};
+  ${singleLine};
+  flex: 0 0 auto;
+  width: 148px;
+`
+
+const UpdatedCell = styled.div`
+  ${bodyMedium};
+  flex: 0 0 auto;
+  width: 176px;
+  color: var(--theme-on-surface-variant);
+`
+
+const ActionsCell = styled.div`
+  flex: 0 0 auto;
+
+  display: flex;
+  align-items: center;
+  gap: 4px;
+`
+
+const EmDash = styled.span`
+  color: var(--theme-on-surface-variant);
+`
+
+const StatusCellRoot = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 2px;
+`
+
+const STATUS_COLORS: Record<PostStatus['kind'], string> = {
+  draft: 'var(--theme-on-surface-variant)',
+  scheduled: 'var(--theme-amber)',
+  published: 'var(--theme-positive)',
+}
+
+const StatusChip = styled.div<{ $kind: PostStatus['kind'] }>`
+  ${labelMedium};
+
+  height: 22px;
+  padding: 0 10px;
+
+  display: inline-flex;
+  align-items: center;
+
+  border: 1px solid currentColor;
+  border-radius: 11px;
+  color: ${props => STATUS_COLORS[props.$kind]};
+`
+
+const StatusDate = styled.div`
+  ${bodyMedium};
+  color: var(--theme-on-surface-variant);
+`
+
+function StatusDisplay({
+  publishedAt,
+  now,
+}: {
+  publishedAt: string | null | undefined
+  now: number
+}) {
+  const { t } = useTranslation()
+  const status = getPostStatus(publishedAt, now)
+
+  let label: string
+  switch (status.kind) {
+    case 'draft':
+      label = t('admin.news.status.draft', 'Draft')
+      break
+    case 'scheduled':
+      label = t('admin.news.status.scheduled', 'Scheduled')
+      break
+    case 'published':
+      label = t('admin.news.status.published', 'Published')
+      break
+    default:
+      label = status satisfies never
+  }
+
+  return (
+    <StatusCellRoot>
+      <StatusChip $kind={status.kind}>{label}</StatusChip>
+      {status.kind !== 'draft' ? (
+        <StatusDate>{longTimestamp.format(status.date)}</StatusDate>
+      ) : null}
+    </StatusCellRoot>
+  )
+}
+
+const LoadMoreRow = styled.div`
+  display: flex;
+  justify-content: center;
+  padding: 12px;
+`
+
+function AdminNewsList() {
+  const { t } = useTranslation()
+  // One `after` cursor per loaded page (the first page has none). We page with cursors rather than
+  // growing `first`, because the server clamps `first` — an ever-growing page size would silently
+  // stop returning new rows past the clamp.
+  const [pageCursors, setPageCursors] = useState<Array<string | null>>([null])
+  // Bumped on refresh to re-mount the pages and force a fresh fetch. Publishing/unpublishing/
+  // deleting reorders the connection, so we reset to the first page rather than trying to patch it
+  // in the (awkward-to-invalidate) graphcache.
+  const [refreshToken, setRefreshToken] = useState(0)
+  // `useNow`'s tick can be up to 30s stale, which would briefly classify a just-published post as
+  // "Scheduled" — refreshes floor the clock to the refresh time so new statuses classify correctly.
+  const [minNow, setMinNow] = useState(0)
+  const now = Math.max(useNow(30_000), minNow)
+
+  const [{ fetching: updating, error: updateError }, updatePost] =
+    useMutation(NewsUpdatePostMutation)
+  const [{ fetching: deleting, error: deleteError }, deletePost] =
+    useMutation(NewsDeletePostMutation)
+  const mutating = updating || deleting
+
+  const refresh = () => {
+    setMinNow(Date.now())
+    setPageCursors([null])
+    setRefreshToken(token => token + 1)
+  }
+
+  const setPublishedAt = (id: string, publishedAt: string | null) => {
+    updatePost({ id, updates: { publishedAt } })
+      .then(result => {
+        if (!result.error) {
+          refresh()
+        }
+      })
+      .catch(swallowNonBuiltins)
+  }
+
+  const onDelete = (id: string) => {
+    deletePost({ id })
+      .then(result => {
+        if (!result.error) {
+          refresh()
+        }
+      })
+      .catch(swallowNonBuiltins)
+  }
+
+  return (
+    <CenteredContentContainer>
+      <Root>
+        <HeaderRow>
+          <Title>{t('admin.news.title', 'Manage news')}</Title>
+          <HeaderActions>
+            <OutlinedButton
+              label={t('admin.news.refresh', 'Refresh')}
+              onClick={refresh}
+              disabled={mutating}
+            />
+            <FilledButton
+              label={t('admin.news.newPost', 'New post')}
+              iconStart={<MaterialIcon icon='add' />}
+              onClick={() => push('/admin/news/new')}
+            />
+          </HeaderActions>
+        </HeaderRow>
+        {updateError ? (
+          <ErrorText>
+            {t('admin.news.updateError', 'Error updating post:')} {updateError.message}
+          </ErrorText>
+        ) : null}
+        {deleteError ? (
+          <ErrorText>
+            {t('admin.news.deleteError', 'Error deleting post:')} {deleteError.message}
+          </ErrorText>
+        ) : null}
+        <ListTable>
+          <ListHeaderRow>
+            <TitleCell>{t('admin.news.column.title', 'Title')}</TitleCell>
+            <StatusCell>{t('admin.news.column.status', 'Status')}</StatusCell>
+            <AuthorCell>{t('admin.news.column.author', 'Author')}</AuthorCell>
+            <UpdatedCell>{t('admin.news.column.updated', 'Updated')}</UpdatedCell>
+            <ActionsCell>{t('admin.news.column.actions', 'Actions')}</ActionsCell>
+          </ListHeaderRow>
+          {pageCursors.map((cursor, i) => (
+            <NewsListPage
+              key={`${refreshToken}:${cursor ?? 'first'}`}
+              after={cursor}
+              now={now}
+              isLastPage={i === pageCursors.length - 1}
+              mutating={mutating}
+              onLoadMore={endCursor => setPageCursors(prev => [...prev, endCursor])}
+              onPublishNow={id => setPublishedAt(id, new Date().toISOString())}
+              onUnpublish={id => setPublishedAt(id, null)}
+              onDelete={onDelete}
+            />
+          ))}
+        </ListTable>
+      </Root>
+    </CenteredContentContainer>
+  )
+}
+
+type NewsListPost = ResultOf<typeof AdminNewsListQuery>['newsPosts']['edges'][number]['node']
+
+function NewsListPage({
+  after,
+  now,
+  isLastPage,
+  mutating,
+  onLoadMore,
+  onPublishNow,
+  onUnpublish,
+  onDelete,
+}: {
+  after: string | null
+  now: number
+  isLastPage: boolean
+  mutating: boolean
+  onLoadMore: (endCursor: string) => void
+  onPublishNow: (id: string) => void
+  onUnpublish: (id: string) => void
+  onDelete: (id: string) => void
+}) {
+  const { t } = useTranslation()
+  const [{ data, fetching, error }] = useQuery({
+    query: AdminNewsListQuery,
+    variables: { first: PAGE_SIZE, after: after ?? undefined },
+    // Show cached rows immediately but always revalidate, so a refresh (or returning from an edit)
+    // reflects server state.
+    requestPolicy: 'cache-and-network',
+  })
+
+  const posts = data?.newsPosts.edges.map(e => e.node) ?? []
+  const pageInfo = data?.newsPosts.pageInfo
+
+  return (
+    <>
+      {posts.map(post => (
+        <NewsPostRow
+          key={post.id}
+          post={post}
+          now={now}
+          mutating={mutating}
+          onPublishNow={onPublishNow}
+          onUnpublish={onUnpublish}
+          onDelete={onDelete}
+        />
+      ))}
+      {fetching && !data ? <LoadingDotsArea /> : null}
+      {error ? (
+        <ErrorText>
+          {t('admin.news.loadError', 'Error loading news posts:')} {error.message}
+        </ErrorText>
+      ) : null}
+      {isLastPage && pageInfo?.hasNextPage && pageInfo.endCursor ? (
+        <LoadMoreRow>
+          <OutlinedButton
+            label={t('admin.news.loadMore', 'Load more')}
+            onClick={() => onLoadMore(pageInfo.endCursor!)}
+          />
+        </LoadMoreRow>
+      ) : null}
+    </>
+  )
+}
+
+const ConfirmDeleteRoot = styled.div`
+  ${bodyLarge};
+
+  flex: 1 1 auto;
+
+  display: flex;
+  align-items: center;
+  gap: 16px;
+`
+
+const ConfirmDeleteText = styled.div`
+  flex: 1 1 auto;
+`
+
+function NewsPostRow({
+  post,
+  now,
+  mutating,
+  onPublishNow,
+  onUnpublish,
+  onDelete,
+}: {
+  post: NewsListPost
+  now: number
+  mutating: boolean
+  onPublishNow: (id: string) => void
+  onUnpublish: (id: string) => void
+  onDelete: (id: string) => void
+}) {
+  const { t } = useTranslation()
+  const [confirmingDelete, setConfirmingDelete] = useState(false)
+  const status = getPostStatus(post.publishedAt, now)
+
+  if (confirmingDelete) {
+    return (
+      <RowRoot>
+        <ConfirmDeleteRoot>
+          <ConfirmDeleteText>
+            {t('admin.news.confirmDelete', 'Delete "{{title}}"? This cannot be undone.', {
+              title: post.title,
+            })}
+          </ConfirmDeleteText>
+          <TextButton
+            label={t('common.actions.cancel', 'Cancel')}
+            onClick={() => setConfirmingDelete(false)}
+            disabled={mutating}
+          />
+          <TextButton
+            label={t('common.actions.delete', 'Delete')}
+            onClick={() => {
+              setConfirmingDelete(false)
+              onDelete(post.id)
+            }}
+            disabled={mutating}
+          />
+        </ConfirmDeleteRoot>
+      </RowRoot>
+    )
+  }
+
+  return (
+    <RowRoot data-test='news-post-row'>
+      <TitleCell>
+        <TitleText>{post.title}</TitleText>
+        <SummaryText>{post.summary}</SummaryText>
+      </TitleCell>
+      <StatusCell>
+        <StatusDisplay publishedAt={post.publishedAt} now={now} />
+      </StatusCell>
+      <AuthorCell>
+        {post.author ? <ConnectedUsername userId={post.author.id} /> : <EmDash>—</EmDash>}
+      </AuthorCell>
+      <UpdatedCell>{longTimestamp.format(new Date(post.updatedAt))}</UpdatedCell>
+      <ActionsCell>
+        <IconButton
+          icon={<MaterialIcon icon='edit' />}
+          title={t('admin.news.action.edit', 'Edit')}
+          onClick={() => push(urlPath`/admin/news/${post.id}`)}
+          disabled={mutating}
+        />
+        <IconButton
+          icon={<MaterialIcon icon='history' />}
+          title={t('admin.news.action.history', 'Edit history')}
+          onClick={() => push(urlPath`/admin/news/${post.id}/history`)}
+          disabled={mutating}
+        />
+        {status.kind !== 'published' ? (
+          <IconButton
+            icon={<MaterialIcon icon='publish' />}
+            title={t('admin.news.action.publishNow', 'Publish now')}
+            onClick={() => onPublishNow(post.id)}
+            disabled={mutating}
+          />
+        ) : null}
+        {status.kind !== 'draft' ? (
+          <IconButton
+            icon={<MaterialIcon icon='unpublished' />}
+            title={t('admin.news.action.unpublish', 'Unpublish')}
+            onClick={() => onUnpublish(post.id)}
+            disabled={mutating}
+          />
+        ) : null}
+        <IconButton
+          icon={<MaterialIcon icon='delete' />}
+          title={t('admin.news.action.delete', 'Delete')}
+          onClick={() => setConfirmingDelete(true)}
+          disabled={mutating}
+        />
+      </ActionsCell>
+    </RowRoot>
+  )
+}
+
+function AdminNewsCreate() {
+  return <NewsEditor post={undefined} />
+}
+
+function AdminNewsEdit({ params: { id } }: { params: { id: string } }) {
+  const { t } = useTranslation()
+  const [{ data, fetching, error }] = useQuery({
+    query: AdminNewsPostQuery,
+    variables: { id },
+  })
+
+  const post = data?.newsPost
+
+  if (error) {
+    return (
+      <CenteredContentContainer>
+        <Root>
+          <ErrorText>
+            {t('admin.news.loadError', 'Error loading news posts:')} {error.message}
+          </ErrorText>
+        </Root>
+      </CenteredContentContainer>
+    )
+  }
+  if (!post) {
+    return fetching ? (
+      <LoadingDotsArea />
+    ) : (
+      <CenteredContentContainer>
+        <Root>
+          <NotFoundText>
+            {t('admin.news.notFound', 'No news post found with this ID.')}
+          </NotFoundText>
+        </Root>
+      </CenteredContentContainer>
+    )
+  }
+
+  return <NewsEditor post={post} />
+}
+
+type EditablePost = NonNullable<ResultOf<typeof AdminNewsPostQuery>['newsPost']>
+
+interface NewsEditorModel {
+  title: string
+  summary: string
+  content: string
+  publishMode: PublishMode
+  scheduledAt: string
+}
+
+const FormArea = styled.div`
+  display: flex;
+  gap: 24px;
+  align-items: stretch;
+`
+
+const ContentField = styled(TextField)`
+  flex: 1 1 50%;
+  min-width: 0;
+`
+
+const MarkdownPreview = styled(Markdown)`
+  flex: 1 1 50%;
+  min-width: 0;
+  min-height: 480px;
+  padding: 16px 24px;
+
+  border: 1px solid var(--theme-outline-variant);
+  border-radius: 4px;
+  overflow-y: auto;
+`
+
+const Form = styled.form`
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+`
+
+const PublishControl = styled.div`
+  ${containerStyles(ContainerLevel.Low)};
+
+  padding: 16px;
+
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+
+  border-radius: 4px;
+`
+
+const ScheduleHint = styled.div`
+  ${bodyMedium};
+  color: var(--theme-on-surface-variant);
+`
+
+const SaveRow = styled.div`
+  display: flex;
+  gap: 8px;
+`
+
+/** Computes the `publishedAt` value for a newly-created post (undefined leaves it a draft). */
+function createPublishedAt(model: NewsEditorModel): string | undefined {
+  switch (model.publishMode) {
+    case PUBLISH_MODE_DRAFT:
+      return undefined
+    case PUBLISH_MODE_NOW:
+      return new Date().toISOString()
+    case PUBLISH_MODE_SCHEDULE:
+      return new Date(model.scheduledAt).toISOString()
+    default:
+      return model.publishMode satisfies never
+  }
+}
+
+/**
+ * Computes the `publishedAt` change to send in an update, or `undefined` if the publish state is
+ * unchanged (so we omit the field and leave it alone). A returned `{ value: null }` unpublishes.
+ */
+function publishedAtUpdate(
+  model: NewsEditorModel,
+  originalPublishedAt: string | null,
+): { value: string | null } | undefined {
+  if (model.publishMode === PUBLISH_MODE_DRAFT) {
+    return originalPublishedAt === null ? undefined : { value: null }
+  }
+  if (model.publishMode === PUBLISH_MODE_NOW) {
+    // An explicit "publish now" always re-dates the post to the current time.
+    return { value: new Date().toISOString() }
+  }
+
+  // Scheduled: compare at minute precision (the input's granularity) so re-saving an untouched
+  // post doesn't bump its publish time.
+  const targetMinute = Math.floor(new Date(model.scheduledAt).getTime() / 60_000)
+  const originalMinute =
+    originalPublishedAt !== null
+      ? Math.floor(new Date(originalPublishedAt).getTime() / 60_000)
+      : null
+  if (targetMinute === originalMinute) {
+    return undefined
+  }
+  return { value: new Date(model.scheduledAt).toISOString() }
+}
+
+function NewsEditor({ post }: { post: EditablePost | undefined }) {
+  const { t } = useTranslation()
+  const selfUser = useSelfUser()
+  const snackbarController = useSnackbarController()
+  const [{ fetching: creating, error: createError }, createPost] =
+    useMutation(NewsCreatePostMutation)
+  const [{ fetching: updating, error: updateError }, updatePost] =
+    useMutation(NewsUpdatePostMutation)
+  const fetching = creating || updating
+  const error = createError ?? updateError
+
+  let publishMode: PublishMode = PUBLISH_MODE_DRAFT
+  let scheduledAt = toDateTimeLocalString(new Date())
+  if (post?.publishedAt) {
+    // Both scheduled (future) and already-published (past) posts start here with their current
+    // publish time prefilled; leaving it untouched preserves it on save.
+    publishMode = PUBLISH_MODE_SCHEDULE
+    scheduledAt = toDateTimeLocalString(new Date(post.publishedAt))
+  }
+
+  const defaults: NewsEditorModel = {
+    title: post?.title ?? '',
+    summary: post?.summary ?? '',
+    content: post?.content ?? '',
+    publishMode,
+    scheduledAt,
+  }
+
+  const validations: ValidatorMap<NewsEditorModel> = {
+    title: required(t('admin.news.form.titleRequired', 'Title is required')),
+    summary: required(t('admin.news.form.summaryRequired', 'Summary is required')),
+    content: required(t('admin.news.form.contentRequired', 'Content is required')),
+    scheduledAt: (value, model) => {
+      if (model.publishMode !== PUBLISH_MODE_SCHEDULE) {
+        return undefined
+      }
+      if (!value || Number.isNaN(new Date(value).getTime())) {
+        return t('admin.news.form.scheduleRequired', 'Choose a valid date and time')
+      }
+      return undefined
+    },
+  }
+
+  const { submit, bindInput, form, getInputValue } = useForm<NewsEditorModel>(defaults, validations)
+
+  useFormCallbacks(form, {
+    onSubmit: model => {
+      if (post) {
+        const updates: NewsPostUpdates = {}
+        if (model.title !== post.title) {
+          updates.title = model.title
+        }
+        if (model.summary !== post.summary) {
+          updates.summary = model.summary
+        }
+        if (model.content !== post.content) {
+          updates.content = model.content
+        }
+        const publishedChange = publishedAtUpdate(model, post.publishedAt ?? null)
+        if (publishedChange) {
+          updates.publishedAt = publishedChange.value
+        }
+
+        if (Object.keys(updates).length === 0) {
+          push('/admin/news')
+          return
+        }
+
+        updatePost({ id: post.id, updates })
+          .then(result => {
+            if (!result.error) {
+              snackbarController.showSnackbar(t('admin.news.saved', 'News post saved'))
+              push('/admin/news')
+            }
+          })
+          .catch(swallowNonBuiltins)
+      } else {
+        const publishedAt = createPublishedAt(model)
+        const creation: NewsPostCreation = {
+          // The server records the creator in the edit log and enforces authorId == self; sending
+          // it makes the post render "by {name}" like an authored post.
+          authorId: selfUser?.id,
+          title: model.title,
+          summary: model.summary,
+          content: model.content,
+          ...(publishedAt !== undefined ? { publishedAt } : {}),
+        }
+
+        createPost({ post: creation })
+          .then(result => {
+            if (!result.error) {
+              snackbarController.showSnackbar(t('admin.news.created', 'News post created'))
+              push('/admin/news')
+            }
+          })
+          .catch(swallowNonBuiltins)
+      }
+    },
+  })
+
+  const currentPublishMode = getInputValue('publishMode')
+
+  return (
+    <CenteredContentContainer>
+      <Root>
+        <HeaderRow>
+          <Title>
+            {post
+              ? t('admin.news.editTitle', 'Edit news post')
+              : t('admin.news.createTitle', 'Create news post')}
+          </Title>
+          <HeaderActions>
+            {post ? (
+              <TextButton
+                label={t('admin.news.viewPost', 'View post')}
+                iconStart={<MaterialIcon icon='open_in_new' />}
+                onClick={() => push(urlPath`/news/${post.id}`)}
+              />
+            ) : null}
+            <TextButton
+              label={t('admin.news.backToList', 'Back to list')}
+              onClick={() => push('/admin/news')}
+            />
+          </HeaderActions>
+        </HeaderRow>
+        {error ? <ErrorText>{error.message}</ErrorText> : null}
+        <Form onSubmit={submit}>
+          <TextField {...bindInput('title')} label={t('admin.news.form.title', 'Title')} />
+          <TextField
+            {...bindInput('summary')}
+            label={t('admin.news.form.summary', 'Summary')}
+            multiline={true}
+            rows={2}
+            maxRows={4}
+          />
+          <FormArea>
+            <ContentField
+              {...bindInput('content')}
+              label={t('admin.news.form.content', 'Content (Markdown)')}
+              multiline={true}
+              rows={18}
+              maxRows={40}
+            />
+            <MarkdownPreview source={getInputValue('content')} />
+          </FormArea>
+          <PublishControl>
+            <RadioGroup
+              {...bindInput('publishMode')}
+              label={t('admin.news.form.publish', 'Publish')}
+              dense={true}>
+              <RadioButton
+                value={PUBLISH_MODE_DRAFT}
+                label={t('admin.news.form.publishDraft', 'Draft (not published)')}
+              />
+              <RadioButton
+                value={PUBLISH_MODE_NOW}
+                label={t('admin.news.form.publishNow', 'Publish now')}
+              />
+              <RadioButton
+                value={PUBLISH_MODE_SCHEDULE}
+                label={t('admin.news.form.publishSchedule', 'Schedule')}
+              />
+            </RadioGroup>
+            {currentPublishMode === PUBLISH_MODE_SCHEDULE ? (
+              <>
+                <DateTimeTextField
+                  {...bindInput('scheduledAt')}
+                  label={t('admin.news.form.scheduleDate', 'Publish date and time')}
+                  floatingLabel={true}
+                />
+                <ScheduleHint>
+                  {t(
+                    'admin.news.form.scheduleHint',
+                    'A future date/time schedules the post; a past date/time publishes it immediately.',
+                  )}
+                </ScheduleHint>
+              </>
+            ) : null}
+          </PublishControl>
+          <SaveRow>
+            <FilledButton
+              label={
+                post
+                  ? t('admin.news.saveChanges', 'Save changes')
+                  : t('admin.news.createPost', 'Create post')
+              }
+              onClick={submit}
+              disabled={fetching}
+            />
+          </SaveRow>
+        </Form>
+      </Root>
+    </CenteredContentContainer>
+  )
+}
+
+const HistoryList = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+`
+
+const HistoryEntryRoot = styled.div`
+  ${containerStyles(ContainerLevel.Low)};
+
+  padding: 12px 16px;
+
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+
+  border-radius: 4px;
+`
+
+const HistoryEntryHeader = styled.div`
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 16px;
+`
+
+const HistoryEntryWhen = styled.div`
+  ${bodyMedium};
+  color: var(--theme-on-surface-variant);
+`
+
+const HistoryEntryChangeKind = styled.div`
+  ${labelMedium};
+  color: var(--theme-amber);
+`
+
+const HistoryEntryTitle = styled.div`
+  ${titleMedium};
+`
+
+const HistoryEntryMeta = styled.div`
+  ${bodyMedium};
+  color: var(--theme-on-surface-variant);
+`
+
+const HistoryEntryChanges = styled.div`
+  ${bodyMedium};
+`
+
+type NewsPostEdit = NonNullable<ResultOf<typeof AdminNewsHistoryQuery>['newsPost']>['edits'][number]
+
+/** Field labels that changed between an edit and the next-older revision. */
+function changedFieldLabels(
+  edit: NewsPostEdit,
+  older: NewsPostEdit | undefined,
+  t: ReturnType<typeof useTranslation>['t'],
+): string[] {
+  if (!older) {
+    return []
+  }
+  const labels: string[] = []
+  if (edit.title !== older.title) {
+    labels.push(t('admin.news.field.title', 'Title'))
+  }
+  if (edit.summary !== older.summary) {
+    labels.push(t('admin.news.field.summary', 'Summary'))
+  }
+  if (edit.content !== older.content) {
+    labels.push(t('admin.news.field.content', 'Content'))
+  }
+  if ((edit.publishedAt ?? null) !== (older.publishedAt ?? null)) {
+    labels.push(t('admin.news.field.publish', 'Publish date'))
+  }
+  if ((edit.coverImagePath ?? null) !== (older.coverImagePath ?? null)) {
+    labels.push(t('admin.news.field.cover', 'Cover image'))
+  }
+  return labels
+}
+
+function publishStateLabel(
+  publishedAt: string | null | undefined,
+  now: number,
+  t: ReturnType<typeof useTranslation>['t'],
+): string {
+  const status = getPostStatus(publishedAt, now)
+  switch (status.kind) {
+    case 'draft':
+      return t('admin.news.status.draft', 'Draft')
+    case 'scheduled':
+      return t('admin.news.historyScheduled', 'Scheduled for {{date}}', {
+        date: longTimestamp.format(status.date),
+      })
+    case 'published':
+      return t('admin.news.historyPublished', 'Published {{date}}', {
+        date: longTimestamp.format(status.date),
+      })
+    default:
+      return status satisfies never
+  }
+}
+
+function AdminNewsHistory({ params: { id } }: { params: { id: string } }) {
+  const { t } = useTranslation()
+  const now = useNow(30_000)
+  const [{ data, fetching, error }] = useQuery({
+    query: AdminNewsHistoryQuery,
+    variables: { id },
+  })
+
+  const post = data?.newsPost
+  const edits = post?.edits ?? []
+
+  return (
+    <CenteredContentContainer>
+      <Root>
+        <HeaderRow>
+          <Title>{t('admin.news.history.title', 'Edit history')}</Title>
+          <HeaderActions>
+            <TextButton
+              label={t('admin.news.editPost', 'Edit post')}
+              onClick={() => push(urlPath`/admin/news/${id}`)}
+            />
+            <TextButton
+              label={t('admin.news.backToList', 'Back to list')}
+              onClick={() => push('/admin/news')}
+            />
+          </HeaderActions>
+        </HeaderRow>
+        {post ? <HistoryEntryMeta>{post.title}</HistoryEntryMeta> : null}
+        {error ? (
+          <ErrorText>
+            {t('admin.news.loadError', 'Error loading news posts:')} {error.message}
+          </ErrorText>
+        ) : null}
+        {fetching && !data ? <LoadingDotsArea /> : null}
+        {!fetching && !error && !post ? (
+          <NotFoundText>
+            {t('admin.news.notFound', 'No news post found with this ID.')}
+          </NotFoundText>
+        ) : null}
+        {post && edits.length === 0 ? (
+          <NotFoundText>
+            {t('admin.news.history.empty', 'No edit history for this post.')}
+          </NotFoundText>
+        ) : null}
+        <HistoryList>
+          {edits.map((edit, i) => {
+            // `edits` is newest-first, so the next-older revision is the following index and the
+            // final entry is the post's creation.
+            const older = edits[i + 1]
+            const isCreation = i === edits.length - 1
+            const changedLabels = changedFieldLabels(edit, older, t)
+
+            return (
+              <HistoryEntryRoot key={i}>
+                <HistoryEntryHeader>
+                  <HistoryEntryWhen>
+                    {longTimestamp.format(new Date(edit.editedAt))}
+                  </HistoryEntryWhen>
+                  <HistoryEntryChangeKind>
+                    {isCreation
+                      ? t('admin.news.history.created', 'Created')
+                      : t('admin.news.history.edited', 'Edited')}
+                  </HistoryEntryChangeKind>
+                </HistoryEntryHeader>
+                <HistoryEntryTitle>{edit.title}</HistoryEntryTitle>
+                <HistoryEntryMeta>
+                  {publishStateLabel(edit.publishedAt, now, t)}
+                  {' · '}
+                  {edit.editor ? (
+                    <>
+                      {t('admin.news.history.by', 'by ')}
+                      <ConnectedUsername userId={edit.editor.id} />
+                    </>
+                  ) : (
+                    t('admin.news.history.byUnknown', 'by an unknown user')
+                  )}
+                </HistoryEntryMeta>
+                {!isCreation ? (
+                  <HistoryEntryChanges>
+                    {changedLabels.length > 0
+                      ? t('admin.news.history.changed', 'Changed: {{fields}}', {
+                          fields: changedLabels.join(', '),
+                        })
+                      : t('admin.news.history.noFieldChanges', 'No tracked field changes')}
+                  </HistoryEntryChanges>
+                ) : null}
+              </HistoryEntryRoot>
+            )
+          })}
+        </HistoryList>
+      </Root>
+    </CenteredContentContainer>
+  )
+}

--- a/client/admin/admin-news.tsx
+++ b/client/admin/admin-news.tsx
@@ -90,10 +90,6 @@ const AdminNewsHistoryQuery = graphql(/* GraphQL */ `
           id
           name
         }
-        author {
-          id
-          name
-        }
       }
     }
   }
@@ -683,7 +679,9 @@ function AdminNewsEdit({ params: { id } }: { params: { id: string } }) {
     )
   }
 
-  return <NewsEditor post={post} />
+  // Keyed by id so switching directly between two edit pages (e.g. via history) remounts the
+  // editor instead of keeping the previous post's form state.
+  return <NewsEditor key={post.id} post={post} />
 }
 
 type EditablePost = NonNullable<ResultOf<typeof AdminNewsPostQuery>['newsPost']>

--- a/client/admin/panel.tsx
+++ b/client/admin/panel.tsx
@@ -7,6 +7,9 @@ import { LoadingDotsArea } from '../progress/dots'
 const LoadableBugReports = React.lazy(async () => ({
   default: (await import('../bugs/admin-bug-reports')).AdminBugReports,
 }))
+const LoadableManageNews = React.lazy(async () => ({
+  default: (await import('./admin-news')).AdminNews,
+}))
 const LoadableGameReports = React.lazy(async () => ({
   default: (await import('../games/admin-game-reports')).AdminGameReports,
 }))
@@ -60,6 +63,7 @@ export default function AdminPanel() {
       'Manage maps',
     ],
     ['/admin/map-pools', perms?.manageMapPools, LoadableMapPools, 'Manage matchmaking map pools'],
+    ['/admin/news', perms?.manageNews, LoadableManageNews, 'Manage news'],
     [
       '/admin/matchmaking-config',
       perms?.manageMatchmaking,

--- a/client/gql/gql.ts
+++ b/client/gql/gql.ts
@@ -14,6 +14,12 @@ import * as types from './graphql'
  * Learn more about it here: https://the-guild.dev/graphql/codegen/plugins/presets/preset-client#reducing-bundle-size
  */
 type Documents = {
+  '\n  query AdminNewsList($first: Int, $after: String) {\n    newsPosts(includeUnpublished: true, first: $first, after: $after) {\n      edges {\n        node {\n          id\n          title\n          summary\n          publishedAt\n          updatedAt\n          author {\n            id\n            name\n          }\n        }\n      }\n      pageInfo {\n        hasNextPage\n        endCursor\n      }\n    }\n  }\n': typeof types.AdminNewsListDocument
+  '\n  query AdminNewsPost($id: UUID!) {\n    newsPost(id: $id) {\n      id\n      title\n      summary\n      content\n      publishedAt\n      author {\n        id\n        name\n      }\n    }\n  }\n': typeof types.AdminNewsPostDocument
+  '\n  query AdminNewsHistory($id: UUID!) {\n    newsPost(id: $id) {\n      id\n      title\n      edits {\n        title\n        summary\n        content\n        publishedAt\n        coverImagePath\n        editedAt\n        editor {\n          id\n          name\n        }\n        author {\n          id\n          name\n        }\n      }\n    }\n  }\n': typeof types.AdminNewsHistoryDocument
+  '\n  mutation NewsCreatePost($post: NewsPostCreation!) {\n    newsCreatePost(post: $post) {\n      id\n    }\n  }\n': typeof types.NewsCreatePostDocument
+  '\n  mutation NewsUpdatePost($id: UUID!, $updates: NewsPostUpdates!) {\n    newsUpdatePost(id: $id, updates: $updates) {\n      id\n      title\n      summary\n      content\n      publishedAt\n      updatedAt\n    }\n  }\n': typeof types.NewsUpdatePostDocument
+  '\n  mutation NewsDeletePost($id: UUID!) {\n    newsDeletePost(id: $id)\n  }\n': typeof types.NewsDeletePostDocument
   '\n  query AdminMatchmakingConfig {\n    matchmakingConfig {\n      searchIntervalSeconds\n      maxPlayersExamined\n      global {\n        weightRatingVariance\n        weightWinProb\n        weightLatency\n        uncertaintyK\n        minQuality\n        adaptiveComfortableMultiplier\n        adaptiveDecayPerMissing\n        populationHalfLifeSeconds\n      }\n      perMode {\n        matchmakingType\n        config {\n          weightRatingVariance\n          weightWinProb\n          weightLatency\n          uncertaintyK\n          minQuality\n          adaptiveComfortableMultiplier\n          adaptiveDecayPerMissing\n          populationHalfLifeSeconds\n        }\n      }\n      defaults {\n        searchIntervalSeconds\n        maxPlayersExamined\n        weightRatingVariance\n        weightWinProb\n        weightLatency\n        uncertaintyK\n        minQuality\n        adaptiveComfortableMultiplier\n        adaptiveDecayPerMissing\n        populationHalfLifeSeconds\n      }\n    }\n  }\n': typeof types.AdminMatchmakingConfigDocument
   '\n  mutation AdminUpdateMatchmakingConfig($config: MatchmakerConfigInput!) {\n    updateMatchmakingConfig(config: $config) {\n      searchIntervalSeconds\n      maxPlayersExamined\n      global {\n        minQuality\n      }\n    }\n  }\n': typeof types.AdminUpdateMatchmakingConfigDocument
   '\n  query RestrictedNames {\n    restrictedNames {\n      id\n      pattern\n      kind\n      reason\n      createdAt\n      createdBy {\n        id\n      }\n    }\n  }\n': typeof types.RestrictedNamesDocument
@@ -63,6 +69,18 @@ type Documents = {
   '\n  query UserProfileTwitch($userId: SbUserId!) {\n    user(id: $userId) {\n      id\n      twitchChannel {\n        twitchLogin\n        twitchDisplayName\n      }\n      liveStream {\n        twitchLogin\n        title\n        gameName\n        viewerCount\n        startedAt\n        thumbnailUrl\n      }\n    }\n  }\n': typeof types.UserProfileTwitchDocument
 }
 const documents: Documents = {
+  '\n  query AdminNewsList($first: Int, $after: String) {\n    newsPosts(includeUnpublished: true, first: $first, after: $after) {\n      edges {\n        node {\n          id\n          title\n          summary\n          publishedAt\n          updatedAt\n          author {\n            id\n            name\n          }\n        }\n      }\n      pageInfo {\n        hasNextPage\n        endCursor\n      }\n    }\n  }\n':
+    types.AdminNewsListDocument,
+  '\n  query AdminNewsPost($id: UUID!) {\n    newsPost(id: $id) {\n      id\n      title\n      summary\n      content\n      publishedAt\n      author {\n        id\n        name\n      }\n    }\n  }\n':
+    types.AdminNewsPostDocument,
+  '\n  query AdminNewsHistory($id: UUID!) {\n    newsPost(id: $id) {\n      id\n      title\n      edits {\n        title\n        summary\n        content\n        publishedAt\n        coverImagePath\n        editedAt\n        editor {\n          id\n          name\n        }\n        author {\n          id\n          name\n        }\n      }\n    }\n  }\n':
+    types.AdminNewsHistoryDocument,
+  '\n  mutation NewsCreatePost($post: NewsPostCreation!) {\n    newsCreatePost(post: $post) {\n      id\n    }\n  }\n':
+    types.NewsCreatePostDocument,
+  '\n  mutation NewsUpdatePost($id: UUID!, $updates: NewsPostUpdates!) {\n    newsUpdatePost(id: $id, updates: $updates) {\n      id\n      title\n      summary\n      content\n      publishedAt\n      updatedAt\n    }\n  }\n':
+    types.NewsUpdatePostDocument,
+  '\n  mutation NewsDeletePost($id: UUID!) {\n    newsDeletePost(id: $id)\n  }\n':
+    types.NewsDeletePostDocument,
   '\n  query AdminMatchmakingConfig {\n    matchmakingConfig {\n      searchIntervalSeconds\n      maxPlayersExamined\n      global {\n        weightRatingVariance\n        weightWinProb\n        weightLatency\n        uncertaintyK\n        minQuality\n        adaptiveComfortableMultiplier\n        adaptiveDecayPerMissing\n        populationHalfLifeSeconds\n      }\n      perMode {\n        matchmakingType\n        config {\n          weightRatingVariance\n          weightWinProb\n          weightLatency\n          uncertaintyK\n          minQuality\n          adaptiveComfortableMultiplier\n          adaptiveDecayPerMissing\n          populationHalfLifeSeconds\n        }\n      }\n      defaults {\n        searchIntervalSeconds\n        maxPlayersExamined\n        weightRatingVariance\n        weightWinProb\n        weightLatency\n        uncertaintyK\n        minQuality\n        adaptiveComfortableMultiplier\n        adaptiveDecayPerMissing\n        populationHalfLifeSeconds\n      }\n    }\n  }\n':
     types.AdminMatchmakingConfigDocument,
   '\n  mutation AdminUpdateMatchmakingConfig($config: MatchmakerConfigInput!) {\n    updateMatchmakingConfig(config: $config) {\n      searchIntervalSeconds\n      maxPlayersExamined\n      global {\n        minQuality\n      }\n    }\n  }\n':
@@ -172,6 +190,42 @@ const documents: Documents = {
  */
 export function graphql(source: string): unknown
 
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(
+  source: '\n  query AdminNewsList($first: Int, $after: String) {\n    newsPosts(includeUnpublished: true, first: $first, after: $after) {\n      edges {\n        node {\n          id\n          title\n          summary\n          publishedAt\n          updatedAt\n          author {\n            id\n            name\n          }\n        }\n      }\n      pageInfo {\n        hasNextPage\n        endCursor\n      }\n    }\n  }\n',
+): (typeof documents)['\n  query AdminNewsList($first: Int, $after: String) {\n    newsPosts(includeUnpublished: true, first: $first, after: $after) {\n      edges {\n        node {\n          id\n          title\n          summary\n          publishedAt\n          updatedAt\n          author {\n            id\n            name\n          }\n        }\n      }\n      pageInfo {\n        hasNextPage\n        endCursor\n      }\n    }\n  }\n']
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(
+  source: '\n  query AdminNewsPost($id: UUID!) {\n    newsPost(id: $id) {\n      id\n      title\n      summary\n      content\n      publishedAt\n      author {\n        id\n        name\n      }\n    }\n  }\n',
+): (typeof documents)['\n  query AdminNewsPost($id: UUID!) {\n    newsPost(id: $id) {\n      id\n      title\n      summary\n      content\n      publishedAt\n      author {\n        id\n        name\n      }\n    }\n  }\n']
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(
+  source: '\n  query AdminNewsHistory($id: UUID!) {\n    newsPost(id: $id) {\n      id\n      title\n      edits {\n        title\n        summary\n        content\n        publishedAt\n        coverImagePath\n        editedAt\n        editor {\n          id\n          name\n        }\n        author {\n          id\n          name\n        }\n      }\n    }\n  }\n',
+): (typeof documents)['\n  query AdminNewsHistory($id: UUID!) {\n    newsPost(id: $id) {\n      id\n      title\n      edits {\n        title\n        summary\n        content\n        publishedAt\n        coverImagePath\n        editedAt\n        editor {\n          id\n          name\n        }\n        author {\n          id\n          name\n        }\n      }\n    }\n  }\n']
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(
+  source: '\n  mutation NewsCreatePost($post: NewsPostCreation!) {\n    newsCreatePost(post: $post) {\n      id\n    }\n  }\n',
+): (typeof documents)['\n  mutation NewsCreatePost($post: NewsPostCreation!) {\n    newsCreatePost(post: $post) {\n      id\n    }\n  }\n']
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(
+  source: '\n  mutation NewsUpdatePost($id: UUID!, $updates: NewsPostUpdates!) {\n    newsUpdatePost(id: $id, updates: $updates) {\n      id\n      title\n      summary\n      content\n      publishedAt\n      updatedAt\n    }\n  }\n',
+): (typeof documents)['\n  mutation NewsUpdatePost($id: UUID!, $updates: NewsPostUpdates!) {\n    newsUpdatePost(id: $id, updates: $updates) {\n      id\n      title\n      summary\n      content\n      publishedAt\n      updatedAt\n    }\n  }\n']
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(
+  source: '\n  mutation NewsDeletePost($id: UUID!) {\n    newsDeletePost(id: $id)\n  }\n',
+): (typeof documents)['\n  mutation NewsDeletePost($id: UUID!) {\n    newsDeletePost(id: $id)\n  }\n']
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */

--- a/client/gql/gql.ts
+++ b/client/gql/gql.ts
@@ -16,7 +16,7 @@ import * as types from './graphql'
 type Documents = {
   '\n  query AdminNewsList($first: Int, $after: String) {\n    newsPosts(includeUnpublished: true, first: $first, after: $after) {\n      edges {\n        node {\n          id\n          title\n          summary\n          publishedAt\n          updatedAt\n          author {\n            id\n            name\n          }\n        }\n      }\n      pageInfo {\n        hasNextPage\n        endCursor\n      }\n    }\n  }\n': typeof types.AdminNewsListDocument
   '\n  query AdminNewsPost($id: UUID!) {\n    newsPost(id: $id) {\n      id\n      title\n      summary\n      content\n      publishedAt\n      author {\n        id\n        name\n      }\n    }\n  }\n': typeof types.AdminNewsPostDocument
-  '\n  query AdminNewsHistory($id: UUID!) {\n    newsPost(id: $id) {\n      id\n      title\n      edits {\n        title\n        summary\n        content\n        publishedAt\n        coverImagePath\n        editedAt\n        editor {\n          id\n          name\n        }\n        author {\n          id\n          name\n        }\n      }\n    }\n  }\n': typeof types.AdminNewsHistoryDocument
+  '\n  query AdminNewsHistory($id: UUID!) {\n    newsPost(id: $id) {\n      id\n      title\n      edits {\n        title\n        summary\n        content\n        publishedAt\n        coverImagePath\n        editedAt\n        editor {\n          id\n          name\n        }\n      }\n    }\n  }\n': typeof types.AdminNewsHistoryDocument
   '\n  mutation NewsCreatePost($post: NewsPostCreation!) {\n    newsCreatePost(post: $post) {\n      id\n    }\n  }\n': typeof types.NewsCreatePostDocument
   '\n  mutation NewsUpdatePost($id: UUID!, $updates: NewsPostUpdates!) {\n    newsUpdatePost(id: $id, updates: $updates) {\n      id\n      title\n      summary\n      content\n      publishedAt\n      updatedAt\n    }\n  }\n': typeof types.NewsUpdatePostDocument
   '\n  mutation NewsDeletePost($id: UUID!) {\n    newsDeletePost(id: $id)\n  }\n': typeof types.NewsDeletePostDocument
@@ -73,7 +73,7 @@ const documents: Documents = {
     types.AdminNewsListDocument,
   '\n  query AdminNewsPost($id: UUID!) {\n    newsPost(id: $id) {\n      id\n      title\n      summary\n      content\n      publishedAt\n      author {\n        id\n        name\n      }\n    }\n  }\n':
     types.AdminNewsPostDocument,
-  '\n  query AdminNewsHistory($id: UUID!) {\n    newsPost(id: $id) {\n      id\n      title\n      edits {\n        title\n        summary\n        content\n        publishedAt\n        coverImagePath\n        editedAt\n        editor {\n          id\n          name\n        }\n        author {\n          id\n          name\n        }\n      }\n    }\n  }\n':
+  '\n  query AdminNewsHistory($id: UUID!) {\n    newsPost(id: $id) {\n      id\n      title\n      edits {\n        title\n        summary\n        content\n        publishedAt\n        coverImagePath\n        editedAt\n        editor {\n          id\n          name\n        }\n      }\n    }\n  }\n':
     types.AdminNewsHistoryDocument,
   '\n  mutation NewsCreatePost($post: NewsPostCreation!) {\n    newsCreatePost(post: $post) {\n      id\n    }\n  }\n':
     types.NewsCreatePostDocument,
@@ -206,8 +206,8 @@ export function graphql(
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
 export function graphql(
-  source: '\n  query AdminNewsHistory($id: UUID!) {\n    newsPost(id: $id) {\n      id\n      title\n      edits {\n        title\n        summary\n        content\n        publishedAt\n        coverImagePath\n        editedAt\n        editor {\n          id\n          name\n        }\n        author {\n          id\n          name\n        }\n      }\n    }\n  }\n',
-): (typeof documents)['\n  query AdminNewsHistory($id: UUID!) {\n    newsPost(id: $id) {\n      id\n      title\n      edits {\n        title\n        summary\n        content\n        publishedAt\n        coverImagePath\n        editedAt\n        editor {\n          id\n          name\n        }\n        author {\n          id\n          name\n        }\n      }\n    }\n  }\n']
+  source: '\n  query AdminNewsHistory($id: UUID!) {\n    newsPost(id: $id) {\n      id\n      title\n      edits {\n        title\n        summary\n        content\n        publishedAt\n        coverImagePath\n        editedAt\n        editor {\n          id\n          name\n        }\n      }\n    }\n  }\n',
+): (typeof documents)['\n  query AdminNewsHistory($id: UUID!) {\n    newsPost(id: $id) {\n      id\n      title\n      edits {\n        title\n        summary\n        content\n        publishedAt\n        coverImagePath\n        editedAt\n        editor {\n          id\n          name\n        }\n      }\n    }\n  }\n']
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */

--- a/client/gql/graphql.ts
+++ b/client/gql/graphql.ts
@@ -84,6 +84,29 @@ export type MatchmakerPerModeOverrideInput = {
   matchmakingType: Types.MatchmakingType
 }
 
+export type NewsPostCreation = {
+  authorId?: Types.SbUserId | null | undefined
+  content: string
+  coverImagePath?: string | null | undefined
+  publishedAt?: string | null | undefined
+  summary: string
+  title: string
+}
+
+/**
+ * Partial updates for an existing news post. Fields omitted from the input are left unchanged.
+ * For `publishedAt` and `coverImagePath`, an explicit null clears the current value (e.g.
+ * unpublishing a post), so a single mutation covers editing, publishing now, scheduling, and
+ * unpublishing.
+ */
+export type NewsPostUpdates = {
+  content?: string | null | undefined
+  coverImagePath?: string | null | undefined
+  publishedAt?: string | null | undefined
+  summary?: string | null | undefined
+  title?: string | null | undefined
+}
+
 export type ReportGameInput = {
   details?: string | null | undefined
   gameId: string
@@ -130,6 +153,91 @@ export type UrgentMessageInput = {
   message: string
   title: string
 }
+
+export type AdminNewsListQueryVariables = Exact<{
+  first?: number | null | undefined
+  after?: string | null | undefined
+}>
+
+export type AdminNewsListQuery = {
+  newsPosts: {
+    edges: Array<{
+      node: {
+        id: string
+        title: string
+        summary: string
+        publishedAt: string | null
+        updatedAt: string
+        author: { id: Types.SbUserId; name: string } | null
+      }
+    }>
+    pageInfo: { hasNextPage: boolean; endCursor: string | null }
+  }
+}
+
+export type AdminNewsPostQueryVariables = Exact<{
+  id: string
+}>
+
+export type AdminNewsPostQuery = {
+  newsPost: {
+    id: string
+    title: string
+    summary: string
+    content: string
+    publishedAt: string | null
+    author: { id: Types.SbUserId; name: string } | null
+  } | null
+}
+
+export type AdminNewsHistoryQueryVariables = Exact<{
+  id: string
+}>
+
+export type AdminNewsHistoryQuery = {
+  newsPost: {
+    id: string
+    title: string
+    edits: Array<{
+      title: string
+      summary: string
+      content: string
+      publishedAt: string | null
+      coverImagePath: string | null
+      editedAt: string
+      editor: { id: Types.SbUserId; name: string } | null
+      author: { id: Types.SbUserId; name: string } | null
+    }>
+  } | null
+}
+
+export type NewsCreatePostMutationVariables = Exact<{
+  post: NewsPostCreation
+}>
+
+export type NewsCreatePostMutation = { newsCreatePost: { id: string } }
+
+export type NewsUpdatePostMutationVariables = Exact<{
+  id: string
+  updates: NewsPostUpdates
+}>
+
+export type NewsUpdatePostMutation = {
+  newsUpdatePost: {
+    id: string
+    title: string
+    summary: string
+    content: string
+    publishedAt: string | null
+    updatedAt: string
+  }
+}
+
+export type NewsDeletePostMutationVariables = Exact<{
+  id: string
+}>
+
+export type NewsDeletePostMutation = { newsDeletePost: boolean }
 
 export type AdminMatchmakingConfigQueryVariables = Exact<{ [key: string]: never }>
 
@@ -1719,6 +1827,377 @@ export const AdminUserProfile_PermissionsFragmentDoc = {
     },
   ],
 } as unknown as DocumentNode<AdminUserProfile_PermissionsFragment, unknown>
+export const AdminNewsListDocument = {
+  kind: 'Document',
+  definitions: [
+    {
+      kind: 'OperationDefinition',
+      operation: 'query',
+      name: { kind: 'Name', value: 'AdminNewsList' },
+      variableDefinitions: [
+        {
+          kind: 'VariableDefinition',
+          variable: { kind: 'Variable', name: { kind: 'Name', value: 'first' } },
+          type: { kind: 'NamedType', name: { kind: 'Name', value: 'Int' } },
+        },
+        {
+          kind: 'VariableDefinition',
+          variable: { kind: 'Variable', name: { kind: 'Name', value: 'after' } },
+          type: { kind: 'NamedType', name: { kind: 'Name', value: 'String' } },
+        },
+      ],
+      selectionSet: {
+        kind: 'SelectionSet',
+        selections: [
+          {
+            kind: 'Field',
+            name: { kind: 'Name', value: 'newsPosts' },
+            arguments: [
+              {
+                kind: 'Argument',
+                name: { kind: 'Name', value: 'includeUnpublished' },
+                value: { kind: 'BooleanValue', value: true },
+              },
+              {
+                kind: 'Argument',
+                name: { kind: 'Name', value: 'first' },
+                value: { kind: 'Variable', name: { kind: 'Name', value: 'first' } },
+              },
+              {
+                kind: 'Argument',
+                name: { kind: 'Name', value: 'after' },
+                value: { kind: 'Variable', name: { kind: 'Name', value: 'after' } },
+              },
+            ],
+            selectionSet: {
+              kind: 'SelectionSet',
+              selections: [
+                {
+                  kind: 'Field',
+                  name: { kind: 'Name', value: 'edges' },
+                  selectionSet: {
+                    kind: 'SelectionSet',
+                    selections: [
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'node' },
+                        selectionSet: {
+                          kind: 'SelectionSet',
+                          selections: [
+                            { kind: 'Field', name: { kind: 'Name', value: 'id' } },
+                            { kind: 'Field', name: { kind: 'Name', value: 'title' } },
+                            { kind: 'Field', name: { kind: 'Name', value: 'summary' } },
+                            { kind: 'Field', name: { kind: 'Name', value: 'publishedAt' } },
+                            { kind: 'Field', name: { kind: 'Name', value: 'updatedAt' } },
+                            {
+                              kind: 'Field',
+                              name: { kind: 'Name', value: 'author' },
+                              selectionSet: {
+                                kind: 'SelectionSet',
+                                selections: [
+                                  { kind: 'Field', name: { kind: 'Name', value: 'id' } },
+                                  { kind: 'Field', name: { kind: 'Name', value: 'name' } },
+                                ],
+                              },
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+                {
+                  kind: 'Field',
+                  name: { kind: 'Name', value: 'pageInfo' },
+                  selectionSet: {
+                    kind: 'SelectionSet',
+                    selections: [
+                      { kind: 'Field', name: { kind: 'Name', value: 'hasNextPage' } },
+                      { kind: 'Field', name: { kind: 'Name', value: 'endCursor' } },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<AdminNewsListQuery, AdminNewsListQueryVariables>
+export const AdminNewsPostDocument = {
+  kind: 'Document',
+  definitions: [
+    {
+      kind: 'OperationDefinition',
+      operation: 'query',
+      name: { kind: 'Name', value: 'AdminNewsPost' },
+      variableDefinitions: [
+        {
+          kind: 'VariableDefinition',
+          variable: { kind: 'Variable', name: { kind: 'Name', value: 'id' } },
+          type: {
+            kind: 'NonNullType',
+            type: { kind: 'NamedType', name: { kind: 'Name', value: 'UUID' } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: 'SelectionSet',
+        selections: [
+          {
+            kind: 'Field',
+            name: { kind: 'Name', value: 'newsPost' },
+            arguments: [
+              {
+                kind: 'Argument',
+                name: { kind: 'Name', value: 'id' },
+                value: { kind: 'Variable', name: { kind: 'Name', value: 'id' } },
+              },
+            ],
+            selectionSet: {
+              kind: 'SelectionSet',
+              selections: [
+                { kind: 'Field', name: { kind: 'Name', value: 'id' } },
+                { kind: 'Field', name: { kind: 'Name', value: 'title' } },
+                { kind: 'Field', name: { kind: 'Name', value: 'summary' } },
+                { kind: 'Field', name: { kind: 'Name', value: 'content' } },
+                { kind: 'Field', name: { kind: 'Name', value: 'publishedAt' } },
+                {
+                  kind: 'Field',
+                  name: { kind: 'Name', value: 'author' },
+                  selectionSet: {
+                    kind: 'SelectionSet',
+                    selections: [
+                      { kind: 'Field', name: { kind: 'Name', value: 'id' } },
+                      { kind: 'Field', name: { kind: 'Name', value: 'name' } },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<AdminNewsPostQuery, AdminNewsPostQueryVariables>
+export const AdminNewsHistoryDocument = {
+  kind: 'Document',
+  definitions: [
+    {
+      kind: 'OperationDefinition',
+      operation: 'query',
+      name: { kind: 'Name', value: 'AdminNewsHistory' },
+      variableDefinitions: [
+        {
+          kind: 'VariableDefinition',
+          variable: { kind: 'Variable', name: { kind: 'Name', value: 'id' } },
+          type: {
+            kind: 'NonNullType',
+            type: { kind: 'NamedType', name: { kind: 'Name', value: 'UUID' } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: 'SelectionSet',
+        selections: [
+          {
+            kind: 'Field',
+            name: { kind: 'Name', value: 'newsPost' },
+            arguments: [
+              {
+                kind: 'Argument',
+                name: { kind: 'Name', value: 'id' },
+                value: { kind: 'Variable', name: { kind: 'Name', value: 'id' } },
+              },
+            ],
+            selectionSet: {
+              kind: 'SelectionSet',
+              selections: [
+                { kind: 'Field', name: { kind: 'Name', value: 'id' } },
+                { kind: 'Field', name: { kind: 'Name', value: 'title' } },
+                {
+                  kind: 'Field',
+                  name: { kind: 'Name', value: 'edits' },
+                  selectionSet: {
+                    kind: 'SelectionSet',
+                    selections: [
+                      { kind: 'Field', name: { kind: 'Name', value: 'title' } },
+                      { kind: 'Field', name: { kind: 'Name', value: 'summary' } },
+                      { kind: 'Field', name: { kind: 'Name', value: 'content' } },
+                      { kind: 'Field', name: { kind: 'Name', value: 'publishedAt' } },
+                      { kind: 'Field', name: { kind: 'Name', value: 'coverImagePath' } },
+                      { kind: 'Field', name: { kind: 'Name', value: 'editedAt' } },
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'editor' },
+                        selectionSet: {
+                          kind: 'SelectionSet',
+                          selections: [
+                            { kind: 'Field', name: { kind: 'Name', value: 'id' } },
+                            { kind: 'Field', name: { kind: 'Name', value: 'name' } },
+                          ],
+                        },
+                      },
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'author' },
+                        selectionSet: {
+                          kind: 'SelectionSet',
+                          selections: [
+                            { kind: 'Field', name: { kind: 'Name', value: 'id' } },
+                            { kind: 'Field', name: { kind: 'Name', value: 'name' } },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<AdminNewsHistoryQuery, AdminNewsHistoryQueryVariables>
+export const NewsCreatePostDocument = {
+  kind: 'Document',
+  definitions: [
+    {
+      kind: 'OperationDefinition',
+      operation: 'mutation',
+      name: { kind: 'Name', value: 'NewsCreatePost' },
+      variableDefinitions: [
+        {
+          kind: 'VariableDefinition',
+          variable: { kind: 'Variable', name: { kind: 'Name', value: 'post' } },
+          type: {
+            kind: 'NonNullType',
+            type: { kind: 'NamedType', name: { kind: 'Name', value: 'NewsPostCreation' } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: 'SelectionSet',
+        selections: [
+          {
+            kind: 'Field',
+            name: { kind: 'Name', value: 'newsCreatePost' },
+            arguments: [
+              {
+                kind: 'Argument',
+                name: { kind: 'Name', value: 'post' },
+                value: { kind: 'Variable', name: { kind: 'Name', value: 'post' } },
+              },
+            ],
+            selectionSet: {
+              kind: 'SelectionSet',
+              selections: [{ kind: 'Field', name: { kind: 'Name', value: 'id' } }],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<NewsCreatePostMutation, NewsCreatePostMutationVariables>
+export const NewsUpdatePostDocument = {
+  kind: 'Document',
+  definitions: [
+    {
+      kind: 'OperationDefinition',
+      operation: 'mutation',
+      name: { kind: 'Name', value: 'NewsUpdatePost' },
+      variableDefinitions: [
+        {
+          kind: 'VariableDefinition',
+          variable: { kind: 'Variable', name: { kind: 'Name', value: 'id' } },
+          type: {
+            kind: 'NonNullType',
+            type: { kind: 'NamedType', name: { kind: 'Name', value: 'UUID' } },
+          },
+        },
+        {
+          kind: 'VariableDefinition',
+          variable: { kind: 'Variable', name: { kind: 'Name', value: 'updates' } },
+          type: {
+            kind: 'NonNullType',
+            type: { kind: 'NamedType', name: { kind: 'Name', value: 'NewsPostUpdates' } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: 'SelectionSet',
+        selections: [
+          {
+            kind: 'Field',
+            name: { kind: 'Name', value: 'newsUpdatePost' },
+            arguments: [
+              {
+                kind: 'Argument',
+                name: { kind: 'Name', value: 'id' },
+                value: { kind: 'Variable', name: { kind: 'Name', value: 'id' } },
+              },
+              {
+                kind: 'Argument',
+                name: { kind: 'Name', value: 'updates' },
+                value: { kind: 'Variable', name: { kind: 'Name', value: 'updates' } },
+              },
+            ],
+            selectionSet: {
+              kind: 'SelectionSet',
+              selections: [
+                { kind: 'Field', name: { kind: 'Name', value: 'id' } },
+                { kind: 'Field', name: { kind: 'Name', value: 'title' } },
+                { kind: 'Field', name: { kind: 'Name', value: 'summary' } },
+                { kind: 'Field', name: { kind: 'Name', value: 'content' } },
+                { kind: 'Field', name: { kind: 'Name', value: 'publishedAt' } },
+                { kind: 'Field', name: { kind: 'Name', value: 'updatedAt' } },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<NewsUpdatePostMutation, NewsUpdatePostMutationVariables>
+export const NewsDeletePostDocument = {
+  kind: 'Document',
+  definitions: [
+    {
+      kind: 'OperationDefinition',
+      operation: 'mutation',
+      name: { kind: 'Name', value: 'NewsDeletePost' },
+      variableDefinitions: [
+        {
+          kind: 'VariableDefinition',
+          variable: { kind: 'Variable', name: { kind: 'Name', value: 'id' } },
+          type: {
+            kind: 'NonNullType',
+            type: { kind: 'NamedType', name: { kind: 'Name', value: 'UUID' } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: 'SelectionSet',
+        selections: [
+          {
+            kind: 'Field',
+            name: { kind: 'Name', value: 'newsDeletePost' },
+            arguments: [
+              {
+                kind: 'Argument',
+                name: { kind: 'Name', value: 'id' },
+                value: { kind: 'Variable', name: { kind: 'Name', value: 'id' } },
+              },
+            ],
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<NewsDeletePostMutation, NewsDeletePostMutationVariables>
 export const AdminMatchmakingConfigDocument = {
   kind: 'Document',
   definitions: [

--- a/client/gql/graphql.ts
+++ b/client/gql/graphql.ts
@@ -206,7 +206,6 @@ export type AdminNewsHistoryQuery = {
       coverImagePath: string | null
       editedAt: string
       editor: { id: Types.SbUserId; name: string } | null
-      author: { id: Types.SbUserId; name: string } | null
     }>
   } | null
 }
@@ -2032,17 +2031,6 @@ export const AdminNewsHistoryDocument = {
                       {
                         kind: 'Field',
                         name: { kind: 'Name', value: 'editor' },
-                        selectionSet: {
-                          kind: 'SelectionSet',
-                          selections: [
-                            { kind: 'Field', name: { kind: 'Name', value: 'id' } },
-                            { kind: 'Field', name: { kind: 'Name', value: 'name' } },
-                          ],
-                        },
-                      },
-                      {
-                        kind: 'Field',
-                        name: { kind: 'Name', value: 'author' },
                         selectionSet: {
                           kind: 'SelectionSet',
                           selections: [

--- a/server/public/locales/en/global.json
+++ b/server/public/locales/en/global.json
@@ -1,4 +1,79 @@
 {
+  "admin": {
+    "news": {
+      "action": {
+        "delete": "Delete",
+        "edit": "Edit",
+        "history": "Edit history",
+        "publishNow": "Publish now",
+        "unpublish": "Unpublish"
+      },
+      "backToList": "Back to list",
+      "column": {
+        "actions": "Actions",
+        "author": "Author",
+        "status": "Status",
+        "title": "Title",
+        "updated": "Updated"
+      },
+      "confirmDelete": "Delete \"{{title}}\"? This cannot be undone.",
+      "created": "News post created",
+      "createPost": "Create post",
+      "createTitle": "Create news post",
+      "deleteError": "Error deleting post:",
+      "editPost": "Edit post",
+      "editTitle": "Edit news post",
+      "field": {
+        "content": "Content",
+        "cover": "Cover image",
+        "publish": "Publish date",
+        "summary": "Summary",
+        "title": "Title"
+      },
+      "form": {
+        "content": "Content (Markdown)",
+        "contentRequired": "Content is required",
+        "publish": "Publish",
+        "publishDraft": "Draft (not published)",
+        "publishNow": "Publish now",
+        "publishSchedule": "Schedule",
+        "scheduleDate": "Publish date and time",
+        "scheduleHint": "A future date/time schedules the post; a past date/time publishes it immediately.",
+        "scheduleRequired": "Choose a valid date and time",
+        "summary": "Summary",
+        "summaryRequired": "Summary is required",
+        "title": "Title",
+        "titleRequired": "Title is required"
+      },
+      "history": {
+        "by": "by ",
+        "byUnknown": "by an unknown user",
+        "changed": "Changed: {{fields}}",
+        "created": "Created",
+        "edited": "Edited",
+        "empty": "No edit history for this post.",
+        "noFieldChanges": "No tracked field changes",
+        "title": "Edit history"
+      },
+      "historyPublished": "Published {{date}}",
+      "historyScheduled": "Scheduled for {{date}}",
+      "loadError": "Error loading news posts:",
+      "loadMore": "Load more",
+      "newPost": "New post",
+      "notFound": "No news post found with this ID.",
+      "refresh": "Refresh",
+      "saveChanges": "Save changes",
+      "saved": "News post saved",
+      "status": {
+        "draft": "Draft",
+        "published": "Published",
+        "scheduled": "Scheduled"
+      },
+      "title": "Manage news",
+      "updateError": "Error updating post:",
+      "viewPost": "View post"
+    }
+  },
   "auth": {
     "emailValidator": {
       "pattern": "Enter a valid email address",
@@ -305,6 +380,7 @@
       "close": "Close",
       "copy": "Copy",
       "decline": "Decline",
+      "delete": "Delete",
       "download": "Download",
       "edit": "Edit",
       "hide": "Hide",


### PR DESCRIPTION
Third PR of the dynamic news stack (on top of #1346). Admins with `manageNews` can now author posts entirely in-app.

## Changes

- **`/admin/news`** (new panel entry): cursor-paged list of all posts including drafts, with a color-coded status chip (Draft / Scheduled + date / Published + date), author, and last-updated. Row actions: edit, edit history, publish now, unpublish, and delete (inline confirmation row, matching the restricted-names pattern). Mutations refresh the list with a network-only refetch since relay connections don't invalidate cleanly in graphcache.
- **Create/edit form** (`/admin/news/new`, `/admin/news/:id`): title, summary, and a large markdown content field with a live side-by-side preview (urgent-message form pattern). Publish control is Draft / Publish now / Schedule (datetime-local). Edits send **only changed fields** — the schedule comparison is minute-precision so re-saving an untouched post doesn't bump its publish date, an explicit `publishedAt: null` unpublishes, and a save with no changes skips the mutation entirely (no spurious edit-log rows). Creation sends `authorId` as self so posts render "by {name}". A "View post" button opens the real `/news/:id` page, where admins see drafts with the Draft chip.
- **Edit history** (`/admin/news/:id/history`): renders the `NewsPost.edits` log newest-first — timestamp, editor, then-current title and publish state, and which of title/summary/content/publish date/cover image changed vs the previous revision. The oldest entry is labeled Created.

## Verification

Full round-trip driven in the real web client as an admin: create draft (live preview rendering) → draft sorts first in the list → view post shows the Draft chip → edit title → history shows Created + Edited with "Changed: Title" → publish now (home feed hero becomes the post) → unpublish → delete via inline confirm (home feed reverts). Also fixed a status-classification staleness issue found during verification: `useNow(30s)` could briefly label a just-published post "Scheduled", so list refreshes now floor the clock to the refresh time. `lint`, `typecheck`, unit tests, `gen-graphql`, `gen-translations` all clean.