### PR TITLE
Only show social sidebar entry buttons on hover or keyboard focus

### DIFF
--- a/client/social/social-sidebar.tsx
+++ b/client/social/social-sidebar.tsx
@@ -687,7 +687,9 @@ const EntryButton = styled.div`
 
   opacity: 0;
 
-  ${EntryRoot}:hover &, ${EntryRoot}:focus-within & {
+  ${EntryRoot}:hover &,
+  ${EntryRoot}:focus-visible &,
+  ${EntryRoot}:has(:focus-visible) & {
     opacity: 1;
   }
 `


### PR DESCRIPTION
#### What

Fixes the leave-channel "X" button in the social sidebar staying visible after clicking a channel entry (same latent issue applied to whisper entries' close button, since they share `Entry`).

#### Why

Clicking an entry gives the anchor focus, so the `${EntryRoot}:focus-within` selector kept the button revealed until focus moved somewhere else entirely.

#### How

Key the non-hover reveal on keyboard focus instead: `:focus-visible` on the entry plus `:has(:focus-visible)` for when the inner icon button itself is tabbed onto. Mouse-driven focus no longer matches, keyboard accessibility is unchanged.

Verified live in the web client (real mouse/keyboard input, reading computed opacity of the button wrapper): idle 0, hover 1, click-then-mouse-away 0 (previously 1 — the bug), Tab onto entry 1, Tab onto the X itself 1.