### PR TITLE
Add route-based page metadata (link previews), starting with news posts

### DIFF
--- a/.claude/skills/verify-pr/SKILL.md
+++ b/.claude/skills/verify-pr/SKILL.md
@@ -313,9 +313,12 @@ bits in here, and keep this lean:
   participation isn't DB-enforced; delete after). In dev the replay URL has **no
   Content-Disposition** (Local FileStore can't set headers — documented, not a bug; Spaces sets it).
 
-- **Dynamic news (T2 public/admin, T3 badge).** Navigation gotcha app-wide: a bare
-  `history.pushState` often doesn't re-render — follow it with
-  `dispatchEvent(new PopStateEvent('popstate'))`.
+- **Dynamic news (T2 public/admin, T3 badge).** Public pages + admin editor are GraphQL/HTTP-driven
+  and work in a plain browser at :5555 — no Electron needed (Electron only for the live-badge pip,
+  which needs the nydus socket). Navigation gotcha app-wide: a bare `history.pushState` often
+  doesn't re-render — follow it with `dispatchEvent(new PopStateEvent('popstate'))`. Login page has
+  TWO "Log in" buttons (app-bar nav + form submit) — click the *last* match;
+  `claude-admin`/`shieldbattery` has `manageNews` (re-run `pnpm run seed-dev` if unsure).
   - *Public*: feed cards are `a[href^="/news/"]`; archive `/news` has a "Load more" button (assert
     unique hrefs across the cursor seam). Coverless posts get a deterministic stock srcSet
     (`static-news/*.jpg`, hash of UUID); uploaded covers serve `news-images/...` 800w/1600w. Feed
@@ -327,19 +330,36 @@ bits in here, and keep this lean:
     marks-seen instantly, so the pip never shows (that's correct, not a missed event). LastSeen
     lives in per-user localStorage `news.lastSeenNewsPost`. Scheduled posts flip via a server timer
     (~1s slop past the minute); immediate publish/unpublish push within ~2s.
-  - *Admin* (`/admin/news`, needs manageNews): list row actions are icon-text buttons
+  - *Admin* (`/admin/news`, needs manageNews; editor at `/admin/news/:id`, reach via double
+    `history.pushState`): list row actions are icon-text buttons
     `edit|history|publish|unpublished|delete`; drafts sort first. Delete confirm is inline (not
-    `role=dialog`) — snapshot for the "Delete"/"Cancel" refs. Schedule = radio + playwright `fill`
-    on `input[type=datetime-local]` (local-TZ `YYYY-MM-DDTHH:mm`). Multiline markdown content must
-    be set via the native value setter — a shell-arg `fill` silently drops everything past the
-    first newline. Cover upload: `page.setInputFiles('input[type=file]', <jpg>)` → POST
-    `/api/1/news/cover-images` → sharded pair under `server/uploaded_files/news-images/` (full +
-    `_0.5x`); the save button disables while the upload is in flight. Every mutation writes one
-    `news_post_edits` row (CASCADE on post delete) — count rows to prove the audit trail.
+    `role=dialog`) — snapshot for the "Delete"/"Cancel" refs. In the editor the *first* `textarea`
+    is the summary, the *second* is the content — don't `querySelector('textarea')` blindly.
+    Schedule = radio + playwright `fill` on `input[type=datetime-local]` (local-TZ
+    `YYYY-MM-DDTHH:mm`). Multiline markdown content must be set via the native value setter — a
+    shell-arg `fill` silently drops everything past the first newline. Cover upload:
+    `page.setInputFiles('input[type=file]', <jpg>)` → POST `/api/1/news/images` → sharded pair
+    under `server/uploaded_files/news-images/` (full + `_0.5x`). Inline image upload:
+    `page.setInputFiles('[data-test=news-inline-image-file-input]', path)` (pass Windows paths via
+    `String.raw` — double-backslash escapes get eaten through bash quoting and the call silently
+    no-ops). Save = button matching /save changes/i, disabled while an upload is in flight; success
+    shows a "saved" snackbar in `body.innerText`. Every mutation writes one `news_post_edits` row
+    (CASCADE on post delete) — count rows to prove the audit trail.
+  - *OG/meta tags*: `curl -s localhost:5555/news/<uuid> | tr '\n' ' '` before grepping `<meta`
+    tags — a multi-line summary puts a newline inside the content attribute and line-based grep
+    silently misses the tag. Check: cover post → `/files/news-images/...` og:image; coverless →
+    deterministic `/images/static-news/<name>.jpg`; draft/unknown-uuid/other routes → default tags.
+  - *Media-origin restriction*: dev post `019f5c2c-0593-7474-8424-99ad2ec7559d` is a fixture with
+    a file-store cover + external picsum/mp4/webm inline media — externals must render as `<a>`
+    (0 `<video>`), file-store images as loaded `<img>`. Cover images use `srcSet` only (empty
+    `src` attribute on the `<img>` is normal — check `srcset`/`naturalWidth`).
   - *Guards*: the GraphQL patch arg is `updates` (`newsUpdatePost(id, updates: {...})`); non-admin →
     `FORBIDDEN`, Node upload endpoint → 403. Test the Node endpoint with an **absolute**
     `http://localhost:5555/...` URL + Bearer JWT — a relative fetch from `shieldbattery://app/`
     hits the app-shell protocol handler and fake-200s.
+  - *Server code isn't hot-reloaded* — after editing `server/`, restart `pnpm run start-server`;
+    killing the task can orphan the child node.exe holding :5555 (new boot dies with EADDRINUSE but
+    curl still answers with **old** code) — `netstat -ano | findstr :5555` and kill the PID.
 
 ### Known issues / open questions (prune when resolved)
 

--- a/client/news/news-image.tsx
+++ b/client/news/news-image.tsx
@@ -1,37 +1,19 @@
+import {
+  NEWS_STOCK_IMAGES,
+  NEWS_STOCK_IMAGES_PATH_PREFIX,
+  newsStockImageIndex,
+} from '../../common/news'
 import { AutoSizeImage } from '../dom/auto-size-image'
 import { makePublicAssetUrl } from '../network/server-url'
 
 const LARGE_IMAGE_WIDTH = 1600
 const SMALL_IMAGE_WIDTH = 800
 
-const NEWS_IMAGE_PATH = '/images/static-news/'
-const NEWS_IMAGES: ReadonlyArray<string> = [
-  'ashworld0',
-  'badlands0',
-  'space0',
-  'ice0',
-  'jungle0',
-  'space1',
-]
-
 export const newsDateFormatter = new Intl.DateTimeFormat(navigator.language, {
   month: 'short',
   day: 'numeric',
   year: 'numeric',
 })
-
-/**
- * Deterministically maps a post's UUID to one of the stock fallback images. Hashing the id (rather
- * than using a list position) keeps a post's fallback image stable as new posts are added or pages
- * are loaded.
- */
-function stockImageIndex(id: string): number {
-  let hash = 0
-  for (let i = 0; i < id.length; i++) {
-    hash = (hash * 31 + id.charCodeAt(i)) | 0
-  }
-  return ((hash % NEWS_IMAGES.length) + NEWS_IMAGES.length) % NEWS_IMAGES.length
-}
 
 /**
  * Renders a news post's cover image, preferring its uploaded cover (falling back to a deterministic
@@ -54,9 +36,9 @@ export function NewsImage({
     largeSrc = coverImageUrl
     smallSrc = coverImageSmallUrl ?? coverImageUrl
   } else {
-    const name = NEWS_IMAGES[stockImageIndex(id)]
-    largeSrc = makePublicAssetUrl(`${NEWS_IMAGE_PATH}${name}.jpg`)
-    smallSrc = makePublicAssetUrl(`${NEWS_IMAGE_PATH}${name}_0.5x.jpg`)
+    const name = NEWS_STOCK_IMAGES[newsStockImageIndex(id)]
+    largeSrc = makePublicAssetUrl(`${NEWS_STOCK_IMAGES_PATH_PREFIX}${name}.jpg`)
+    smallSrc = makePublicAssetUrl(`${NEWS_STOCK_IMAGES_PATH_PREFIX}${name}_0.5x.jpg`)
   }
 
   return (

--- a/client/news/news-post-page.tsx
+++ b/client/news/news-post-page.tsx
@@ -5,6 +5,7 @@ import { useQuery } from 'urql'
 import { graphql } from '../gql'
 import { BottomLinks } from '../home/bottom-links'
 import { Markdown } from '../markdown/markdown'
+import { CopyLinkButton } from '../navigation/copy-link-button'
 import { push } from '../navigation/routing'
 import { LoadingDotsArea } from '../progress/dots'
 import { useNow } from '../react/date-hooks'
@@ -79,6 +80,12 @@ const TitleRow = styled.div`
 
   display: flex;
   flex-direction: column;
+  align-items: center;
+  gap: 8px;
+`
+
+const TitleAndCopyLink = styled.div`
+  display: flex;
   align-items: center;
   gap: 8px;
 `
@@ -161,7 +168,13 @@ export function NewsPostPage({ params }: { params: { id: string } }) {
       <Content>
         <TitleRow>
           {isDraft ? <DraftLabel>{t('news.draft', 'Draft')}</DraftLabel> : null}
-          <Title data-test='news-post-title'>{post.title}</Title>
+          <TitleAndCopyLink>
+            <Title data-test='news-post-title'>{post.title}</Title>
+            <CopyLinkButton
+              tooltipPosition='right'
+              startingText={t('news.copyLink', 'Copy link to news post')}
+            />
+          </TitleAndCopyLink>
         </TitleRow>
         {post.publishedAt ? (
           <PostDate>{newsDateFormatter.format(new Date(post.publishedAt))}</PostDate>

--- a/client/news/news-post-page.tsx
+++ b/client/news/news-post-page.tsx
@@ -34,7 +34,9 @@ const Root = styled(CenteredContentContainer)`
   position: relative;
 
   display: grid;
-  grid-template-columns: 1fr;
+  /* minmax so the track's auto minimum can't inflate past the container when content (e.g. a long
+     title) has a large intrinsic width — 1fr alone means minmax(auto, 1fr). */
+  grid-template-columns: minmax(0, 1fr);
   grid-template-rows: minmax(auto, 1fr) auto;
 
   --_header-height: 480px;
@@ -77,6 +79,10 @@ const Content = styled.div`
 
 const TitleRow = styled.div`
   margin-top: round(var(--_header-height) * 0.45, 1px);
+  /* Without this cap the intrinsic size of a long title propagates up through this (also
+     intrinsically-sized) box, letting TitleAndCopyLink's own max-width resolve against an
+     already-overflowing parent instead of the real content width. */
+  max-width: 100%;
 
   display: flex;
   flex-direction: column;
@@ -86,16 +92,23 @@ const TitleRow = styled.div`
 
 const TitleAndCopyLink = styled.div`
   position: relative;
+  /* Reserve symmetric space for the copy-link button so the title text stays visually centered
+     and the button can't extend past the content edge (and get clipped) when a long title makes
+     this box span the full content width. The max-width keeps a long unbreakable word from
+     inflating this box past the container (which would push the button offscreen again). */
+  padding-inline: 56px;
+  max-width: 100%;
 `
 
 const Title = styled.div`
   ${headlineLarge};
   text-align: center;
+  overflow-wrap: break-word;
 `
 
 const PositionedCopyLinkButton = styled(CopyLinkButton)`
   position: absolute;
-  left: calc(100% + 8px);
+  right: 0;
   top: 50%;
   transform: translateY(-50%);
 `

--- a/client/news/news-post-page.tsx
+++ b/client/news/news-post-page.tsx
@@ -85,14 +85,19 @@ const TitleRow = styled.div`
 `
 
 const TitleAndCopyLink = styled.div`
-  display: flex;
-  align-items: center;
-  gap: 8px;
+  position: relative;
 `
 
 const Title = styled.div`
   ${headlineLarge};
   text-align: center;
+`
+
+const PositionedCopyLinkButton = styled(CopyLinkButton)`
+  position: absolute;
+  left: calc(100% + 8px);
+  top: 50%;
+  transform: translateY(-50%);
 `
 
 const DraftLabel = styled.div`
@@ -170,7 +175,7 @@ export function NewsPostPage({ params }: { params: { id: string } }) {
           {isDraft ? <DraftLabel>{t('news.draft', 'Draft')}</DraftLabel> : null}
           <TitleAndCopyLink>
             <Title data-test='news-post-title'>{post.title}</Title>
-            <CopyLinkButton
+            <PositionedCopyLinkButton
               tooltipPosition='right'
               startingText={t('news.copyLink', 'Copy link to news post')}
             />

--- a/common/news.ts
+++ b/common/news.ts
@@ -39,3 +39,29 @@ export interface NewsImageUploadResponse {
   /** A fully-qualified URL to the half-resolution (`_0.5x`) image. */
   smallUrl: string
 }
+
+/** The public-assets path prefix under which the stock news fallback images live. */
+export const NEWS_STOCK_IMAGES_PATH_PREFIX = 'images/static-news/'
+
+/** The set of stock images used as a cover fallback for posts that don't have one uploaded. */
+export const NEWS_STOCK_IMAGES: ReadonlyArray<string> = [
+  'ashworld0',
+  'badlands0',
+  'space0',
+  'ice0',
+  'jungle0',
+  'space1',
+]
+
+/**
+ * Deterministically maps a post's UUID to one of the stock fallback images. Hashing the id (rather
+ * than using a list position) keeps a post's fallback image stable as new posts are added or pages
+ * are loaded.
+ */
+export function newsStockImageIndex(id: string): number {
+  let hash = 0
+  for (let i = 0; i < id.length; i++) {
+    hash = (hash * 31 + id.charCodeAt(i)) | 0
+  }
+  return ((hash % NEWS_STOCK_IMAGES.length) + NEWS_STOCK_IMAGES.length) % NEWS_STOCK_IMAGES.length
+}

--- a/integration/tests/news.spec.ts
+++ b/integration/tests/news.spec.ts
@@ -5,6 +5,20 @@ import { LoginPage } from '../pages/login-page'
 
 // The newest seeded news post (see migrations/20260711120000_seed_news_posts.sql).
 const NEWEST_POST_TITLE = 'Update 10.4.0'
+const NEWEST_POST_ID = '5eed0000-0000-0000-0000-000000000023'
+
+/**
+ * Extracts the `content` attribute of the first `<meta>` tag matching the given `property`/`name`
+ * attribute, regardless of attribute order or quote style.
+ */
+function extractMetaContent(
+  html: string,
+  attr: 'property' | 'name',
+  key: string,
+): string | undefined {
+  const tag = html.match(new RegExp(`<meta[^>]*${attr}=["']${key}["'][^>]*>`, 'i'))?.[0]
+  return tag?.match(/content=["']([^"']*)["']/i)?.[1]
+}
 
 let loginPage: LoginPage
 let homePage: HomePage
@@ -36,4 +50,20 @@ test('home page news feed links to the newest post', async () => {
   await primaryCard.click()
 
   await expect(homePage.newsPostTitleLocator()).toHaveText(NEWEST_POST_TITLE)
+})
+
+test('news post permalinks serve Open Graph tags for the post', async ({ request }) => {
+  const response = await request.get(`/news/${NEWEST_POST_ID}`)
+  const html = await response.text()
+
+  expect(extractMetaContent(html, 'property', 'og:title')).toBe(NEWEST_POST_TITLE)
+  expect(extractMetaContent(html, 'property', 'og:type')).toBe('article')
+  expect(extractMetaContent(html, 'property', 'og:description')).toBeTruthy()
+})
+
+test('other pages keep the default Open Graph tags', async ({ request }) => {
+  const response = await request.get('/')
+  const html = await response.text()
+
+  expect(extractMetaContent(html, 'property', 'og:title')).toBe('ShieldBattery')
 })

--- a/package.json
+++ b/package.json
@@ -124,6 +124,7 @@
     "pug": "^3.0.4",
     "rally-point-creator": "^3.0.0",
     "rally-point-server": "^3.0.1",
+    "regexparam": "^3.0.0",
     "rimraf": "^6.1.3",
     "scm-extractor": "^1.1.0",
     "semver-compare": "^1.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -205,6 +205,9 @@ importers:
       rally-point-server:
         specifier: ^3.0.1
         version: 3.0.1
+      regexparam:
+        specifier: ^3.0.0
+        version: 3.0.0
       rimraf:
         specifier: ^6.1.3
         version: 6.1.3
@@ -17619,7 +17622,7 @@ snapshots:
       es6-error: 4.1.1
       matcher: 3.0.0
       roarr: 2.15.4
-      semver: 7.7.4
+      semver: 7.8.4
       serialize-error: 7.0.1
     optional: true
 
@@ -19339,7 +19342,7 @@ snapshots:
 
   node-abi@4.31.0:
     dependencies:
-      semver: 7.7.4
+      semver: 7.8.4
 
   node-addon-api@7.1.1: {}
 
@@ -19347,7 +19350,7 @@ snapshots:
 
   node-api-version@0.2.1:
     dependencies:
-      semver: 7.7.4
+      semver: 7.8.4
 
   node-domexception@1.0.0: {}
 
@@ -19381,7 +19384,7 @@ snapshots:
       graceful-fs: 4.2.11
       nopt: 9.0.0
       proc-log: 6.1.0
-      semver: 7.7.4
+      semver: 7.8.4
       tar: 7.5.16
       tinyglobby: 0.2.17
       undici: 6.26.0

--- a/server/lib/news/news-page-meta.test.ts
+++ b/server/lib/news/news-page-meta.test.ts
@@ -1,7 +1,8 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 import { asMockedFunction } from '../../../common/testing/mocks'
 import { getUrl } from '../files'
-import { getNewsPageMeta, matchNewsPostRoute } from './news-page-meta'
+import { PageMetadataContext } from '../page-metadata/page-metadata'
+import { newsPostPageMetadata } from './news-page-meta'
 import { getPublishedNewsPostMeta, PublishedNewsPostMeta } from './news-post-models'
 
 vi.mock('./news-post-models', () => ({
@@ -15,52 +16,17 @@ vi.mock('../files', () => ({
 const getPublishedNewsPostMetaMock = asMockedFunction(getPublishedNewsPostMeta)
 const getUrlMock = asMockedFunction(getUrl)
 
-const PUBLIC_ASSETS_URL = 'https://cdn.example.com/public/'
+const CONTEXT: PageMetadataContext = {
+  canonicalHost: 'https://shieldbattery.net',
+  publicAssetsUrl: 'https://cdn.example.com/public/',
+}
+
 // Hashes to the 'ashworld0' stock image (index 0), verified against the shared implementation in
 // common/news.ts.
 const UUID = '5eed0000-0000-0000-0000-000000000023'
 
 describe('news/news-page-meta', () => {
-  describe('matchNewsPostRoute', () => {
-    test('matches a bare uuid path', () => {
-      expect(matchNewsPostRoute(`/news/${UUID}`)).toBe(UUID)
-    })
-
-    test('matches with a single trailing slash', () => {
-      expect(matchNewsPostRoute(`/news/${UUID}/`)).toBe(UUID)
-    })
-
-    test('is case-insensitive', () => {
-      const upper = UUID.toUpperCase()
-      expect(matchNewsPostRoute(`/news/${upper}`)).toBe(upper)
-    })
-
-    test('rejects the bare /news route', () => {
-      expect(matchNewsPostRoute('/news')).toBeUndefined()
-      expect(matchNewsPostRoute('/news/')).toBeUndefined()
-    })
-
-    test('rejects extra path segments after the id', () => {
-      expect(matchNewsPostRoute(`/news/${UUID}/extra`)).toBeUndefined()
-      expect(matchNewsPostRoute('/news/foo/bar')).toBeUndefined()
-    })
-
-    test('rejects a non-uuid id', () => {
-      expect(matchNewsPostRoute('/news/not-a-uuid')).toBeUndefined()
-      expect(matchNewsPostRoute('/news/12345')).toBeUndefined()
-      // Too few hex digits in the last group.
-      expect(matchNewsPostRoute('/news/5eed0000-0000-0000-0000-00000000')).toBeUndefined()
-    })
-
-    test('rejects unrelated routes', () => {
-      expect(matchNewsPostRoute('/')).toBeUndefined()
-      expect(matchNewsPostRoute('/newsletter')).toBeUndefined()
-      expect(matchNewsPostRoute(`/admin/news/${UUID}`)).toBeUndefined()
-      expect(matchNewsPostRoute(`/news/${UUID}?query=1`)).toBeUndefined()
-    })
-  })
-
-  describe('getNewsPageMeta', () => {
+  describe('newsPostPageMetadata', () => {
     const BASE_POST: PublishedNewsPostMeta = {
       title: 'Update 10.4.0',
       summary: '  Automatic replay uploads, replay viewing from game results, and more!  ',
@@ -71,11 +37,17 @@ describe('news/news-page-meta', () => {
     beforeEach(() => {
       getPublishedNewsPostMetaMock.mockReset()
       getUrlMock.mockClear()
-      process.env.SB_CANONICAL_HOST = 'https://shieldbattery.net'
     })
 
-    test('returns undefined for a non-news route without querying the model', async () => {
-      const result = await getNewsPageMeta('/ladder', PUBLIC_ASSETS_URL)
+    test('returns undefined for a non-uuid id without querying the model', async () => {
+      const result = await newsPostPageMetadata({ id: 'not-a-uuid' }, CONTEXT)
+
+      expect(result).toBeUndefined()
+      expect(getPublishedNewsPostMetaMock).not.toHaveBeenCalled()
+    })
+
+    test('returns undefined when the id param is missing without querying the model', async () => {
+      const result = await newsPostPageMetadata({ id: undefined }, CONTEXT)
 
       expect(result).toBeUndefined()
       expect(getPublishedNewsPostMetaMock).not.toHaveBeenCalled()
@@ -84,15 +56,7 @@ describe('news/news-page-meta', () => {
     test('returns undefined when the post is not found/unpublished', async () => {
       getPublishedNewsPostMetaMock.mockResolvedValueOnce(undefined)
 
-      const result = await getNewsPageMeta(`/news/${UUID}`, PUBLIC_ASSETS_URL)
-
-      expect(result).toBeUndefined()
-    })
-
-    test('returns undefined when the model throws', async () => {
-      getPublishedNewsPostMetaMock.mockRejectedValueOnce(new Error('db went away'))
-
-      const result = await getNewsPageMeta(`/news/${UUID}`, PUBLIC_ASSETS_URL)
+      const result = await newsPostPageMetadata({ id: UUID }, CONTEXT)
 
       expect(result).toBeUndefined()
     })
@@ -103,10 +67,11 @@ describe('news/news-page-meta', () => {
         coverImagePath: 'news-images/ab/cd/xyz.jpg',
       })
 
-      const result = await getNewsPageMeta(`/news/${UUID}`, PUBLIC_ASSETS_URL)
+      const result = await newsPostPageMetadata({ id: UUID }, CONTEXT)
 
       expect(result).toEqual({
         url: `https://shieldbattery.net/news/${UUID}`,
+        type: 'article',
         title: 'Update 10.4.0',
         description: 'Automatic replay uploads, replay viewing from game results, and more!',
         image: 'https://cdn.example.com/news-images/ab/cd/xyz.jpg',
@@ -118,24 +83,26 @@ describe('news/news-page-meta', () => {
     test('falls back to a deterministic stock image when there is no cover', async () => {
       getPublishedNewsPostMetaMock.mockResolvedValueOnce({ ...BASE_POST, coverImagePath: null })
 
-      const result = await getNewsPageMeta(`/news/${UUID}`, PUBLIC_ASSETS_URL)
+      const result = await newsPostPageMetadata({ id: UUID }, CONTEXT)
 
-      expect(result?.image).toBe(`${PUBLIC_ASSETS_URL}images/static-news/ashworld0.jpg`)
+      expect(result?.image).toBe(`${CONTEXT.publicAssetsUrl}images/static-news/ashworld0.jpg`)
 
       // Deterministic: the same id always maps to the same stock image.
       getPublishedNewsPostMetaMock.mockResolvedValueOnce({ ...BASE_POST, coverImagePath: null })
-      const again = await getNewsPageMeta(`/news/${UUID}`, PUBLIC_ASSETS_URL)
+      const again = await newsPostPageMetadata({ id: UUID }, CONTEXT)
 
       expect(again?.image).toBe(result?.image)
     })
 
-    test('strips a trailing slash from SB_CANONICAL_HOST', async () => {
-      process.env.SB_CANONICAL_HOST = 'https://shieldbattery.net/'
+    test('builds the url from the context canonical host', async () => {
       getPublishedNewsPostMetaMock.mockResolvedValueOnce({ ...BASE_POST })
 
-      const result = await getNewsPageMeta(`/news/${UUID}`, PUBLIC_ASSETS_URL)
+      const result = await newsPostPageMetadata(
+        { id: UUID },
+        { ...CONTEXT, canonicalHost: 'https://staging.example.com' },
+      )
 
-      expect(result?.url).toBe(`https://shieldbattery.net/news/${UUID}`)
+      expect(result?.url).toBe(`https://staging.example.com/news/${UUID}`)
     })
   })
 })

--- a/server/lib/news/news-page-meta.test.ts
+++ b/server/lib/news/news-page-meta.test.ts
@@ -1,0 +1,141 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { asMockedFunction } from '../../../common/testing/mocks'
+import { getUrl } from '../files'
+import { getNewsPageMeta, matchNewsPostRoute } from './news-page-meta'
+import { getPublishedNewsPostMeta, PublishedNewsPostMeta } from './news-post-models'
+
+vi.mock('./news-post-models', () => ({
+  getPublishedNewsPostMeta: vi.fn(),
+}))
+
+vi.mock('../files', () => ({
+  getUrl: vi.fn((path: string) => `https://cdn.example.com/${path}`),
+}))
+
+const getPublishedNewsPostMetaMock = asMockedFunction(getPublishedNewsPostMeta)
+const getUrlMock = asMockedFunction(getUrl)
+
+const PUBLIC_ASSETS_URL = 'https://cdn.example.com/public/'
+// Hashes to the 'ashworld0' stock image (index 0), verified against the shared implementation in
+// common/news.ts.
+const UUID = '5eed0000-0000-0000-0000-000000000023'
+
+describe('news/news-page-meta', () => {
+  describe('matchNewsPostRoute', () => {
+    test('matches a bare uuid path', () => {
+      expect(matchNewsPostRoute(`/news/${UUID}`)).toBe(UUID)
+    })
+
+    test('matches with a single trailing slash', () => {
+      expect(matchNewsPostRoute(`/news/${UUID}/`)).toBe(UUID)
+    })
+
+    test('is case-insensitive', () => {
+      const upper = UUID.toUpperCase()
+      expect(matchNewsPostRoute(`/news/${upper}`)).toBe(upper)
+    })
+
+    test('rejects the bare /news route', () => {
+      expect(matchNewsPostRoute('/news')).toBeUndefined()
+      expect(matchNewsPostRoute('/news/')).toBeUndefined()
+    })
+
+    test('rejects extra path segments after the id', () => {
+      expect(matchNewsPostRoute(`/news/${UUID}/extra`)).toBeUndefined()
+      expect(matchNewsPostRoute('/news/foo/bar')).toBeUndefined()
+    })
+
+    test('rejects a non-uuid id', () => {
+      expect(matchNewsPostRoute('/news/not-a-uuid')).toBeUndefined()
+      expect(matchNewsPostRoute('/news/12345')).toBeUndefined()
+      // Too few hex digits in the last group.
+      expect(matchNewsPostRoute('/news/5eed0000-0000-0000-0000-00000000')).toBeUndefined()
+    })
+
+    test('rejects unrelated routes', () => {
+      expect(matchNewsPostRoute('/')).toBeUndefined()
+      expect(matchNewsPostRoute('/newsletter')).toBeUndefined()
+      expect(matchNewsPostRoute(`/admin/news/${UUID}`)).toBeUndefined()
+      expect(matchNewsPostRoute(`/news/${UUID}?query=1`)).toBeUndefined()
+    })
+  })
+
+  describe('getNewsPageMeta', () => {
+    const BASE_POST: PublishedNewsPostMeta = {
+      title: 'Update 10.4.0',
+      summary: '  Automatic replay uploads, replay viewing from game results, and more!  ',
+      coverImagePath: null,
+      publishedAt: new Date('2026-03-14T23:09:10.776Z'),
+    }
+
+    beforeEach(() => {
+      getPublishedNewsPostMetaMock.mockReset()
+      getUrlMock.mockClear()
+      process.env.SB_CANONICAL_HOST = 'https://shieldbattery.net'
+    })
+
+    test('returns undefined for a non-news route without querying the model', async () => {
+      const result = await getNewsPageMeta('/ladder', PUBLIC_ASSETS_URL)
+
+      expect(result).toBeUndefined()
+      expect(getPublishedNewsPostMetaMock).not.toHaveBeenCalled()
+    })
+
+    test('returns undefined when the post is not found/unpublished', async () => {
+      getPublishedNewsPostMetaMock.mockResolvedValueOnce(undefined)
+
+      const result = await getNewsPageMeta(`/news/${UUID}`, PUBLIC_ASSETS_URL)
+
+      expect(result).toBeUndefined()
+    })
+
+    test('returns undefined when the model throws', async () => {
+      getPublishedNewsPostMetaMock.mockRejectedValueOnce(new Error('db went away'))
+
+      const result = await getNewsPageMeta(`/news/${UUID}`, PUBLIC_ASSETS_URL)
+
+      expect(result).toBeUndefined()
+    })
+
+    test('uses the uploaded cover image and trims the summary when a cover is present', async () => {
+      getPublishedNewsPostMetaMock.mockResolvedValueOnce({
+        ...BASE_POST,
+        coverImagePath: 'news-images/ab/cd/xyz.jpg',
+      })
+
+      const result = await getNewsPageMeta(`/news/${UUID}`, PUBLIC_ASSETS_URL)
+
+      expect(result).toEqual({
+        url: `https://shieldbattery.net/news/${UUID}`,
+        title: 'Update 10.4.0',
+        description: 'Automatic replay uploads, replay viewing from game results, and more!',
+        image: 'https://cdn.example.com/news-images/ab/cd/xyz.jpg',
+        publishedTime: '2026-03-14T23:09:10.776Z',
+      })
+      expect(getUrlMock).toHaveBeenCalledWith('news-images/ab/cd/xyz.jpg')
+    })
+
+    test('falls back to a deterministic stock image when there is no cover', async () => {
+      getPublishedNewsPostMetaMock.mockResolvedValueOnce({ ...BASE_POST, coverImagePath: null })
+
+      const result = await getNewsPageMeta(`/news/${UUID}`, PUBLIC_ASSETS_URL)
+
+      expect(result?.image).toBe(`${PUBLIC_ASSETS_URL}images/static-news/ashworld0.jpg`)
+
+      // Deterministic: the same id always maps to the same stock image.
+      getPublishedNewsPostMetaMock.mockResolvedValueOnce({ ...BASE_POST, coverImagePath: null })
+      const again = await getNewsPageMeta(`/news/${UUID}`, PUBLIC_ASSETS_URL)
+
+      expect(again?.image).toBe(result?.image)
+    })
+
+    test('strips a trailing slash from SB_CANONICAL_HOST', async () => {
+      process.env.SB_CANONICAL_HOST = 'https://shieldbattery.net/'
+      getPublishedNewsPostMetaMock.mockResolvedValueOnce({ ...BASE_POST })
+
+      const result = await getNewsPageMeta(`/news/${UUID}`, PUBLIC_ASSETS_URL)
+
+      expect(result?.url).toBe(`https://shieldbattery.net/news/${UUID}`)
+    })
+  })
+})

--- a/server/lib/news/news-page-meta.ts
+++ b/server/lib/news/news-page-meta.ts
@@ -4,35 +4,10 @@ import {
   newsStockImageIndex,
 } from '../../../common/news'
 import { getUrl } from '../files'
-import logger from '../logging/logger'
+import type { PageMetadataResolver } from '../page-metadata/page-metadata'
 import { getPublishedNewsPostMeta } from './news-post-models'
 
-const NEWS_POST_ROUTE_PATTERN =
-  /^\/news\/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\/?$/i
-
-/**
- * Returns the post id for a pathname of the form `/news/<uuid>` (with an optional single trailing
- * slash), or `undefined` if the pathname isn't a news post permalink.
- */
-export function matchNewsPostRoute(pathname: string): string | undefined {
-  const match = NEWS_POST_ROUTE_PATTERN.exec(pathname)
-  return match ? match[1] : undefined
-}
-
-/** Server-rendered Open Graph/Twitter meta tag values for a news post permalink. */
-export interface NewsPageMeta {
-  url: string
-  title: string
-  description: string
-  image: string
-  /** ISO 8601 timestamp of when the post was published. */
-  publishedTime: string
-}
-
-function canonicalHost(): string {
-  const host = process.env.SB_CANONICAL_HOST!
-  return host.endsWith('/') ? host.slice(0, -1) : host
-}
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
 function stockImageUrl(id: string, publicAssetsUrl: string): string {
   const name = NEWS_STOCK_IMAGES[newsStockImageIndex(id)]
@@ -40,37 +15,33 @@ function stockImageUrl(id: string, publicAssetsUrl: string): string {
 }
 
 /**
- * Returns the Open Graph/Twitter meta tag values for a news post permalink, or `undefined` if the
- * pathname isn't a news post permalink, the post doesn't exist, or the post isn't currently
- * published (in which case the default site-wide tags should be used instead).
+ * Resolves the Open Graph/Twitter Card metadata for a news post permalink (registered for the
+ * `/news/:id/*?` route in `page-metadata.ts`).
  *
- * This never throws: any error looking up the post is logged and treated the same as "not found".
+ * `params.id` is expected to be the post's raw UUID; anything else returns `undefined` (so we
+ * never hit the database with garbage), as does a post that doesn't exist or isn't currently
+ * published. Either case falls back to the default site-wide metadata.
  */
-export async function getNewsPageMeta(
-  pathname: string,
-  publicAssetsUrl: string,
-): Promise<NewsPageMeta | undefined> {
-  const id = matchNewsPostRoute(pathname)
-  if (!id) {
+export const newsPostPageMetadata: PageMetadataResolver = async (params, context) => {
+  const id = params.id
+  if (!id || !UUID_PATTERN.test(id)) {
     return undefined
   }
 
-  try {
-    const post = await getPublishedNewsPostMeta(id)
-    if (!post) {
-      return undefined
-    }
-
-    return {
-      url: `${canonicalHost()}/news/${id}`,
-      title: post.title,
-      // Meta descriptions are single-line, so collapse any newlines/whitespace runs in the summary
-      description: post.summary.replace(/\s+/g, ' ').trim(),
-      image: post.coverImagePath ? getUrl(post.coverImagePath) : stockImageUrl(id, publicAssetsUrl),
-      publishedTime: post.publishedAt.toISOString(),
-    }
-  } catch (err) {
-    logger.warn({ err }, 'failed to retrieve news post meta for page tags')
+  const post = await getPublishedNewsPostMeta(id)
+  if (!post) {
     return undefined
+  }
+
+  return {
+    url: `${context.canonicalHost}/news/${id}`,
+    type: 'article',
+    title: post.title,
+    // Meta descriptions are single-line, so collapse any newlines/whitespace runs in the summary.
+    description: post.summary.replace(/\s+/g, ' ').trim(),
+    image: post.coverImagePath
+      ? getUrl(post.coverImagePath)
+      : stockImageUrl(id, context.publicAssetsUrl),
+    publishedTime: post.publishedAt.toISOString(),
   }
 }

--- a/server/lib/news/news-page-meta.ts
+++ b/server/lib/news/news-page-meta.ts
@@ -4,7 +4,7 @@ import {
   newsStockImageIndex,
 } from '../../../common/news'
 import { getUrl } from '../files'
-import type { PageMetadataResolver } from '../page-metadata/page-metadata'
+import type { PageMetadataResolver } from '../page-metadata/types'
 import { getPublishedNewsPostMeta } from './news-post-models'
 
 const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i

--- a/server/lib/news/news-page-meta.ts
+++ b/server/lib/news/news-page-meta.ts
@@ -1,0 +1,76 @@
+import {
+  NEWS_STOCK_IMAGES,
+  NEWS_STOCK_IMAGES_PATH_PREFIX,
+  newsStockImageIndex,
+} from '../../../common/news'
+import { getUrl } from '../files'
+import logger from '../logging/logger'
+import { getPublishedNewsPostMeta } from './news-post-models'
+
+const NEWS_POST_ROUTE_PATTERN =
+  /^\/news\/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\/?$/i
+
+/**
+ * Returns the post id for a pathname of the form `/news/<uuid>` (with an optional single trailing
+ * slash), or `undefined` if the pathname isn't a news post permalink.
+ */
+export function matchNewsPostRoute(pathname: string): string | undefined {
+  const match = NEWS_POST_ROUTE_PATTERN.exec(pathname)
+  return match ? match[1] : undefined
+}
+
+/** Server-rendered Open Graph/Twitter meta tag values for a news post permalink. */
+export interface NewsPageMeta {
+  url: string
+  title: string
+  description: string
+  image: string
+  /** ISO 8601 timestamp of when the post was published. */
+  publishedTime: string
+}
+
+function canonicalHost(): string {
+  const host = process.env.SB_CANONICAL_HOST!
+  return host.endsWith('/') ? host.slice(0, -1) : host
+}
+
+function stockImageUrl(id: string, publicAssetsUrl: string): string {
+  const name = NEWS_STOCK_IMAGES[newsStockImageIndex(id)]
+  return `${publicAssetsUrl}${NEWS_STOCK_IMAGES_PATH_PREFIX}${name}.jpg`
+}
+
+/**
+ * Returns the Open Graph/Twitter meta tag values for a news post permalink, or `undefined` if the
+ * pathname isn't a news post permalink, the post doesn't exist, or the post isn't currently
+ * published (in which case the default site-wide tags should be used instead).
+ *
+ * This never throws: any error looking up the post is logged and treated the same as "not found".
+ */
+export async function getNewsPageMeta(
+  pathname: string,
+  publicAssetsUrl: string,
+): Promise<NewsPageMeta | undefined> {
+  const id = matchNewsPostRoute(pathname)
+  if (!id) {
+    return undefined
+  }
+
+  try {
+    const post = await getPublishedNewsPostMeta(id)
+    if (!post) {
+      return undefined
+    }
+
+    return {
+      url: `${canonicalHost()}/news/${id}`,
+      title: post.title,
+      // Meta descriptions are single-line, so collapse any newlines/whitespace runs in the summary
+      description: post.summary.replace(/\s+/g, ' ').trim(),
+      image: post.coverImagePath ? getUrl(post.coverImagePath) : stockImageUrl(id, publicAssetsUrl),
+      publishedTime: post.publishedAt.toISOString(),
+    }
+  } catch (err) {
+    logger.warn({ err }, 'failed to retrieve news post meta for page tags')
+    return undefined
+  }
+}

--- a/server/lib/news/news-post-models.ts
+++ b/server/lib/news/news-post-models.ts
@@ -8,6 +8,14 @@ export interface LatestPublishedNewsPost {
 }
 type DbLatestPublishedNewsPost = Dbify<LatestPublishedNewsPost>
 
+export interface PublishedNewsPostMeta {
+  title: string
+  summary: string
+  coverImagePath: string | null
+  publishedAt: Date
+}
+type DbPublishedNewsPostMeta = Dbify<PublishedNewsPostMeta>
+
 /**
  * Returns the id and publish time of the most recently published news post (that is, the newest
  * post whose `published_at` is set and has already passed), or `undefined` if no posts are
@@ -52,6 +60,36 @@ export async function getNextScheduledNewsPostTime(
       WHERE published_at > NOW();
     `)
     return result.rows[0]?.next_published_at ?? undefined
+  } finally {
+    done()
+  }
+}
+
+/**
+ * Returns the title, summary, cover image path, and publish time of a published news post by id,
+ * or `undefined` if it doesn't exist or isn't currently published.
+ */
+export async function getPublishedNewsPostMeta(
+  id: string,
+  withClient?: DbClient,
+): Promise<PublishedNewsPostMeta | undefined> {
+  const { client, done } = await db(withClient)
+  try {
+    const result = await client.query<DbPublishedNewsPostMeta>(sql`
+      SELECT title, summary, cover_image_path, published_at
+      FROM news_posts
+      WHERE id = ${id} AND published_at IS NOT NULL AND published_at <= NOW();
+    `)
+    if (result.rows.length === 0) {
+      return undefined
+    }
+    const row = result.rows[0]
+    return {
+      title: row.title,
+      summary: row.summary,
+      coverImagePath: row.cover_image_path,
+      publishedAt: row.published_at,
+    }
   } finally {
     done()
   }

--- a/server/lib/page-metadata/page-metadata.test.ts
+++ b/server/lib/page-metadata/page-metadata.test.ts
@@ -1,0 +1,102 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { asMockedFunction } from '../../../common/testing/mocks'
+import { newsPostPageMetadata } from '../news/news-page-meta'
+import { PageMetadata, PageMetadataContext, resolvePageMetadata } from './page-metadata'
+
+vi.mock('../news/news-page-meta', () => ({
+  newsPostPageMetadata: vi.fn(),
+}))
+
+const newsPostPageMetadataMock = asMockedFunction(newsPostPageMetadata)
+
+const CONTEXT: PageMetadataContext = {
+  canonicalHost: 'https://shieldbattery.net',
+  publicAssetsUrl: 'https://cdn.example.com/public/',
+}
+
+const DEFAULT_METADATA: PageMetadata = {
+  url: 'https://shieldbattery.net',
+  type: 'website',
+  title: 'ShieldBattery',
+  description: 'Play StarCraft 1 on the premier community-run platform.',
+  image: 'https://shieldbattery.net/images/logo-and-text-1200x630.png',
+}
+
+describe('page-metadata/page-metadata', () => {
+  beforeEach(() => {
+    newsPostPageMetadataMock.mockReset()
+  })
+
+  test('matches a news post route and calls the resolver with the id param (no wildcard)', async () => {
+    newsPostPageMetadataMock.mockResolvedValueOnce(undefined)
+
+    await resolvePageMetadata('/news/abc123', CONTEXT)
+
+    expect(newsPostPageMetadataMock).toHaveBeenCalledWith({ id: 'abc123', '*': undefined }, CONTEXT)
+  })
+
+  test('matches a news post route and passes the trailing wildcard segment', async () => {
+    newsPostPageMetadataMock.mockResolvedValueOnce(undefined)
+
+    await resolvePageMetadata('/news/abc123/some-post-slug', CONTEXT)
+
+    expect(newsPostPageMetadataMock).toHaveBeenCalledWith(
+      { id: 'abc123', '*': 'some-post-slug' },
+      CONTEXT,
+    )
+  })
+
+  test('returns the metadata a matching resolver produces', async () => {
+    const metadata: PageMetadata = {
+      url: 'https://shieldbattery.net/news/abc123',
+      type: 'article',
+      title: 'A post',
+      description: 'A description',
+      image: 'https://cdn.example.com/image.jpg',
+      publishedTime: '2026-03-14T23:09:10.776Z',
+    }
+    newsPostPageMetadataMock.mockResolvedValueOnce(metadata)
+
+    const result = await resolvePageMetadata('/news/abc123', CONTEXT)
+
+    expect(result).toEqual(metadata)
+  })
+
+  test('falls back to the default metadata when the resolver returns undefined', async () => {
+    newsPostPageMetadataMock.mockResolvedValueOnce(undefined)
+
+    const result = await resolvePageMetadata('/news/abc123', CONTEXT)
+
+    expect(result).toEqual(DEFAULT_METADATA)
+  })
+
+  test('falls back to the default metadata when the resolver throws, without propagating', async () => {
+    newsPostPageMetadataMock.mockRejectedValueOnce(new Error('db went away'))
+
+    await expect(resolvePageMetadata('/news/abc123', CONTEXT)).resolves.toEqual(DEFAULT_METADATA)
+  })
+
+  test('falls back to the default metadata for an unmatched path without calling any resolver', async () => {
+    const result = await resolvePageMetadata('/ladder', CONTEXT)
+
+    expect(newsPostPageMetadataMock).not.toHaveBeenCalled()
+    expect(result).toEqual(DEFAULT_METADATA)
+  })
+
+  test('derives default field values from the given context', async () => {
+    const otherContext: PageMetadataContext = {
+      canonicalHost: 'https://staging.example.com',
+      publicAssetsUrl: 'https://cdn.other.com/public/',
+    }
+
+    const result = await resolvePageMetadata('/some/unmatched/path', otherContext)
+
+    expect(result).toEqual({
+      url: 'https://staging.example.com',
+      type: 'website',
+      title: 'ShieldBattery',
+      description: 'Play StarCraft 1 on the premier community-run platform.',
+      image: 'https://staging.example.com/images/logo-and-text-1200x630.png',
+    })
+  })
+})

--- a/server/lib/page-metadata/page-metadata.ts
+++ b/server/lib/page-metadata/page-metadata.ts
@@ -1,42 +1,9 @@
 import { parse } from 'regexparam'
 import logger from '../logging/logger'
 import { newsPostPageMetadata } from '../news/news-page-meta'
+import { PageMetadata, PageMetadataContext, PageMetadataResolver } from './types'
 
-/**
- * Server-rendered Open Graph/Twitter Card metadata for a page, rendered into the page's
- * `<head>` by `server/views/index.pug`.
- */
-export interface PageMetadata {
-  url: string
-  type: 'website' | 'article'
-  title: string
-  description: string
-  image: string
-  /** ISO 8601 timestamp of when the page's content was published. Article pages only. */
-  publishedTime?: string
-}
-
-/** Values available to every {@link PageMetadataResolver}, regardless of the matched route. */
-export interface PageMetadataContext {
-  /** The canonical origin for the site, e.g. `https://shieldbattery.net` (no trailing slash). */
-  canonicalHost: string
-  /** The base URL that public assets (images, fonts, etc.) are served from. */
-  publicAssetsUrl: string
-}
-
-/**
- * Resolves the {@link PageMetadata} for a route match. `params` holds the route's named/wildcard
- * segments (see {@link ROUTES}).
- *
- * Returning `undefined` means the route matched but there's nothing to render metadata for (e.g.
- * an unpublished or missing post) — the router falls back to the default site-wide metadata.
- * Throwing is treated the same way; a metadata resolver must never be the reason a page fails to
- * render.
- */
-export type PageMetadataResolver = (
-  params: Record<string, string | undefined>,
-  context: PageMetadataContext,
-) => Promise<PageMetadata | undefined>
+export * from './types'
 
 interface RouteDefinition {
   pattern: string

--- a/server/lib/page-metadata/page-metadata.ts
+++ b/server/lib/page-metadata/page-metadata.ts
@@ -1,0 +1,103 @@
+import { parse } from 'regexparam'
+import logger from '../logging/logger'
+import { newsPostPageMetadata } from '../news/news-page-meta'
+
+/**
+ * Server-rendered Open Graph/Twitter Card metadata for a page, rendered into the page's
+ * `<head>` by `server/views/index.pug`.
+ */
+export interface PageMetadata {
+  url: string
+  type: 'website' | 'article'
+  title: string
+  description: string
+  image: string
+  /** ISO 8601 timestamp of when the page's content was published. Article pages only. */
+  publishedTime?: string
+}
+
+/** Values available to every {@link PageMetadataResolver}, regardless of the matched route. */
+export interface PageMetadataContext {
+  /** The canonical origin for the site, e.g. `https://shieldbattery.net` (no trailing slash). */
+  canonicalHost: string
+  /** The base URL that public assets (images, fonts, etc.) are served from. */
+  publicAssetsUrl: string
+}
+
+/**
+ * Resolves the {@link PageMetadata} for a route match. `params` holds the route's named/wildcard
+ * segments (see {@link ROUTES}).
+ *
+ * Returning `undefined` means the route matched but there's nothing to render metadata for (e.g.
+ * an unpublished or missing post) — the router falls back to the default site-wide metadata.
+ * Throwing is treated the same way; a metadata resolver must never be the reason a page fails to
+ * render.
+ */
+export type PageMetadataResolver = (
+  params: Record<string, string | undefined>,
+  context: PageMetadataContext,
+) => Promise<PageMetadata | undefined>
+
+interface RouteDefinition {
+  pattern: string
+  resolver: PageMetadataResolver
+}
+
+// Route patterns use the same syntax as the client's wouter routes (`client/app-routes.tsx`) —
+// `regexparam` is wouter's own route parser under the hood. When a client route should get its
+// own server-rendered preview metadata, register its matching pattern here.
+const ROUTES: ReadonlyArray<RouteDefinition> = [
+  { pattern: '/news/:id/*?', resolver: newsPostPageMetadata },
+]
+
+// Patterns are fixed at startup, so parse them once rather than on every request.
+const PARSED_ROUTES = ROUTES.map(({ pattern, resolver }) => ({
+  parsed: parse(pattern),
+  resolver,
+}))
+
+/**
+ * Resolves the Open Graph/Twitter Card metadata to render for `pathname`.
+ *
+ * Routes are tried in registration order. The first resolver to return metadata wins; a resolver
+ * that returns `undefined` (or throws) falls through to the next route. If no route produces
+ * metadata, the default site-wide metadata is returned.
+ */
+export async function resolvePageMetadata(
+  pathname: string,
+  context: PageMetadataContext,
+): Promise<PageMetadata> {
+  for (const { parsed, resolver } of PARSED_ROUTES) {
+    const match = parsed.pattern.exec(pathname)
+    if (!match) {
+      continue
+    }
+
+    const params: Record<string, string | undefined> = {}
+    for (const [i, key] of parsed.keys.entries()) {
+      params[key] = match[i + 1]
+    }
+
+    try {
+      const metadata = await resolver(params, context)
+      if (metadata) {
+        return metadata
+      }
+    } catch (err) {
+      logger.warn({ err }, 'page metadata resolver threw, falling back to default page metadata')
+    }
+  }
+
+  return defaultPageMetadata(context)
+}
+
+/** The metadata used for any page that doesn't have a more specific resolver match. */
+function defaultPageMetadata(context: PageMetadataContext): PageMetadata {
+  return {
+    url: context.canonicalHost,
+    type: 'website',
+    title: 'ShieldBattery',
+    description: 'Play StarCraft 1 on the premier community-run platform.',
+    image: `${context.canonicalHost}/images/logo-and-text-1200x630.png`,
+  }
+}

--- a/server/lib/page-metadata/types.ts
+++ b/server/lib/page-metadata/types.ts
@@ -1,0 +1,35 @@
+/**
+ * Server-rendered Open Graph/Twitter Card metadata for a page, rendered into the page's
+ * `<head>` by `server/views/index.pug`.
+ */
+export interface PageMetadata {
+  url: string
+  type: 'website' | 'article'
+  title: string
+  description: string
+  image: string
+  /** ISO 8601 timestamp of when the page's content was published. Article pages only. */
+  publishedTime?: string
+}
+
+/** Values available to every {@link PageMetadataResolver}, regardless of the matched route. */
+export interface PageMetadataContext {
+  /** The canonical origin for the site, e.g. `https://shieldbattery.net` (no trailing slash). */
+  canonicalHost: string
+  /** The base URL that public assets (images, fonts, etc.) are served from. */
+  publicAssetsUrl: string
+}
+
+/**
+ * Resolves the {@link PageMetadata} for a route match. `params` holds the route's named/wildcard
+ * segments (see {@link ROUTES}).
+ *
+ * Returning `undefined` means the route matched but there's nothing to render metadata for (e.g.
+ * an unpublished or missing post) — the router falls back to the default site-wide metadata.
+ * Throwing is treated the same way; a metadata resolver must never be the reason a page fails to
+ * render.
+ */
+export type PageMetadataResolver = (
+  params: Record<string, string | undefined>,
+  context: PageMetadataContext,
+) => Promise<PageMetadata | undefined>

--- a/server/public/locales/en/global.json
+++ b/server/public/locales/en/global.json
@@ -1163,6 +1163,7 @@
       "title": "News"
     },
     "byAuthor": "by {{name}}",
+    "copyLink": "Copy link to news post",
     "draft": "Draft",
     "manageNews": "Manage news",
     "seeAll": "See all news",

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -17,6 +17,7 @@ import { FileStoreType, PublicAssetsConfig } from './lib/files/public-assets-con
 import { GameReportNotificationService } from './lib/games/game-report-notification-service'
 import { applyApiRoutes, resolveAllHttpApis } from './lib/http/http-api'
 import logger from './lib/logging/logger'
+import { getNewsPageMeta } from './lib/news/news-page-meta'
 import { NewsService } from './lib/news/news-service'
 import { getCspNonce } from './lib/security/csp'
 import { getJwt } from './lib/session/jwt-session-middleware'
@@ -148,8 +149,10 @@ export default function applyRoutes(
             : undefined,
       }
       const webpackAssets = await getWebpackAssets()
+      const pageMeta = await getNewsPageMeta(ctx.path, publicAssetsConfig.publicAssetsUrl)
       await ctx.render('index', {
         initData,
+        pageMeta,
         cspNonce: getCspNonce(ctx),
         analyticsId: process.env.SB_ANALYTICS_ID,
         assetsOrigin:

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -17,8 +17,8 @@ import { FileStoreType, PublicAssetsConfig } from './lib/files/public-assets-con
 import { GameReportNotificationService } from './lib/games/game-report-notification-service'
 import { applyApiRoutes, resolveAllHttpApis } from './lib/http/http-api'
 import logger from './lib/logging/logger'
-import { getNewsPageMeta } from './lib/news/news-page-meta'
 import { NewsService } from './lib/news/news-service'
+import { PageMetadataContext, resolvePageMetadata } from './lib/page-metadata/page-metadata'
 import { getCspNonce } from './lib/security/csp'
 import { getJwt } from './lib/session/jwt-session-middleware'
 import { monotonicNow } from './lib/time/monotonic-now'
@@ -86,6 +86,10 @@ export default function applyRoutes(
     publicAssetsUrl: publicAssetsConfig.publicAssetsUrl,
     graphqlOrigin,
   }
+  const pageMetadataContext: PageMetadataContext = {
+    canonicalHost: process.env.SB_CANONICAL_HOST!.replace(/\/$/, ''),
+    publicAssetsUrl: publicAssetsConfig.publicAssetsUrl,
+  }
 
   router.get('/config', async ctx => {
     ctx.body = serverConfig
@@ -149,7 +153,7 @@ export default function applyRoutes(
             : undefined,
       }
       const webpackAssets = await getWebpackAssets()
-      const pageMeta = await getNewsPageMeta(ctx.path, publicAssetsConfig.publicAssetsUrl)
+      const pageMeta = await resolvePageMetadata(ctx.path, pageMetadataContext)
       await ctx.render('index', {
         initData,
         pageMeta,

--- a/server/views/index.pug
+++ b/server/views/index.pug
@@ -9,17 +9,31 @@ block headScripts
       src='https://cdn.usefathom.com/script.js', data-site=analyticsId, data-auto='false')
 
 block metaTags
-  meta(property='og:url', content='https://www.shieldbattery.net', data-react-helmet='true')
-  meta(property='og:type', content='website', data-react-helmet='true')
-  meta(property='og:title', content='ShieldBattery', data-react-helmet='true')
-  meta(property='og:description', content='Play StarCraft 1 on the premier community-run platform.', data-react-helmet='true')
-  meta(property='og:image', content='/images/logo-and-text-1200x630.png', data-react-helmet='true')
+  if pageMeta
+    meta(property='og:url', content=pageMeta.url, data-react-helmet='true')
+    meta(property='og:type', content='article', data-react-helmet='true')
+    meta(property='og:title', content=pageMeta.title, data-react-helmet='true')
+    meta(property='og:description', content=pageMeta.description, data-react-helmet='true')
+    meta(property='og:image', content=pageMeta.image, data-react-helmet='true')
+    meta(property='article:published_time', content=pageMeta.publishedTime, data-react-helmet='true')
 
-  meta(name='twitter:card', content='summary_large_image', data-react-helmet='true')
-  meta(name='twitter:title', content='ShieldBattery', data-react-helmet='true')
-  meta(name='twitter:site', content='@ShieldBatteryBW', data-react-helmet='true')
-  meta(name='twitter:description', content='Play StarCraft 1 on the premier community-run platform.', data-react-helmet='true')
-  meta(name='twitter:image', content='https://shieldbattery.net/images/logo-and-text-1200x630.png', data-react-helmet='true')
+    meta(name='twitter:card', content='summary_large_image', data-react-helmet='true')
+    meta(name='twitter:title', content=pageMeta.title, data-react-helmet='true')
+    meta(name='twitter:site', content='@ShieldBatteryBW', data-react-helmet='true')
+    meta(name='twitter:description', content=pageMeta.description, data-react-helmet='true')
+    meta(name='twitter:image', content=pageMeta.image, data-react-helmet='true')
+  else
+    meta(property='og:url', content='https://www.shieldbattery.net', data-react-helmet='true')
+    meta(property='og:type', content='website', data-react-helmet='true')
+    meta(property='og:title', content='ShieldBattery', data-react-helmet='true')
+    meta(property='og:description', content='Play StarCraft 1 on the premier community-run platform.', data-react-helmet='true')
+    meta(property='og:image', content='/images/logo-and-text-1200x630.png', data-react-helmet='true')
+
+    meta(name='twitter:card', content='summary_large_image', data-react-helmet='true')
+    meta(name='twitter:title', content='ShieldBattery', data-react-helmet='true')
+    meta(name='twitter:site', content='@ShieldBatteryBW', data-react-helmet='true')
+    meta(name='twitter:description', content='Play StarCraft 1 on the premier community-run platform.', data-react-helmet='true')
+    meta(name='twitter:image', content='https://shieldbattery.net/images/logo-and-text-1200x630.png', data-react-helmet='true')
 
 block content
   div#app

--- a/server/views/index.pug
+++ b/server/views/index.pug
@@ -9,31 +9,19 @@ block headScripts
       src='https://cdn.usefathom.com/script.js', data-site=analyticsId, data-auto='false')
 
 block metaTags
-  if pageMeta
-    meta(property='og:url', content=pageMeta.url, data-react-helmet='true')
-    meta(property='og:type', content='article', data-react-helmet='true')
-    meta(property='og:title', content=pageMeta.title, data-react-helmet='true')
-    meta(property='og:description', content=pageMeta.description, data-react-helmet='true')
-    meta(property='og:image', content=pageMeta.image, data-react-helmet='true')
+  meta(property='og:url', content=pageMeta.url, data-react-helmet='true')
+  meta(property='og:type', content=pageMeta.type, data-react-helmet='true')
+  meta(property='og:title', content=pageMeta.title, data-react-helmet='true')
+  meta(property='og:description', content=pageMeta.description, data-react-helmet='true')
+  meta(property='og:image', content=pageMeta.image, data-react-helmet='true')
+  if pageMeta.publishedTime
     meta(property='article:published_time', content=pageMeta.publishedTime, data-react-helmet='true')
 
-    meta(name='twitter:card', content='summary_large_image', data-react-helmet='true')
-    meta(name='twitter:title', content=pageMeta.title, data-react-helmet='true')
-    meta(name='twitter:site', content='@ShieldBatteryBW', data-react-helmet='true')
-    meta(name='twitter:description', content=pageMeta.description, data-react-helmet='true')
-    meta(name='twitter:image', content=pageMeta.image, data-react-helmet='true')
-  else
-    meta(property='og:url', content='https://www.shieldbattery.net', data-react-helmet='true')
-    meta(property='og:type', content='website', data-react-helmet='true')
-    meta(property='og:title', content='ShieldBattery', data-react-helmet='true')
-    meta(property='og:description', content='Play StarCraft 1 on the premier community-run platform.', data-react-helmet='true')
-    meta(property='og:image', content='/images/logo-and-text-1200x630.png', data-react-helmet='true')
-
-    meta(name='twitter:card', content='summary_large_image', data-react-helmet='true')
-    meta(name='twitter:title', content='ShieldBattery', data-react-helmet='true')
-    meta(name='twitter:site', content='@ShieldBatteryBW', data-react-helmet='true')
-    meta(name='twitter:description', content='Play StarCraft 1 on the premier community-run platform.', data-react-helmet='true')
-    meta(name='twitter:image', content='https://shieldbattery.net/images/logo-and-text-1200x630.png', data-react-helmet='true')
+  meta(name='twitter:card', content='summary_large_image', data-react-helmet='true')
+  meta(name='twitter:title', content=pageMeta.title, data-react-helmet='true')
+  meta(name='twitter:site', content='@ShieldBatteryBW', data-react-helmet='true')
+  meta(name='twitter:description', content=pageMeta.description, data-react-helmet='true')
+  meta(name='twitter:image', content=pageMeta.image, data-react-helmet='true')
 
 block content
   div#app


### PR DESCRIPTION
Seventh PR of the dynamic news stack (on top of #1350). Links to the app shared in Discord/Twitter/etc. can now unfurl with page-specific previews. Per review feedback this is built as a general route-based system rather than a news-specific check in the catch-all — news posts are just the first registered route — and the post page gets a copy-link button so there's actually a way to grab a post URL from the desktop app.

## Changes

- **`server/lib/page-metadata/page-metadata.ts`** (new): a small metadata router. Route patterns use the same syntax as the client's wouter routes (matched with `regexparam`, wouter's own parser — added as a direct dependency; the exact version was already in the lockfile via wouter) and map to async resolver functions. `resolvePageMetadata(pathname, context)` runs through them and always returns metadata: a resolver returning `undefined` (route matched but nothing to preview, e.g. an unpublished post) or throwing (logged — metadata must never be the reason the shell fails) falls back to the general site-wide metadata. Adding a preview for another route means registering one `{ pattern, resolver }` entry.
- **Default metadata is now derived from `SB_CANONICAL_HOST`** rather than the previous hardcoded values, which were inconsistent with each other (og:url said `https://www.shieldbattery.net`, og:image was a relative path, twitter:image hardcoded `https://shieldbattery.net/...`).
- **`server/lib/news/news-page-meta.ts`**: the news resolver — `/news/:id/*?` → published posts serve `og:type=article`, title, whitespace-collapsed summary as description, the cover image or the same deterministic stock image the client feed shows (image list + hash moved to `common/news.ts`, shared client/server), and `article:published_time`; twitter: equivalents included. Drafts and unknown ids fall through to the defaults.
- **`server/views/index.pug`**: one uniform tag block driven by the resolved metadata (no duplicated if/else branches).
- **Copy-link button on the post page** (`client/news/news-post-page.tsx`): the existing `CopyLinkButton` (leagues/game-results pattern, Electron-aware via `makeServerUrl`) next to the title — the desktop app has no address bar, so there was previously no way to get a post's URL for sharing.
- Deliberately not touched: `<title>` stays static — the SPA never manages `document.title`, so a server-set per-page title would go stale on client-side navigation; scrapers read `og:title` anyway.
- Unit tests for the router (matching/params, fallback on undefined/throw/no-match, default values) and the news resolver (cover, stock-fallback determinism, invalid/missing ids). Integration tests assert a seeded post's permalink serves its og tags and `/` keeps the defaults.

## Verification

Live against the dev stack (curl on the served shell): news permalink → article tags with the absolute cover URL (or the deterministic `ashworld0.jpg` stock fallback, hash-matched with the client feed) and `article:published_time`; `/`, `/news` (the archive), unknown ids, and an unpublished draft all serve the default tags — now canonical-host-derived and mutually consistent, with no `article:published_time`. Copy-link button clicked in the real client puts the full post URL on the clipboard. `lint`, `typecheck`, unit tests, `gen-translations` clean.
