### PR TITLE
Add avatar moderation: admin removal and upload restriction

### DIFF
--- a/client/auth/auth-reducer.ts
+++ b/client/auth/auth-reducer.ts
@@ -71,4 +71,9 @@ export default immerKeyedReducer(DEFAULT_STATE, {
       state.self.user = { ...action.payload.user }
     }
   },
+  ['@users/avatarCleared'](state, { payload: { userId } }) {
+    if (state.self?.user.id === userId) {
+      state.self.user.avatarUrl = undefined
+    }
+  },
 })

--- a/client/auth/user-error-display.tsx
+++ b/client/auth/user-error-display.tsx
@@ -94,9 +94,11 @@ function UserError({ error }: { error: FetchError }) {
         </span>
       )
 
-    // InappropriateImage is only produced by the avatar upload flow, which surfaces its own message
-    // (see account-settings.tsx); it never reaches this auth-focused display.
+    // InappropriateImage and AvatarUploadRestricted are only produced by the avatar upload flow,
+    // which surfaces its own messages (see account-settings.tsx); they never reach this
+    // auth-focused display.
     case UserErrorCode.InappropriateImage:
+    case UserErrorCode.AvatarUploadRestricted:
     case UserErrorCode.NotAllowedOnSelf:
     case UserErrorCode.NotFound:
       break

--- a/client/auth/user-restricted-notification-ui.tsx
+++ b/client/auth/user-restricted-notification-ui.tsx
@@ -33,6 +33,8 @@ function kindToIcon(kind: RestrictionKind): string {
       return 'flag'
     case RestrictionKind.Matchmaking:
       return 'block'
+    case RestrictionKind.AvatarUpload:
+      return 'no_accounts'
     default:
       return kind satisfies never
   }
@@ -78,6 +80,12 @@ export function UserRestrictedNotificationUi({
       intro = t(
         'auth.restriction.matchmaking.notification',
         'Your account has been restricted from matchmaking.',
+      )
+      break
+    case RestrictionKind.AvatarUpload:
+      intro = t(
+        'auth.restriction.avatarUpload.notification',
+        'Your account has been restricted from uploading avatars.',
       )
       break
     default:

--- a/client/dialogs/connected-dialog-overlay.tsx
+++ b/client/dialogs/connected-dialog-overlay.tsx
@@ -42,6 +42,7 @@ import {
 import { ShieldBatteryHealthDialog } from '../starcraft/shieldbattery-health'
 import { StarcraftHealthCheckupDialog } from '../starcraft/starcraft-health'
 import { dialogScrimOpacity } from '../styles/colors'
+import { RemoveUserAvatarDialog } from '../users/remove-user-avatar-dialog'
 import { CreateWhisper as CreateWhisperSessionDialog } from '../whispers/create-whisper'
 import { closeDialogById } from './action-creators'
 import { DialogState } from './dialog-reducer'
@@ -113,6 +114,8 @@ function getDialog(dialogType: DialogType): {
       return { component: PostMatchDialog }
     case DialogType.PrivacyPolicy:
       return { component: PrivacyPolicyDialog }
+    case DialogType.RemoveUserAvatar:
+      return { component: RemoveUserAvatarDialog }
     case DialogType.ReplayInfo:
       return { component: ReplayInfoDialog }
     case DialogType.ReplayLoad:

--- a/client/dialogs/dialog-type.ts
+++ b/client/dialogs/dialog-type.ts
@@ -28,6 +28,7 @@ export enum DialogType {
   MatchmakingBanned = 'matchmakingBanned',
   PostMatch = 'postMatch',
   PrivacyPolicy = 'privacyPolicy',
+  RemoveUserAvatar = 'removeUserAvatar',
   ReplayInfo = 'replayInfo',
   ReplayLoad = 'replayLoad',
   ReportGame = 'reportGame',
@@ -134,6 +135,12 @@ export type PostMatchDialogPayload = BaseDialogPayload<
   }
 >
 type PrivacyPolicyDialogPayload = BaseDialogPayload<typeof DialogType.PrivacyPolicy>
+type RemoveUserAvatarDialogPayload = BaseDialogPayload<
+  typeof DialogType.RemoveUserAvatar,
+  {
+    userId: SbUserId
+  }
+>
 type ReplayInfoDialogPayload = BaseDialogPayload<
   typeof DialogType.ReplayInfo,
   {
@@ -189,6 +196,7 @@ export type DialogPayload =
   | MatchmakingBannedDialogPayload
   | PostMatchDialogPayload
   | PrivacyPolicyDialogPayload
+  | RemoveUserAvatarDialogPayload
   | ReplayInfoDialogPayload
   | ReplayLoadDialogPayload
   | ReportGameDialogPayload

--- a/client/settings/user/account-settings.tsx
+++ b/client/settings/user/account-settings.tsx
@@ -10,6 +10,7 @@ import {
 } from '../../../common/constants'
 import { getErrorStack } from '../../../common/errors'
 import { MAX_IMAGE_SIZE_BYTES } from '../../../common/images'
+import { RestrictionKind } from '../../../common/users/restrictions'
 import { LOGIN_NAME_CHANGE_COOLDOWN_MS } from '../../../common/users/sb-user'
 import { UserErrorCode } from '../../../common/users/user-network'
 import { removeUserAvatar, uploadUserAvatar } from '../../auth/action-creators'
@@ -33,6 +34,7 @@ import {
   required,
 } from '../../forms/validators'
 import { graphql, useFragment } from '../../gql'
+import { longTimestamp } from '../../i18n/date-formats'
 import { MaterialIcon } from '../../icons/material/material-icon'
 import logger from '../../logging/logger'
 import { useAutoFocusRef } from '../../material/auto-focus'
@@ -44,13 +46,14 @@ import { TextField } from '../../material/text-field'
 import { Tooltip } from '../../material/tooltip'
 import { isFetchError } from '../../network/fetch-errors'
 import { useNow } from '../../react/date-hooks'
-import { useAppDispatch } from '../../redux-hooks'
+import { useAppDispatch, useAppSelector } from '../../redux-hooks'
 import { useSnackbarController } from '../../snackbars/snackbar-overlay'
 import { styledWithAttrs } from '../../styles/styled-with-attrs'
 import {
   BodyLarge,
   bodyLarge,
   BodyMedium,
+  bodyMedium,
   labelMedium,
   titleLarge,
   TitleMedium,
@@ -134,6 +137,11 @@ const AvatarActions = styled.div`
   gap: 8px;
 `
 
+const AvatarRestrictionText = styled.div`
+  ${bodyMedium};
+  color: var(--theme-error);
+`
+
 const HiddenFileInput = styled.input`
   display: none;
 `
@@ -175,6 +183,9 @@ export function AccountSettings() {
   const snackbarController = useSnackbarController()
   const avatarFileInputRef = useRef<HTMLInputElement>(null)
   const [avatarUpdating, setAvatarUpdating] = useState(false)
+  const avatarRestriction = useAppSelector(s =>
+    s.auth.self?.restrictions.get(RestrictionKind.AvatarUpload),
+  )
 
   useEffect(() => {
     if (currentUser && reduxEmailVerified !== currentUser.emailVerified) {
@@ -215,16 +226,23 @@ export function AccountSettings() {
         },
         onError: err => {
           setAvatarUpdating(false)
-          const message =
-            isFetchError(err) && err.code === UserErrorCode.InappropriateImage
-              ? t(
-                  'settings.user.account.avatar.inappropriate',
-                  'That image was flagged as inappropriate. Please choose a different one.',
-                )
-              : t(
-                  'settings.user.account.avatar.uploadError',
-                  'Something went wrong updating your avatar.',
-                )
+          let message: string
+          if (isFetchError(err) && err.code === UserErrorCode.InappropriateImage) {
+            message = t(
+              'settings.user.account.avatar.inappropriate',
+              'That image was flagged as inappropriate. Please choose a different one.',
+            )
+          } else if (isFetchError(err) && err.code === UserErrorCode.AvatarUploadRestricted) {
+            message = t(
+              'settings.user.account.avatar.uploadRestrictedError',
+              'You are currently restricted from uploading avatars.',
+            )
+          } else {
+            message = t(
+              'settings.user.account.avatar.uploadError',
+              'Something went wrong updating your avatar.',
+            )
+          }
           snackbarController.showSnackbar(message)
           logger.error(`Error uploading avatar: ${getErrorStack(err)}`)
         },
@@ -295,10 +313,18 @@ export function AccountSettings() {
                   ? t('settings.user.account.avatar.change', 'Change avatar')
                   : t('settings.user.account.avatar.upload', 'Upload avatar')
               }
-              disabled={avatarUpdating}
+              disabled={avatarUpdating || !!avatarRestriction}
               onClick={() => avatarFileInputRef.current?.click()}
               testName='upload-avatar-button'
             />
+            {avatarRestriction ? (
+              <AvatarRestrictionText data-test='avatar-upload-restricted-text'>
+                {t('settings.user.account.avatar.uploadRestricted', {
+                  defaultValue: 'Restricted from uploading avatars until {{date}}',
+                  date: longTimestamp.format(avatarRestriction.endTime),
+                })}
+              </AvatarRestrictionText>
+            ) : null}
             {selfUser?.avatarUrl ? (
               <TextButton
                 label={t('common.actions.remove', 'Remove')}

--- a/client/users/action-creators.ts
+++ b/client/users/action-creators.ts
@@ -11,6 +11,7 @@ import {
   AdminGetPermissionsResponse,
   AdminGetRestrictionsResponse,
   AdminGetUserIpsResponse,
+  AdminRemoveUserAvatarResponse,
   AdminUpdatePermissionsRequest,
   GetBatchUserInfoResponse,
   GetMatchHistoryQueryParams,
@@ -209,6 +210,24 @@ export function adminGetUserIps(
       signal: spec.signal,
     })
     dispatch({ type: '@users/adminGetUserIps', payload: res })
+
+    return res
+  })
+}
+
+export function adminRemoveUserAvatar(
+  userId: SbUserId,
+  spec: RequestHandlingSpec<AdminRemoveUserAvatarResponse>,
+): ThunkAction {
+  return abortableThunk(spec, async dispatch => {
+    const res = await fetchJson<AdminRemoveUserAvatarResponse>(
+      apiUrl`admin/users/${userId}/avatar`,
+      {
+        method: 'DELETE',
+        signal: spec.signal,
+      },
+    )
+    dispatch({ type: '@users/avatarCleared', payload: { userId } })
 
     return res
   })

--- a/client/users/actions.ts
+++ b/client/users/actions.ts
@@ -18,6 +18,7 @@ export type UserActions =
   | AdminGetUserBanHistory
   | AdminBanUser
   | AdminGetUserIps
+  | AdminAvatarCleared
   | GetUserRankingHistory
 
 export interface GetUserProfile {
@@ -67,6 +68,12 @@ export interface AdminBanUser {
 export interface AdminGetUserIps {
   type: '@users/adminGetUserIps'
   payload: AdminGetUserIpsResponse
+}
+
+/** An admin removed a user's avatar. */
+export interface AdminAvatarCleared {
+  type: '@users/avatarCleared'
+  payload: { userId: SbUserId }
 }
 
 export type GetUserRankingHistory = {

--- a/client/users/remove-user-avatar-dialog.tsx
+++ b/client/users/remove-user-avatar-dialog.tsx
@@ -1,0 +1,62 @@
+import { useTranslation } from 'react-i18next'
+import { SbUserId } from '../../common/users/sb-user-id'
+import { closeDialog } from '../dialogs/action-creators'
+import { CommonDialogProps } from '../dialogs/common-dialog-props'
+import { DialogType } from '../dialogs/dialog-type'
+import { TextButton } from '../material/button'
+import { Dialog } from '../material/dialog'
+import { useAppDispatch, useAppSelector } from '../redux-hooks'
+import { useSnackbarController } from '../snackbars/snackbar-overlay'
+import { BodyLarge } from '../styles/typography'
+import { adminRemoveUserAvatar } from './action-creators'
+
+export interface RemoveUserAvatarDialogProps extends CommonDialogProps {
+  userId: SbUserId
+}
+
+export function RemoveUserAvatarDialog({ onCancel, userId }: RemoveUserAvatarDialogProps) {
+  const { t } = useTranslation()
+  const dispatch = useAppDispatch()
+  const snackbarController = useSnackbarController()
+  const user = useAppSelector(s => s.users.byId.get(userId))
+
+  const onConfirmClick = () => {
+    dispatch(
+      adminRemoveUserAvatar(userId, {
+        onSuccess: () => {
+          snackbarController.showSnackbar(t('users.profile.admin.avatarRemoved', 'Avatar removed'))
+          dispatch(closeDialog(DialogType.RemoveUserAvatar))
+        },
+        onError: () => {
+          snackbarController.showSnackbar(
+            t('users.profile.admin.avatarRemoveError', 'There was a problem removing the avatar'),
+          )
+        },
+      }),
+    )
+  }
+
+  const buttons = [
+    <TextButton label={t('common.actions.cancel', 'Cancel')} key='cancel' onClick={onCancel} />,
+    <TextButton
+      label={t('users.profile.admin.removeAvatarAction', 'Remove avatar')}
+      key='remove'
+      onClick={onConfirmClick}
+    />,
+  ]
+
+  return (
+    <Dialog
+      title={t('users.profile.admin.removeAvatarTitle', 'Remove avatar?')}
+      buttons={buttons}
+      onCancel={onCancel}>
+      <BodyLarge>
+        {t(
+          'users.profile.admin.removeAvatarBody',
+          "This will permanently delete {{user}}'s avatar. This can't be undone.",
+          { user: user?.name ?? '' },
+        )}
+      </BodyLarge>
+    </Dialog>
+  )
+}

--- a/client/users/user-profile.tsx
+++ b/client/users/user-profile.tsx
@@ -16,11 +16,15 @@ import { UserProfileJson } from '../../common/users/user-network'
 import { useHasAnyPermission } from '../admin/admin-permissions'
 import { ConnectedAvatar } from '../avatars/avatar'
 import { ComingSoon } from '../coming-soon/coming-soon'
+import { openDialog } from '../dialogs/action-creators'
+import { DialogType } from '../dialogs/dialog-type'
 import { graphql } from '../gql'
 import TwitchIcon from '../icons/brands/twitch.svg'
 import { MaterialIcon } from '../icons/material/material-icon'
 import { RaceIcon } from '../lobbies/race-icon'
+import { IconButton } from '../material/button'
 import { TabItem, Tabs } from '../material/tabs'
+import { Tooltip } from '../material/tooltip'
 import { CopyLinkButton } from '../navigation/copy-link-button'
 import { replace } from '../navigation/routing'
 import { LoadingDotsArea } from '../progress/dots'
@@ -261,6 +265,14 @@ const UsernameRow = styled.div`
   gap: 4px;
 `
 
+const RemoveAvatarButton = styled(IconButton)`
+  color: var(--theme-on-surface-variant);
+
+  &:hover {
+    color: var(--theme-error);
+  }
+`
+
 const Username = styled.div`
   ${headlineLarge};
   ${singleLine};
@@ -301,8 +313,14 @@ export function UserProfilePage({
   seasons,
 }: UserProfilePageProps) {
   const { t } = useTranslation()
+  const dispatch = useAppDispatch()
   // TODO(tec27): Build the title feature :)
   const title = t('users.titles.novice', 'Novice')
+
+  const canRemoveAvatar = useHasAnyPermission('banUsers') && !!user.avatarUrl
+  const onRemoveAvatarClick = () => {
+    dispatch(openDialog({ type: DialogType.RemoveUserAvatar, initData: { userId: user.id } }))
+  }
 
   // `suspense: false` so a first (uncached) fetch doesn't suspend the profile page (blanking it
   // behind a loading fallback) just to resolve the optional Twitch channel/live state -- these
@@ -366,6 +384,16 @@ export function UserProfilePage({
               tooltipPosition='right'
               startingText={t('users.profile.copyLink', 'Copy link to profile')}
             />
+            {canRemoveAvatar ? (
+              <Tooltip
+                text={t('users.profile.admin.removeAvatarTooltip', 'Remove avatar (admin)')}
+                position='right'>
+                <RemoveAvatarButton
+                  icon={<MaterialIcon icon='no_photography' />}
+                  onClick={onRemoveAvatarClick}
+                />
+              </Tooltip>
+            ) : null}
           </UsernameRow>
           <TitleMedium>{title}</TitleMedium>
           {twitchChannel ? (

--- a/client/users/user-reducer.ts
+++ b/client/users/user-reducer.ts
@@ -146,6 +146,13 @@ export default immerKeyedReducer(DEFAULT_STATE, {
     updateUsers(state, action.payload.users)
   },
 
+  ['@users/avatarCleared'](state, { payload: { userId } }) {
+    const userState = state.byId.get(userId)
+    if (userState) {
+      userState.avatarUrl = undefined
+    }
+  },
+
   ['@users/getBatchUserInfo'](state, action) {
     if (!action.error) {
       updateUsers(state, action.payload.userInfos)

--- a/common/users/restrictions.ts
+++ b/common/users/restrictions.ts
@@ -4,6 +4,7 @@ export enum RestrictionKind {
   Chat = 'chat',
   Reporting = 'reporting',
   Matchmaking = 'matchmaking',
+  AvatarUpload = 'avatar_upload',
 }
 
 export const ALL_RESTRICTION_KINDS: ReadonlyArray<RestrictionKind> = Object.values(RestrictionKind)
@@ -20,6 +21,8 @@ export enum RestrictionReason {
   Cheating = 'cheating',
   LeftGame = 'left_game',
   Griefing = 'griefing',
+  // Avatar upload restriction reasons
+  InappropriateContent = 'inappropriate_content',
 }
 
 export function restrictionReasonToLabel(reason: RestrictionReason, t: TFunction): string {
@@ -42,6 +45,8 @@ export function restrictionReasonToLabel(reason: RestrictionReason, t: TFunction
       return t('users.restrictions.reason.left_game', 'Left the game')
     case RestrictionReason.Griefing:
       return t('users.restrictions.reason.griefing', 'Griefing')
+    case RestrictionReason.InappropriateContent:
+      return t('users.restrictions.reason.inappropriate_content', 'Inappropriate content')
     default:
       return reason satisfies never
   }
@@ -72,6 +77,12 @@ export const RESTRICTION_REASONS_BY_KIND: Record<
     RestrictionReason.Cheating,
     RestrictionReason.LeftGame,
     RestrictionReason.Griefing,
+  ],
+  [RestrictionKind.AvatarUpload]: [
+    RestrictionReason.InappropriateContent,
+    RestrictionReason.Harassment,
+    RestrictionReason.HateSpeech,
+    RestrictionReason.Other,
   ],
 }
 

--- a/common/users/user-network.ts
+++ b/common/users/user-network.ts
@@ -63,6 +63,7 @@ export enum UserErrorCode {
   MachineBanned = 'machineBanned',
   TooManyAccounts = 'tooManyAccounts',
   InappropriateImage = 'inappropriateImage',
+  AvatarUploadRestricted = 'avatarUploadRestricted',
 }
 
 /** Information returned for /users/:id/profile, intended to be able to fill out a profile page. */
@@ -249,6 +250,15 @@ export interface AdminGetUserIpsResponse {
   ips: UserIpInfoJson[]
   relatedUsers: Array<[ip: string, infos: Array<UserIpInfoJson>]>
   users: SbUser[]
+}
+
+/**
+ * The response returned when an admin removes another user's avatar. Deliberately returns a
+ * `SbUser` (not a `SelfUser`/`SelfUserJson`) since the target user is not the requester and
+ * `SelfUser` includes private fields such as their email.
+ */
+export interface AdminRemoveUserAvatarResponse {
+  user: SbUser
 }
 
 export interface EmailChangedEvent {

--- a/migrations/20260714120000_add_avatar_upload_restriction_kind.sql
+++ b/migrations/20260714120000_add_avatar_upload_restriction_kind.sql
@@ -1,0 +1,14 @@
+-- no-transaction
+
+-- Adds the `avatar_upload` value to the restriction_kind enum so admins can restrict a user from
+-- uploading profile avatars (e.g. for repeatedly uploading inappropriate images). It reuses the
+-- time-bound, admin-attributed user_restrictions system (with the evasion-resistant identifier
+-- variant), just as the `chat`, `reporting`, and `matchmaking` kinds do. Removing an existing
+-- avatar stays allowed while restricted.
+--
+-- `ALTER TYPE ... ADD VALUE` runs outside a transaction here: sqlx wraps each migration body in an
+-- implicit transaction block, and an enum value added inside a transaction can't be used until that
+-- transaction commits. We don't use the value in this migration, but the `-- no-transaction`
+-- directive keeps it unambiguous and matches the project convention for statements that don't
+-- belong in a transaction block.
+ALTER TYPE restriction_kind ADD VALUE IF NOT EXISTS 'avatar_upload';

--- a/server/lib/users/user-api-errors.ts
+++ b/server/lib/users/user-api-errors.ts
@@ -33,6 +33,8 @@ export const convertUserApiErrors = makeErrorConverterMiddleware(err => {
       throw asHttpError(403, err)
     case UserErrorCode.InappropriateImage:
       throw asHttpError(400, err)
+    case UserErrorCode.AvatarUploadRestricted:
+      throw asHttpError(403, err)
 
     default:
       assertUnreachable(err.code)

--- a/server/lib/users/user-api.ts
+++ b/server/lib/users/user-api.ts
@@ -41,6 +41,7 @@ import {
 import {
   ALL_RESTRICTION_KINDS,
   RESTRICTION_REASONS_BY_KIND,
+  RestrictionKind,
 } from '../../../common/users/restrictions'
 import { SbUser, SelfUser, toSelfUserJson } from '../../../common/users/sb-user'
 import { SbUserId } from '../../../common/users/sb-user-id'
@@ -55,6 +56,7 @@ import {
   AdminGetBansResponse,
   AdminGetRestrictionsResponse,
   AdminGetUserIpsResponse,
+  AdminRemoveUserAvatarResponse,
   AuthEvent,
   ChangeLanguageRequest,
   ChangeLanguagesResponse,
@@ -280,6 +282,7 @@ export class UserApi {
     private chatService: ChatService,
     private replayService: ReplayService,
     private imageService: ImageService,
+    private restrictionService: RestrictionService,
   ) {
     container.resolve(PasswordResetCleanupJob)
     container.resolve(SignupCodeCleanupJob)
@@ -908,6 +911,16 @@ export class UserApi {
       }).required(),
     })
 
+    // Removing an avatar stays allowed while restricted, so this check is only done here
+    if (
+      await this.restrictionService.isRestricted(ctx.session!.user.id, RestrictionKind.AvatarUpload)
+    ) {
+      throw new UserApiError(
+        UserErrorCode.AvatarUploadRestricted,
+        'User is restricted from uploading avatars',
+      )
+    }
+
     const avatarFile = ctx.request.files?.avatar
     if (!avatarFile) {
       throw new httpErrors.BadRequest('an avatar file must be provided')
@@ -928,7 +941,7 @@ export class UserApi {
     const avatarPath = createImagePath('user-avatars', imageExtension)
     const buffer = await image.toBuffer()
 
-    const { userInfo, previousPath } = await this.userService.updateCurrentUserAvatar(
+    const { userInfo, previousPath } = await this.userService.updateUserAvatar(
       params.id,
       { path: avatarPath, data: buffer, contentType: mime.getType(imageExtension) ?? undefined },
       ctx,
@@ -957,7 +970,7 @@ export class UserApi {
       }).required(),
     })
 
-    const { userInfo, previousPath } = await this.userService.updateCurrentUserAvatar(
+    const { userInfo, previousPath } = await this.userService.updateUserAvatar(
       params.id,
       undefined,
       ctx,
@@ -1234,6 +1247,7 @@ export class AdminUserApi {
   constructor(
     private banEnacter: BanEnacter,
     private restrictionService: RestrictionService,
+    private userService: UserService,
   ) {}
 
   @httpGet('/:id/bans')
@@ -1442,6 +1456,44 @@ export class AdminUserApi {
         infos.map(i => toUserIpInfoJson(i)),
       ]),
       users: otherUsers.concat(user),
+    }
+  }
+
+  @httpDelete('/:id/avatar')
+  @httpBefore(checkAllPermissions('banUsers'))
+  async removeAvatar(ctx: RouterContext): Promise<AdminRemoveUserAvatarResponse> {
+    const { params } = validateRequest(ctx, {
+      params: Joi.object<{ id: SbUserId }>({
+        id: joiUserId().required(),
+      }).required(),
+    })
+
+    const user = await findUserById(params.id)
+    if (!user) {
+      throw new UserApiError(UserErrorCode.NotFound, 'user not found')
+    }
+
+    const { userInfo, previousPath } = await this.userService.updateUserAvatar(
+      params.id,
+      undefined,
+      ctx,
+    )
+
+    if (previousPath) {
+      deleteFile(previousPath).catch(err =>
+        ctx.log.error({ err }, 'error deleting previous avatar file'),
+      )
+    }
+
+    // NOTE: `userInfo.user` is a `SelfUser` (includes email), so we build the `SbUser` response
+    // explicitly rather than reusing it wholesale.
+    return {
+      user: {
+        id: userInfo.user.id,
+        name: userInfo.user.name,
+        created: userInfo.user.created,
+        avatarUrl: userInfo.user.avatarUrl,
+      },
     }
   }
 

--- a/server/lib/users/user-service.ts
+++ b/server/lib/users/user-service.ts
@@ -121,15 +121,17 @@ export class UserService {
   }
 
   /**
-   * Sets (or clears, when `avatar` is `undefined`) the current user's avatar, returning the updated
-   * user info along with the previously-stored path (so the caller can delete the orphaned file).
-   * Refreshes the cached user data and, if `ctx` is provided, the current session.
+   * Sets (or clears, when `avatar` is `undefined`) a user's avatar, returning the updated user info
+   * along with the previously-stored path (so the caller can delete the orphaned file). Works for
+   * any user ID, not just the current user (e.g. admin moderation removing another user's avatar).
+   * Refreshes the cached user data and, if `ctx` is provided and its session belongs to the
+   * affected user, the current session.
    *
    * When setting an avatar, the file is written to the store *before* the DB is updated so the DB
    * never references a file that doesn't exist; if the DB update then fails, the just-written file
    * is cleaned up.
    */
-  async updateCurrentUserAvatar(
+  async updateUserAvatar(
     id: SbUserId,
     avatar: { path: string; data: Buffer; contentType?: string } | undefined,
     ctx?: Koa.Context,

--- a/server/public/locales/en/global.json
+++ b/server/public/locales/en/global.json
@@ -160,6 +160,9 @@
       "codePattern": "Invalid code. It should look like {{example}}."
     },
     "restriction": {
+      "avatarUpload": {
+        "notification": "Your account has been restricted from uploading avatars."
+      },
       "chat": {
         "notification": "Your account has been restricted from sending chat messages."
       },
@@ -1422,6 +1425,8 @@
           "tooLarge": "That image is too large (max 5 MB).",
           "upload": "Upload avatar",
           "uploadError": "Something went wrong updating your avatar.",
+          "uploadRestricted": "Restricted from uploading avatars until {{date}}",
+          "uploadRestrictedError": "You are currently restricted from uploading avatars.",
           "uploadSuccess": "Avatar updated."
         },
         "changeDisplayName": {
@@ -1663,6 +1668,14 @@
     },
     "profile": {
       "achievements": "Achievements",
+      "admin": {
+        "avatarRemoved": "Avatar removed",
+        "avatarRemoveError": "There was a problem removing the avatar",
+        "removeAvatarAction": "Remove avatar",
+        "removeAvatarBody": "This will permanently delete {{user}}'s avatar. This can't be undone.",
+        "removeAvatarTitle": "Remove avatar?",
+        "removeAvatarTooltip": "Remove avatar (admin)"
+      },
       "copyLink": "Copy link to profile",
       "latestGames": "Latest games",
       "points": "Points",
@@ -1697,6 +1710,7 @@
         "griefing": "Griefing",
         "harassment": "Harassment",
         "hate_speech": "Hate speech",
+        "inappropriate_content": "Inappropriate content",
         "left_game": "Left the game",
         "other": "Other",
         "spam": "Spam",

--- a/server/public/locales/es/global.json
+++ b/server/public/locales/es/global.json
@@ -160,6 +160,9 @@
       "codePattern": "Código inválido. Debe tener este formato: {{example}}."
     },
     "restriction": {
+      "avatarUpload": {
+        "notification": "Tu cuenta ha sido restringida para subir avatares."
+      },
       "chat": {
         "notification": "Tu cuenta ha sido restringida para enviar mensajes de chat."
       },
@@ -1428,6 +1431,8 @@
           "tooLarge": "Esa imagen es demasiado grande (máx. 5 MB).",
           "upload": "Subir avatar",
           "uploadError": "Algo salió mal al actualizar tu avatar.",
+          "uploadRestricted": "Subida de avatares restringida hasta el {{date}}",
+          "uploadRestrictedError": "Actualmente tienes restringida la subida de avatares.",
           "uploadSuccess": "Avatar actualizado."
         },
         "changeDisplayName": {
@@ -1672,6 +1677,14 @@
     },
     "profile": {
       "achievements": "Logros",
+      "admin": {
+        "avatarRemoved": "Avatar eliminado",
+        "avatarRemoveError": "Algo salió mal al eliminar el avatar",
+        "removeAvatarAction": "Eliminar avatar",
+        "removeAvatarBody": "Esto eliminará permanentemente el avatar de {{user}}. No se puede deshacer.",
+        "removeAvatarTitle": "¿Eliminar avatar?",
+        "removeAvatarTooltip": "Eliminar avatar (admin)"
+      },
       "copyLink": "Copiar enlace al perfil",
       "latestGames": "Últimos juegos",
       "points": "Puntos",
@@ -1706,6 +1719,7 @@
         "griefing": "Sabotaje",
         "harassment": "Acoso",
         "hate_speech": "Discurso de odio",
+        "inappropriate_content": "Contenido inapropiado",
         "left_game": "Abandonó la partida",
         "other": "Otros",
         "spam": "Spam",

--- a/server/public/locales/ko/global.json
+++ b/server/public/locales/ko/global.json
@@ -160,6 +160,9 @@
       "codePattern": "유효하지 않은 코드입니다. {{example}}처럼 보여야 해요."
     },
     "restriction": {
+      "avatarUpload": {
+        "notification": "아바타 업로드가 제한되었습니다."
+      },
       "chat": {
         "notification": "채팅 메시지 전송이 제한되었습니다."
       },
@@ -1416,6 +1419,8 @@
           "tooLarge": "이미지가 너무 큽니다 (최대 5MB).",
           "upload": "아바타 업로드",
           "uploadError": "아바타를 업데이트하는 중 문제가 발생했습니다.",
+          "uploadRestricted": "{{date}}까지 아바타 업로드가 제한됩니다",
+          "uploadRestrictedError": "현재 아바타 업로드가 제한되어 있습니다.",
           "uploadSuccess": "아바타가 업데이트되었습니다."
         },
         "changeDisplayName": {
@@ -1654,6 +1659,14 @@
     },
     "profile": {
       "achievements": "업적",
+      "admin": {
+        "avatarRemoved": "아바타가 제거되었습니다",
+        "avatarRemoveError": "아바타를 제거하는 중 문제가 발생했습니다",
+        "removeAvatarAction": "아바타 제거",
+        "removeAvatarBody": "{{user}}님의 아바타를 영구적으로 삭제합니다. 이 작업은 되돌릴 수 없습니다.",
+        "removeAvatarTitle": "아바타를 제거하시겠습니까?",
+        "removeAvatarTooltip": "아바타 제거 (관리자)"
+      },
       "copyLink": "프로필 링크 복사",
       "latestGames": "최근 게임",
       "points": "점수",
@@ -1688,6 +1701,7 @@
         "griefing": "고의적 방해",
         "harassment": "괴롭힘",
         "hate_speech": "혐오 발언",
+        "inappropriate_content": "부적절한 콘텐츠",
         "left_game": "게임 이탈",
         "other": "기타",
         "spam": "스팸",

--- a/server/public/locales/ru/global.json
+++ b/server/public/locales/ru/global.json
@@ -160,6 +160,9 @@
       "codePattern": "Неверный код. Он должен выглядеть как {{example}}."
     },
     "restriction": {
+      "avatarUpload": {
+        "notification": "Вашей учетной записи ограничен доступ к загрузке аватаров."
+      },
       "chat": {
         "notification": "Вашей учетной записи ограничен доступ к отправке сообщений в чат."
       },
@@ -1434,6 +1437,8 @@
           "tooLarge": "Изображение слишком большое (макс. 5 МБ).",
           "upload": "Загрузить аватар",
           "uploadError": "Не удалось обновить аватар.",
+          "uploadRestricted": "Загрузка аватаров ограничена до {{date}}",
+          "uploadRestrictedError": "Загрузка аватаров для вашей учетной записи сейчас ограничена.",
           "uploadSuccess": "Аватар обновлён."
         },
         "changeDisplayName": {
@@ -1681,6 +1686,14 @@
     },
     "profile": {
       "achievements": "Достижения",
+      "admin": {
+        "avatarRemoved": "Аватар удалён",
+        "avatarRemoveError": "Не удалось удалить аватар",
+        "removeAvatarAction": "Удалить аватар",
+        "removeAvatarBody": "Аватар пользователя {{user}} будет удалён навсегда. Это действие нельзя отменить.",
+        "removeAvatarTitle": "Удалить аватар?",
+        "removeAvatarTooltip": "Удалить аватар (администратор)"
+      },
       "copyLink": "Скопировать ссылку на профиль",
       "latestGames": "Последние игры",
       "points": "Очки",
@@ -1715,6 +1728,7 @@
         "griefing": "Саботаж",
         "harassment": "Преследование",
         "hate_speech": "Речь ненависти",
+        "inappropriate_content": "Неприемлемый контент",
         "left_game": "Покинул игру",
         "other": "Прочее",
         "spam": "Спам",

--- a/server/public/locales/zh-Hans/global.json
+++ b/server/public/locales/zh-Hans/global.json
@@ -160,6 +160,9 @@
       "codePattern": "无效的代码，格式应为 {{example}}。"
     },
     "restriction": {
+      "avatarUpload": {
+        "notification": "你的账户已被限制上传头像。"
+      },
       "chat": {
         "notification": "你的账户已被限制发送聊天消息。"
       },
@@ -1416,6 +1419,8 @@
           "tooLarge": "图片过大（最大 5 MB）。",
           "upload": "上传头像",
           "uploadError": "更新头像时出错。",
+          "uploadRestricted": "头像上传已被限制至 {{date}}",
+          "uploadRestrictedError": "你目前已被限制上传头像。",
           "uploadSuccess": "头像已更新。"
         },
         "changeDisplayName": {
@@ -1654,6 +1659,14 @@
     },
     "profile": {
       "achievements": "成就",
+      "admin": {
+        "avatarRemoved": "头像已移除",
+        "avatarRemoveError": "移除头像时出错",
+        "removeAvatarAction": "移除头像",
+        "removeAvatarBody": "这将永久删除 {{user}} 的头像。此操作无法撤销。",
+        "removeAvatarTitle": "移除头像？",
+        "removeAvatarTooltip": "移除头像（管理员）"
+      },
       "copyLink": "复制个人资料链接",
       "latestGames": "最近游戏",
       "points": "积分",
@@ -1688,6 +1701,7 @@
         "griefing": "恶意破坏",
         "harassment": "骚扰",
         "hate_speech": "仇恨言论",
+        "inappropriate_content": "不当内容",
         "left_game": "中途退出游戏",
         "other": "其他",
         "spam": "垃圾信息",


### PR DESCRIPTION
Users can now upload their own avatars (#1344), which needs moderation tools to curb bad actors. This adds both halves in one package:

## Admin avatar removal

- **`DELETE /api/1/admin/users/:id/avatar`**, guarded by `banUsers` (the same permission that gates bans and restrictions). Reuses the existing clear pipeline: `setUserAvatarPath`, orphaned-file deletion, and a forced refresh of the shared Redis user cache. `UserService.updateCurrentUserAvatar` is renamed to `updateUserAvatar` since it now serves any user, not just self.
- The response is a hand-built `SbUser` rather than `toSelfUserJson`, which would leak the target's email to the admin.
- The affordance is a small icon button on the profile header next to the copy-link button — visible only with `banUsers` and only when the user actually has an avatar — with a confirmation dialog (new `DialogType.RemoveUserAvatar`, same shape as the channel-ban dialog).
- Clearing the store uses a dedicated `@users/avatarCleared` action: the wire response omits `undefined` keys, so the generic user-merge could never clear a stale `avatarUrl`. The auth reducer handles the same action for the edge case of an admin removing their own avatar.

## Avatar upload restriction

- New **`RestrictionKind.AvatarUpload`** (`'avatar_upload'` enum value, `-- no-transaction` migration) riding the existing time-bound, admin-attributed, alt-evasion-resistant restrictions system, plus a new `InappropriateContent` reason preset. The admin punishments form and the per-kind server validation pick the new kind up automatically from `RESTRICTION_REASONS_BY_KIND`.
- Enforced in `POST /users/:id/avatar` before any file work → **403 `avatarUploadRestricted`**. Removing an existing avatar deliberately stays allowed while restricted (pair a restriction with a removal to fully clean up).
- Account settings disables the upload button live (restrictions already arrive over the `/restrictions/:userId` websocket push) and shows "Restricted from uploading avatars until {date}"; the upload error handler surfaces the specific 403; the restriction notification renders a new icon/text arm.

## Verification

- Typecheck, lint, and the full unit suite (74 files / 1007 tests) pass; `i18n check` clean for all four languages (10 new keys translated in a separate commit).
- Live-verified end to end with two Electron clients: victim uploaded an avatar through the settings UI → admin removed it from the profile header (DELETE 200, `avatar_path` NULL in Postgres, file deleted from the store, button disappeared reactively) → admin applied an `avatar_upload` restriction via the punishments page → the victim's settings disabled itself live over the websocket, the notification appeared, and a forced API upload returned `403 {"code":"avatarUploadRestricted"}`.

## Notes / follow-ups

- Avatar changes have no live push to other clients (pre-existing design from #1344), so a user whose avatar was admin-removed keeps seeing it in their own client until a refetch. Possible follow-up: an `avatarChanged` AuthEvent and/or a "your avatar was removed by a moderator" notification.
- Removals leave no audit row beyond server logs (restrictions record `restricted_by` + admin notes as usual).