### PR TITLE
Push a live signal to clients when news posts are published

### DIFF
--- a/client/main-layout.tsx
+++ b/client/main-layout.tsx
@@ -41,6 +41,7 @@ import {
   useNavigationMenuState,
 } from './navigation/navigation-menu'
 import { push } from './navigation/routing'
+import { useHasNewNewsPost } from './news/last-seen-news-post'
 import { NotificationsButton } from './notifications/app-bar-entry'
 import NotificationPopups from './notifications/notifications-popup'
 import { useShowPolicyNotificationsIfNeeded } from './policies/show-notifications'
@@ -609,7 +610,9 @@ function AppBar({
   const [settingsButton, setSettingsButton] = useState<HTMLButtonElement | null>(null)
   useButtonHotkey({ elem: settingsButton, hotkey: ALT_S })
 
-  const homeHasPip = useHasNewUrgentMessage()
+  const hasNewUrgentMessage = useHasNewUrgentMessage()
+  const hasNewNewsPost = useHasNewNewsPost()
+  const homeHasPip = hasNewUrgentMessage || hasNewNewsPost
 
   useKeyListener({
     onKeyDown: (event: KeyboardEvent) => {

--- a/client/news/last-seen-news-post.ts
+++ b/client/news/last-seen-news-post.ts
@@ -1,0 +1,23 @@
+import { atom, useAtom } from 'jotai'
+import { useUserLocalStorageValue } from '../react/state-hooks'
+
+export const latestNewsPostId = atom<string | undefined>(undefined)
+
+export function useLastSeenNewsPost(): [
+  lastSeenId: string | undefined,
+  markSeen: (id: string) => void,
+] {
+  const [lastSeenNewsPost, setLastSeenNewsPost] = useUserLocalStorageValue<string | undefined>(
+    'news.lastSeenNewsPost',
+    undefined,
+  )
+
+  return [lastSeenNewsPost, setLastSeenNewsPost]
+}
+
+export function useHasNewNewsPost(): boolean {
+  const [lastSeenNewsPost] = useLastSeenNewsPost()
+  const [curId] = useAtom(latestNewsPostId)
+
+  return !!curId && curId !== lastSeenNewsPost
+}

--- a/client/news/news-feed.tsx
+++ b/client/news/news-feed.tsx
@@ -1,5 +1,5 @@
 import { ResultOf } from '@graphql-typed-document-node/core'
-import { ReactNode } from 'react'
+import { ReactNode, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 import { Link } from 'wouter'
@@ -11,6 +11,7 @@ import { LinkButton } from '../material/link-button'
 import { Ripple } from '../material/ripple'
 import { ContainerLevel, containerStyles } from '../styles/colors'
 import { bodyMedium, singleLine, titleMedium, titleSmall } from '../styles/typography'
+import { useLastSeenNewsPost } from './last-seen-news-post'
 import { NewsImage, newsDateFormatter } from './news-image'
 
 export const News_HomeFeedFragment = graphql(/* GraphQL */ `
@@ -229,6 +230,13 @@ export function NewsFeed({
   const primary = posts[0]
   const twoUp = posts.slice(1, 3)
   const remaining = posts.slice(3, 10)
+
+  const [lastSeenNewsPost, markNewsPostSeen] = useLastSeenNewsPost()
+  useEffect(() => {
+    if (primary && primary.id !== lastSeenNewsPost) {
+      markNewsPostSeen(primary.id)
+    }
+  }, [lastSeenNewsPost, markNewsPostSeen, primary])
 
   let body: ReactNode = null
   if (posts.length > 0) {

--- a/client/news/socket-handlers.ts
+++ b/client/news/socket-handlers.ts
@@ -1,8 +1,9 @@
-import { NydusClient } from 'nydus-client'
+import type { NydusClient, RouteInfo } from 'nydus-client'
 import { NewsEvent } from '../../common/news'
 import { dispatch, Dispatchable } from '../dispatch-registry'
 import { urgentMessageId } from '../home/last-seen-urgent-message'
 import { jotaiStore } from '../jotai-store'
+import { latestNewsPostId } from './last-seen-news-post'
 
 type EventToNewsActionMap = {
   [E in NewsEvent['type']]: (
@@ -14,13 +15,19 @@ const eventToAction: EventToNewsActionMap = {
   urgentMessageChange(event) {
     jotaiStore.set(urgentMessageId, event.id)
   },
+  newsPostChange(event) {
+    jotaiStore.set(latestNewsPostId, event.id)
+  },
+}
+
+function handleNewsEvent(_route: RouteInfo, event: NewsEvent) {
+  const action = eventToAction[event.type]?.(event as any)
+  if (action) {
+    dispatch(action)
+  }
 }
 
 export default function registerModule({ siteSocket }: { siteSocket: NydusClient }) {
-  siteSocket.registerRoute('/news', (_route, event: NewsEvent) => {
-    const action = eventToAction[event.type]?.(event)
-    if (action) {
-      dispatch(action)
-    }
-  })
+  siteSocket.registerRoute('/news', handleNewsEvent)
+  siteSocket.registerRoute('/newsPosts', handleNewsEvent)
 }

--- a/common/news.ts
+++ b/common/news.ts
@@ -1,4 +1,4 @@
-export type NewsEvent = UrgentMessageChangeEvent
+export type NewsEvent = UrgentMessageChangeEvent | NewsPostChangeEvent
 
 export type UrgentMessageChangeEvent =
   | {
@@ -8,6 +8,18 @@ export type UrgentMessageChangeEvent =
     }
   | {
       type: 'urgentMessageChange'
+      publishedAt: number
+      id: string
+    }
+
+export type NewsPostChangeEvent =
+  | {
+      type: 'newsPostChange'
+      publishedAt?: undefined
+      id?: undefined
+    }
+  | {
+      type: 'newsPostChange'
       publishedAt: number
       id: string
     }

--- a/server/lib/news/news-post-models.ts
+++ b/server/lib/news/news-post-models.ts
@@ -1,0 +1,58 @@
+import db, { DbClient } from '../db'
+import { sql } from '../db/sql'
+import { Dbify } from '../db/types'
+
+export interface LatestPublishedNewsPost {
+  id: string
+  publishedAt: Date
+}
+type DbLatestPublishedNewsPost = Dbify<LatestPublishedNewsPost>
+
+/**
+ * Returns the id and publish time of the most recently published news post (that is, the newest
+ * post whose `published_at` is set and has already passed), or `undefined` if no posts are
+ * currently published.
+ */
+export async function getLatestPublishedNewsPost(
+  withClient?: DbClient,
+): Promise<LatestPublishedNewsPost | undefined> {
+  const { client, done } = await db(withClient)
+  try {
+    const result = await client.query<DbLatestPublishedNewsPost>(sql`
+      SELECT id, published_at
+      FROM news_posts
+      WHERE published_at IS NOT NULL AND published_at <= NOW()
+      ORDER BY published_at DESC, id DESC
+      LIMIT 1;
+    `)
+    if (result.rows.length === 0) {
+      return undefined
+    }
+    return {
+      id: result.rows[0].id,
+      publishedAt: result.rows[0].published_at,
+    }
+  } finally {
+    done()
+  }
+}
+
+/**
+ * Returns the earliest future `published_at` among scheduled news posts (those whose publish time
+ * hasn't passed yet), or `undefined` if none are scheduled.
+ */
+export async function getNextScheduledNewsPostTime(
+  withClient?: DbClient,
+): Promise<Date | undefined> {
+  const { client, done } = await db(withClient)
+  try {
+    const result = await client.query<{ next_published_at: Date | null }>(sql`
+      SELECT MIN(published_at) AS next_published_at
+      FROM news_posts
+      WHERE published_at > NOW();
+    `)
+    return result.rows[0]?.next_published_at ?? undefined
+  } finally {
+    done()
+  }
+}

--- a/server/lib/news/news-service.test.ts
+++ b/server/lib/news/news-service.test.ts
@@ -224,6 +224,25 @@ describe('news/news-service', () => {
     })
   })
 
+  test('retries after a transient DB error instead of stalling scheduled publishing', async () => {
+    testState.posts.push({ id: 'p1', publishedAt: BASE_TIME + 1000 })
+    await emitNewsPostsChanged()
+
+    // The reconcile triggered by the scheduled-publish timer fails (the timer is already cleared
+    // at this point, so without a retry the signal would never fire)...
+    getLatestPublishedNewsPostMock.mockRejectedValueOnce(new Error('db went away'))
+    await runNextTimer()
+    expect(client1.publish).not.toHaveBeenCalledWith(NEWS_POSTS_PATH, expect.anything())
+
+    // ...but a retry timer was armed, and the next pass publishes the event.
+    await runNextTimer()
+    expect(client1.publish).toHaveBeenCalledWith(NEWS_POSTS_PATH, {
+      type: 'newsPostChange',
+      id: 'p1',
+      publishedAt: BASE_TIME + 1000,
+    })
+  })
+
   test('clamps and re-arms for a post scheduled beyond the max timeout', async () => {
     const publishedAt = BASE_TIME + MAX_TIMEOUT_MS + 10000
     testState.posts.push({ id: 'p1', publishedAt })

--- a/server/lib/news/news-service.test.ts
+++ b/server/lib/news/news-service.test.ts
@@ -1,0 +1,244 @@
+import { NydusServer } from 'nydus'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { NewsEvent } from '../../../common/news'
+import { asMockedFunction } from '../../../common/testing/mocks'
+import { makeSbUserId } from '../../../common/users/sb-user-id'
+import { Redis, RedisSubscriber } from '../redis/redis'
+import { FakeClock, StopCriteria } from '../time/testing/fake-clock'
+import { RequestSessionLookup } from '../websockets/session-lookup'
+import { UserSocketsManager } from '../websockets/socket-groups'
+import {
+  clearTestLogs,
+  createFakeNydusServer,
+  InspectableNydusClient,
+  NydusConnector,
+} from '../websockets/testing/websockets'
+import { TypedPublisher } from '../websockets/typed-publisher'
+import { getLatestPublishedNewsPost, getNextScheduledNewsPostTime } from './news-post-models'
+import { NewsService } from './news-service'
+
+const MAX_TIMEOUT_MS = 2 ** 31 - 1
+
+interface TestPost {
+  id: string
+  publishedAt: number
+}
+
+interface NewsTestState {
+  now: () => number
+  posts: TestPost[]
+}
+
+vi.mock('./news-post-models', () => ({
+  getLatestPublishedNewsPost: vi.fn(async () => {
+    const state = (global as any).__NEWS_TEST as NewsTestState
+    const now = state.now()
+    const published = state.posts.filter(p => p.publishedAt <= now)
+    if (published.length === 0) {
+      return undefined
+    }
+    published.sort((a, b) => b.publishedAt - a.publishedAt || (a.id < b.id ? 1 : -1))
+    const top = published[0]
+    return { id: top.id, publishedAt: new Date(top.publishedAt) }
+  }),
+  getNextScheduledNewsPostTime: vi.fn(async () => {
+    const state = (global as any).__NEWS_TEST as NewsTestState
+    const now = state.now()
+    const future = state.posts.filter(p => p.publishedAt > now).map(p => p.publishedAt)
+    if (future.length === 0) {
+      return undefined
+    }
+    return new Date(Math.min(...future))
+  }),
+}))
+
+const getLatestPublishedNewsPostMock = asMockedFunction(getLatestPublishedNewsPost)
+const getNextScheduledNewsPostTimeMock = asMockedFunction(getNextScheduledNewsPostTime)
+
+class FakeRedisSubscriber {
+  private handlers = new Map<string, Array<(message: any) => void>>()
+
+  subscribe = vi.fn(async (channel: string, handler: (message: any) => void) => {
+    const existing = this.handlers.get(channel) ?? []
+    existing.push(handler)
+    this.handlers.set(channel, existing)
+  })
+
+  emit(channel: string, message: any) {
+    for (const handler of this.handlers.get(channel) ?? []) {
+      handler(message)
+    }
+  }
+}
+
+const NEWS_POSTS_PATH = '/newsPosts'
+const BASE_TIME = Number(new Date('2024-01-01T00:00:00.000Z'))
+
+async function flush() {
+  await new Promise(resolve => setImmediate(resolve))
+}
+
+describe('news/news-service', () => {
+  let clock: FakeClock
+  let nydus: NydusServer
+  let publisher: TypedPublisher<NewsEvent>
+  let userSocketsManager: UserSocketsManager
+  let connector: NydusConnector
+  let redisSubscriber: FakeRedisSubscriber
+  let service: NewsService
+  let testState: NewsTestState
+
+  let client1: InspectableNydusClient
+
+  async function emitNewsPostsChanged() {
+    redisSubscriber.emit('news', { type: 'newsPostsChanged', data: undefined })
+    await (service as any).latestNewsPostReconcile
+  }
+
+  async function runNextTimer() {
+    await clock.runTimeoutsUntil({ criteria: StopCriteria.NumTasks, numTasks: 1 })
+    await (service as any).latestNewsPostReconcile
+    await flush()
+  }
+
+  beforeEach(async () => {
+    clock = new FakeClock()
+    clock.autoRunTimeouts = false
+    clock.setCurrentTime(BASE_TIME)
+
+    testState = { now: () => clock.now(), posts: [] }
+    ;(global as any).__NEWS_TEST = testState
+
+    getLatestPublishedNewsPostMock.mockClear()
+    getNextScheduledNewsPostTimeMock.mockClear()
+
+    nydus = createFakeNydusServer()
+    const sessionLookup = new RequestSessionLookup()
+    userSocketsManager = new UserSocketsManager(nydus, sessionLookup, async () => {})
+    publisher = new TypedPublisher(nydus)
+    redisSubscriber = new FakeRedisSubscriber()
+    const redis = { get: vi.fn(async () => null) } as unknown as Redis
+
+    service = new NewsService(
+      redis,
+      redisSubscriber as unknown as RedisSubscriber,
+      publisher,
+      userSocketsManager,
+      clock,
+    )
+    await (service as any).latestNewsPostReconcile
+
+    connector = new NydusConnector(nydus, sessionLookup)
+    client1 = connector.connectClient(
+      { id: makeSbUserId(1), name: 'One', created: 1577836800000 },
+      'one',
+    )
+    await flush()
+
+    asMockedFunction(client1.publish).mockClear()
+    clearTestLogs(nydus)
+  })
+
+  test('publishes and seeds when a post becomes the latest published one', async () => {
+    testState.posts.push({ id: 'p1', publishedAt: BASE_TIME - 1000 })
+
+    await emitNewsPostsChanged()
+
+    expect(client1.publish).toHaveBeenCalledWith(NEWS_POSTS_PATH, {
+      type: 'newsPostChange',
+      id: 'p1',
+      publishedAt: BASE_TIME - 1000,
+    })
+
+    // A user connecting afterwards should be seeded with the current latest post.
+    const client2 = connector.connectClient(
+      { id: makeSbUserId(2), name: 'Two', created: 1577836800000 },
+      'two',
+    )
+    await flush()
+
+    expect(client2.publish).toHaveBeenCalledWith(NEWS_POSTS_PATH, {
+      type: 'newsPostChange',
+      id: 'p1',
+      publishedAt: BASE_TIME - 1000,
+    })
+  })
+
+  test('does not publish again when nothing has changed', async () => {
+    testState.posts.push({ id: 'p1', publishedAt: BASE_TIME - 1000 })
+    await emitNewsPostsChanged()
+    asMockedFunction(client1.publish).mockClear()
+
+    await emitNewsPostsChanged()
+
+    expect(client1.publish).not.toHaveBeenCalled()
+  })
+
+  test('publishes the cleared variant when everything is unpublished', async () => {
+    testState.posts.push({ id: 'p1', publishedAt: BASE_TIME - 1000 })
+    await emitNewsPostsChanged()
+    asMockedFunction(client1.publish).mockClear()
+
+    testState.posts = []
+    await emitNewsPostsChanged()
+
+    expect(client1.publish).toHaveBeenCalledWith(NEWS_POSTS_PATH, {
+      type: 'newsPostChange',
+    })
+  })
+
+  test('fires the event when a scheduled post reaches its publish time', async () => {
+    testState.posts.push({ id: 'p1', publishedAt: BASE_TIME + 1000 })
+    await emitNewsPostsChanged()
+
+    // Not published yet, so nothing has been broadcast.
+    expect(client1.publish).not.toHaveBeenCalledWith(NEWS_POSTS_PATH, expect.anything())
+
+    await runNextTimer()
+
+    expect(client1.publish).toHaveBeenCalledWith(NEWS_POSTS_PATH, {
+      type: 'newsPostChange',
+      id: 'p1',
+      publishedAt: BASE_TIME + 1000,
+    })
+  })
+
+  test('re-arms the timer for the next scheduled post', async () => {
+    testState.posts.push({ id: 'p1', publishedAt: BASE_TIME + 1000 })
+    testState.posts.push({ id: 'p2', publishedAt: BASE_TIME + 6000 })
+    await emitNewsPostsChanged()
+
+    await runNextTimer()
+    expect(client1.publish).toHaveBeenCalledWith(NEWS_POSTS_PATH, {
+      type: 'newsPostChange',
+      id: 'p1',
+      publishedAt: BASE_TIME + 1000,
+    })
+    asMockedFunction(client1.publish).mockClear()
+
+    await runNextTimer()
+    expect(client1.publish).toHaveBeenCalledWith(NEWS_POSTS_PATH, {
+      type: 'newsPostChange',
+      id: 'p2',
+      publishedAt: BASE_TIME + 6000,
+    })
+  })
+
+  test('clamps and re-arms for a post scheduled beyond the max timeout', async () => {
+    const publishedAt = BASE_TIME + MAX_TIMEOUT_MS + 10000
+    testState.posts.push({ id: 'p1', publishedAt })
+    await emitNewsPostsChanged()
+
+    // First tick only advances by the clamped max, so the post still isn't live.
+    await runNextTimer()
+    expect(client1.publish).not.toHaveBeenCalledWith(NEWS_POSTS_PATH, expect.anything())
+
+    // Second tick reaches the publish time.
+    await runNextTimer()
+    expect(client1.publish).toHaveBeenCalledWith(NEWS_POSTS_PATH, {
+      type: 'newsPostChange',
+      id: 'p1',
+      publishedAt,
+    })
+  })
+})

--- a/server/lib/news/news-service.ts
+++ b/server/lib/news/news-service.ts
@@ -1,15 +1,33 @@
 import { singleton } from 'tsyringe'
 import swallowNonBuiltins from '../../../common/async/swallow-non-builtins'
-import { NewsEvent, UrgentMessageChangeEvent } from '../../../common/news'
+import { NewsEvent, NewsPostChangeEvent, UrgentMessageChangeEvent } from '../../../common/news'
 import { UrgentMessage } from '../../../common/typeshare'
 import logger from '../logging/logger'
 import { Redis, RedisSubscriber } from '../redis/redis'
+import { Clock, TimeoutId } from '../time/clock'
 import { UserSocketsManager } from '../websockets/socket-groups'
 import { TypedPublisher } from '../websockets/typed-publisher'
+import { getLatestPublishedNewsPost, getNextScheduledNewsPostTime } from './news-post-models'
 
 const REDIS_KEY = 'news:urgentMessage'
 
-function toEvent(message?: UrgentMessage): UrgentMessageChangeEvent {
+const URGENT_MESSAGE_PATH = '/news'
+const NEWS_POSTS_PATH = '/newsPosts'
+
+// `setTimeout` stores its delay in a 32-bit signed int; anything larger overflows and fires
+// immediately. We clamp to this and re-arm each time it elapses until the real time arrives.
+const MAX_TIMEOUT_MS = 2 ** 31 - 1
+// A small amount of extra time to wait past a scheduled post's publish time before re-querying, so
+// that the post is reliably visible as published (and we don't busy-loop re-arming right at the
+// boundary).
+const SCHEDULED_PUBLISH_SLOP_MS = 1000
+
+interface LatestNewsPost {
+  id: string
+  publishedAt: number
+}
+
+function toUrgentMessageEvent(message?: UrgentMessage): UrgentMessageChangeEvent {
   return message
     ? {
         type: 'urgentMessageChange',
@@ -21,17 +39,37 @@ function toEvent(message?: UrgentMessage): UrgentMessageChangeEvent {
       }
 }
 
+function toNewsPostEvent(post?: LatestNewsPost): NewsPostChangeEvent {
+  return post
+    ? {
+        type: 'newsPostChange',
+        id: post.id,
+        publishedAt: post.publishedAt,
+      }
+    : {
+        type: 'newsPostChange',
+      }
+}
+
 @singleton()
 export class NewsService {
   private urgentMessageCache: Promise<UrgentMessage | undefined>
+  private latestNewsPost: LatestNewsPost | undefined
+  // Holds the most recent reconcile pass so newly-connected users seed off up-to-date state.
+  // NOTE: this promise is infallible.
+  private latestNewsPostReconcile: Promise<void>
+  private scheduledPublishTimer: TimeoutId | undefined
+  private scheduledPublishGeneration = 0
 
   constructor(
     private redis: Redis,
     private redisSubscriber: RedisSubscriber,
     private publisher: TypedPublisher<NewsEvent>,
     private userSocketsManager: UserSocketsManager,
+    private clock: Clock,
   ) {
     this.urgentMessageCache = Promise.resolve().then(() => this.getUrgentMessage())
+    this.latestNewsPostReconcile = this.reconcileLatestNewsPost()
 
     this.redisSubscriber
       .subscribe('news', message => {
@@ -41,9 +79,12 @@ export class NewsService {
             // NOTE(tec27): this promise is infallible
             this.urgentMessageCache
               .then(message => {
-                this.publisher.publish('/news', toEvent(message))
+                this.publisher.publish(URGENT_MESSAGE_PATH, toUrgentMessageEvent(message))
               })
               .catch(swallowNonBuiltins)
+            break
+          case 'newsPostsChanged':
+            this.queueLatestNewsPostReconcile()
             break
         }
       })
@@ -52,10 +93,14 @@ export class NewsService {
       })
 
     this.userSocketsManager.on('newUser', u => {
-      u.subscribe<NewsEvent>('/news', async () => {
+      u.subscribe<NewsEvent>(URGENT_MESSAGE_PATH, async () => {
         // NOTE(tec27): this promise is infallible
         const message = await this.urgentMessageCache
-        return toEvent(message)
+        return toUrgentMessageEvent(message)
+      })
+      u.subscribe<NewsEvent>(NEWS_POSTS_PATH, async () => {
+        await this.latestNewsPostReconcile
+        return toNewsPostEvent(this.latestNewsPost)
       })
     })
   }
@@ -71,5 +116,68 @@ export class NewsService {
     }
 
     return undefined
+  }
+
+  /**
+   * Chains a reconcile pass after any already-running one. Reconciles read the DB and then update
+   * cached state, so two overlapping passes could otherwise complete out of order and leave stale
+   * state cached (and published) until the next change.
+   */
+  private queueLatestNewsPostReconcile(): void {
+    this.latestNewsPostReconcile = this.latestNewsPostReconcile.then(() =>
+      this.reconcileLatestNewsPost(),
+    )
+  }
+
+  private async reconcileLatestNewsPost(): Promise<void> {
+    let latest: LatestNewsPost | undefined
+    try {
+      const post = await getLatestPublishedNewsPost()
+      latest = post ? { id: post.id, publishedAt: Number(post.publishedAt) } : undefined
+    } catch (err) {
+      logger.error({ err }, 'failed to retrieve the latest published news post')
+      return
+    }
+
+    const current = this.latestNewsPost
+    if (current?.id !== latest?.id || current?.publishedAt !== latest?.publishedAt) {
+      this.latestNewsPost = latest
+      this.publisher.publish(NEWS_POSTS_PATH, toNewsPostEvent(latest))
+    }
+
+    await this.armScheduledPublishTimer()
+  }
+
+  private async armScheduledPublishTimer(): Promise<void> {
+    const generation = ++this.scheduledPublishGeneration
+    if (this.scheduledPublishTimer !== undefined) {
+      this.clock.clearTimeout(this.scheduledPublishTimer)
+      this.scheduledPublishTimer = undefined
+    }
+
+    let nextTime: Date | undefined
+    try {
+      nextTime = await getNextScheduledNewsPostTime()
+    } catch (err) {
+      logger.error({ err }, 'failed to retrieve the next scheduled news post time')
+      return
+    }
+
+    if (generation !== this.scheduledPublishGeneration || nextTime === undefined) {
+      // Another reconcile pass superseded us, or nothing is scheduled.
+      return
+    }
+
+    const delay = Math.min(
+      Math.max(Number(nextTime) - this.clock.now() + SCHEDULED_PUBLISH_SLOP_MS, 0),
+      MAX_TIMEOUT_MS,
+    )
+    this.scheduledPublishTimer = this.clock.setTimeout(() => {
+      if (generation !== this.scheduledPublishGeneration) {
+        return
+      }
+      this.scheduledPublishTimer = undefined
+      this.queueLatestNewsPostReconcile()
+    }, delay)
   }
 }

--- a/server/lib/news/news-service.ts
+++ b/server/lib/news/news-service.ts
@@ -148,7 +148,13 @@ export class NewsService {
     const current = this.latestNewsPost
     if (current?.id !== latest?.id || current?.publishedAt !== latest?.publishedAt) {
       this.latestNewsPost = latest
-      this.publisher.publish(NEWS_POSTS_PATH, toNewsPostEvent(latest))
+      try {
+        this.publisher.publish(NEWS_POSTS_PATH, toNewsPostEvent(latest))
+      } catch (err) {
+        // A publish failure must not reject this pass — the reconcile promise is chained and
+        // awaited on the assumption that it never rejects.
+        swallowNonBuiltins(err)
+      }
     }
 
     await this.armScheduledPublishTimer()

--- a/server/lib/news/news-service.ts
+++ b/server/lib/news/news-service.ts
@@ -21,6 +21,9 @@ const MAX_TIMEOUT_MS = 2 ** 31 - 1
 // that the post is reliably visible as published (and we don't busy-loop re-arming right at the
 // boundary).
 const SCHEDULED_PUBLISH_SLOP_MS = 1000
+// How long to wait before retrying after a reconcile pass fails (e.g. a transient DB error), so
+// scheduled publishing recovers without needing another post mutation.
+const RECONCILE_RETRY_MS = 60 * 1000
 
 interface LatestNewsPost {
   id: string
@@ -136,6 +139,9 @@ export class NewsService {
       latest = post ? { id: post.id, publishedAt: Number(post.publishedAt) } : undefined
     } catch (err) {
       logger.error({ err }, 'failed to retrieve the latest published news post')
+      // A transient DB error must not stall scheduled publishing — the timer that may have
+      // triggered this reconcile has already been cleared — so retry on a delay.
+      this.armReconcileTimer(this.takeTimerGeneration(), RECONCILE_RETRY_MS)
       return
     }
 
@@ -148,18 +154,42 @@ export class NewsService {
     await this.armScheduledPublishTimer()
   }
 
-  private async armScheduledPublishTimer(): Promise<void> {
+  /**
+   * Invalidates any pending reconcile timer and returns the generation a replacement timer should
+   * be armed under.
+   */
+  private takeTimerGeneration(): number {
     const generation = ++this.scheduledPublishGeneration
     if (this.scheduledPublishTimer !== undefined) {
       this.clock.clearTimeout(this.scheduledPublishTimer)
       this.scheduledPublishTimer = undefined
     }
+    return generation
+  }
+
+  /** Arms a timer that queues a reconcile pass after `delay`, unless `generation` is stale. */
+  private armReconcileTimer(generation: number, delay: number): void {
+    if (generation !== this.scheduledPublishGeneration) {
+      return
+    }
+    this.scheduledPublishTimer = this.clock.setTimeout(() => {
+      if (generation !== this.scheduledPublishGeneration) {
+        return
+      }
+      this.scheduledPublishTimer = undefined
+      this.queueLatestNewsPostReconcile()
+    }, delay)
+  }
+
+  private async armScheduledPublishTimer(): Promise<void> {
+    const generation = this.takeTimerGeneration()
 
     let nextTime: Date | undefined
     try {
       nextTime = await getNextScheduledNewsPostTime()
     } catch (err) {
       logger.error({ err }, 'failed to retrieve the next scheduled news post time')
+      this.armReconcileTimer(generation, RECONCILE_RETRY_MS)
       return
     }
 
@@ -172,12 +202,6 @@ export class NewsService {
       Math.max(Number(nextTime) - this.clock.now() + SCHEDULED_PUBLISH_SLOP_MS, 0),
       MAX_TIMEOUT_MS,
     )
-    this.scheduledPublishTimer = this.clock.setTimeout(() => {
-      if (generation !== this.scheduledPublishGeneration) {
-        return
-      }
-      this.scheduledPublishTimer = undefined
-      this.queueLatestNewsPostReconcile()
-    }, delay)
+    this.armReconcileTimer(generation, delay)
   }
 }

--- a/server/lib/time/clock.ts
+++ b/server/lib/time/clock.ts
@@ -35,4 +35,13 @@ export class Clock {
   setTimeout(fn: () => void, timeoutMillis: number): TimeoutId {
     return setTimeout(fn, timeoutMillis)
   }
+
+  /**
+   * Cancels a timeout previously scheduled via `setTimeout`.
+   *
+   * @see window.clearTimeout
+   */
+  clearTimeout(id: TimeoutId): void {
+    clearTimeout(id)
+  }
 }

--- a/server/lib/time/testing/fake-clock.ts
+++ b/server/lib/time/testing/fake-clock.ts
@@ -1,7 +1,7 @@
 import { assertUnreachable } from '../../../../common/assert-unreachable'
 import { Clock, TimeoutId } from '../clock'
 
-type ScheduledTimeout = [fn: () => void, timeoutMillis: number]
+type ScheduledTimeout = [fn: () => void, timeoutMillis: number, id: TimeoutId]
 
 export enum StopCriteria {
   EmptyQueue,
@@ -58,7 +58,8 @@ export class FakeClock extends Clock {
   // TODO(tec27): Build a system for only running X timeouts. This auto setup only works if the
   // timeout setting terminates (e.g. a called timeout doesn't schedule an additional timeout).
   override setTimeout(fn: () => void, timeoutMillis: number): TimeoutId {
-    this.timeoutsToRun.push([fn, this.currentTime + timeoutMillis])
+    this.currentTimeoutId = (Number(this.currentTimeoutId) + 1) as unknown as TimeoutId
+    this.timeoutsToRun.push([fn, this.currentTime + timeoutMillis, this.currentTimeoutId])
     if (this.autoRunTimeouts && !this.timeoutRunnerScheduled) {
       this.timeoutRunnerScheduled = true
       this.timeoutsCompletedPromise = new Promise(resolve => {
@@ -72,8 +73,11 @@ export class FakeClock extends Clock {
       })
     }
 
-    this.currentTimeoutId = (Number(this.currentTimeoutId) + 1) as unknown as TimeoutId
     return this.currentTimeoutId
+  }
+
+  override clearTimeout(id: TimeoutId): void {
+    this.timeoutsToRun = this.timeoutsToRun.filter(([, , timeoutId]) => timeoutId !== id)
   }
 
   /**


### PR DESCRIPTION
Fourth PR of the dynamic news stack (on top of #1347). Publishing a news post now lights an unread pip on the Home nav entry for connected clients in real time — including posts that go live on a schedule.

## Changes

- **Node `NewsService`**: consumes the `newsPostsChanged` Redis message the Rust side publishes on every post mutation. It reconciles the latest published post, publishes a `newsPostChange` event on a new `/newsPosts` socket path only when the `(id, publishedAt)` pair actually changes (a cleared variant when nothing is published), and seeds newly-connected clients with the current state. Reconcile passes are serialized (chained promises) so overlapping Redis messages can't complete out of order and cache stale state.
- **Scheduled publishes**: after each reconcile the service arms a single timer for the next future `published_at` (generation-guarded against re-arms, clamped to the 32-bit setTimeout max with re-arming, +1s slop past the boundary), so a scheduled post pushes the signal the moment it goes live with no mutation involved.
- **`Clock.clearTimeout`** added to the clock abstraction with a real `FakeClock` override (which also fixes FakeClock returning ids that were never attached to its queue entries).
- **Client**: `newsPostChange` events feed a `latestNewsPostId` atom; a per-user `news.lastSeenNewsPost` (localStorage) drives `useHasNewNewsPost()`, which joins `useHasNewUrgentMessage()` on the Home nav pip in the app bar. Rendering the home news feed marks the newest post seen.
- A separate `/newsPosts` path (rather than reusing `/news`) because socket-group subscriptions deliver exactly one initial-data payload per path — urgent-message state and post state each need their own seed.
- 6 unit tests for the service (FakeClock + mocked models): publish-on-change, no-op on no-change, cleared variant, timer fire, timer re-arm, max-timeout clamping.

## Verification

Two live browser clients against the dev stack: a viewer's pip lit ~2s after an admin published a new post (viewer parked on another page, no reload); visiting home marked it seen and cleared the pip; republishing an already-seen post correctly did not relight it (id-based semantics); creating a *scheduled* post did not light the pip, and the pip then lit within seconds of the scheduled minute passing, driven purely by the service timer. Wire-level check confirmed the `/newsPosts` seed payload on socket connect. `lint`, `typecheck`, full unit suite (870) clean.