### PR TITLE
Redesign games list + match history to match the replay library

### DIFF
--- a/app/app.ts
+++ b/app/app.ts
@@ -180,10 +180,11 @@ function defaultReplayFolder(): string {
 
 /**
  * The absolute folders the replay library should index for the given settings: the user's
- * configured list, normalized with empty entries dropped. An explicit empty array means "index
- * nothing". Only an absent (`undefined`) list falls back to the default folder, which is a
- * defensive path: the folder list is materialized to a concrete array at first boot (see the boot
- * migration in the init block), so it should never be `undefined` by the time the library runs.
+ * configured list, normalized with empty entries dropped. An explicit empty array still resolves
+ * to `[]` here ("index nothing"), and `undefined` falls back to the default folder; both are
+ * defensive paths, since the boot migration (see the init block) materializes the list to a
+ * non-empty array before the library starts. An empty list can only be observed transiently, if
+ * the user removes every configured folder mid-session — the next boot restores the default.
  */
 function resolveReplayFolders(settings: Readonly<Partial<LocalSettings>>): string[] {
   const configured = settings.replayLibraryFolders
@@ -1308,14 +1309,17 @@ app.on('ready', () => {
       gameServer = createGameServer(localSettings)
       await createWindow()
 
-      // Materialize the replay folder list once: the default folder becomes a regular first entry
-      // so every consumer (settings UI, watcher, save-replay) can treat all folders uniformly, and
-      // `undefined` only ever occurs before this runs. Fresh installs and users still on the default
-      // get `[default]`; users who already configured folders (including an explicit empty list,
-      // meaning "index nothing") are left untouched. `merge` fires the local-settings `change`
-      // listener, which is safe here: `replayLibrary` is still undefined, so its branch is skipped,
-      // and the folder set is read fresh below for the initial setup.
-      if ((await localSettings.get()).replayLibraryFolders === undefined) {
+      // Materialize the replay folder list once, at boot: after this runs, the list is always
+      // non-empty. A missing or empty list (older builds wrote `[]` for "use the default") is
+      // replaced by the default folder as a regular first entry, so every consumer (settings UI,
+      // watcher, save-replay) can treat all folders uniformly. Users who already configured
+      // folders keep them untouched. Removing every folder in the settings UI mid-session empties
+      // the index only for that run; this migration restores the default folder on the next
+      // launch. `merge` fires the local-settings `change` listener, which is safe here:
+      // `replayLibrary` is still undefined, so its branch is skipped, and the folder set is read
+      // fresh below for the initial setup.
+      const currentReplayFolders = (await localSettings.get()).replayLibraryFolders
+      if (currentReplayFolders === undefined || currentReplayFolders.length === 0) {
         await localSettings.merge({ replayLibraryFolders: [defaultReplayFolder()] })
       }
 

--- a/app/app.ts
+++ b/app/app.ts
@@ -18,6 +18,7 @@ import { URL } from 'url'
 import swallowNonBuiltins from '../common/async/swallow-non-builtins'
 import { getErrorStack } from '../common/errors'
 import { FsDirent, TwitchOauthFlowResult, TypedIpcMain, TypedIpcSender } from '../common/ipc'
+import { LocalSettings } from '../common/settings/local-settings'
 import { setAppId } from './app-id'
 import { checkShieldBatteryFiles } from './check-shieldbattery-files'
 import currentSession from './current-session'
@@ -32,7 +33,7 @@ import { MapStore } from './game/map-store'
 import { ReplayStore } from './game/replay-store'
 import { appLogBaseName, gameLogBaseName } from './log-paths'
 import logger from './logger'
-import { setupReplayLibrary } from './replay-library'
+import { ReplayLibraryService, setupReplayLibrary } from './replay-library'
 import { parseReplayMetadata } from './replay-library/replay-parser'
 import { LocalSettingsManager, ScrSettingsManager } from './settings'
 import type { NewInstanceNotification } from './single-instance'
@@ -134,6 +135,10 @@ let mainWindow: BrowserWindow | null
 let systemTray: SystemTray
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 let gameServer: GameServer
+let replayLibrary: ReplayLibraryService | undefined
+// The replay folders last handed to the library service, so a settings change is only forwarded
+// when the resolved list actually differs. Seeded when the service is created.
+let lastReplayFolders: string[] | undefined
 // Only one Twitch OAuth flow can run at a time (it binds a fixed loopback port).
 let twitchOauthFlowActive = false
 // Settles the in-flight Twitch OAuth flow early (set while one is running).
@@ -166,6 +171,22 @@ function handleLaunchArgs(args: string[]) {
     TypedIpcSender.from(mainWindow?.webContents).send('replaysOpen', replays)
     mainWindow?.show()
   }
+}
+
+/** The default replay folder, indexed when the user hasn't configured their own. */
+function defaultReplayFolder(): string {
+  return path.join(app.getPath('documents'), 'Starcraft', 'maps', 'replays')
+}
+
+/**
+ * The absolute folders the replay library should index for the given settings: the user's
+ * configured non-empty list (normalized), or the default folder when none are configured.
+ */
+function resolveReplayFolders(settings: Readonly<Partial<LocalSettings>>): string[] {
+  const configured = settings.replayLibraryFolders
+    ?.map(folder => path.normalize(folder))
+    .filter(folder => folder.length > 0)
+  return configured && configured.length > 0 ? configured : [defaultReplayFolder()]
 }
 
 let cachedIds: [number, string][] = []
@@ -509,6 +530,18 @@ function setupIpc(localSettings: LocalSettingsManager, scrSettings: ScrSettingsM
       lastRunAppAtSystemStartMinimized = settings.runAppAtSystemStartMinimized
     }
 
+    if (replayLibrary) {
+      const folders = resolveReplayFolders(settings)
+      if (
+        !lastReplayFolders ||
+        folders.length !== lastReplayFolders.length ||
+        folders.some((folder, i) => folder !== lastReplayFolders![i])
+      ) {
+        lastReplayFolders = folders
+        replayLibrary.setWatchedFolders(folders)
+      }
+    }
+
     TypedIpcSender.from(mainWindow?.webContents).send('settingsLocalChanged', settings)
   })
   scrSettings.on('change', settings => {
@@ -672,6 +705,18 @@ function setupIpc(localSettings: LocalSettingsManager, scrSettings: ScrSettingsM
 
     return { canceled, filePaths }
   })
+
+  ipcMain.handle('settingsBrowseForFolder', async (event, options) => {
+    const { canceled, filePaths } = await dialog.showOpenDialog(mainWindow!, {
+      title: options.title,
+      defaultPath: options.defaultPath,
+      properties: ['openDirectory'],
+    })
+
+    return { canceled, filePaths }
+  })
+
+  ipcMain.handle('settingsGetDefaultReplayFolder', async () => defaultReplayFolder())
 
   ipcMain.handle('settingsGetPrimaryResolution', async event => {
     const primaryDisplay = screen.getPrimaryDisplay()
@@ -1260,9 +1305,11 @@ app.on('ready', () => {
       await createWindow()
 
       try {
-        setupReplayLibrary({
+        const watchedFolders = resolveReplayFolders(await localSettings.get())
+        lastReplayFolders = watchedFolders
+        replayLibrary = setupReplayLibrary({
           dbPath: path.join(app.getPath('userData'), 'replay-library.sqlite'),
-          watchedFolder: path.join(app.getPath('documents'), 'Starcraft', 'maps', 'replays'),
+          watchedFolders,
           getSender: () => TypedIpcSender.from(mainWindow?.webContents),
         })
       } catch (err) {

--- a/app/app.ts
+++ b/app/app.ts
@@ -180,11 +180,9 @@ function defaultReplayFolder(): string {
 
 /**
  * The absolute folders the replay library should index for the given settings: the user's
- * configured list, normalized with empty entries dropped. An explicit empty array still resolves
- * to `[]` here ("index nothing"), and `undefined` falls back to the default folder; both are
- * defensive paths, since the boot migration (see the init block) materializes the list to a
- * non-empty array before the library starts. An empty list can only be observed transiently, if
- * the user removes every configured folder mid-session — the next boot restores the default.
+ * configured list, normalized with empty entries dropped. `undefined` (the folders were never
+ * configured) falls back to the default folder; an explicit empty array (the user removed every
+ * configured folder) resolves to `[]`, indexing nothing. Both are ordinary durable states.
  */
 function resolveReplayFolders(settings: Readonly<Partial<LocalSettings>>): string[] {
   const configured = settings.replayLibraryFolders
@@ -1308,20 +1306,6 @@ app.on('ready', () => {
       setupAnalytics(currentSession())
       gameServer = createGameServer(localSettings)
       await createWindow()
-
-      // Materialize the replay folder list once, at boot: after this runs, the list is always
-      // non-empty. A missing or empty list (older builds wrote `[]` for "use the default") is
-      // replaced by the default folder as a regular first entry, so every consumer (settings UI,
-      // watcher, save-replay) can treat all folders uniformly. Users who already configured
-      // folders keep them untouched. Removing every folder in the settings UI mid-session empties
-      // the index only for that run; this migration restores the default folder on the next
-      // launch. `merge` fires the local-settings `change` listener, which is safe here:
-      // `replayLibrary` is still undefined, so its branch is skipped, and the folder set is read
-      // fresh below for the initial setup.
-      const currentReplayFolders = (await localSettings.get()).replayLibraryFolders
-      if (currentReplayFolders === undefined || currentReplayFolders.length === 0) {
-        await localSettings.merge({ replayLibraryFolders: [defaultReplayFolder()] })
-      }
 
       try {
         const watchedFolders = resolveReplayFolders(await localSettings.get())

--- a/app/app.ts
+++ b/app/app.ts
@@ -180,13 +180,17 @@ function defaultReplayFolder(): string {
 
 /**
  * The absolute folders the replay library should index for the given settings: the user's
- * configured non-empty list (normalized), or the default folder when none are configured.
+ * configured list, normalized with empty entries dropped. An explicit empty array means "index
+ * nothing". Only an absent (`undefined`) list falls back to the default folder, which is a
+ * defensive path: the folder list is materialized to a concrete array at first boot (see the boot
+ * migration in the init block), so it should never be `undefined` by the time the library runs.
  */
 function resolveReplayFolders(settings: Readonly<Partial<LocalSettings>>): string[] {
   const configured = settings.replayLibraryFolders
-    ?.map(folder => path.normalize(folder))
-    .filter(folder => folder.length > 0)
-  return configured && configured.length > 0 ? configured : [defaultReplayFolder()]
+  if (configured === undefined) {
+    return [defaultReplayFolder()]
+  }
+  return configured.map(folder => path.normalize(folder)).filter(folder => folder.length > 0)
 }
 
 let cachedIds: [number, string][] = []
@@ -1303,6 +1307,17 @@ app.on('ready', () => {
       setupAnalytics(currentSession())
       gameServer = createGameServer(localSettings)
       await createWindow()
+
+      // Materialize the replay folder list once: the default folder becomes a regular first entry
+      // so every consumer (settings UI, watcher, save-replay) can treat all folders uniformly, and
+      // `undefined` only ever occurs before this runs. Fresh installs and users still on the default
+      // get `[default]`; users who already configured folders (including an explicit empty list,
+      // meaning "index nothing") are left untouched. `merge` fires the local-settings `change`
+      // listener, which is safe here: `replayLibrary` is still undefined, so its branch is skipped,
+      // and the folder set is read fresh below for the initial setup.
+      if ((await localSettings.get()).replayLibraryFolders === undefined) {
+        await localSettings.merge({ replayLibraryFolders: [defaultReplayFolder()] })
+      }
 
       try {
         const watchedFolders = resolveReplayFolders(await localSettings.get())

--- a/app/replay-library/index.ts
+++ b/app/replay-library/index.ts
@@ -23,8 +23,8 @@ const MAX_CONSECUTIVE_RESTARTS = 5
 export interface ReplayLibraryOptions {
   /** Absolute path to the SQLite index file. */
   dbPath: string
-  /** Absolute path to the replay folder to index (watched recursively). */
-  watchedFolder: string
+  /** Absolute paths of the replay folders to index (each watched recursively). */
+  watchedFolders: ReadonlyArray<string>
   /** Returns the sender for the current renderer window, so change events reach it even after the
    * window is recreated. */
   getSender: () => TypedIpcSender
@@ -42,8 +42,15 @@ export class ReplayLibraryService {
   private nextRequestId = 0
   private consecutiveRestarts = 0
   private readonly pending = new Map<number, Deferred<any>>()
+  /**
+   * The folders currently being indexed. Kept as service state (rather than reading `options` each
+   * time) so a crashed worker respawns with the latest set, not the one it was first created with.
+   */
+  private watchedFolders: ReadonlyArray<string>
 
   constructor(private readonly options: ReplayLibraryOptions) {
+    this.watchedFolders = options.watchedFolders
+
     const ipcMain = new TypedIpcMain()
     ipcMain.handle('replayLibraryQuery', async (_event, filters) => this.call('query', filters))
     ipcMain.handle('replayLibraryStatus', async () => this.call('status'))
@@ -90,10 +97,25 @@ export class ReplayLibraryService {
     ipcMain.handle(
       'replayLibrarySaveReplay',
       async (_event, gameId, filename, expectedHash, data) =>
-        saveReplayToLibrary(this.options.watchedFolder, gameId, filename, expectedHash, data),
+        // Saved replays go into the first configured folder; the watcher then indexes them from
+        // there. The list is always non-empty (it resolves to the default folder when unset).
+        saveReplayToLibrary(this.watchedFolders[0], gameId, filename, expectedHash, data),
     )
 
     this.startWorker()
+  }
+
+  /**
+   * Swaps the folders being indexed: updates the stored set (so a worker respawn uses it) and
+   * forwards it to the running worker's watcher. Also notifies the renderer, since the folder set is
+   * surfaced in the library status and a folder change may not itself produce a reconcile event.
+   */
+  setWatchedFolders(folders: ReadonlyArray<string>): void {
+    this.watchedFolders = folders
+    this.call('setWatchedFolders', [...folders]).catch(err => {
+      log.error(`Error updating replay library folders: ${getErrorStack(err)}`)
+    })
+    this.notifyChanged()
   }
 
   /** Notifies the renderer that the index changed, for mutations outside the watcher's own path. */
@@ -107,7 +129,7 @@ export class ReplayLibraryService {
       // loads the prebuilt bundle directly (see `webpack.config.js`), so `entry` is unused there.
       entry: isDev ? path.join(__dirname, 'worker', 'db-worker.ts') : undefined,
       dbPath: this.options.dbPath,
-      watchedFolder: this.options.watchedFolder,
+      watchedFolders: [...this.watchedFolders],
     }
     const worker = isDev
       ? new Worker(path.join(__dirname, 'worker', 'launch.js'), {

--- a/app/replay-library/index.ts
+++ b/app/replay-library/index.ts
@@ -96,10 +96,16 @@ export class ReplayLibraryService {
     )
     ipcMain.handle(
       'replayLibrarySaveReplay',
-      async (_event, gameId, filename, expectedHash, data) =>
+      async (_event, gameId, filename, expectedHash, data) => {
         // Saved replays go into the first configured folder; the watcher then indexes them from
-        // there. The list is always non-empty (it resolves to the default folder when unset).
-        saveReplayToLibrary(this.watchedFolders[0], gameId, filename, expectedHash, data),
+        // there. With no folders configured there's nowhere to save to, so reject clearly rather
+        // than crashing on an undefined path.
+        const destFolder = this.watchedFolders[0]
+        if (destFolder === undefined) {
+          throw new Error('No replay folder is configured')
+        }
+        return saveReplayToLibrary(destFolder, gameId, filename, expectedHash, data)
+      },
     )
 
     this.startWorker()

--- a/app/replay-library/replay-queries.test.ts
+++ b/app/replay-library/replay-queries.test.ts
@@ -112,6 +112,45 @@ describe('app/replay-library/replay-queries/buildReplaySqlQuery', () => {
     expect(sql).toContain('r.parse_error = 0')
   })
 
+  test('gameTimeFrom becomes a lower bound on game_time', () => {
+    const { sql, params } = buildReplaySqlQuery({ gameTimeFrom: 1000 })
+    expect(sql).toContain('r.game_time >= ?')
+    expect(params).toEqual([1000])
+  })
+
+  test('gameTimeTo becomes an upper bound on game_time', () => {
+    const { sql, params } = buildReplaySqlQuery({ gameTimeTo: 2000 })
+    expect(sql).toContain('r.game_time <= ?')
+    expect(params).toEqual([2000])
+  })
+
+  test('gameTimeFrom and gameTimeTo together bound both ends, params in order', () => {
+    const { sql, params } = buildReplaySqlQuery({ gameTimeFrom: 1000, gameTimeTo: 2000 })
+    expect(sql).toContain('r.game_time >= ?')
+    expect(sql).toContain('r.game_time <= ?')
+    expect(params).toEqual([1000, 2000])
+  })
+
+  test('gameTimeFrom/gameTimeTo exclude parse-error rows (their game_time is zeroed)', () => {
+    const { sql } = buildReplaySqlQuery({ gameTimeFrom: 1000, gameTimeTo: 2000 })
+    expect(sql).toContain('r.parse_error = 0')
+  })
+
+  test('gameTime range combined with another filter still applies both', () => {
+    const { sql, params } = buildReplaySqlQuery({
+      gameTimeFrom: 1000,
+      gameTimeTo: 2000,
+      mapName: 'Fighting Spirit',
+    })
+    expect(sql).toContain('r.game_time >= ?')
+    expect(sql).toContain('r.game_time <= ?')
+    expect(sql).toContain("r.map_name LIKE ? ESCAPE '\\'")
+    expect(sql).toContain('r.parse_error = 0')
+    // Param order follows the clauses' fixed position in the built SQL (mapName before the
+    // gameTime bounds), not the order filter properties were given in.
+    expect(params).toEqual(['%Fighting Spirit%', 1000, 2000])
+  })
+
   test('no sort defaults to newest-first', () => {
     expect(buildReplaySqlQuery({}).sql).toContain(
       'ORDER BY r.parse_error ASC, r.game_time DESC, r.id ASC',

--- a/app/replay-library/replay-queries.ts
+++ b/app/replay-library/replay-queries.ts
@@ -153,6 +153,18 @@ export function buildReplaySqlQuery(filters: ReplayLibraryFilters): ReplaySqlQue
     hasValueFilter = true
   }
 
+  if (filters.gameTimeFrom !== undefined) {
+    whereClauses.push('r.game_time >= ?')
+    params.push(filters.gameTimeFrom)
+    hasValueFilter = true
+  }
+
+  if (filters.gameTimeTo !== undefined) {
+    whereClauses.push('r.game_time <= ?')
+    params.push(filters.gameTimeTo)
+    hasValueFilter = true
+  }
+
   if (filters.format !== undefined) {
     whereClauses.push('r.team_size = ?')
     params.push(getTeamSizeForFormat(filters.format))

--- a/app/replay-library/replay-watcher-paths.test.ts
+++ b/app/replay-library/replay-watcher-paths.test.ts
@@ -53,6 +53,12 @@ describe('app/replay-library/replay-watcher-paths/isIndexedPathVanished', () => 
     expect(vanished).toBe(true)
   })
 
+  test('with no configured roots, every indexed row is pruned', () => {
+    // Removing every folder leaves an empty configured list: a row under no configured root is
+    // pruned regardless of what scanned, so the whole index clears out.
+    expect(isIndexedPathVanished('C:\\replays\\a.rep', [], [], new Set<string>())).toBe(true)
+  })
+
   test('a row under a configured-but-unreadable root is kept (offline drive)', () => {
     // ROOT is configured but not in scannedRoots (its top-level read failed this reconcile).
     const vanished = isIndexedPathVanished('C:\\replays\\a.rep', [ROOT], [], new Set<string>())

--- a/app/replay-library/replay-watcher-paths.test.ts
+++ b/app/replay-library/replay-watcher-paths.test.ts
@@ -49,6 +49,7 @@ describe('app/replay-library/replay-watcher-paths/isIndexedPathVanished', () => 
       [OTHER],
       [OTHER],
       new Set<string>(),
+      [],
     )
     expect(vanished).toBe(true)
   })
@@ -56,17 +57,25 @@ describe('app/replay-library/replay-watcher-paths/isIndexedPathVanished', () => 
   test('with no configured roots, every indexed row is pruned', () => {
     // Removing every folder leaves an empty configured list: a row under no configured root is
     // pruned regardless of what scanned, so the whole index clears out.
-    expect(isIndexedPathVanished('C:\\replays\\a.rep', [], [], new Set<string>())).toBe(true)
+    expect(isIndexedPathVanished('C:\\replays\\a.rep', [], [], new Set<string>(), [])).toBe(true)
   })
 
   test('a row under a configured-but-unreadable root is kept (offline drive)', () => {
     // ROOT is configured but not in scannedRoots (its top-level read failed this reconcile).
-    const vanished = isIndexedPathVanished('C:\\replays\\a.rep', [ROOT], [], new Set<string>())
+    const vanished = isIndexedPathVanished('C:\\replays\\a.rep', [ROOT], [], new Set<string>(), [
+      ROOT,
+    ])
     expect(vanished).toBe(false)
   })
 
   test('a row under a scanned root but missing from the scan is pruned', () => {
-    const vanished = isIndexedPathVanished('C:\\replays\\a.rep', [ROOT], [ROOT], new Set<string>())
+    const vanished = isIndexedPathVanished(
+      'C:\\replays\\a.rep',
+      [ROOT],
+      [ROOT],
+      new Set<string>(),
+      [],
+    )
     expect(vanished).toBe(true)
   })
 
@@ -76,19 +85,58 @@ describe('app/replay-library/replay-watcher-paths/isIndexedPathVanished', () => 
       [ROOT],
       [ROOT],
       new Set(['C:\\replays\\a.rep']),
+      [],
     )
     expect(vanished).toBe(false)
   })
 
-  test('with nested roots, an unreadable outer root keeps rows even when the inner root scanned', () => {
+  test('a row under an unreadable subfolder of a scanned root is kept', () => {
+    // The root's top-level read succeeded but a subfolder's read failed mid-walk (permission blip,
+    // AV lock, offline junction). The file's absence from the scan proves nothing, so it's kept.
+    const vanished = isIndexedPathVanished(
+      'C:\\replays\\locked\\a.rep',
+      [ROOT],
+      [ROOT],
+      new Set<string>(),
+      ['C:\\replays\\locked'],
+    )
+    expect(vanished).toBe(false)
+  })
+
+  test('an unreadable subfolder elsewhere does not stop pruning of a genuinely-missing row', () => {
+    const vanished = isIndexedPathVanished(
+      'C:\\replays\\a.rep',
+      [ROOT],
+      [ROOT],
+      new Set<string>(),
+      ['C:\\replays\\locked'],
+    )
+    expect(vanished).toBe(true)
+  })
+
+  test('with nested roots, an unreadable inner root keeps rows even when the outer root scanned', () => {
     const inner = 'C:\\replays\\pro'
-    // Outer ROOT scanned, inner root did not. A file under the inner root is also under ROOT (which
-    // scanned), so a genuine deletion is still detected.
+    // The inner root is a separately-mountable location (junction/network mount) that was offline
+    // this reconcile, so its own read failed even though the outer ROOT scanned. Rows under it must
+    // be kept: the outer walk couldn't enumerate them either.
     const vanished = isIndexedPathVanished(
       'C:\\replays\\pro\\a.rep',
       [ROOT, inner],
       [ROOT],
       new Set<string>(),
+      [inner],
+    )
+    expect(vanished).toBe(false)
+  })
+
+  test('with nested roots both scanned, a genuinely-missing row is still pruned', () => {
+    const inner = 'C:\\replays\\pro'
+    const vanished = isIndexedPathVanished(
+      'C:\\replays\\pro\\a.rep',
+      [ROOT, inner],
+      [ROOT, inner],
+      new Set<string>(),
+      [],
     )
     expect(vanished).toBe(true)
   })
@@ -101,13 +149,32 @@ describe('app/replay-library/replay-watcher-paths/isIndexedPathVanished', () => 
       [ROOT, inner],
       [],
       new Set<string>(),
+      [ROOT, inner],
     )
     expect(vanished).toBe(false)
   })
 
   test('separator-boundary: a sibling of a configured root is treated as removed', () => {
     // `C:\replays2` is not under `C:\replays`, so a row there is under no configured root.
-    const vanished = isIndexedPathVanished('C:\\replays2\\a.rep', [ROOT], [ROOT], new Set<string>())
+    const vanished = isIndexedPathVanished(
+      'C:\\replays2\\a.rep',
+      [ROOT],
+      [ROOT],
+      new Set<string>(),
+      [],
+    )
+    expect(vanished).toBe(true)
+  })
+
+  test('separator-boundary: an unreadable folder does not protect a sibling sharing its prefix', () => {
+    // `C:\replays\pro2` is not under the unreadable `C:\replays\pro`, so it's still pruned.
+    const vanished = isIndexedPathVanished(
+      'C:\\replays\\pro2\\a.rep',
+      [ROOT],
+      [ROOT],
+      new Set<string>(),
+      ['C:\\replays\\pro'],
+    )
     expect(vanished).toBe(true)
   })
 
@@ -119,6 +186,7 @@ describe('app/replay-library/replay-watcher-paths/isIndexedPathVanished', () => 
       ['c:\\replays'],
       ['c:\\replays'],
       new Set(['C:\\Replays\\a.rep']),
+      [],
     )
     expect(vanished).toBe(false)
   })

--- a/app/replay-library/replay-watcher-paths.test.ts
+++ b/app/replay-library/replay-watcher-paths.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, test } from 'vitest'
+import { isIndexedPathVanished, isPathUnderRoot } from './replay-watcher-paths'
+
+describe('app/replay-library/replay-watcher-paths/isPathUnderRoot', () => {
+  test('a file directly inside the root is under it', () => {
+    expect(isPathUnderRoot('C:\\replays\\a.rep', 'C:\\replays')).toBe(true)
+  })
+
+  test('a file in a nested subfolder is under the root', () => {
+    expect(isPathUnderRoot('C:\\replays\\sub\\deep\\a.rep', 'C:\\replays')).toBe(true)
+  })
+
+  test('a path equal to the root is under it', () => {
+    expect(isPathUnderRoot('C:\\replays', 'C:\\replays')).toBe(true)
+  })
+
+  test('is case-insensitive', () => {
+    expect(isPathUnderRoot('c:\\Replays\\A.REP', 'C:\\REPLAYS')).toBe(true)
+  })
+
+  test('normalizes forward slashes to match backslash roots', () => {
+    expect(isPathUnderRoot('C:/replays/a.rep', 'C:\\replays')).toBe(true)
+  })
+
+  test('normalizes `.`/`..` segments', () => {
+    expect(isPathUnderRoot('C:\\replays\\sub\\..\\a.rep', 'C:\\replays')).toBe(true)
+  })
+
+  test('respects separator boundaries (C:\\replays2 is not under C:\\replays)', () => {
+    expect(isPathUnderRoot('C:\\replays2\\a.rep', 'C:\\replays')).toBe(false)
+  })
+
+  test('a sibling folder sharing a prefix is not under the root', () => {
+    expect(isPathUnderRoot('C:\\replaysbackup\\a.rep', 'C:\\replays')).toBe(false)
+  })
+
+  test('a trailing separator on the root does not change containment', () => {
+    expect(isPathUnderRoot('C:\\replays\\a.rep', 'C:\\replays\\')).toBe(true)
+  })
+})
+
+describe('app/replay-library/replay-watcher-paths/isIndexedPathVanished', () => {
+  const ROOT = 'C:\\replays'
+  const OTHER = 'D:\\archive'
+
+  test('a row under no configured root is pruned (root removed from settings)', () => {
+    const vanished = isIndexedPathVanished(
+      'C:\\replays\\a.rep',
+      [OTHER],
+      [OTHER],
+      new Set<string>(),
+    )
+    expect(vanished).toBe(true)
+  })
+
+  test('a row under a configured-but-unreadable root is kept (offline drive)', () => {
+    // ROOT is configured but not in scannedRoots (its top-level read failed this reconcile).
+    const vanished = isIndexedPathVanished('C:\\replays\\a.rep', [ROOT], [], new Set<string>())
+    expect(vanished).toBe(false)
+  })
+
+  test('a row under a scanned root but missing from the scan is pruned', () => {
+    const vanished = isIndexedPathVanished('C:\\replays\\a.rep', [ROOT], [ROOT], new Set<string>())
+    expect(vanished).toBe(true)
+  })
+
+  test('a row still present in the scan is kept', () => {
+    const vanished = isIndexedPathVanished(
+      'C:\\replays\\a.rep',
+      [ROOT],
+      [ROOT],
+      new Set(['C:\\replays\\a.rep']),
+    )
+    expect(vanished).toBe(false)
+  })
+
+  test('with nested roots, an unreadable outer root keeps rows even when the inner root scanned', () => {
+    const inner = 'C:\\replays\\pro'
+    // Outer ROOT scanned, inner root did not. A file under the inner root is also under ROOT (which
+    // scanned), so a genuine deletion is still detected.
+    const vanished = isIndexedPathVanished(
+      'C:\\replays\\pro\\a.rep',
+      [ROOT, inner],
+      [ROOT],
+      new Set<string>(),
+    )
+    expect(vanished).toBe(true)
+  })
+
+  test('with nested roots, a file kept alive by any scanned containing root', () => {
+    const inner = 'C:\\replays\\pro'
+    // Neither the inner root nor ROOT scanned: the row must be kept.
+    const vanished = isIndexedPathVanished(
+      'C:\\replays\\pro\\a.rep',
+      [ROOT, inner],
+      [],
+      new Set<string>(),
+    )
+    expect(vanished).toBe(false)
+  })
+
+  test('separator-boundary: a sibling of a configured root is treated as removed', () => {
+    // `C:\replays2` is not under `C:\replays`, so a row there is under no configured root.
+    const vanished = isIndexedPathVanished('C:\\replays2\\a.rep', [ROOT], [ROOT], new Set<string>())
+    expect(vanished).toBe(true)
+  })
+
+  test('case-insensitive matching of scanned files keeps a present row', () => {
+    // The scan stores the on-disk casing; the existing row uses the same source, so an exact-cased
+    // hit is kept. A differently-cased configured root still recognizes containment.
+    const vanished = isIndexedPathVanished(
+      'C:\\Replays\\a.rep',
+      ['c:\\replays'],
+      ['c:\\replays'],
+      new Set(['C:\\Replays\\a.rep']),
+    )
+    expect(vanished).toBe(false)
+  })
+})

--- a/app/replay-library/replay-watcher-paths.ts
+++ b/app/replay-library/replay-watcher-paths.ts
@@ -33,25 +33,29 @@ export function isPathUnderRoot(filePath: string, root: string): boolean {
  * Decides whether an already-indexed replay path should be pruned from the index during a
  * reconcile.
  *
- * The hazard this guards against: an offline or unplugged drive makes a configured root temporarily
- * unreadable. Pruning that root's rows then would cascade away the user's bookmarks and playlist
- * entries for replays that still physically exist — so rows under a configured-but-unscannable root
- * are always kept.
+ * The hazard this guards against: a transient read failure — an offline or unplugged drive, a
+ * permission blip, an unavailable network mount or junction — makes a directory temporarily
+ * unreadable. Pruning its rows then would cascade away the user's bookmarks and playlist entries
+ * for replays that still physically exist — so rows under any directory that couldn't be read this
+ * reconcile are always kept.
  *
  * A row is treated as vanished (and pruned) only when:
  *  (a) its path is under NO currently-configured root — the root was removed from settings, so the
  *      user deliberately stopped indexing it; or
- *  (b) its path is under a configured root whose top-level scan succeeded, yet the scan didn't find
- *      the file — it was genuinely deleted/moved.
+ *  (b) its path is under a configured root whose scan succeeded — including every directory on the
+ *      way down to the file — yet the scan didn't find the file: it was genuinely deleted/moved.
  *
  * `scannedRoots` must be the subset of `configuredRoots` whose top-level read succeeded this
- * reconcile.
+ * reconcile; `unreadableDirs` must hold every directory (configured root or subfolder discovered
+ * mid-walk) whose read failed, so a failure anywhere below a scanned root still protects the rows
+ * beneath it.
  */
 export function isIndexedPathVanished(
   existingPath: string,
   configuredRoots: ReadonlyArray<string>,
   scannedRoots: ReadonlyArray<string>,
   scannedFiles: ReadonlySet<string>,
+  unreadableDirs: ReadonlyArray<string>,
 ): boolean {
   const underConfigured = configuredRoots.some(root => isPathUnderRoot(existingPath, root))
   if (!underConfigured) {
@@ -59,6 +63,11 @@ export function isIndexedPathVanished(
     return true
   }
   if (scannedFiles.has(existingPath)) {
+    return false
+  }
+  if (unreadableDirs.some(dir => isPathUnderRoot(existingPath, dir))) {
+    // The scan couldn't read some directory containing this row, so its absence from the scan
+    // proves nothing — keep it.
     return false
   }
   // Under a configured root but not seen in the scan: prune only if a root that could contain it

--- a/app/replay-library/replay-watcher-paths.ts
+++ b/app/replay-library/replay-watcher-paths.ts
@@ -1,0 +1,68 @@
+import path from 'node:path'
+
+/**
+ * Path-containment and index-pruning decisions for the replay watcher, factored out as pure
+ * functions (no filesystem access) so they can be unit-tested directly.
+ *
+ * All comparisons use `path.win32` unconditionally: replay paths are always Windows paths (the app
+ * only runs on Windows), so this keeps behavior identical on a Linux CI runner, where the default
+ * `path` would treat backslashes as ordinary characters.
+ */
+
+/** Lower-cases and canonicalizes a Windows path so containment can compare case-insensitively. */
+function normalizeForContainment(p: string): string {
+  return path.win32.normalize(p).toLowerCase()
+}
+
+/**
+ * Whether `filePath` sits inside `root` (or equals it). The comparison lands on separator
+ * boundaries so `C:\replays2` is not considered to be under `C:\replays`; it is case-insensitive
+ * and normalizes separators (`/` vs `\`) and `.`/`..` segments.
+ */
+export function isPathUnderRoot(filePath: string, root: string): boolean {
+  const normFile = normalizeForContainment(filePath)
+  const normRoot = normalizeForContainment(root)
+  if (normFile === normRoot) {
+    return true
+  }
+  const rootWithSep = normRoot.endsWith(path.win32.sep) ? normRoot : normRoot + path.win32.sep
+  return normFile.startsWith(rootWithSep)
+}
+
+/**
+ * Decides whether an already-indexed replay path should be pruned from the index during a
+ * reconcile.
+ *
+ * The hazard this guards against: an offline or unplugged drive makes a configured root temporarily
+ * unreadable. Pruning that root's rows then would cascade away the user's bookmarks and playlist
+ * entries for replays that still physically exist — so rows under a configured-but-unscannable root
+ * are always kept.
+ *
+ * A row is treated as vanished (and pruned) only when:
+ *  (a) its path is under NO currently-configured root — the root was removed from settings, so the
+ *      user deliberately stopped indexing it; or
+ *  (b) its path is under a configured root whose top-level scan succeeded, yet the scan didn't find
+ *      the file — it was genuinely deleted/moved.
+ *
+ * `scannedRoots` must be the subset of `configuredRoots` whose top-level read succeeded this
+ * reconcile.
+ */
+export function isIndexedPathVanished(
+  existingPath: string,
+  configuredRoots: ReadonlyArray<string>,
+  scannedRoots: ReadonlyArray<string>,
+  scannedFiles: ReadonlySet<string>,
+): boolean {
+  const underConfigured = configuredRoots.some(root => isPathUnderRoot(existingPath, root))
+  if (!underConfigured) {
+    // (a) No longer covered by any configured root.
+    return true
+  }
+  if (scannedFiles.has(existingPath)) {
+    return false
+  }
+  // Under a configured root but not seen in the scan: prune only if a root that could contain it
+  // actually scanned this reconcile. Otherwise its containing root was unreadable (e.g. an offline
+  // drive) and the row is left untouched.
+  return scannedRoots.some(root => isPathUnderRoot(existingPath, root))
+}

--- a/app/replay-library/replay-watcher.ts
+++ b/app/replay-library/replay-watcher.ts
@@ -11,6 +11,7 @@ import {
   parseReplayFile,
   ReplayFileInfo,
 } from './replay-parser'
+import { isIndexedPathVanished } from './replay-watcher-paths'
 
 /** Debounce window for coalescing filesystem events into a single reconcile. */
 const WATCH_DEBOUNCE_MS = 500
@@ -51,34 +52,42 @@ export interface ReplayLibraryLogger {
 }
 
 /**
- * Watches the replay folder and keeps the index reconciled with disk. Reconciliation (used both for
- * the initial backfill and for change events) scans for `.rep` files, parses new/changed ones,
- * re-points moved/renamed files at their new path by content identity instead of re-parsing them,
- * and prunes entries for files that no longer exist.
+ * Watches the configured replay folders and keeps the index reconciled with disk. Reconciliation
+ * (used both for the initial backfill and for change events) scans each configured root for `.rep`
+ * files, parses new/changed ones, re-points moved/renamed files at their new path by content
+ * identity instead of re-parsing them, and prunes entries for files that no longer exist.
  */
 export class ReplayWatcher {
-  private watcher: FSWatcher | undefined
+  private watchers: FSWatcher[] = []
+  private watchedFolders: ReadonlyArray<string>
   private reconciling = false
   private reconcileQueued = false
   private debounceTimer: ReturnType<typeof setTimeout> | undefined
   private backfillProgress: ReplayBackfillProgress | undefined
   /**
    * Whether the initial backfill has begun. The `scanning` phase is only surfaced for it: later,
-   * watch-triggered reconciles re-scan the whole folder too, but their work is small and showing a
+   * watch-triggered reconciles re-scan every folder too, but their work is small and showing a
    * full "scanning" state on every added file would just flicker.
    */
   private initialScanStarted = false
 
   constructor(
-    private readonly watchedFolder: string,
+    watchedFolders: ReadonlyArray<string>,
     private readonly db: ReplayDb,
     private readonly logger: ReplayLibraryLogger,
     private readonly callbacks: ReplayWatcherCallbacks,
-  ) {}
+  ) {
+    this.watchedFolders = watchedFolders
+  }
 
   /** Current backfill progress, or undefined when no reconcile with pending work is running. */
   getBackfillProgress(): ReplayBackfillProgress | undefined {
     return this.backfillProgress
+  }
+
+  /** The folders currently being watched (a fresh, mutable copy). */
+  getWatchedFolders(): string[] {
+    return [...this.watchedFolders]
   }
 
   /** Records the current backfill progress and notifies the renderer of the change. */
@@ -92,24 +101,37 @@ export class ReplayWatcher {
       this.logger.error(`Error during initial replay backfill: ${getErrorStack(err)}`)
     })
 
-    try {
-      this.watcher = watch(this.watchedFolder, { recursive: true }, () => this.onWatchEvent())
-    } catch (err) {
-      // Folder may not exist yet, or recursive watching may be unavailable; the index just stays as
-      // last reconciled.
-      this.logger.warning(
-        `Could not watch replay folder '${this.watchedFolder}': ${getErrorStack(err)}`,
-      )
+    for (const folder of this.watchedFolders) {
+      try {
+        this.watchers.push(watch(folder, { recursive: true }, () => this.onWatchEvent()))
+      } catch (err) {
+        // Folder may not exist yet, or recursive watching may be unavailable; the index just stays
+        // as last reconciled.
+        this.logger.warning(`Could not watch replay folder '${folder}': ${getErrorStack(err)}`)
+      }
     }
   }
 
   stop(): void {
-    this.watcher?.close()
-    this.watcher = undefined
+    for (const watcher of this.watchers) {
+      watcher.close()
+    }
+    this.watchers = []
     if (this.debounceTimer) {
       clearTimeout(this.debounceTimer)
       this.debounceTimer = undefined
     }
+  }
+
+  /**
+   * Swaps the set of watched folders. Restarting kicks off a reconcile, which prunes rows no longer
+   * under any configured root and indexes any newly-added roots (content-hash rename matching
+   * rescues files that physically moved between roots).
+   */
+  setWatchedFolders(folders: ReadonlyArray<string>): void {
+    this.stop()
+    this.watchedFolders = folders
+    this.start()
   }
 
   private onWatchEvent(): void {
@@ -152,21 +174,25 @@ export class ReplayWatcher {
       this.emitProgress({ phase: 'scanning' })
     }
 
-    // If the watched folder can't be read at all (e.g. it doesn't exist), leave the index untouched
-    // rather than treating every entry as deleted.
-    try {
-      await readdir(this.watchedFolder)
-    } catch {
+    const { files, scannedRoots } = await this.scanReplayFiles()
+
+    // If not a single configured root could be read (e.g. every folder is missing or on an offline
+    // drive), leave the whole index untouched rather than treating every entry as deleted.
+    if (scannedRoots.length === 0) {
       this.emitProgress(undefined)
       return
     }
 
-    const files = await this.scanReplayFiles()
     const existing = this.db.getExistingReplays()
 
+    // A configured root that's temporarily unreadable (offline/unplugged drive) must NOT prune its
+    // rows: doing so would cascade away the bookmarks and playlist memberships of replays that still
+    // exist. So a row is only pruned when its root was removed from settings, or when a root that
+    // *did* scan this reconcile no longer contains it. See `isIndexedPathVanished`.
+    const scannedPaths = new Set(files.keys())
     const vanished = new Map<string, ExistingReplayInfo>()
     for (const [existingPath, info] of existing) {
-      if (!files.has(existingPath)) {
+      if (isIndexedPathVanished(existingPath, this.watchedFolders, scannedRoots, scannedPaths)) {
         vanished.set(existingPath, info)
       }
     }
@@ -303,16 +329,27 @@ export class ReplayWatcher {
     }
   }
 
-  private async scanReplayFiles(): Promise<Map<string, FileMeta>> {
+  /**
+   * Walks every configured root into one union map keyed by absolute path (so overlapping roots
+   * dedupe naturally). Also reports which roots were scannable: a root counts as scanned when its
+   * top-level read succeeds. Unreadable subfolders encountered mid-walk are silently skipped and do
+   * not disqualify their root.
+   */
+  private async scanReplayFiles(): Promise<{
+    files: Map<string, FileMeta>
+    scannedRoots: string[]
+  }> {
     const result = new Map<string, FileMeta>()
+    const scannedRoots: string[] = []
 
-    const walk = async (dir: string): Promise<void> => {
+    // Returns whether `dir` itself could be read; callers only use this at the root level, so a
+    // failed read of a nested subfolder just skips that subfolder.
+    const walk = async (dir: string): Promise<boolean> => {
       let entries
       try {
         entries = await readdir(dir, { withFileTypes: true })
       } catch {
-        // A subfolder may be inaccessible or removed mid-scan; skip it.
-        return
+        return false
       }
 
       for (const entry of entries) {
@@ -328,9 +365,14 @@ export class ReplayWatcher {
           }
         }
       }
+      return true
     }
 
-    await walk(this.watchedFolder)
-    return result
+    for (const root of this.watchedFolders) {
+      if (await walk(root)) {
+        scannedRoots.push(root)
+      }
+    }
+    return { files: result, scannedRoots }
   }
 }

--- a/app/replay-library/replay-watcher.ts
+++ b/app/replay-library/replay-watcher.ts
@@ -174,7 +174,7 @@ export class ReplayWatcher {
       this.emitProgress({ phase: 'scanning' })
     }
 
-    const { files, scannedRoots } = await this.scanReplayFiles()
+    const { files, scannedRoots, unreadableDirs } = await this.scanReplayFiles()
 
     // If folders are configured but not a single one could be read (e.g. every folder is missing or
     // on an offline drive), leave the whole index untouched rather than treating every entry as
@@ -187,14 +187,23 @@ export class ReplayWatcher {
 
     const existing = this.db.getExistingReplays()
 
-    // A configured root that's temporarily unreadable (offline/unplugged drive) must NOT prune its
-    // rows: doing so would cascade away the bookmarks and playlist memberships of replays that still
-    // exist. So a row is only pruned when its root was removed from settings, or when a root that
-    // *did* scan this reconcile no longer contains it. See `isIndexedPathVanished`.
+    // A directory that's temporarily unreadable (offline/unplugged drive, permission blip,
+    // unavailable network mount) must NOT prune its rows: doing so would cascade away the bookmarks
+    // and playlist memberships of replays that still exist. So a row is only pruned when its root
+    // was removed from settings, or when every directory on the way down to it was readable this
+    // reconcile yet the scan didn't find it. See `isIndexedPathVanished`.
     const scannedPaths = new Set(files.keys())
     const vanished = new Map<string, ExistingReplayInfo>()
     for (const [existingPath, info] of existing) {
-      if (isIndexedPathVanished(existingPath, this.watchedFolders, scannedRoots, scannedPaths)) {
+      if (
+        isIndexedPathVanished(
+          existingPath,
+          this.watchedFolders,
+          scannedRoots,
+          scannedPaths,
+          unreadableDirs,
+        )
+      ) {
         vanished.set(existingPath, info)
       }
     }
@@ -334,23 +343,26 @@ export class ReplayWatcher {
   /**
    * Walks every configured root into one union map keyed by absolute path (so overlapping roots
    * dedupe naturally). Also reports which roots were scannable: a root counts as scanned when its
-   * top-level read succeeds. Unreadable subfolders encountered mid-walk are silently skipped and do
-   * not disqualify their root.
+   * top-level read succeeds. Every directory whose read failed — a root or a subfolder encountered
+   * mid-walk — is reported in `unreadableDirs`, so already-indexed rows beneath it can be protected
+   * from pruning (its files being absent from the scan proves nothing about their existence).
    */
   private async scanReplayFiles(): Promise<{
     files: Map<string, FileMeta>
     scannedRoots: string[]
+    unreadableDirs: string[]
   }> {
     const result = new Map<string, FileMeta>()
     const scannedRoots: string[] = []
+    const unreadableDirs: string[] = []
 
-    // Returns whether `dir` itself could be read; callers only use this at the root level, so a
-    // failed read of a nested subfolder just skips that subfolder.
+    // Returns whether `dir` itself could be read.
     const walk = async (dir: string): Promise<boolean> => {
       let entries
       try {
         entries = await readdir(dir, { withFileTypes: true })
       } catch {
+        unreadableDirs.push(dir)
         return false
       }
 
@@ -375,6 +387,12 @@ export class ReplayWatcher {
         scannedRoots.push(root)
       }
     }
-    return { files: result, scannedRoots }
+    if (unreadableDirs.length > 0) {
+      this.logger.warning(
+        `Could not read ${unreadableDirs.length} folder(s) during replay scan; ` +
+          `their indexed replays will be kept as-is: ${unreadableDirs.join(', ')}`,
+      )
+    }
+    return { files: result, scannedRoots, unreadableDirs }
   }
 }

--- a/app/replay-library/replay-watcher.ts
+++ b/app/replay-library/replay-watcher.ts
@@ -176,9 +176,11 @@ export class ReplayWatcher {
 
     const { files, scannedRoots } = await this.scanReplayFiles()
 
-    // If not a single configured root could be read (e.g. every folder is missing or on an offline
-    // drive), leave the whole index untouched rather than treating every entry as deleted.
-    if (scannedRoots.length === 0) {
+    // If folders are configured but not a single one could be read (e.g. every folder is missing or
+    // on an offline drive), leave the whole index untouched rather than treating every entry as
+    // deleted. With zero configured folders this guard must NOT fire: the reconcile has to proceed
+    // so every indexed row (now under no configured root) is pruned.
+    if (this.watchedFolders.length > 0 && scannedRoots.length === 0) {
       this.emitProgress(undefined)
       return
     }

--- a/app/replay-library/worker/db-worker.ts
+++ b/app/replay-library/worker/db-worker.ts
@@ -15,7 +15,7 @@ if (isMainThread) {
   throw new Error('db-worker should not be run in the main thread')
 }
 
-const { dbPath, watchedFolder } = workerData as ReplayDbWorkerData
+const { dbPath, watchedFolders } = workerData as ReplayDbWorkerData
 
 function post(message: FromWorkerMessage): void {
   parentPort!.postMessage(message)
@@ -51,7 +51,7 @@ function openReplayDb(path: string): ReplayDb {
 }
 
 const db = openReplayDb(dbPath)
-const watcher = new ReplayWatcher(watchedFolder, db, logger, {
+const watcher = new ReplayWatcher(watchedFolders, db, logger, {
   onProgress: progress => post({ type: 'backfillProgress', progress }),
   onChange: () => post({ type: 'changed' }),
 })
@@ -61,7 +61,7 @@ function getStatus(): ReplayLibraryStatus {
     totalIndexed: db.getTotalIndexed(),
     bookmarkedCount: db.getBookmarkedCount(),
     backfill: watcher.getBackfillProgress(),
-    watchedFolder,
+    watchedFolders: watcher.getWatchedFolders(),
   }
 }
 
@@ -80,6 +80,7 @@ const calls: ReplayDbCalls = {
     db.movePlaylistEntry(playlistId, replayId, toIndex),
   getPlaylistsForReplay: replayId => db.getPlaylistsForReplay(replayId),
   findReplayIdByGameId: gameId => db.findReplayIdByGameId(gameId),
+  setWatchedFolders: folders => watcher.setWatchedFolders(folders),
 }
 
 parentPort!.on('message', (message: ToWorkerMessage) => {

--- a/app/replay-library/worker/messages.ts
+++ b/app/replay-library/worker/messages.ts
@@ -16,8 +16,8 @@ export interface ReplayDbWorkerData {
   entry?: string
   /** Absolute path to the SQLite index file. */
   dbPath: string
-  /** Absolute path to the replay folder to index (watched recursively). */
-  watchedFolder: string
+  /** Absolute paths of the replay folders to index (each watched recursively). */
+  watchedFolders: string[]
 }
 
 /** A page of query results, matching `ReplayDb.query`'s return shape. */
@@ -44,6 +44,11 @@ export interface ReplayDbCalls {
   movePlaylistEntry: (playlistId: number, replayId: number, toIndex: number) => void
   getPlaylistsForReplay: (replayId: number) => Array<{ id: number; name: string }>
   findReplayIdByGameId: (gameId: string) => number | undefined
+  /**
+   * Replaces the set of watched folders. This is watcher control rather than a DB read/write, but it
+   * rides the same call channel so it stays ordered with the queries the worker serves.
+   */
+  setWatchedFolders: (folders: string[]) => void
 }
 
 // --- Main thread -> worker ---

--- a/app/settings.ts
+++ b/app/settings.ts
@@ -16,7 +16,7 @@ import { cloneCustomTeamColors } from '../common/settings/team-colors'
 import { findInstallPath } from './find-install-path'
 import log from './logger'
 
-const VERSION = 17
+const VERSION = 18
 const SCR_VERSION = 5
 
 async function findStarcraftPath() {
@@ -327,6 +327,17 @@ export class LocalSettingsManager extends SettingsManager<LocalSettings> {
       // The Pastel FFA preset was removed; anyone who had it selected falls back to Classic.
       if ((settings.ffaColorPreset as string | undefined) === 'pastel') {
         newSettings.ffaColorPreset = FfaColorPreset.Classic
+      }
+    }
+
+    if (!settings.version || settings.version < 18) {
+      log.verbose('Found settings version 17, migrating to version 18')
+      // Builds before this version wrote an empty array to mean "use the default replay folder",
+      // so it must not be read as "index nothing" now that an empty array is a durable user
+      // choice. Dropping the key falls back to the default folder.
+      const { replayLibraryFolders } = newSettings
+      if (Array.isArray(replayLibraryFolders) && replayLibraryFolders.length === 0) {
+        delete newSettings.replayLibraryFolders
       }
     }
 

--- a/client/games/day-header.test.ts
+++ b/client/games/day-header.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from 'vitest'
+import { resolveDateRangeMs } from './day-header'
+
+describe('resolveDateRangeMs', () => {
+  test('resolves both bounds to local start/end of day', () => {
+    const { startMs, endMs } = resolveDateRangeMs('2026-07-01', '2026-07-21')
+
+    expect(startMs).toBe(new Date(2026, 6, 1).getTime())
+    expect(endMs).toBe(new Date(2026, 6, 22).getTime() - 1)
+  })
+
+  test('resolves only startDate when endDate is omitted', () => {
+    const { startMs, endMs } = resolveDateRangeMs('2026-07-01', undefined)
+
+    expect(startMs).toBe(new Date(2026, 6, 1).getTime())
+    expect(endMs).toBeUndefined()
+  })
+
+  test('resolves only endDate when startDate is omitted', () => {
+    const { startMs, endMs } = resolveDateRangeMs(undefined, '2026-07-21')
+
+    expect(startMs).toBeUndefined()
+    expect(endMs).toBe(new Date(2026, 6, 22).getTime() - 1)
+  })
+
+  test('both bounds undefined when both inputs are undefined', () => {
+    const { startMs, endMs } = resolveDateRangeMs(undefined, undefined)
+
+    expect(startMs).toBeUndefined()
+    expect(endMs).toBeUndefined()
+  })
+
+  test('empty strings resolve to undefined bounds', () => {
+    const { startMs, endMs } = resolveDateRangeMs('', '')
+
+    expect(startMs).toBeUndefined()
+    expect(endMs).toBeUndefined()
+  })
+
+  test('garbage input resolves to undefined, never NaN', () => {
+    const { startMs, endMs } = resolveDateRangeMs('not-a-date', 'also-garbage')
+
+    expect(startMs).toBeUndefined()
+    expect(endMs).toBeUndefined()
+    expect(Number.isNaN(startMs)).toBe(false)
+    expect(Number.isNaN(endMs)).toBe(false)
+  })
+
+  test('a calendar date that does not exist resolves to undefined', () => {
+    // Date would otherwise roll February 30th over into March.
+    const { startMs, endMs } = resolveDateRangeMs('2026-02-30', '2026-02-30')
+
+    expect(startMs).toBeUndefined()
+    expect(endMs).toBeUndefined()
+  })
+
+  test('an out-of-range month resolves to undefined', () => {
+    const { startMs } = resolveDateRangeMs('2026-13-01', undefined)
+
+    expect(startMs).toBeUndefined()
+  })
+
+  test('parses as local time, not UTC (unlike bare `new Date(string)`)', () => {
+    const { startMs } = resolveDateRangeMs('2026-07-01', undefined)
+
+    // Constructing via `new Date(year, month, day)` (rather than passing the raw string through
+    // to `Date`) is what makes this local time rather than UTC; the two would only coincide by
+    // accident in a UTC-offset-zero test environment.
+    expect(startMs).toBe(new Date(2026, 6, 1, 0, 0, 0, 0).getTime())
+  })
+
+  test('endMs is the last millisecond of the day, not midnight of the next day', () => {
+    const { endMs } = resolveDateRangeMs(undefined, '2026-07-21')
+
+    expect(endMs).toBe(new Date(2026, 6, 21, 23, 59, 59, 999).getTime())
+  })
+})

--- a/client/games/day-header.tsx
+++ b/client/games/day-header.tsx
@@ -35,6 +35,56 @@ export function getDayBoundaries(): { todayStartMs: number; yesterdayStartMs: nu
   return { todayStartMs, yesterdayStartMs: startOfLocalDay(todayStartMs - 1) }
 }
 
+/**
+ * Parses a `yyyy-mm-dd` string as a local calendar date, returning `undefined` if it doesn't
+ * describe a real date. Deliberately avoids `new Date('yyyy-mm-dd')`, which parses that format as
+ * UTC midnight rather than local midnight.
+ */
+function parseLocalDate(value: string): Date | undefined {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value)
+  if (!match) {
+    return undefined
+  }
+
+  const year = Number(match[1])
+  const month = Number(match[2])
+  const day = Number(match[3])
+  const date = new Date(year, month - 1, day)
+  // `Date` silently rolls over out-of-range components (e.g. month 13, or day 30 in February)
+  // instead of failing, so confirm the parsed date reflects exactly the components given.
+  if (date.getFullYear() !== year || date.getMonth() !== month - 1 || date.getDate() !== day) {
+    return undefined
+  }
+
+  return date
+}
+
+/**
+ * Resolves `yyyy-mm-dd` date-range bounds (as produced by `<input type='date'>` or read from URL
+ * params) to inclusive unix-ms bounds in local time: `startMs` is local midnight of `startDate`,
+ * `endMs` is the last millisecond of `endDate` (the instant before the following local midnight).
+ * A missing, empty, or malformed bound resolves to `undefined` rather than `NaN`, so a
+ * user-edited URL can't produce an invalid filter.
+ */
+export function resolveDateRangeMs(
+  startDate?: string,
+  endDate?: string,
+): { startMs?: number; endMs?: number } {
+  const startLocalDate = startDate ? parseLocalDate(startDate) : undefined
+  const endLocalDate = endDate ? parseLocalDate(endDate) : undefined
+
+  const startMs = startLocalDate?.getTime()
+  const endMs = endLocalDate
+    ? new Date(
+        endLocalDate.getFullYear(),
+        endLocalDate.getMonth(),
+        endLocalDate.getDate() + 1,
+      ).getTime() - 1
+    : undefined
+
+  return { startMs, endMs }
+}
+
 /** Formats the label for a day header ("Today", "Yesterday", or a localized date). */
 export function formatDayHeaderLabel(
   dayStartMs: number,

--- a/client/games/game-context-menu.tsx
+++ b/client/games/game-context-menu.tsx
@@ -1,0 +1,68 @@
+import { useTranslation } from 'react-i18next'
+import { ReadonlyDeep } from 'type-fest'
+import { GameRecordJson } from '../../common/games/games'
+import { MaterialIcon } from '../icons/material/material-icon'
+import { Divider } from '../material/menu/divider'
+import { MenuItem } from '../material/menu/item'
+import { MenuList } from '../material/menu/menu'
+import { navigateToGameResults } from './action-creators'
+import { useGameReplayActions } from './use-game-replay-actions'
+
+/**
+ * The row context menu shared by the games list and match history pages: "View full results",
+ * plus (in the Electron app, when a replay is available) "Watch replay" and "Save replay".
+ *
+ * Split out from its callers so `useGameReplayActions` (which subscribes to this game's replay
+ * info) only runs while the menu is actually open, rather than for every row on every render.
+ */
+export function GameContextMenuContent({
+  game,
+  onDismiss,
+}: {
+  game: ReadonlyDeep<GameRecordJson>
+  onDismiss: () => void
+}) {
+  const { t } = useTranslation()
+  const { replayInfo, onWatchReplay, onSaveReplay } = useGameReplayActions(game)
+
+  // Built as a flat array (rather than a conditional fragment) so every item stays a direct
+  // child of `MenuList`: it only clones `dense`/focus state onto, and lets arrow-key navigation
+  // reach, its direct `MenuItem` children.
+  const items: React.ReactNode[] = [
+    <MenuItem
+      key='view-full-results'
+      icon={<MaterialIcon icon='open_in_new' />}
+      text={t('games.sidePanel.viewFullResults', 'View full results')}
+      onClick={() => {
+        onDismiss()
+        navigateToGameResults(game.id)
+      }}
+    />,
+  ]
+
+  if (IS_ELECTRON && replayInfo) {
+    items.push(
+      <Divider key='divider' $dense={true} />,
+      <MenuItem
+        key='watch-replay'
+        icon={<MaterialIcon icon='play_arrow' />}
+        text={t('gameDetails.buttonWatchReplay', 'Watch replay')}
+        onClick={() => {
+          onDismiss()
+          onWatchReplay()
+        }}
+      />,
+      <MenuItem
+        key='save-replay'
+        icon={<MaterialIcon icon='save' />}
+        text={t('gameDetails.buttonSaveReplay', 'Save replay')}
+        onClick={() => {
+          onDismiss()
+          onSaveReplay()
+        }}
+      />,
+    )
+  }
+
+  return <MenuList dense={true}>{items}</MenuList>
+}

--- a/client/games/game-filter-bar.tsx
+++ b/client/games/game-filter-bar.tsx
@@ -313,14 +313,6 @@ export function GameFilterBar({
         ))}
       </FilterChip>
 
-      <FilterChip
-        ref={anchorRef}
-        label={t('game.filters.advanced', 'Advanced')}
-        icon={<MaterialIcon icon='instant_mix' size={18} />}
-        selected={!!hasAdvancedFilters || opened}
-        onClick={e => (opened ? closePopover() : openPopover(e))}
-      />
-
       {setStartDate && (
         <FilterChip
           ref={dateAnchorRef}
@@ -330,6 +322,14 @@ export function GameFilterBar({
           onClick={e => (dateOpened ? closeDatePopover() : openDatePopover(e))}
         />
       )}
+
+      <FilterChip
+        ref={anchorRef}
+        label={t('game.filters.advanced', 'Advanced')}
+        icon={<MaterialIcon icon='instant_mix' size={18} />}
+        selected={!!hasAdvancedFilters || opened}
+        onClick={e => (opened ? closePopover() : openPopover(e))}
+      />
 
       {hasActiveFilters && (
         <TextButton

--- a/client/games/game-filter-bar.tsx
+++ b/client/games/game-filter-bar.tsx
@@ -179,8 +179,8 @@ export interface GameFilterBarProps {
   gameType?: SupportedReplayGameType | 'others'
   setGameType?: (v: SupportedReplayGameType | 'others' | undefined) => void
   /**
-   * When `setSpoilerFree` is provided, shows a spoiler-free toggle that hides game length; omit it
-   * on surfaces where game length isn't a spoiler (e.g. the Games page).
+   * When `setSpoilerFree` is provided, shows a spoiler-free toggle that hides the game length and,
+   * where shown, the match result.
    */
   spoilerFree?: boolean
   setSpoilerFree?: (v: boolean) => void

--- a/client/games/game-filter-bar.tsx
+++ b/client/games/game-filter-bar.tsx
@@ -1,3 +1,4 @@
+import { TFunction } from 'i18next'
 import { Variants } from 'motion/react'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -19,9 +20,11 @@ import {
   replayGameTypeToLabel,
   SupportedReplayGameType,
 } from '../../common/replays'
+import { monthDay } from '../i18n/date-formats'
 import { MaterialIcon } from '../icons/material/material-icon'
 import { useKeyListener } from '../keyboard/key-listener'
 import { TextButton } from '../material/button'
+import { DateTextField } from '../material/date-text-field'
 import { FilterChip } from '../material/filter-chip'
 import { SelectableMenuItem } from '../material/menu/selectable-item'
 import { Popover, usePopoverController, useRefAnchorPosition } from '../material/popover'
@@ -29,6 +32,7 @@ import { TextField } from '../material/text-field'
 import { ContainerLevel, containerStyles } from '../styles/colors'
 import { FlexSpacer } from '../styles/flex-spacer'
 import { labelLarge, labelMedium } from '../styles/typography'
+import { resolveDateRangeMs } from './day-header'
 import { MatchupFilter } from './matchup-filter'
 
 const FilterBarContainer = styled.div`
@@ -69,6 +73,88 @@ const SORT_OPTIONS = [
   GameSortOption.LongestFirst,
 ] as const
 
+/** Formats a `Date` as a local (not UTC) `yyyy-mm-dd` string, suitable for `<input type='date'>`. */
+function toLocalDateString(date: Date): string {
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
+
+/** A quick-range option offered in the Date filter's popover. */
+enum DatePreset {
+  PastWeek = 'pastWeek',
+  PastMonth = 'pastMonth',
+  Past3Months = 'past3Months',
+  PastYear = 'pastYear',
+}
+
+const DATE_PRESETS: ReadonlyArray<{
+  preset: DatePreset
+  fromDate: (today: Date) => Date
+}> = [
+  {
+    preset: DatePreset.PastWeek,
+    fromDate: today => new Date(today.getFullYear(), today.getMonth(), today.getDate() - 7),
+  },
+  {
+    preset: DatePreset.PastMonth,
+    fromDate: today => new Date(today.getFullYear(), today.getMonth() - 1, today.getDate()),
+  },
+  {
+    preset: DatePreset.Past3Months,
+    fromDate: today => new Date(today.getFullYear(), today.getMonth() - 3, today.getDate()),
+  },
+  {
+    preset: DatePreset.PastYear,
+    fromDate: today => new Date(today.getFullYear() - 1, today.getMonth(), today.getDate()),
+  },
+]
+
+function getDatePresetLabel(preset: DatePreset, t: TFunction): string {
+  switch (preset) {
+    case DatePreset.PastWeek:
+      return t('game.filters.datePastWeek', 'Past week')
+    case DatePreset.PastMonth:
+      return t('game.filters.datePastMonth', 'Past month')
+    case DatePreset.Past3Months:
+      return t('game.filters.datePast3Months', 'Past 3 months')
+    case DatePreset.PastYear:
+      return t('game.filters.datePastYear', 'Past year')
+    default:
+      return preset satisfies never
+  }
+}
+
+/**
+ * Formats the Date filter chip's label: the generic label when unset, or a compact rendering of
+ * the active bound(s) otherwise (an open start or end reads as "From X"/"Until X", a full range as
+ * "X – Y").
+ */
+function getDateFilterChipLabel(startDate: string, endDate: string, t: TFunction): string {
+  const { startMs, endMs } = resolveDateRangeMs(startDate, endDate)
+
+  if (startMs !== undefined && endMs !== undefined) {
+    return t('game.filters.dateRangeBetween', {
+      defaultValue: '{{start}} – {{end}}',
+      start: monthDay.format(startMs),
+      end: monthDay.format(endMs),
+    })
+  } else if (startMs !== undefined) {
+    return t('game.filters.dateRangeFrom', {
+      defaultValue: 'From {{date}}',
+      date: monthDay.format(startMs),
+    })
+  } else if (endMs !== undefined) {
+    return t('game.filters.dateRangeUntil', {
+      defaultValue: 'Until {{date}}',
+      date: monthDay.format(endMs),
+    })
+  }
+
+  return t('game.filters.date', 'Date')
+}
+
 export interface GameFilterBarProps {
   /** When false, hides Ranked and Custom filter chips (e.g. for Games page which only shows matchmaking). */
   showRankedCustom?: boolean
@@ -98,6 +184,14 @@ export interface GameFilterBarProps {
    */
   spoilerFree?: boolean
   setSpoilerFree?: (v: boolean) => void
+  /**
+   * The active date range bounds, as `yyyy-mm-dd` strings (empty = unset). The Date filter chip is
+   * only shown when `setStartDate` is provided.
+   */
+  startDate?: string
+  setStartDate?: (value: string) => void
+  endDate?: string
+  setEndDate?: (value: string) => void
   className?: string
 }
 
@@ -128,18 +222,31 @@ export function GameFilterBar({
   setGameType,
   spoilerFree = false,
   setSpoilerFree,
+  startDate = '',
+  setStartDate,
+  endDate = '',
+  setEndDate,
   className,
 }: GameFilterBarProps) {
   const { t } = useTranslation()
   const [anchorRef, anchorX, anchorY, refreshAnchorPos] = useRefAnchorPosition('left', 'bottom')
   const [opened, openPopover, closePopover] = usePopoverController({ refreshAnchorPos })
+  const [dateAnchorRef, dateAnchorX, dateAnchorY, refreshDateAnchorPos] = useRefAnchorPosition(
+    'left',
+    'bottom',
+  )
+  const [dateOpened, openDatePopover, closeDatePopover] = usePopoverController({
+    refreshAnchorPos: refreshDateAnchorPos,
+  })
 
   const hasAdvancedFilters = !!mapName || !!playerName || !!format || !!matchup
+  const hasDateRange = !!startDate || !!endDate
   const hasActiveFilters =
     (showRankedCustom && (ranked || custom)) ||
     duration !== GameDurationFilter.All ||
     hasAdvancedFilters ||
-    (showGameType && gameType !== undefined)
+    (showGameType && gameType !== undefined) ||
+    hasDateRange
 
   let gameTypeLabel = t('game.filters.mode', 'Mode')
   if (gameType === 'others') {
@@ -214,6 +321,16 @@ export function GameFilterBar({
         onClick={e => (opened ? closePopover() : openPopover(e))}
       />
 
+      {setStartDate && (
+        <FilterChip
+          ref={dateAnchorRef}
+          label={getDateFilterChipLabel(startDate, endDate, t)}
+          icon={<MaterialIcon icon='calendar_month' size={18} />}
+          selected={hasDateRange || dateOpened}
+          onClick={e => (dateOpened ? closeDatePopover() : openDatePopover(e))}
+        />
+      )}
+
       {hasActiveFilters && (
         <TextButton
           label={t('common.actions.clear', 'Clear')}
@@ -227,6 +344,8 @@ export function GameFilterBar({
             setFormat(undefined)
             setMatchup(undefined)
             setGameType?.(undefined)
+            setStartDate?.('')
+            setEndDate?.('')
           }}
         />
       )}
@@ -279,11 +398,36 @@ export function GameFilterBar({
           onClose={closePopover}
         />
       </Popover>
+
+      {setStartDate && (
+        <Popover
+          open={dateOpened}
+          onDismiss={closeDatePopover}
+          anchorX={dateAnchorX ?? 0}
+          anchorY={dateAnchorY ?? 0}
+          originX='left'
+          originY='top'
+          motionVariants={popoverVariants}
+          motionInitial='entering'
+          motionAnimate='visible'
+          motionExit='exiting'>
+          <DateFiltersPanel
+            startDate={startDate}
+            endDate={endDate}
+            onApply={dateValues => {
+              setStartDate(dateValues.startDate)
+              setEndDate?.(dateValues.endDate)
+              closeDatePopover()
+            }}
+          />
+        </Popover>
+      )}
     </FilterBarContainer>
   )
 }
 
-const AdvancedPanelContainer = styled.div`
+/** Shared popover panel shell for the filter bar's draft-state panels (Advanced, Date). */
+const FilterPanelContainer = styled.div`
   ${containerStyles(ContainerLevel.Low)};
 
   display: flex;
@@ -368,7 +512,7 @@ function AdvancedFiltersPanel({
   })
 
   return (
-    <AdvancedPanelContainer>
+    <FilterPanelContainer>
       <PanelContent>
         <PanelSection>
           <SectionLabel>{t('common.actions.search', 'Search')}</SectionLabel>
@@ -448,6 +592,96 @@ function AdvancedFiltersPanel({
           }
         />
       </PanelActions>
-    </AdvancedPanelContainer>
+    </FilterPanelContainer>
+  )
+}
+
+const PresetButtonsContainer = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+`
+
+interface DateFiltersPanelProps {
+  startDate: string
+  endDate: string
+  onApply: (values: { startDate: string; endDate: string }) => void
+}
+
+function DateFiltersPanel({ startDate, endDate, onApply }: DateFiltersPanelProps) {
+  const { t } = useTranslation()
+
+  const [draftStartDate, setDraftStartDate] = useState(startDate)
+  const [draftEndDate, setDraftEndDate] = useState(endDate)
+
+  useKeyListener({
+    onKeyDown: (event: KeyboardEvent) => {
+      if (event.code === 'Enter' || event.code === 'NumpadEnter') {
+        onApply({ startDate: draftStartDate, endDate: draftEndDate })
+        return true
+      }
+
+      return false
+    },
+  })
+
+  const today = new Date()
+
+  return (
+    <FilterPanelContainer>
+      <PanelContent>
+        <PanelSection>
+          <SectionLabel>{t('game.filters.datePresets', 'Quick ranges')}</SectionLabel>
+          <PresetButtonsContainer>
+            {DATE_PRESETS.map(({ preset, fromDate }) => {
+              const presetStartDate = toLocalDateString(fromDate(today))
+              const presetEndDate = toLocalDateString(today)
+              return (
+                <FilterChip
+                  key={preset}
+                  label={getDatePresetLabel(preset, t)}
+                  selected={draftStartDate === presetStartDate && draftEndDate === presetEndDate}
+                  onClick={() => {
+                    setDraftStartDate(presetStartDate)
+                    setDraftEndDate(presetEndDate)
+                  }}
+                />
+              )
+            })}
+          </PresetButtonsContainer>
+        </PanelSection>
+
+        <PanelSection>
+          <DateTextField
+            label={t('game.filters.dateFrom', 'From')}
+            value={draftStartDate}
+            onChange={e => setDraftStartDate(e.target.value)}
+            dense={true}
+            allowErrors={false}
+          />
+          <DateTextField
+            label={t('game.filters.dateTo', 'To')}
+            value={draftEndDate}
+            onChange={e => setDraftEndDate(e.target.value)}
+            dense={true}
+            allowErrors={false}
+          />
+        </PanelSection>
+      </PanelContent>
+
+      <PanelActions>
+        <TextButton
+          label={t('common.actions.reset', 'Reset')}
+          onClick={() => {
+            setDraftStartDate('')
+            setDraftEndDate('')
+          }}
+        />
+        <TextButton
+          label={t('common.actions.apply', 'Apply')}
+          onClick={() => onApply({ startDate: draftStartDate, endDate: draftEndDate })}
+        />
+      </PanelActions>
+    </FilterPanelContainer>
   )
 }

--- a/client/games/game-list-entry.tsx
+++ b/client/games/game-list-entry.tsx
@@ -5,68 +5,35 @@ import { ReadonlyDeep } from 'type-fest'
 import { GameRecordJson, getGameDurationString, getGameTypeLabel } from '../../common/games/games'
 import { getResultLabel, ReconciledResult } from '../../common/games/results'
 import { SbUserId } from '../../common/users/sb-user-id'
-import { longTimestamp, narrowDuration } from '../i18n/date-formats'
-import { MaterialIcon } from '../icons/material/material-icon'
-import { ReduxMapThumbnail } from '../maps/map-thumbnail'
-import { ButtonStateStyleProps, IconButton, useButtonState } from '../material/button'
-import { LinkButton } from '../material/link-button'
+import { ButtonStateStyleProps, useButtonState } from '../material/button'
 import { Ripple } from '../material/ripple'
-import { elevationPlus1 } from '../material/shadows'
-import { Tooltip } from '../material/tooltip'
 import { useAppSelector } from '../redux-hooks'
-import { styledWithAttrs } from '../styles/styled-with-attrs'
-import {
-  bodyMedium,
-  headlineMedium,
-  labelMedium,
-  singleLine,
-  titleSmall,
-} from '../styles/typography'
-import { getGameResultsUrl } from './action-creators'
+import { bodyMedium, singleLine, titleMedium, titleSmall } from '../styles/typography'
 import { GamePlayersDisplay } from './game-players-display'
-import { useGameReplayActions } from './use-game-replay-actions'
 
-const GameListEntryRoot = styled.div<{
-  $fillPlayers?: boolean
-  $dense?: boolean
-  $hasThumbnail?: boolean
-}>`
+const GameListEntryRoot = styled.div<{ $hasLeadingAction?: boolean }>`
   width: 100%;
   /*
-    The floor keeps a single-team (e.g. 1v1) row from collapsing to nothing; taller multi-team rows
-    exceed it and drive their own height, so team matchups still read as taller. The dense floor
-    suits rows without a thumbnail (the replay library), where the default 80px — sized around the
-    64px thumbnail — would leave a 1v1 mostly empty.
+    Keeps a single-team (e.g. 1v1) row from collapsing to nothing; taller multi-team rows exceed it
+    and drive their own height, so team matchups still read as taller.
   */
-  min-height: ${props => (props.$dense ? '52px' : '80px')};
-  padding-top: 8px;
-  padding-bottom: 8px;
-  padding-left: 6px;
+  min-height: 52px;
+  padding: 8px 16px;
   /*
-    A trailing thumbnail (games list) already holds the map name / game type well clear of the right
-    edge. Without one (the replay library) that text would sit almost flush against the edge, so
-    those rows take a bit more trailing room to breathe.
+    The leading action cell (e.g. a bookmark toggle) already provides breathing room, so the row's
+    own left padding shrinks to keep the icon optically aligned with content above/below.
   */
-  padding-right: ${props => (props.$hasThumbnail ? '6px' : '16px')};
+  padding-left: ${props => (props.$hasLeadingAction ? '6px' : '16px')};
 
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 16px;
-
-  /*
-    Controls how a row wider than its content distributes the slack. By default every cell shares it
-    evenly (fine for a narrow, capped list). Under the fill-players mode, only the players cell grows
-    so the duration + map stay compact and read as a stats cluster pinned to the right — used by the
-    full-width replay library, where spreading every cell would leave the duration floating in an
-    empty middle.
-  */
-  --_side-cell-grow: ${props => (props.$fillPlayers ? 0 : 1)};
 `
 
 const BaseCell = styled.div`
   height: 100%;
-  flex-grow: var(--_side-cell-grow, 1);
+  flex-grow: 0;
   flex-shrink: 1;
   flex-basis: auto;
 `
@@ -86,7 +53,7 @@ const BookmarkCell = styled.div`
 `
 
 const LeadingCell = styled(BaseCell)`
-  width: 128px;
+  width: 96px;
 
   display: flex;
   flex-direction: column;
@@ -95,13 +62,28 @@ const LeadingCell = styled(BaseCell)`
 
 const PlayersCell = styled(BaseCell)`
   width: 328px;
-  /* Always grows, so under the fill-players mode it's the cell that absorbs a row's extra width. */
   flex-grow: 1;
+
+  & > * {
+    /*
+     * Caps the team columns' spread: in a wide row the players cell absorbs all the slack, and
+     * without a cap the evenly-split team columns would push the second team toward the middle
+     * of the row, far from the first. The cap keeps opposing teams reading as one matchup and
+     * gives the second column a stable position to scan down the list.
+     */
+    max-width: 480px;
+  }
 `
 
 const GameLengthCell = styled(BaseCell)`
-  ${headlineMedium};
-  width: 128px;
+  ${titleMedium};
+  font-variant-numeric: tabular-nums;
+  width: 96px;
+  /*
+    The duration is the one cell that must never truncate — narrow rows collapse the map cell and
+    squeeze player names instead.
+  */
+  flex-shrink: 0;
 
   display: flex;
   justify-content: flex-end;
@@ -109,8 +91,7 @@ const GameLengthCell = styled(BaseCell)`
 
 const MapAndGameTypeCell = styled(BaseCell)`
   width: 196px;
-  position: relative;
-  z-index: 1;
+  min-width: 0;
 
   display: flex;
   align-items: center;
@@ -119,7 +100,7 @@ const MapAndGameTypeCell = styled(BaseCell)`
 `
 
 const GameListEntryResult = styled.div<{ $result: ReconciledResult }>`
-  ${headlineMedium};
+  ${titleMedium};
   color: ${props => {
     switch (props.$result) {
       case 'win':
@@ -131,13 +112,6 @@ const GameListEntryResult = styled.div<{ $result: ReconciledResult }>`
     }
   }};
   flex-shrink: 0;
-`
-
-/** The muted, single-line text style used for the date/time in the leading cell of a game row. */
-export const GameDate = styled.div`
-  ${labelMedium};
-  ${singleLine};
-  color: var(--theme-on-surface-variant);
 `
 
 const MapNameAndGameTypeContainer = styled.div`
@@ -166,62 +140,6 @@ const GameType = styled.div`
   text-align: right;
 `
 
-/** Positioned wrapper for a 64×64 thumbnail (or placeholder) plus its hover overlay. */
-export const ThumbnailContainer = styled.div`
-  position: relative;
-  flex-shrink: 0;
-`
-
-const StyledMapThumbnail = styled(ReduxMapThumbnail)`
-  ${elevationPlus1};
-  width: 64px;
-  height: 64px;
-  flex-shrink: 0;
-`
-
-/** A 64×64 tile used when no real map thumbnail is available; holds a centered placeholder icon. */
-export const MapNoImageContainer = styled.div`
-  ${elevationPlus1};
-  width: 64px;
-  height: 64px;
-  flex-shrink: 0;
-
-  display: flex;
-  justify-content: center;
-  align-items: center;
-
-  border-radius: 4px;
-  background-color: var(--theme-container);
-`
-
-const MapNoImageIcon = styledWithAttrs(MaterialIcon, { icon: 'question_mark', size: 36 })`
-  opacity: 0.5;
-`
-
-/**
- * A hover-reveal overlay over a game/replay thumbnail that surfaces a "watch replay" control. Keys
- * off `GameListEntryRoot`, so any row that renders the layout gets the hover behavior for free.
- */
-export const WatchReplayOverlay = styled.div`
-  position: absolute;
-  inset: 0;
-  z-index: 1;
-  border-radius: 4px;
-  background-color: rgba(0, 0, 0, 0.5);
-
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 4px;
-
-  opacity: 0;
-  transition: opacity 0.2s ease;
-
-  ${GameListEntryRoot}:hover & {
-    opacity: 1;
-  }
-`
-
 export interface GameListEntryLayoutProps {
   /**
    * Content of a narrow, dedicated leading action column (e.g. a replay's star / bookmark toggle).
@@ -229,8 +147,8 @@ export interface GameListEntryLayoutProps {
    */
   bookmark?: React.ReactNode
   /**
-   * Content of the leading cell (e.g. the result + date, or a date/time on its own). When omitted,
-   * the cell isn't rendered.
+   * Content of the leading cell (e.g. a match result label). When omitted, the cell isn't
+   * rendered.
    */
   leading?: React.ReactNode
   /** Content of the players cell (a players/teams display). */
@@ -241,22 +159,6 @@ export interface GameListEntryLayoutProps {
   mapName: string
   /** Game type / mode label. */
   gameTypeLabel: string
-  /**
-   * Thumbnail cell content (a `ThumbnailContainer` with a thumbnail or placeholder + overlay). When
-   * omitted, no thumbnail is rendered and the map name / game type take the full cell.
-   */
-  thumbnail?: React.ReactNode
-  /**
-   * When set, a row wider than its content lets only the players cell grow (keeping duration + map
-   * as a compact right-side cluster) instead of spreading the slack across every cell. Suited to
-   * full-width lists.
-   */
-  fillPlayers?: boolean
-  /**
-   * When set, uses a shorter min-height so short (single-team) rows are compact while taller
-   * multi-team rows still drive their own height. Suited to thumbnail-less rows (e.g. replays).
-   */
-  dense?: boolean
   className?: string
   /** Extra content rendered inside the row root after the cells (e.g. a `Ripple`). */
   children?: React.ReactNode
@@ -264,9 +166,8 @@ export interface GameListEntryLayoutProps {
 
 /**
  * The purely presentational layout for a game/replay list row: the row root plus its cells (an
- * optional bookmark column and leading cell, then players, duration, map + game type, and an
- * optional thumbnail). Carries no data dependencies so it can back both real games (see
- * `GameListEntry`) and local replay files.
+ * optional bookmark column and leading cell, then players, duration, and map + game type). Carries
+ * no data dependencies so it can back both real games (see `GameListEntry`) and local replay files.
  */
 export function GameListEntryLayout({
   bookmark,
@@ -275,18 +176,11 @@ export function GameListEntryLayout({
   duration,
   mapName,
   gameTypeLabel,
-  thumbnail,
-  fillPlayers,
-  dense,
   className,
   children,
 }: GameListEntryLayoutProps) {
   return (
-    <GameListEntryRoot
-      className={className}
-      $fillPlayers={fillPlayers}
-      $dense={dense}
-      $hasThumbnail={thumbnail !== undefined}>
+    <GameListEntryRoot className={className} $hasLeadingAction={bookmark !== undefined}>
       {bookmark !== undefined ? <BookmarkCell>{bookmark}</BookmarkCell> : null}
 
       {leading !== undefined ? <LeadingCell>{leading}</LeadingCell> : null}
@@ -300,8 +194,6 @@ export function GameListEntryLayout({
           <MapName title={mapName}>{mapName}</MapName>
           <GameType>{gameTypeLabel}</GameType>
         </MapNameAndGameTypeContainer>
-
-        {thumbnail}
       </MapAndGameTypeCell>
 
       {children}
@@ -336,13 +228,8 @@ export interface GameListEntryProps {
   game: ReadonlyDeep<GameRecordJson>
   showResult?: boolean
   forUserId?: SbUserId
-  /** Shows the row in its selected state. Only meaningful when `onClick` is provided. */
+  /** Shows the row in its selected state. */
   selected?: boolean
-  /**
-   * When provided, the row is rendered as a selectable row (see `SelectableRowContainer`) that
-   * calls this instead of navigating to the game's results page. Use `onDoubleClick` for
-   * navigation in that case.
-   */
   onClick?: (gameId: string) => void
   onDoubleClick?: (gameId: string) => void
   onContextMenu?: (gameId: string, event: React.MouseEvent) => void
@@ -361,14 +248,13 @@ export function GameListEntry({
 }: GameListEntryProps) {
   const { t } = useTranslation()
   const map = useAppSelector(s => s.maps.byId.get(game.mapId))
-  const { replayInfo, onWatchReplay, onSaveReplay } = useGameReplayActions(game)
 
   const [buttonProps, rippleRef] = useButtonState({
     onClick: onClick ? () => onClick(game.id) : undefined,
     onDoubleClick: onDoubleClick ? () => onDoubleClick(game.id) : undefined,
   })
 
-  const { results, startTime } = game
+  const { results } = game
 
   // NOTE(2Pac): No need to memoize this under react-compiler; it re-derives only when its inputs
   // change.
@@ -385,98 +271,27 @@ export function GameListEntry({
   const gameType = getGameTypeLabel(game, t)
   const mapName = map?.name ?? t('game.mapName.unknown', 'Unknown map')
 
-  const handleWatchReplay = (e: React.MouseEvent) => {
-    e.stopPropagation()
-    // This is needed to prevent the link from being followed / the row from being selected.
-    e.preventDefault()
-    onWatchReplay()
-  }
-
-  const handleSaveReplay = (e: React.MouseEvent) => {
-    e.stopPropagation()
-    // This is needed to prevent the link from being followed / the row from being selected.
-    e.preventDefault()
-    onSaveReplay()
-  }
-
-  const dateCell = (
-    <Tooltip text={longTimestamp.format(startTime)} position='right'>
-      <GameDate>{narrowDuration.format(startTime)}</GameDate>
-    </Tooltip>
-  )
-
   const layoutProps: GameListEntryLayoutProps = {
     leading:
       showResult && forUserId ? (
-        <>
-          <GameListEntryResult $result={result}>
-            {getResultLabel(result, t, true)}
-          </GameListEntryResult>
-          {dateCell}
-        </>
-      ) : (
-        dateCell
-      ),
+        <GameListEntryResult $result={result}>
+          {getResultLabel(result, t, true)}
+        </GameListEntryResult>
+      ) : undefined,
     players: <GamePlayersDisplay game={game} forUserId={forUserId} showTeamLabels={false} />,
     duration: game.gameLength ? getGameDurationString(game.gameLength) : '—',
     mapName,
     gameTypeLabel: gameType,
-    thumbnail: (
-      <ThumbnailContainer>
-        {map ? (
-          <StyledMapThumbnail
-            key={map.hash}
-            mapId={map.id}
-            size={64}
-            forceAspectRatio={1}
-            hasMapPreviewAction={false}
-            hasFavoriteAction={false}
-          />
-        ) : (
-          <MapNoImageContainer>
-            <MapNoImageIcon />
-          </MapNoImageContainer>
-        )}
-        {IS_ELECTRON && replayInfo && (
-          <WatchReplayOverlay>
-            <Tooltip text={t('gameDetails.buttonWatchReplay', 'Watch replay')} position='top'>
-              <IconButton
-                styledAs='div'
-                icon={<MaterialIcon icon='play_circle' />}
-                onClick={handleWatchReplay}
-              />
-            </Tooltip>
-            <Tooltip text={t('gameDetails.buttonSaveReplay', 'Save replay')} position='top'>
-              <IconButton
-                styledAs='div'
-                icon={<MaterialIcon icon='save' />}
-                onClick={handleSaveReplay}
-              />
-            </Tooltip>
-          </WatchReplayOverlay>
-        )}
-      </ThumbnailContainer>
-    ),
-  }
-
-  if (onClick) {
-    return (
-      <SelectableRowContainer
-        {...buttonProps}
-        $selected={selected}
-        ref={ref}
-        onContextMenu={onContextMenu ? e => onContextMenu(game.id, e) : undefined}>
-        <GameListEntryLayout {...layoutProps} />
-        <Ripple ref={rippleRef} />
-      </SelectableRowContainer>
-    )
   }
 
   return (
-    <LinkButton {...buttonProps} href={getGameResultsUrl(game.id)}>
-      <GameListEntryLayout {...layoutProps}>
-        <Ripple ref={rippleRef} />
-      </GameListEntryLayout>
-    </LinkButton>
+    <SelectableRowContainer
+      {...buttonProps}
+      $selected={selected}
+      ref={ref}
+      onContextMenu={onContextMenu ? e => onContextMenu(game.id, e) : undefined}>
+      <GameListEntryLayout {...layoutProps} />
+      <Ripple ref={rippleRef} />
+    </SelectableRowContainer>
   )
 }

--- a/client/games/game-list-entry.tsx
+++ b/client/games/game-list-entry.tsx
@@ -2,23 +2,18 @@ import * as React from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 import { ReadonlyDeep } from 'type-fest'
-import { getErrorStack } from '../../common/errors'
 import { GameRecordJson, getGameDurationString, getGameTypeLabel } from '../../common/games/games'
 import { getResultLabel, ReconciledResult } from '../../common/games/results'
 import { SbUserId } from '../../common/users/sb-user-id'
-import { openSimpleDialog } from '../dialogs/action-creators'
 import { longTimestamp, narrowDuration } from '../i18n/date-formats'
 import { MaterialIcon } from '../icons/material/material-icon'
-import logger from '../logging/logger'
 import { ReduxMapThumbnail } from '../maps/map-thumbnail'
-import { IconButton, useButtonState } from '../material/button'
+import { ButtonStateStyleProps, IconButton, useButtonState } from '../material/button'
 import { LinkButton } from '../material/link-button'
 import { Ripple } from '../material/ripple'
 import { elevationPlus1 } from '../material/shadows'
 import { Tooltip } from '../material/tooltip'
-import { useAppDispatch, useAppSelector } from '../redux-hooks'
-import { saveReplayToLibrary, watchReplayFromUrl } from '../replays/action-creators'
-import { useSnackbarController } from '../snackbars/snackbar-overlay'
+import { useAppSelector } from '../redux-hooks'
 import { styledWithAttrs } from '../styles/styled-with-attrs'
 import {
   bodyMedium,
@@ -29,6 +24,7 @@ import {
 } from '../styles/typography'
 import { getGameResultsUrl } from './action-creators'
 import { GamePlayersDisplay } from './game-players-display'
+import { useGameReplayActions } from './use-game-replay-actions'
 
 const GameListEntryRoot = styled.div<{
   $fillPlayers?: boolean
@@ -313,20 +309,64 @@ export function GameListEntryLayout({
   )
 }
 
+/**
+ * A selectable row container matching the replay library's row, for pages that let a game row be
+ * clicked to show its details in a side panel rather than navigating straight to its results page.
+ */
+export const SelectableRowContainer = styled.div<ButtonStateStyleProps & { $selected: boolean }>`
+  position: relative;
+  width: 100%;
+
+  border-radius: 8px;
+  contain: content;
+  cursor: pointer;
+
+  background-color: ${props =>
+    props.$selected ? 'rgb(from var(--theme-on-surface) r g b / 0.1)' : 'transparent'};
+
+  &:hover {
+    background-color: ${props =>
+      props.$selected
+        ? 'rgb(from var(--theme-on-surface) r g b / 0.12)'
+        : 'rgb(from var(--theme-on-surface) r g b / 0.06)'};
+  }
+`
+
 export interface GameListEntryProps {
   game: ReadonlyDeep<GameRecordJson>
   showResult?: boolean
   forUserId?: SbUserId
+  /** Shows the row in its selected state. Only meaningful when `onClick` is provided. */
+  selected?: boolean
+  /**
+   * When provided, the row is rendered as a selectable row (see `SelectableRowContainer`) that
+   * calls this instead of navigating to the game's results page. Use `onDoubleClick` for
+   * navigation in that case.
+   */
+  onClick?: (gameId: string) => void
+  onDoubleClick?: (gameId: string) => void
+  onContextMenu?: (gameId: string, event: React.MouseEvent) => void
+  ref?: React.Ref<HTMLDivElement>
 }
 
-export function GameListEntry({ game, showResult = false, forUserId }: GameListEntryProps) {
+export function GameListEntry({
+  game,
+  showResult = false,
+  forUserId,
+  selected = false,
+  onClick,
+  onDoubleClick,
+  onContextMenu,
+  ref,
+}: GameListEntryProps) {
   const { t } = useTranslation()
-  const dispatch = useAppDispatch()
-  const snackbarController = useSnackbarController()
   const map = useAppSelector(s => s.maps.byId.get(game.mapId))
-  const replayInfo = useAppSelector(s => s.games.replayInfoById.get(game.id))
+  const { replayInfo, onWatchReplay, onSaveReplay } = useGameReplayActions(game)
 
-  const [buttonProps, rippleRef] = useButtonState({})
+  const [buttonProps, rippleRef] = useButtonState({
+    onClick: onClick ? () => onClick(game.id) : undefined,
+    onDoubleClick: onDoubleClick ? () => onDoubleClick(game.id) : undefined,
+  })
 
   const { results, startTime } = game
 
@@ -345,60 +385,18 @@ export function GameListEntry({ game, showResult = false, forUserId }: GameListE
   const gameType = getGameTypeLabel(game, t)
   const mapName = map?.name ?? t('game.mapName.unknown', 'Unknown map')
 
-  const onWatchReplay = (e: React.MouseEvent) => {
+  const handleWatchReplay = (e: React.MouseEvent) => {
     e.stopPropagation()
-    // This is needed to prevent the link from being followed
+    // This is needed to prevent the link from being followed / the row from being selected.
     e.preventDefault()
-
-    if (!replayInfo) return
-
-    dispatch(
-      watchReplayFromUrl(replayInfo, game.id, {
-        onSuccess: () => {},
-        onError: err => {
-          logger.error(`Error watching replay: ${getErrorStack(err)}`)
-          dispatch(
-            openSimpleDialog(
-              t('replays.watch.errorTitle', 'Error loading replay'),
-              err?.message ??
-                t(
-                  'replays.watch.errorBody',
-                  'There was a problem downloading or loading the replay. Please try again later.',
-                ),
-            ),
-          )
-        },
-      }),
-    )
+    onWatchReplay()
   }
 
-  const onSaveReplay = (e: React.MouseEvent) => {
+  const handleSaveReplay = (e: React.MouseEvent) => {
     e.stopPropagation()
-    // This is needed to prevent the link from being followed
+    // This is needed to prevent the link from being followed / the row from being selected.
     e.preventDefault()
-
-    if (!replayInfo) return
-
-    dispatch(
-      saveReplayToLibrary(replayInfo, {
-        onSuccess: result => {
-          snackbarController.showSnackbar(
-            result.alreadySaved
-              ? t(
-                  'gameDetails.saveReplayAlreadySaved',
-                  "This game's replay is already in your library",
-                )
-              : t('gameDetails.saveReplaySuccess', 'Replay saved to your library'),
-          )
-        },
-        onError: err => {
-          logger.error(`Error saving replay: ${getErrorStack(err)}`)
-          snackbarController.showSnackbar(
-            t('gameDetails.saveReplayError', 'There was a problem saving the replay'),
-          )
-        },
-      }),
-    )
+    onSaveReplay()
   }
 
   const dateCell = (
@@ -407,61 +405,76 @@ export function GameListEntry({ game, showResult = false, forUserId }: GameListE
     </Tooltip>
   )
 
+  const layoutProps: GameListEntryLayoutProps = {
+    leading:
+      showResult && forUserId ? (
+        <>
+          <GameListEntryResult $result={result}>
+            {getResultLabel(result, t, true)}
+          </GameListEntryResult>
+          {dateCell}
+        </>
+      ) : (
+        dateCell
+      ),
+    players: <GamePlayersDisplay game={game} forUserId={forUserId} showTeamLabels={false} />,
+    duration: game.gameLength ? getGameDurationString(game.gameLength) : '—',
+    mapName,
+    gameTypeLabel: gameType,
+    thumbnail: (
+      <ThumbnailContainer>
+        {map ? (
+          <StyledMapThumbnail
+            key={map.hash}
+            mapId={map.id}
+            size={64}
+            forceAspectRatio={1}
+            hasMapPreviewAction={false}
+            hasFavoriteAction={false}
+          />
+        ) : (
+          <MapNoImageContainer>
+            <MapNoImageIcon />
+          </MapNoImageContainer>
+        )}
+        {IS_ELECTRON && replayInfo && (
+          <WatchReplayOverlay>
+            <Tooltip text={t('gameDetails.buttonWatchReplay', 'Watch replay')} position='top'>
+              <IconButton
+                styledAs='div'
+                icon={<MaterialIcon icon='play_circle' />}
+                onClick={handleWatchReplay}
+              />
+            </Tooltip>
+            <Tooltip text={t('gameDetails.buttonSaveReplay', 'Save replay')} position='top'>
+              <IconButton
+                styledAs='div'
+                icon={<MaterialIcon icon='save' />}
+                onClick={handleSaveReplay}
+              />
+            </Tooltip>
+          </WatchReplayOverlay>
+        )}
+      </ThumbnailContainer>
+    ),
+  }
+
+  if (onClick) {
+    return (
+      <SelectableRowContainer
+        {...buttonProps}
+        $selected={selected}
+        ref={ref}
+        onContextMenu={onContextMenu ? e => onContextMenu(game.id, e) : undefined}>
+        <GameListEntryLayout {...layoutProps} />
+        <Ripple ref={rippleRef} />
+      </SelectableRowContainer>
+    )
+  }
+
   return (
     <LinkButton {...buttonProps} href={getGameResultsUrl(game.id)}>
-      <GameListEntryLayout
-        leading={
-          showResult && forUserId ? (
-            <>
-              <GameListEntryResult $result={result}>
-                {getResultLabel(result, t, true)}
-              </GameListEntryResult>
-              {dateCell}
-            </>
-          ) : (
-            dateCell
-          )
-        }
-        players={<GamePlayersDisplay game={game} forUserId={forUserId} showTeamLabels={false} />}
-        duration={game.gameLength ? getGameDurationString(game.gameLength) : '—'}
-        mapName={mapName}
-        gameTypeLabel={gameType}
-        thumbnail={
-          <ThumbnailContainer>
-            {map ? (
-              <StyledMapThumbnail
-                key={map.hash}
-                mapId={map.id}
-                size={64}
-                forceAspectRatio={1}
-                hasMapPreviewAction={false}
-                hasFavoriteAction={false}
-              />
-            ) : (
-              <MapNoImageContainer>
-                <MapNoImageIcon />
-              </MapNoImageContainer>
-            )}
-            {IS_ELECTRON && replayInfo && (
-              <WatchReplayOverlay>
-                <Tooltip text={t('gameDetails.buttonWatchReplay', 'Watch replay')} position='top'>
-                  <IconButton
-                    styledAs='div'
-                    icon={<MaterialIcon icon='play_circle' />}
-                    onClick={onWatchReplay}
-                  />
-                </Tooltip>
-                <Tooltip text={t('gameDetails.buttonSaveReplay', 'Save replay')} position='top'>
-                  <IconButton
-                    styledAs='div'
-                    icon={<MaterialIcon icon='save' />}
-                    onClick={onSaveReplay}
-                  />
-                </Tooltip>
-              </WatchReplayOverlay>
-            )}
-          </ThumbnailContainer>
-        }>
+      <GameListEntryLayout {...layoutProps}>
         <Ripple ref={rippleRef} />
       </GameListEntryLayout>
     </LinkButton>

--- a/client/games/game-list-entry.tsx
+++ b/client/games/game-list-entry.tsx
@@ -228,6 +228,11 @@ export interface GameListEntryProps {
   game: ReadonlyDeep<GameRecordJson>
   showResult?: boolean
   forUserId?: SbUserId
+  /**
+   * Hides the game length and, when results are shown, the match result — both spoilers for
+   * someone rewatching their games.
+   */
+  spoilerFree?: boolean
   /** Shows the row in its selected state. */
   selected?: boolean
   onClick?: (gameId: string) => void
@@ -240,6 +245,7 @@ export function GameListEntry({
   game,
   showResult = false,
   forUserId,
+  spoilerFree = false,
   selected = false,
   onClick,
   onDoubleClick,
@@ -274,12 +280,12 @@ export function GameListEntry({
   const layoutProps: GameListEntryLayoutProps = {
     leading:
       showResult && forUserId ? (
-        <GameListEntryResult $result={result}>
-          {getResultLabel(result, t, true)}
+        <GameListEntryResult $result={spoilerFree ? 'unknown' : result}>
+          {spoilerFree ? '—' : getResultLabel(result, t, true)}
         </GameListEntryResult>
       ) : undefined,
     players: <GamePlayersDisplay game={game} forUserId={forUserId} showTeamLabels={false} />,
-    duration: game.gameLength ? getGameDurationString(game.gameLength) : '—',
+    duration: spoilerFree || !game.gameLength ? '—' : getGameDurationString(game.gameLength),
     mapName,
     gameTypeLabel: gameType,
   }

--- a/client/games/game-list.tsx
+++ b/client/games/game-list.tsx
@@ -17,6 +17,7 @@ import InfiniteScrollList from '../lists/infinite-scroll-list'
 import { Popover } from '../material/popover'
 import { elevationPlus1 } from '../material/shadows'
 import { useLocationSearchParam } from '../navigation/router-hooks'
+import { useUserLocalStorageValue } from '../react/state-hooks'
 import { useAppDispatch } from '../redux-hooks'
 import { CenteredContentContainer } from '../styles/centered-container'
 import { ContainerLevel, containerStyles } from '../styles/colors'
@@ -149,6 +150,10 @@ export function GameList() {
 
   const [selectedId, setSelectedId] = useState<string>()
   const rowElemsRef = useRef(new Map<string, HTMLDivElement>())
+
+  // Remembered per-user, shared with the replay library and match history pages: hides the game
+  // length (a spoiler) from the list rows.
+  const [spoilerFree, setSpoilerFree] = useUserLocalStorageValue('gamesSpoilerFree', false)
 
   const { onContextMenu, contextMenuPopoverProps } = useContextMenu()
 
@@ -294,6 +299,8 @@ export function GameList() {
         setMatchupParam(v ?? '')
         reset()
       }}
+      spoilerFree={spoilerFree}
+      setSpoilerFree={setSpoilerFree}
       startDate={startDateParam}
       setStartDate={v => {
         setStartDateParam(v)
@@ -328,6 +335,7 @@ export function GameList() {
         key={game.id}
         game={game}
         showResult={false}
+        spoilerFree={spoilerFree}
         selected={game.id === selectedGame?.id}
         onClick={setSelectedId}
         onDoubleClick={gameId => navigateToGameResults(gameId)}

--- a/client/games/game-list.tsx
+++ b/client/games/game-list.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useRef, useState } from 'react'
+import { useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
+import { ReadonlyDeep } from 'type-fest'
 import { useQuery } from 'urql'
 import {
   ALL_GAME_FORMATS,
@@ -10,47 +11,29 @@ import {
   GameSortOption,
   makeEncodedMatchupString,
 } from '../../common/games/game-filters'
+import { GameRecordJson } from '../../common/games/games'
+import { useContextMenu } from '../dom/use-context-menu'
 import { FragmentType, graphql, useFragment } from '../gql'
+import { useKeyListener } from '../keyboard/key-listener'
 import InfiniteScrollList from '../lists/infinite-scroll-list'
+import { Divider } from '../material/menu/divider'
+import { MenuItem } from '../material/menu/item'
+import { MenuList } from '../material/menu/menu'
+import { Popover } from '../material/popover'
 import { elevationPlus1 } from '../material/shadows'
 import { useLocationSearchParam } from '../navigation/router-hooks'
-import { useRefreshToken } from '../network/refresh-token'
-import { useAppDispatch, useAppSelector } from '../redux-hooks'
+import { useAppDispatch } from '../redux-hooks'
+import { CenteredContentContainer } from '../styles/centered-container'
 import { ContainerLevel, containerStyles } from '../styles/colors'
 import { bodyLarge, singleLine, titleLarge } from '../styles/typography'
-import { getGames } from './action-creators'
-import { renderGamesWithDayHeaders } from './day-header'
+import { getGames, navigateToGameResults } from './action-creators'
+import { renderGamesWithDayHeaders, resolveDateRangeMs } from './day-header'
 import { GameFilterBar } from './game-filter-bar'
 import { GameListEntry } from './game-list-entry'
+import { GameRecordSidePanel } from './game-record-side-panel'
 import { LiveGameEntry, LiveGames_FeedFragment } from './live-game-entry'
-
-const NoResults = styled.div`
-  ${bodyLarge};
-
-  color: var(--theme-on-surface-variant);
-`
-
-const ErrorText = styled.div`
-  ${bodyLarge};
-
-  color: var(--theme-error);
-`
-
-const GamesListContainer = styled.div`
-  width: 100%;
-  padding-top: 24px;
-
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
-`
-
-const SearchResults = styled.div`
-  width: 100%;
-
-  display: flex;
-  flex-direction: column;
-`
+import { GameListSearchPage, useGameListSearch } from './use-game-list-search'
+import { useGameReplayActions } from './use-game-replay-actions'
 
 function parseDuration(value: string): GameDurationFilter {
   return Object.values(GameDurationFilter).includes(value as GameDurationFilter)
@@ -72,11 +55,132 @@ function parseMatchup(value: string): EncodedMatchupString | undefined {
   return value ? makeEncodedMatchupString(value) : undefined
 }
 
+/** A date-based sort groups games by calendar day; the duration sorts render as a flat list. */
+function isDateSort(sort: GameSortOption): boolean {
+  return sort === GameSortOption.LatestFirst || sort === GameSortOption.OldestFirst
+}
+
+// ---- Layout ----------------------------------------------------------------------------------
+
+const PageColumn = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-height: 100%;
+  padding: 24px 0;
+`
+
+const BodyRow = styled.div`
+  display: flex;
+  flex-direction: row;
+  gap: 24px;
+`
+
+const ListColumn = styled.div`
+  flex-grow: 1;
+  min-width: 0;
+`
+
+const NoResults = styled.div`
+  ${bodyLarge};
+
+  color: var(--theme-on-surface-variant);
+`
+
+const ErrorText = styled.div`
+  ${bodyLarge};
+
+  color: var(--theme-error);
+`
+
+const Title = styled.div`
+  ${titleLarge};
+  ${singleLine};
+`
+
+const GameEntriesRoot = styled.div`
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 16px;
+  padding-top: 8px;
+`
+
+const StyledLiveGameEntry = styled(LiveGameEntry)`
+  ${elevationPlus1};
+  ${containerStyles(ContainerLevel.Low)};
+`
+
 const GamesListQuery = graphql(/* GraphQL */ `
   query GamesPageContent {
     ...LiveGames_FeedFragment
   }
 `)
+
+function LiveGamesFeed({ query }: { query?: FragmentType<typeof LiveGames_FeedFragment> }) {
+  const { t } = useTranslation()
+  const { liveGames } = useFragment(LiveGames_FeedFragment, query) ?? { liveGames: [] }
+
+  return liveGames.length > 0 ? (
+    <div>
+      <Title>{t('games.liveGames.title', 'Live games')}</Title>
+      <GameEntriesRoot>
+        {liveGames.map(liveGame => (
+          <StyledLiveGameEntry key={liveGame.id} query={liveGame} />
+        ))}
+      </GameEntriesRoot>
+    </div>
+  ) : null
+}
+
+// ---- Context menu -----------------------------------------------------------------------------
+
+/**
+ * Split out from the page so `useGameReplayActions` (which subscribes to this game's replay info)
+ * only runs while the menu is actually open, rather than for every row on every render.
+ */
+function GameListContextMenuContent({
+  game,
+  onDismiss,
+}: {
+  game: ReadonlyDeep<GameRecordJson>
+  onDismiss: () => void
+}) {
+  const { t } = useTranslation()
+  const { replayInfo, onWatchReplay, onSaveReplay } = useGameReplayActions(game)
+
+  return (
+    <MenuList dense={true}>
+      <MenuItem
+        text={t('games.sidePanel.viewFullResults', 'View full results')}
+        onClick={() => {
+          onDismiss()
+          navigateToGameResults(game.id)
+        }}
+      />
+      {IS_ELECTRON && replayInfo ? (
+        <>
+          <Divider $dense={true} />
+          <MenuItem
+            text={t('gameDetails.buttonWatchReplay', 'Watch replay')}
+            onClick={() => {
+              onDismiss()
+              onWatchReplay()
+            }}
+          />
+          <MenuItem
+            text={t('gameDetails.buttonSaveReplay', 'Save replay')}
+            onClick={() => {
+              onDismiss()
+              onSaveReplay()
+            }}
+          />
+        </>
+      ) : null}
+    </MenuList>
+  )
+}
+
+// ---- Main component --------------------------------------------------------------------------
 
 export function GameList() {
   const { t } = useTranslation()
@@ -88,24 +192,18 @@ export function GameList() {
   const [playerName, setPlayerNameParam] = useLocationSearchParam('playerName')
   const [formatParam, setFormatParam] = useLocationSearchParam('format')
   const [matchupParam, setMatchupParam] = useLocationSearchParam('matchup')
+  const [startDateParam, setStartDateParam] = useLocationSearchParam('startDate')
+  const [endDateParam, setEndDateParam] = useLocationSearchParam('endDate')
 
   const duration = parseDuration(durationParam)
   const sort = parseSort(sortParam)
   const format = parseFormat(formatParam)
   const matchup = parseMatchup(matchupParam)
 
-  const [gameIds, setGameIds] = useState<string[]>()
-  const [hasMoreGames, setHasMoreGames] = useState(true)
-  const [isLoadingMoreGames, setIsLoadingMoreGames] = useState(false)
-  const [searchError, setSearchError] = useState<Error>()
-  const abortControllerRef = useRef<AbortController>(undefined)
-  const [refreshToken, triggerRefresh] = useRefreshToken()
+  const [selectedId, setSelectedId] = useState<string>()
+  const rowElemsRef = useRef(new Map<string, HTMLDivElement>())
 
-  // NOTE(2Pac): We select the (stable) map and derive the list in render rather than mapping inside
-  // the selector, which would return a fresh array on every store update and re-render the whole
-  // list on any Redux action. react-compiler memoizes the derivation below.
-  const gamesById = useAppSelector(s => s.games.byId)
-  const games = gameIds?.map(id => gamesById.get(id)!) ?? []
+  const { onContextMenu, contextMenuPopoverProps } = useContextMenu()
 
   // TODO(marko): Figure out if we particularly care about the errors when loading this, since we're
   // hiding the live games feed if there are no live games anyway.
@@ -114,60 +212,107 @@ export function GameList() {
   // but if this page is meant to feel live we should re-run it periodically.
   const [{ data }] = useQuery({ query: GamesListQuery, context: { ttl: 10 * 1000 } })
 
-  const reset = () => {
-    abortControllerRef.current?.abort()
-    setGameIds(undefined)
-    setHasMoreGames(true)
-    setIsLoadingMoreGames(false)
-    setSearchError(undefined)
-    triggerRefresh()
+  const loadPage = (offset: number, signal: AbortSignal): Promise<GameListSearchPage> => {
+    const { startMs, endMs } = resolveDateRangeMs(startDateParam, endDateParam)
+    return new Promise((resolve, reject) => {
+      dispatch(
+        getGames(
+          {
+            duration: duration === GameDurationFilter.All ? undefined : duration,
+            sort: sort === GameSortOption.LatestFirst ? undefined : sort,
+            mapName: mapName || undefined,
+            playerName: playerName || undefined,
+            format,
+            matchup,
+            startDate: startMs,
+            endDate: endMs,
+            offset,
+          },
+          {
+            signal,
+            onSuccess: result => {
+              resolve({ gameIds: result.games.map(g => g.id), hasMoreGames: result.hasMoreGames })
+            },
+            onError: err => reject(err),
+          },
+        ),
+      )
+    })
   }
 
-  const onLoadMoreGames = () => {
-    setIsLoadingMoreGames(true)
+  const { games, hasMoreGames, isLoadingMore, searchError, refreshToken, reset, onLoadMore } =
+    useGameListSearch(loadPage)
 
-    abortControllerRef.current?.abort()
-    abortControllerRef.current = new AbortController()
+  const selectedGame = games.find(g => g.id === selectedId) ?? games[0]
+  const selectedIndex = selectedGame ? games.findIndex(g => g.id === selectedGame.id) : -1
+  const sortIsDateBased = isDateSort(sort)
 
-    dispatch(
-      getGames(
-        {
-          duration: duration === GameDurationFilter.All ? undefined : duration,
-          sort: sort === GameSortOption.LatestFirst ? undefined : sort,
-          mapName: mapName || undefined,
-          playerName: playerName || undefined,
-          format,
-          matchup: matchup ? makeEncodedMatchupString(matchup) : undefined,
-          offset: gameIds?.length ?? 0,
-        },
-        {
-          signal: abortControllerRef.current.signal,
-          onSuccess: data => {
-            setIsLoadingMoreGames(false)
-            // This is a moving window (games complete continuously), so a later page can re-serve
-            // rows from an earlier one. Dedupe on concat to avoid duplicate React keys / repeated
-            // rows.
-            setGameIds(prev => {
-              const existingIds = new Set(prev ?? [])
-              return (prev ?? []).concat(
-                data.games.map(g => g.id).filter(id => !existingIds.has(id)),
-              )
-            })
-            setHasMoreGames(data.hasMoreGames)
-            setSearchError(undefined)
-          },
-          onError: err => {
-            setIsLoadingMoreGames(false)
-            setSearchError(err)
-          },
-        },
-      ),
-    )
+  const selectIndex = (index: number) => {
+    if (index < 0 || index >= games.length) return
+    const game = games[index]
+    setSelectedId(game.id)
+    rowElemsRef.current.get(game.id)?.scrollIntoView({ block: 'nearest' })
+  }
+  const moveSelection = (delta: number) => {
+    if (games.length === 0) return
+    const base = selectedIndex < 0 ? 0 : selectedIndex
+    const next = Math.min(Math.max(base + delta, 0), games.length - 1)
+    selectIndex(next)
   }
 
-  useEffect(() => {
-    return () => abortControllerRef.current?.abort()
-  }, [])
+  useKeyListener({
+    onKeyDown: (event: KeyboardEvent) => {
+      // Every key here acts on the game list, but this page's key listener boundary is shared with
+      // other UI (e.g. the social sidebar's chat input, whose keydowns bubble to the document).
+      // While a text-entry element has focus, the keystroke belongs to it instead.
+      const target = event.target
+      if (
+        target instanceof HTMLElement &&
+        (target.tagName === 'INPUT' ||
+          target.tagName === 'TEXTAREA' ||
+          target.tagName === 'SELECT' ||
+          target.isContentEditable)
+      ) {
+        return false
+      }
+
+      switch (event.code) {
+        case 'ArrowUp':
+          moveSelection(-1)
+          return true
+        case 'ArrowDown':
+          moveSelection(1)
+          return true
+        case 'PageUp':
+          moveSelection(-10)
+          return true
+        case 'PageDown':
+          moveSelection(10)
+          return true
+        case 'Home':
+          selectIndex(0)
+          return true
+        case 'End':
+          selectIndex(games.length - 1)
+          return true
+        case 'Enter':
+        case 'NumpadEnter': {
+          const active = document.activeElement
+          // If the user is on an interactive control (e.g. a focused button), let it handle Enter.
+          if (
+            active instanceof HTMLElement &&
+            (active.tagName === 'BUTTON' || active.tagName === 'A')
+          ) {
+            return false
+          }
+          if (selectedGame) navigateToGameResults(selectedGame.id)
+          return true
+        }
+      }
+
+      return false
+    },
+  })
 
   const filterBar = (
     <GameFilterBar
@@ -202,77 +347,101 @@ export function GameList() {
         setMatchupParam(v ?? '')
         reset()
       }}
+      startDate={startDateParam}
+      setStartDate={v => {
+        setStartDateParam(v)
+        reset()
+      }}
+      endDate={endDateParam}
+      setEndDate={v => {
+        setEndDateParam(v)
+        reset()
+      }}
     />
   )
 
+  // A page load that's returned at least once with nothing left to fetch is a confirmed empty
+  // result; until then (including the very first, still in-flight page) we render the list shell so
+  // its own loading indicator can show, matching how this page behaved before it was rewired onto
+  // `useGameListSearch`.
+  const confirmedEmpty = !hasMoreGames && games.length === 0
+
+  let listBody: React.ReactNode
   if (searchError) {
-    return (
-      <GamesListContainer>
-        {filterBar}
-        <ErrorText>
-          {t('games.list.retrievingError', 'There was an error retrieving the games.')}
-        </ErrorText>
-      </GamesListContainer>
+    listBody = (
+      <ErrorText>
+        {t('games.list.retrievingError', 'There was an error retrieving the games.')}
+      </ErrorText>
     )
-  } else if (gameIds?.length === 0) {
-    return (
-      <GamesListContainer>
-        <LiveGamesFeed query={data} />
-        {filterBar}
-        <NoResults>{t('games.list.noMatchingGames', 'No matching games.')}</NoResults>
-      </GamesListContainer>
-    )
+  } else if (confirmedEmpty) {
+    listBody = <NoResults>{t('games.list.noMatchingGames', 'No matching games.')}</NoResults>
   } else {
     const gameItems = renderGamesWithDayHeaders(games, sort, t, game => (
-      <GameListEntry key={game.id} game={game} showResult={false} />
+      <GameListEntry
+        key={game.id}
+        game={game}
+        showResult={false}
+        selected={game.id === selectedGame?.id}
+        onClick={setSelectedId}
+        onDoubleClick={gameId => navigateToGameResults(gameId)}
+        onContextMenu={(gameId, event) => {
+          setSelectedId(gameId)
+          onContextMenu(event)
+        }}
+        ref={el => {
+          if (el) {
+            rowElemsRef.current.set(game.id, el)
+          } else {
+            rowElemsRef.current.delete(game.id)
+          }
+        }}
+      />
     ))
 
-    return (
+    listBody = (
       <InfiniteScrollList
         nextLoadingEnabled={true}
-        isLoadingNext={isLoadingMoreGames}
+        isLoadingNext={isLoadingMore}
         hasNextData={hasMoreGames}
         refreshToken={refreshToken}
-        onLoadNextData={onLoadMoreGames}>
-        <GamesListContainer>
-          <LiveGamesFeed query={data} />
-          {filterBar}
-          <SearchResults>{gameItems}</SearchResults>
-        </GamesListContainer>
+        onLoadNextData={onLoadMore}>
+        {gameItems}
       </InfiniteScrollList>
     )
   }
-}
 
-const Title = styled.div`
-  ${titleLarge};
-  ${singleLine};
-`
+  // Mirrors the replay library's inspector: dropped entirely once there are confirmed to be no
+  // results, rather than showing an empty "select a game" placeholder beside the empty-state message.
+  const showPanel = !confirmedEmpty && !searchError
 
-const GameEntriesRoot = styled.div`
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 16px;
-  padding-top: 8px;
-`
+  return (
+    <CenteredContentContainer $fullWidth={true} data-content-fullbleed=''>
+      <PageColumn>
+        <LiveGamesFeed query={data} />
 
-const StyledLiveGameEntry = styled(LiveGameEntry)`
-  ${elevationPlus1};
-  ${containerStyles(ContainerLevel.Low)};
-`
+        {filterBar}
 
-function LiveGamesFeed({ query }: { query?: FragmentType<typeof LiveGames_FeedFragment> }) {
-  const { t } = useTranslation()
-  const { liveGames } = useFragment(LiveGames_FeedFragment, query) ?? { liveGames: [] }
+        <BodyRow>
+          <ListColumn>{listBody}</ListColumn>
 
-  return liveGames.length > 0 ? (
-    <div>
-      <Title>{t('games.liveGames.title', 'Live games')}</Title>
-      <GameEntriesRoot>
-        {liveGames.map(liveGame => (
-          <StyledLiveGameEntry key={liveGame.id} query={liveGame} />
-        ))}
-      </GameEntriesRoot>
-    </div>
-  ) : null
+          {showPanel ? (
+            <GameRecordSidePanel
+              game={selectedGame}
+              alignWithFirstRow={sortIsDateBased}
+              onViewResults={gameId => navigateToGameResults(gameId)}
+            />
+          ) : null}
+        </BodyRow>
+      </PageColumn>
+
+      {selectedGame ? (
+        <Popover {...contextMenuPopoverProps}>
+          <GameListContextMenuContent
+            game={selectedGame}
+            onDismiss={contextMenuPopoverProps.onDismiss}
+          />
+        </Popover>
+      ) : null}
+    </CenteredContentContainer>
+  )
 }

--- a/client/games/game-list.tsx
+++ b/client/games/game-list.tsx
@@ -1,7 +1,6 @@
 import { useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
-import { ReadonlyDeep } from 'type-fest'
 import { useQuery } from 'urql'
 import {
   ALL_GAME_FORMATS,
@@ -11,14 +10,10 @@ import {
   GameSortOption,
   makeEncodedMatchupString,
 } from '../../common/games/game-filters'
-import { GameRecordJson } from '../../common/games/games'
 import { useContextMenu } from '../dom/use-context-menu'
 import { FragmentType, graphql, useFragment } from '../gql'
 import { useKeyListener } from '../keyboard/key-listener'
 import InfiniteScrollList from '../lists/infinite-scroll-list'
-import { Divider } from '../material/menu/divider'
-import { MenuItem } from '../material/menu/item'
-import { MenuList } from '../material/menu/menu'
 import { Popover } from '../material/popover'
 import { elevationPlus1 } from '../material/shadows'
 import { useLocationSearchParam } from '../navigation/router-hooks'
@@ -28,12 +23,12 @@ import { ContainerLevel, containerStyles } from '../styles/colors'
 import { bodyLarge, singleLine, titleLarge } from '../styles/typography'
 import { getGames, navigateToGameResults } from './action-creators'
 import { renderGamesWithDayHeaders, resolveDateRangeMs } from './day-header'
+import { GameContextMenuContent } from './game-context-menu'
 import { GameFilterBar } from './game-filter-bar'
 import { GameListEntry } from './game-list-entry'
 import { GameRecordSidePanel } from './game-record-side-panel'
 import { LiveGameEntry, LiveGames_FeedFragment } from './live-game-entry'
 import { GameListSearchPage, useGameListSearch } from './use-game-list-search'
-import { useGameReplayActions } from './use-game-replay-actions'
 
 function parseDuration(value: string): GameDurationFilter {
   return Object.values(GameDurationFilter).includes(value as GameDurationFilter)
@@ -130,54 +125,6 @@ function LiveGamesFeed({ query }: { query?: FragmentType<typeof LiveGames_FeedFr
       </GameEntriesRoot>
     </div>
   ) : null
-}
-
-// ---- Context menu -----------------------------------------------------------------------------
-
-/**
- * Split out from the page so `useGameReplayActions` (which subscribes to this game's replay info)
- * only runs while the menu is actually open, rather than for every row on every render.
- */
-function GameListContextMenuContent({
-  game,
-  onDismiss,
-}: {
-  game: ReadonlyDeep<GameRecordJson>
-  onDismiss: () => void
-}) {
-  const { t } = useTranslation()
-  const { replayInfo, onWatchReplay, onSaveReplay } = useGameReplayActions(game)
-
-  return (
-    <MenuList dense={true}>
-      <MenuItem
-        text={t('games.sidePanel.viewFullResults', 'View full results')}
-        onClick={() => {
-          onDismiss()
-          navigateToGameResults(game.id)
-        }}
-      />
-      {IS_ELECTRON && replayInfo ? (
-        <>
-          <Divider $dense={true} />
-          <MenuItem
-            text={t('gameDetails.buttonWatchReplay', 'Watch replay')}
-            onClick={() => {
-              onDismiss()
-              onWatchReplay()
-            }}
-          />
-          <MenuItem
-            text={t('gameDetails.buttonSaveReplay', 'Save replay')}
-            onClick={() => {
-              onDismiss()
-              onSaveReplay()
-            }}
-          />
-        </>
-      ) : null}
-    </MenuList>
-  )
 }
 
 // ---- Main component --------------------------------------------------------------------------
@@ -436,7 +383,7 @@ export function GameList() {
 
       {selectedGame ? (
         <Popover {...contextMenuPopoverProps}>
-          <GameListContextMenuContent
+          <GameContextMenuContent
             game={selectedGame}
             onDismiss={contextMenuPopoverProps.onDismiss}
           />

--- a/client/games/game-players-display.tsx
+++ b/client/games/game-players-display.tsx
@@ -45,11 +45,18 @@ export function GamePlayersDisplay({
   game,
   forUserId,
   showTeamLabels = true,
+  interactiveNames = false,
   className,
 }: {
   game: ReadonlyDeep<GameRecordJson>
   forUserId?: SbUserId
   showTeamLabels?: boolean
+  /**
+   * When true, human players' names render as store-connected, interactive usernames (clicking
+   * opens the profile overlay, right-clicking opens the user context menu) instead of plain text.
+   * Computer opponents always render as plain text.
+   */
+  interactiveNames?: boolean
   className?: string
 }) {
   const { t } = useTranslation()
@@ -77,6 +84,7 @@ export function GamePlayersDisplay({
       name: player.isComputer
         ? t('game.playerName.computer', 'Computer')
         : (playersMapping.get(player.id)?.name ?? t('game.playerName.unknown', 'Unknown player')),
+      userId: interactiveNames && !player.isComputer ? player.id : undefined,
     }
   }
 

--- a/client/games/game-record-side-panel.tsx
+++ b/client/games/game-record-side-panel.tsx
@@ -1,0 +1,136 @@
+import { useTranslation } from 'react-i18next'
+import styled from 'styled-components'
+import { ReadonlyDeep } from 'type-fest'
+import { GameRecordJson, getGameTypeLabel } from '../../common/games/games'
+import { SbUserId } from '../../common/users/sb-user-id'
+import { longTimestamp } from '../i18n/date-formats'
+import { MaterialIcon } from '../icons/material/material-icon'
+import { FilledButton, IconButton } from '../material/button'
+import { useAppSelector } from '../redux-hooks'
+import { labelMedium } from '../styles/typography'
+import { GamePlayersDisplay } from './game-players-display'
+import {
+  GameSidePanel,
+  GameSidePanelActions,
+  GameSidePanelChipsRow,
+  GameSidePanelEmpty,
+  GameSidePanelHeader,
+  GameSidePanelSection,
+  GameSidePanelSubline,
+  GameSidePanelTitle,
+} from './game-side-panel'
+import { useGameReplayActions } from './use-game-replay-actions'
+
+const GameTypeChip = styled.div`
+  ${labelMedium};
+
+  padding: 2px 8px;
+
+  border-radius: 6px;
+  border: 1px solid var(--theme-outline);
+  color: var(--theme-on-surface-variant);
+`
+
+const ViewResultsButton = styled(FilledButton)`
+  flex-grow: 1;
+`
+
+export interface GameRecordSidePanelProps {
+  game?: ReadonlyDeep<GameRecordJson>
+  /** When set, the roster shows win/loss coloring for this user's perspective. */
+  forUserId?: SbUserId
+  alignWithFirstRow?: boolean
+  onViewResults: (gameId: string) => void
+  className?: string
+}
+
+/**
+ * The shared right-hand detail panel for a selected game, used by the games list and match
+ * history pages. Mirrors the replay library's inspector so the two feel like the same surface.
+ */
+export function GameRecordSidePanel({
+  game,
+  forUserId,
+  alignWithFirstRow = false,
+  onViewResults,
+  className,
+}: GameRecordSidePanelProps) {
+  const { t } = useTranslation()
+
+  if (!game) {
+    return (
+      <GameSidePanelEmpty alignWithFirstRow={alignWithFirstRow} className={className}>
+        {t('games.sidePanel.empty', 'Select a game to see its details')}
+      </GameSidePanelEmpty>
+    )
+  }
+
+  return (
+    <GameRecordSidePanelContent
+      game={game}
+      forUserId={forUserId}
+      alignWithFirstRow={alignWithFirstRow}
+      onViewResults={onViewResults}
+      className={className}
+    />
+  )
+}
+
+interface GameRecordSidePanelContentProps {
+  game: ReadonlyDeep<GameRecordJson>
+  forUserId?: SbUserId
+  alignWithFirstRow: boolean
+  onViewResults: (gameId: string) => void
+  className?: string
+}
+
+function GameRecordSidePanelContent({
+  game,
+  forUserId,
+  alignWithFirstRow,
+  onViewResults,
+  className,
+}: GameRecordSidePanelContentProps) {
+  const { t } = useTranslation()
+  const map = useAppSelector(s => s.maps.byId.get(game.mapId))
+  const { replayInfo, onWatchReplay, onSaveReplay } = useGameReplayActions(game)
+
+  const mapName = map?.name ?? t('game.mapName.unknown', 'Unknown map')
+
+  return (
+    <GameSidePanel map={map} alignWithFirstRow={alignWithFirstRow} className={className}>
+      <GameSidePanelHeader>
+        <GameSidePanelChipsRow>
+          <GameTypeChip>{getGameTypeLabel(game, t)}</GameTypeChip>
+        </GameSidePanelChipsRow>
+        <GameSidePanelTitle>{mapName}</GameSidePanelTitle>
+        <GameSidePanelSubline>{longTimestamp.format(game.startTime)}</GameSidePanelSubline>
+      </GameSidePanelHeader>
+
+      <GameSidePanelSection>
+        <GamePlayersDisplay game={game} forUserId={forUserId} showTeamLabels={true} />
+      </GameSidePanelSection>
+
+      <GameSidePanelActions>
+        <ViewResultsButton
+          label={t('games.sidePanel.viewFullResults', 'View full results')}
+          onClick={() => onViewResults(game.id)}
+        />
+        {IS_ELECTRON && replayInfo ? (
+          <>
+            <IconButton
+              icon={<MaterialIcon icon='play_circle' />}
+              title={t('gameDetails.buttonWatchReplay', 'Watch replay')}
+              onClick={onWatchReplay}
+            />
+            <IconButton
+              icon={<MaterialIcon icon='save' />}
+              title={t('gameDetails.buttonSaveReplay', 'Save replay')}
+              onClick={onSaveReplay}
+            />
+          </>
+        ) : null}
+      </GameSidePanelActions>
+    </GameSidePanel>
+  )
+}

--- a/client/games/game-record-side-panel.tsx
+++ b/client/games/game-record-side-panel.tsx
@@ -108,7 +108,12 @@ function GameRecordSidePanelContent({
       </GameSidePanelHeader>
 
       <GameSidePanelSection>
-        <GamePlayersDisplay game={game} forUserId={forUserId} showTeamLabels={true} />
+        <GamePlayersDisplay
+          game={game}
+          forUserId={forUserId}
+          showTeamLabels={true}
+          interactiveNames={true}
+        />
       </GameSidePanelSection>
 
       <GameSidePanelActions>

--- a/client/games/player-teams-display.tsx
+++ b/client/games/player-teams-display.tsx
@@ -7,6 +7,11 @@ import { ConnectedUsername } from '../users/connected-username'
 
 const PlayerTeamsRoot = styled.div`
   display: flex;
+  /*
+    A team column with fewer rows (e.g. a lone player against a duo) centers against its taller
+    neighbor instead of hanging from the first line.
+  */
+  align-items: center;
   gap: 16px;
 `
 

--- a/client/games/route.tsx
+++ b/client/games/route.tsx
@@ -24,11 +24,7 @@ export function GamesRouteComponent() {
   }
 
   if (!params.routeId) {
-    return (
-      <CenteredContentContainer>
-        <GameList />
-      </CenteredContentContainer>
-    )
+    return <GameList />
   }
 
   // Game route ids are encoded ("pretty") game ids, so an arbitrary/mistyped URL segment may not

--- a/client/games/use-game-list-search.ts
+++ b/client/games/use-game-list-search.ts
@@ -1,0 +1,100 @@
+import { useEffect, useRef, useState } from 'react'
+import { ReadonlyDeep } from 'type-fest'
+import { GameRecordJson } from '../../common/games/games'
+import { useRefreshToken } from '../network/refresh-token'
+import { useAppSelector } from '../redux-hooks'
+
+/** A single page of game ids, as returned by a `useGameListSearch` caller's `loadPage`. */
+export interface GameListSearchPage {
+  gameIds: string[]
+  hasMoreGames: boolean
+}
+
+export interface UseGameListSearchResult {
+  games: ReadonlyArray<ReadonlyDeep<GameRecordJson>>
+  hasMoreGames: boolean
+  isLoadingMore: boolean
+  searchError?: Error
+  /** Bumped on every `reset()`; pass through to `InfiniteScrollList`'s `refreshToken` prop. */
+  refreshToken: number
+  /** Aborts any in-flight page load, clears the accumulated results, and bumps `refreshToken`. */
+  reset: () => void
+  /** Loads the next page (called by `InfiniteScrollList`'s `onLoadNextData`). */
+  onLoadMore: () => void
+}
+
+/**
+ * Shared offset-paging search logic for a games list backed by the global `games.byId` store.
+ * Accumulates game ids across pages (deduping on append, since the underlying window can shift —
+ * e.g. new games completing, or a user's match history changing between page loads — and re-serve
+ * rows already loaded), aborts any in-flight page load on `reset()` or unmount, and tracks the
+ * loading/error state a caller's `InfiniteScrollList` needs.
+ *
+ * Callers own their own filter/URL-param state and provide `loadPage`, which should fetch a single
+ * page (e.g. by dispatching a thunk) for a given offset and resolve with the ids of the games it
+ * returned plus whether more pages remain. Once `signal` has been aborted, this hook ignores
+ * whatever `loadPage`'s returned promise eventually does (matching how `abortableThunk` itself
+ * skips `onSuccess`/`onError` for a canceled request), so a stale response from a superseded page
+ * load never corrupts the accumulated results.
+ */
+export function useGameListSearch(
+  loadPage: (offset: number, signal: AbortSignal) => Promise<GameListSearchPage>,
+): UseGameListSearchResult {
+  const [gameIds, setGameIds] = useState<string[]>()
+  const [hasMoreGames, setHasMoreGames] = useState(true)
+  const [isLoadingMore, setIsLoadingMore] = useState(false)
+  const [searchError, setSearchError] = useState<Error>()
+  const abortControllerRef = useRef<AbortController>(undefined)
+  const [refreshToken, triggerRefresh] = useRefreshToken()
+
+  // The (stable) map is selected and the list is derived in render rather than inside the
+  // selector, which would return a fresh array on every store update and re-render the whole list
+  // on any Redux action. react-compiler memoizes the derivation below.
+  const gamesById = useAppSelector(s => s.games.byId)
+  const games = gameIds?.map(id => gamesById.get(id)!) ?? []
+
+  const reset = () => {
+    abortControllerRef.current?.abort()
+    setGameIds(undefined)
+    setHasMoreGames(true)
+    setIsLoadingMore(false)
+    setSearchError(undefined)
+    triggerRefresh()
+  }
+
+  const onLoadMore = () => {
+    setIsLoadingMore(true)
+
+    abortControllerRef.current?.abort()
+    abortControllerRef.current = new AbortController()
+    const { signal } = abortControllerRef.current
+
+    loadPage(gameIds?.length ?? 0, signal).then(
+      page => {
+        if (signal.aborted) return
+
+        setIsLoadingMore(false)
+        // This is a moving window, so a later page can re-serve rows from an earlier one. Dedupe
+        // on concat to avoid duplicate React keys / repeated rows.
+        setGameIds(prev => {
+          const existingIds = new Set(prev ?? [])
+          return (prev ?? []).concat(page.gameIds.filter(id => !existingIds.has(id)))
+        })
+        setHasMoreGames(page.hasMoreGames)
+        setSearchError(undefined)
+      },
+      (err: Error) => {
+        if (signal.aborted) return
+
+        setIsLoadingMore(false)
+        setSearchError(err)
+      },
+    )
+  }
+
+  useEffect(() => {
+    return () => abortControllerRef.current?.abort()
+  }, [])
+
+  return { games, hasMoreGames, isLoadingMore, searchError, refreshToken, reset, onLoadMore }
+}

--- a/client/games/use-game-replay-actions.ts
+++ b/client/games/use-game-replay-actions.ts
@@ -1,0 +1,83 @@
+import { useTranslation } from 'react-i18next'
+import { ReadonlyDeep } from 'type-fest'
+import { getErrorStack } from '../../common/errors'
+import { GameRecordJson, GameReplayInfo } from '../../common/games/games'
+import { openSimpleDialog } from '../dialogs/action-creators'
+import logger from '../logging/logger'
+import { useAppDispatch, useAppSelector } from '../redux-hooks'
+import { saveReplayToLibrary, watchReplayFromUrl } from '../replays/action-creators'
+import { useSnackbarController } from '../snackbars/snackbar-overlay'
+
+export interface UseGameReplayActionsResult {
+  /** Info about this game's replay, if one is available and the user has access to it. */
+  replayInfo: GameReplayInfo | undefined
+  /** Downloads (if needed) and starts watching this game's replay. No-op if there isn't one. */
+  onWatchReplay: () => void
+  /** Downloads (if needed) and saves this game's replay into the local replay library. No-op if
+   * there isn't one. */
+  onSaveReplay: () => void
+}
+
+/**
+ * Watch/save actions for a game's replay, shared by any surface that offers those controls (list
+ * rows, side panels). Callers handle their own mouse-event concerns (e.g. `stopPropagation` to
+ * keep a click on these actions from also selecting the underlying row).
+ */
+export function useGameReplayActions(
+  game: ReadonlyDeep<GameRecordJson>,
+): UseGameReplayActionsResult {
+  const { t } = useTranslation()
+  const dispatch = useAppDispatch()
+  const snackbarController = useSnackbarController()
+  const replayInfo = useAppSelector(s => s.games.replayInfoById.get(game.id))
+
+  const onWatchReplay = () => {
+    if (!replayInfo) return
+
+    dispatch(
+      watchReplayFromUrl(replayInfo, game.id, {
+        onSuccess: () => {},
+        onError: err => {
+          logger.error(`Error watching replay: ${getErrorStack(err)}`)
+          dispatch(
+            openSimpleDialog(
+              t('replays.watch.errorTitle', 'Error loading replay'),
+              err?.message ??
+                t(
+                  'replays.watch.errorBody',
+                  'There was a problem downloading or loading the replay. Please try again later.',
+                ),
+            ),
+          )
+        },
+      }),
+    )
+  }
+
+  const onSaveReplay = () => {
+    if (!replayInfo) return
+
+    dispatch(
+      saveReplayToLibrary(replayInfo, {
+        onSuccess: result => {
+          snackbarController.showSnackbar(
+            result.alreadySaved
+              ? t(
+                  'gameDetails.saveReplayAlreadySaved',
+                  "This game's replay is already in your library",
+                )
+              : t('gameDetails.saveReplaySuccess', 'Replay saved to your library'),
+          )
+        },
+        onError: err => {
+          logger.error(`Error saving replay: ${getErrorStack(err)}`)
+          snackbarController.showSnackbar(
+            t('gameDetails.saveReplayError', 'There was a problem saving the replay'),
+          )
+        },
+      }),
+    )
+  }
+
+  return { replayInfo, onWatchReplay, onSaveReplay }
+}

--- a/client/material/date-text-field.tsx
+++ b/client/material/date-text-field.tsx
@@ -14,13 +14,18 @@ const StyledTextField = styled(TextField)`
   }
 `
 
-/** A `TextField` that accepts a local calendar date (using the native picker). */
+/**
+ * A `TextField` that accepts a local calendar date (using the native picker).
+ *
+ * The label always floats: date inputs render placeholder text (e.g. mm/dd/yyyy) even when empty,
+ * so the field always appears filled and a non-floating label would never be visible.
+ */
 export function DateTextField({
   value,
   ref,
   ...rest
 }: Simplify<
-  Except<TextFieldProps, 'value' | 'alwaysHasValue'> & {
+  Except<TextFieldProps, 'value' | 'alwaysHasValue' | 'floatingLabel'> & {
     /**
      * The current value of the field, in local date format (YYYY-MM-DD).
      *
@@ -39,6 +44,7 @@ export function DateTextField({
       ref={multiplexedRef}
       type='date'
       alwaysHasValue={true}
+      floatingLabel={true}
       value={value}
       trailingIcons={[
         <IconButton

--- a/client/material/date-text-field.tsx
+++ b/client/material/date-text-field.tsx
@@ -1,9 +1,18 @@
 import { useRef } from 'react'
 import { useTranslation } from 'react-i18next'
+import styled from 'styled-components'
 import { Except, Simplify } from 'type-fest'
 import { useMultiplexRef } from '../react/refs'
 import { IconButton } from './button'
 import { TextField, TextFieldProps } from './text-field'
+
+// The field already renders its own picker button (below), which opens the native picker via
+// `showPicker()`, so the browser's built-in indicator would just be a redundant second icon.
+const StyledTextField = styled(TextField)`
+  & input::-webkit-calendar-picker-indicator {
+    display: none;
+  }
+`
 
 /** A `TextField` that accepts a local calendar date (using the native picker). */
 export function DateTextField({
@@ -25,7 +34,7 @@ export function DateTextField({
   const multiplexedRef = useMultiplexRef(inputRef, ref)
 
   return (
-    <TextField
+    <StyledTextField
       {...rest}
       ref={multiplexedRef}
       type='date'

--- a/client/material/date-text-field.tsx
+++ b/client/material/date-text-field.tsx
@@ -1,0 +1,46 @@
+import { useRef } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Except, Simplify } from 'type-fest'
+import { useMultiplexRef } from '../react/refs'
+import { IconButton } from './button'
+import { TextField, TextFieldProps } from './text-field'
+
+/** A `TextField` that accepts a local calendar date (using the native picker). */
+export function DateTextField({
+  value,
+  ref,
+  ...rest
+}: Simplify<
+  Except<TextFieldProps, 'value' | 'alwaysHasValue'> & {
+    /**
+     * The current value of the field, in local date format (YYYY-MM-DD).
+     *
+     * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Guides/Date_and_time_formats#local_date_and_time_strings
+     */
+    value: string
+  }
+>) {
+  const { t } = useTranslation()
+  const inputRef = useRef<HTMLInputElement | null>(null)
+  const multiplexedRef = useMultiplexRef(inputRef, ref)
+
+  return (
+    <TextField
+      {...rest}
+      ref={multiplexedRef}
+      type='date'
+      alwaysHasValue={true}
+      value={value}
+      trailingIcons={[
+        <IconButton
+          key='picker'
+          icon='calendar_month'
+          onClick={() => {
+            inputRef.current?.showPicker()
+          }}
+          ariaLabel={t('material.dateTextField.pickerButtonLabel', 'Show picker')}
+        />,
+      ]}
+    />
+  )
+}

--- a/client/replays/replay-inspector.tsx
+++ b/client/replays/replay-inspector.tsx
@@ -1,3 +1,4 @@
+import { TFunction } from 'i18next'
 import * as React from 'react'
 import { useEffect, useEffectEvent, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -107,12 +108,17 @@ const PlaylistChip = styled.div`
 `
 
 /**
- * The "more actions" menu items shared between the inspector's overflow menu and the library's
- * row context menu: add/remove-from-playlist, an optional reorder pair, view-game-page, and
- * show-in-explorer. Watch/Bookmark aren't included here since each caller surfaces those
+ * Builds the "more actions" menu items shared between the inspector's overflow menu and the
+ * library's row context menu: add/remove-from-playlist, an optional reorder pair, view-game-page,
+ * and show-in-explorer. Watch/Bookmark aren't included here since each caller surfaces those
  * differently (dedicated buttons in the inspector, leading menu items in the context menu).
+ *
+ * Returns a flat array of keyed `MenuItem` elements (rather than a component rendering a
+ * fragment) so that spreading it directly into a `<MenuList>`'s children keeps every item a
+ * direct child: `MenuList` only clones `dense`/focus state onto, and lets arrow-key navigation
+ * reach, its direct `MenuItem` children.
  */
-export function ReplayActionMenuItems({
+export function getReplayActionMenuItems({
   entry,
   inPlaylistView,
   closeMenu,
@@ -120,6 +126,7 @@ export function ReplayActionMenuItems({
   onRemoveFromPlaylist,
   onReveal,
   reorder,
+  t,
 }: {
   entry: ReplayLibraryEntry
   inPlaylistView: boolean
@@ -134,122 +141,142 @@ export function ReplayActionMenuItems({
     onMoveUp: () => void
     onMoveDown: () => void
   }
-}) {
-  const { t } = useTranslation()
+  t: TFunction
+}): React.ReactNode[] {
+  const items: React.ReactNode[] = [
+    <MenuItem
+      key='add-to-playlist'
+      icon={<MaterialIcon icon='playlist_add' />}
+      text={t('replays.library.addToPlaylist', 'Add to playlist…')}
+      onClick={event => {
+        closeMenu()
+        onOpenAddToPlaylist(event)
+      }}
+    />,
+  ]
 
-  return (
-    <>
+  if (inPlaylistView) {
+    items.push(
       <MenuItem
-        icon={<MaterialIcon icon='playlist_add' />}
-        text={t('replays.library.addToPlaylist', 'Add to playlist…')}
-        onClick={event => {
-          closeMenu()
-          onOpenAddToPlaylist(event)
-        }}
-      />
-      {inPlaylistView ? (
-        <MenuItem
-          icon={<MaterialIcon icon='playlist_remove' />}
-          text={t('replays.library.removeFromPlaylist', 'Remove from playlist')}
-          onClick={() => {
-            closeMenu()
-            onRemoveFromPlaylist()
-          }}
-        />
-      ) : null}
-      {reorder ? (
-        <>
-          <MenuItem
-            icon={<MaterialIcon icon='arrow_upward' />}
-            text={t('replays.library.moveUp', 'Move up')}
-            disabled={!reorder.canMoveUp}
-            onClick={() => {
-              closeMenu()
-              reorder.onMoveUp()
-            }}
-          />
-          <MenuItem
-            icon={<MaterialIcon icon='arrow_downward' />}
-            text={t('replays.library.moveDown', 'Move down')}
-            disabled={!reorder.canMoveDown}
-            onClick={() => {
-              closeMenu()
-              reorder.onMoveDown()
-            }}
-          />
-        </>
-      ) : null}
-      {entry.sbGameId && !entry.parseError ? (
-        <MenuItem
-          icon={<MaterialIcon icon='open_in_new' />}
-          text={t('replays.library.viewGamePage', 'View game page')}
-          onClick={() => {
-            closeMenu()
-            push(getGameResultsUrl(entry.sbGameId!))
-          }}
-        />
-      ) : null}
-      <MenuItem
-        icon={<MaterialIcon icon='folder_open' />}
-        text={t('replays.library.showInExplorer', 'Show in Explorer')}
+        key='remove-from-playlist'
+        icon={<MaterialIcon icon='playlist_remove' />}
+        text={t('replays.library.removeFromPlaylist', 'Remove from playlist')}
         onClick={() => {
           closeMenu()
-          onReveal(entry)
+          onRemoveFromPlaylist()
         }}
-      />
-    </>
+      />,
+    )
+  }
+
+  if (reorder) {
+    items.push(
+      <MenuItem
+        key='move-up'
+        icon={<MaterialIcon icon='arrow_upward' />}
+        text={t('replays.library.moveUp', 'Move up')}
+        disabled={!reorder.canMoveUp}
+        onClick={() => {
+          closeMenu()
+          reorder.onMoveUp()
+        }}
+      />,
+      <MenuItem
+        key='move-down'
+        icon={<MaterialIcon icon='arrow_downward' />}
+        text={t('replays.library.moveDown', 'Move down')}
+        disabled={!reorder.canMoveDown}
+        onClick={() => {
+          closeMenu()
+          reorder.onMoveDown()
+        }}
+      />,
+    )
+  }
+
+  if (entry.sbGameId && !entry.parseError) {
+    items.push(
+      <MenuItem
+        key='view-game-page'
+        icon={<MaterialIcon icon='open_in_new' />}
+        text={t('replays.library.viewGamePage', 'View game page')}
+        onClick={() => {
+          closeMenu()
+          push(getGameResultsUrl(entry.sbGameId!))
+        }}
+      />,
+    )
+  }
+
+  items.push(
+    <MenuItem
+      key='show-in-explorer'
+      icon={<MaterialIcon icon='folder_open' />}
+      text={t('replays.library.showInExplorer', 'Show in Explorer')}
+      onClick={() => {
+        closeMenu()
+        onReveal(entry)
+      }}
+    />,
   )
+
+  return items
 }
 
 /**
- * The playlist-picker menu items shared between the inspector's and the library's "Add to
+ * Builds the playlist-picker menu items shared between the inspector's and the library's "Add to
  * playlist" submenu: one item per existing playlist, plus a trailing "New playlist…" item that
  * opens the create-playlist dialog.
+ *
+ * Returns a flat array of keyed `MenuItem` elements (rather than a component rendering a
+ * fragment) so that spreading it directly into a `<MenuList>`'s children keeps every item a
+ * direct child: `MenuList` only clones `dense`/focus state onto, and lets arrow-key navigation
+ * reach, its direct `MenuItem` children.
  */
-export function AddToPlaylistMenuItems({
+export function getAddToPlaylistMenuItems({
   entry,
   playlists,
   closeMenu,
   onAddToPlaylist,
+  t,
+  dispatch,
 }: {
   entry: ReplayLibraryEntry
   playlists: ReadonlyArray<ReplayPlaylist>
   closeMenu: () => void
   onAddToPlaylist: (playlistId: number, entry: ReplayLibraryEntry) => void
-}) {
-  const { t } = useTranslation()
-  const dispatch = useAppDispatch()
-
-  return (
-    <>
-      {playlists.map(p => (
-        <MenuItem
-          key={p.id}
-          icon={<MaterialIcon icon='queue_music' />}
-          text={p.name}
-          onClick={() => {
-            closeMenu()
-            onAddToPlaylist(p.id, entry)
-          }}
-        />
-      ))}
+  t: TFunction
+  dispatch: ReturnType<typeof useAppDispatch>
+}): React.ReactNode[] {
+  return [
+    ...playlists.map(p => (
       <MenuItem
-        icon={<MaterialIcon icon='add' />}
-        text={t('replays.library.newPlaylistMenu', 'New playlist…')}
+        key={p.id}
+        icon={<MaterialIcon icon='queue_music' />}
+        text={p.name}
         onClick={() => {
           closeMenu()
-          dispatch(
-            openDialog({
-              type: DialogType.CreatePlaylist,
-              initData: {
-                onCreated: id => onAddToPlaylist(id, entry),
-              },
-            }),
-          )
+          onAddToPlaylist(p.id, entry)
         }}
       />
-    </>
-  )
+    )),
+    <MenuItem
+      key='new-playlist'
+      icon={<MaterialIcon icon='add' />}
+      text={t('replays.library.newPlaylistMenu', 'New playlist…')}
+      onClick={() => {
+        closeMenu()
+        dispatch(
+          openDialog({
+            type: DialogType.CreatePlaylist,
+            initData: {
+              onCreated: id => onAddToPlaylist(id, entry),
+            },
+          }),
+        )
+      }}
+    />,
+  ]
 }
 
 export interface ReplayInspectorProps {
@@ -420,19 +447,19 @@ export function ReplayInspector({
         originX='right'
         originY='top'>
         <MenuList dense={true}>
-          <ReplayActionMenuItems
-            entry={entry}
-            inPlaylistView={inPlaylistView}
-            closeMenu={closeMenu}
-            onOpenAddToPlaylist={openAddMenu}
-            onRemoveFromPlaylist={onRemoveFromPlaylist}
-            onReveal={onReveal}
-            reorder={
+          {getReplayActionMenuItems({
+            entry,
+            inPlaylistView,
+            closeMenu,
+            onOpenAddToPlaylist: openAddMenu,
+            onRemoveFromPlaylist,
+            onReveal,
+            reorder:
               inPlaylistView && canReorder
                 ? { canMoveUp, canMoveDown, onMoveUp, onMoveDown }
-                : undefined
-            }
-          />
+                : undefined,
+            t,
+          })}
         </MenuList>
       </Popover>
       <Popover
@@ -443,12 +470,14 @@ export function ReplayInspector({
         originX='right'
         originY='top'>
         <MenuList dense={true}>
-          <AddToPlaylistMenuItems
-            entry={entry}
-            playlists={playlists}
-            closeMenu={closeAddMenu}
-            onAddToPlaylist={onAddToPlaylist}
-          />
+          {getAddToPlaylistMenuItems({
+            entry,
+            playlists,
+            closeMenu: closeAddMenu,
+            onAddToPlaylist,
+            t,
+            dispatch,
+          })}
         </MenuList>
       </Popover>
     </GameSidePanelActions>

--- a/client/replays/replay-inspector.tsx
+++ b/client/replays/replay-inspector.tsx
@@ -1,8 +1,8 @@
+import * as React from 'react'
 import { useEffect, useEffectEvent, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 import swallowNonBuiltins from '../../common/async/swallow-non-builtins'
-import { getGameDurationString } from '../../common/games/games'
 import { TypedIpcRenderer } from '../../common/ipc'
 import { filterColorCodes } from '../../common/maps'
 import { ReplayLibraryEntry, ReplayPlaylist } from '../../common/replays-library'
@@ -106,6 +106,152 @@ const PlaylistChip = styled.div`
   color: var(--theme-on-surface-variant);
 `
 
+/**
+ * The "more actions" menu items shared between the inspector's overflow menu and the library's
+ * row context menu: add/remove-from-playlist, an optional reorder pair, view-game-page, and
+ * show-in-explorer. Watch/Bookmark aren't included here since each caller surfaces those
+ * differently (dedicated buttons in the inspector, leading menu items in the context menu).
+ */
+export function ReplayActionMenuItems({
+  entry,
+  inPlaylistView,
+  closeMenu,
+  onOpenAddToPlaylist,
+  onRemoveFromPlaylist,
+  onReveal,
+  reorder,
+}: {
+  entry: ReplayLibraryEntry
+  inPlaylistView: boolean
+  closeMenu: () => void
+  onOpenAddToPlaylist: (event: React.MouseEvent | KeyboardEvent) => void
+  onRemoveFromPlaylist: () => void
+  onReveal: (entry: ReplayLibraryEntry) => void
+  /** Present only when Move up/Move down should be offered (the inspector, in manual order). */
+  reorder?: {
+    canMoveUp: boolean
+    canMoveDown: boolean
+    onMoveUp: () => void
+    onMoveDown: () => void
+  }
+}) {
+  const { t } = useTranslation()
+
+  return (
+    <>
+      <MenuItem
+        icon={<MaterialIcon icon='playlist_add' />}
+        text={t('replays.library.addToPlaylist', 'Add to playlist…')}
+        onClick={event => {
+          closeMenu()
+          onOpenAddToPlaylist(event)
+        }}
+      />
+      {inPlaylistView ? (
+        <MenuItem
+          icon={<MaterialIcon icon='playlist_remove' />}
+          text={t('replays.library.removeFromPlaylist', 'Remove from playlist')}
+          onClick={() => {
+            closeMenu()
+            onRemoveFromPlaylist()
+          }}
+        />
+      ) : null}
+      {reorder ? (
+        <>
+          <MenuItem
+            icon={<MaterialIcon icon='arrow_upward' />}
+            text={t('replays.library.moveUp', 'Move up')}
+            disabled={!reorder.canMoveUp}
+            onClick={() => {
+              closeMenu()
+              reorder.onMoveUp()
+            }}
+          />
+          <MenuItem
+            icon={<MaterialIcon icon='arrow_downward' />}
+            text={t('replays.library.moveDown', 'Move down')}
+            disabled={!reorder.canMoveDown}
+            onClick={() => {
+              closeMenu()
+              reorder.onMoveDown()
+            }}
+          />
+        </>
+      ) : null}
+      {entry.sbGameId && !entry.parseError ? (
+        <MenuItem
+          icon={<MaterialIcon icon='open_in_new' />}
+          text={t('replays.library.viewGamePage', 'View game page')}
+          onClick={() => {
+            closeMenu()
+            push(getGameResultsUrl(entry.sbGameId!))
+          }}
+        />
+      ) : null}
+      <MenuItem
+        icon={<MaterialIcon icon='folder_open' />}
+        text={t('replays.library.showInExplorer', 'Show in Explorer')}
+        onClick={() => {
+          closeMenu()
+          onReveal(entry)
+        }}
+      />
+    </>
+  )
+}
+
+/**
+ * The playlist-picker menu items shared between the inspector's and the library's "Add to
+ * playlist" submenu: one item per existing playlist, plus a trailing "New playlist…" item that
+ * opens the create-playlist dialog.
+ */
+export function AddToPlaylistMenuItems({
+  entry,
+  playlists,
+  closeMenu,
+  onAddToPlaylist,
+}: {
+  entry: ReplayLibraryEntry
+  playlists: ReadonlyArray<ReplayPlaylist>
+  closeMenu: () => void
+  onAddToPlaylist: (playlistId: number, entry: ReplayLibraryEntry) => void
+}) {
+  const { t } = useTranslation()
+  const dispatch = useAppDispatch()
+
+  return (
+    <>
+      {playlists.map(p => (
+        <MenuItem
+          key={p.id}
+          icon={<MaterialIcon icon='queue_music' />}
+          text={p.name}
+          onClick={() => {
+            closeMenu()
+            onAddToPlaylist(p.id, entry)
+          }}
+        />
+      ))}
+      <MenuItem
+        icon={<MaterialIcon icon='add' />}
+        text={t('replays.library.newPlaylistMenu', 'New playlist…')}
+        onClick={() => {
+          closeMenu()
+          dispatch(
+            openDialog({
+              type: DialogType.CreatePlaylist,
+              initData: {
+                onCreated: id => onAddToPlaylist(id, entry),
+              },
+            }),
+          )
+        }}
+      />
+    </>
+  )
+}
+
 export interface ReplayInspectorProps {
   entry: ReplayLibraryEntry | undefined
   /** True when the list is day-grouped, so the panel's top should align with the first row. */
@@ -113,8 +259,6 @@ export interface ReplayInspectorProps {
   playlists: ReadonlyArray<ReplayPlaylist>
   /** Bumped whenever the replay index changes, so this entry's playlist membership stays fresh. */
   changeToken: number
-  /** When true, hides the game length (a spoiler) from the panel. */
-  spoilerFree: boolean
   /** True when the library is currently scoped to a single playlist. */
   inPlaylistView: boolean
   /** True when the playlist view is showing its manual order, enabling Move up/Move down. */
@@ -135,7 +279,6 @@ export function ReplayInspector({
   alignWithFirstRow,
   playlists,
   changeToken,
-  spoilerFree,
   inPlaylistView,
   canReorder,
   canMoveUp,
@@ -277,63 +420,18 @@ export function ReplayInspector({
         originX='right'
         originY='top'>
         <MenuList dense={true}>
-          <MenuItem
-            icon={<MaterialIcon icon='playlist_add' />}
-            text={t('replays.library.addToPlaylist', 'Add to playlist…')}
-            onClick={event => {
-              closeMenu()
-              openAddMenu(event)
-            }}
-          />
-          {inPlaylistView ? (
-            <MenuItem
-              icon={<MaterialIcon icon='playlist_remove' />}
-              text={t('replays.library.removeFromPlaylist', 'Remove from playlist')}
-              onClick={() => {
-                closeMenu()
-                onRemoveFromPlaylist()
-              }}
-            />
-          ) : null}
-          {inPlaylistView && canReorder ? (
-            <MenuItem
-              icon={<MaterialIcon icon='arrow_upward' />}
-              text={t('replays.library.moveUp', 'Move up')}
-              disabled={!canMoveUp}
-              onClick={() => {
-                closeMenu()
-                onMoveUp()
-              }}
-            />
-          ) : null}
-          {inPlaylistView && canReorder ? (
-            <MenuItem
-              icon={<MaterialIcon icon='arrow_downward' />}
-              text={t('replays.library.moveDown', 'Move down')}
-              disabled={!canMoveDown}
-              onClick={() => {
-                closeMenu()
-                onMoveDown()
-              }}
-            />
-          ) : null}
-          {entry.sbGameId && !entry.parseError ? (
-            <MenuItem
-              icon={<MaterialIcon icon='open_in_new' />}
-              text={t('replays.library.viewGamePage', 'View game page')}
-              onClick={() => {
-                closeMenu()
-                push(getGameResultsUrl(entry.sbGameId!))
-              }}
-            />
-          ) : null}
-          <MenuItem
-            icon={<MaterialIcon icon='folder_open' />}
-            text={t('replays.library.showInExplorer', 'Show in Explorer')}
-            onClick={() => {
-              closeMenu()
-              onReveal(entry)
-            }}
+          <ReplayActionMenuItems
+            entry={entry}
+            inPlaylistView={inPlaylistView}
+            closeMenu={closeMenu}
+            onOpenAddToPlaylist={openAddMenu}
+            onRemoveFromPlaylist={onRemoveFromPlaylist}
+            onReveal={onReveal}
+            reorder={
+              inPlaylistView && canReorder
+                ? { canMoveUp, canMoveDown, onMoveUp, onMoveDown }
+                : undefined
+            }
           />
         </MenuList>
       </Popover>
@@ -345,31 +443,11 @@ export function ReplayInspector({
         originX='right'
         originY='top'>
         <MenuList dense={true}>
-          {playlists.map(p => (
-            <MenuItem
-              key={p.id}
-              icon={<MaterialIcon icon='queue_music' />}
-              text={p.name}
-              onClick={() => {
-                closeAddMenu()
-                onAddToPlaylist(p.id, entry)
-              }}
-            />
-          ))}
-          <MenuItem
-            icon={<MaterialIcon icon='add' />}
-            text={t('replays.library.newPlaylistMenu', 'New playlist…')}
-            onClick={() => {
-              closeAddMenu()
-              dispatch(
-                openDialog({
-                  type: DialogType.CreatePlaylist,
-                  initData: {
-                    onCreated: id => onAddToPlaylist(id, entry),
-                  },
-                }),
-              )
-            }}
+          <AddToPlaylistMenuItems
+            entry={entry}
+            playlists={playlists}
+            closeMenu={closeAddMenu}
+            onAddToPlaylist={onAddToPlaylist}
           />
         </MenuList>
       </Popover>
@@ -398,15 +476,7 @@ export function ReplayInspector({
             {!map ? (
               <GameSidePanelTitle>{filterColorCodes(entry.mapName)}</GameSidePanelTitle>
             ) : null}
-            <GameSidePanelSubline>
-              <span>{longTimestamp.format(entry.gameTime)}</span>
-              {spoilerFree ? null : (
-                <>
-                  <span>·</span>
-                  <span>{getGameDurationString((entry.durationFrames * 1000) / 24)}</span>
-                </>
-              )}
-            </GameSidePanelSubline>
+            <GameSidePanelSubline>{longTimestamp.format(entry.gameTime)}</GameSidePanelSubline>
           </GameSidePanelHeader>
           <GameSidePanelSection>
             <PlayerTeamsDisplay

--- a/client/replays/replay-library-rail.tsx
+++ b/client/replays/replay-library-rail.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled, { css, keyframes } from 'styled-components'
 import { ReplayBackfillProgress, ReplayPlaylist } from '../../common/replays-library'
@@ -8,7 +9,7 @@ import { MaterialIcon } from '../icons/material/material-icon'
 import { IconButton } from '../material/button'
 import { DestructiveMenuItem, MenuItem } from '../material/menu/item'
 import { MenuList } from '../material/menu/menu'
-import { Popover, usePopoverController, useRefAnchorPosition } from '../material/popover'
+import { OriginX, Popover, usePopoverController, useRefAnchorPosition } from '../material/popover'
 import { useAppDispatch } from '../redux-hooks'
 import { bodyMedium, labelMedium, singleLine } from '../styles/typography'
 import { LibraryView } from './replay-library-helpers'
@@ -151,6 +152,7 @@ function RailItem({
   count,
   selected,
   onClick,
+  onContextMenu,
   actions,
   actionsForceVisible = false,
 }: {
@@ -159,6 +161,7 @@ function RailItem({
   count?: number
   selected: boolean
   onClick: () => void
+  onContextMenu?: (event: React.MouseEvent) => void
   actions?: React.ReactNode
   actionsForceVisible?: boolean
 }) {
@@ -170,6 +173,7 @@ function RailItem({
       role='button'
       tabIndex={0}
       onClick={onClick}
+      onContextMenu={onContextMenu}
       onKeyDown={event => {
         if (event.key === 'Enter' || event.key === ' ') {
           event.preventDefault()
@@ -207,6 +211,13 @@ function PlaylistRailItem({
   const dispatch = useAppDispatch()
   const [anchor, anchorX, anchorY, refreshAnchorPos] = useRefAnchorPosition('right', 'top')
   const [menuOpen, openMenu, closeMenu] = usePopoverController({ refreshAnchorPos })
+  // Overrides the overflow button's anchor with the cursor position when the menu was opened via
+  // right-click instead; cleared again once the button reopens it.
+  const [cursorAnchor, setCursorAnchor] = useState<{ x: number; y: number }>()
+
+  const menuAnchorX = cursorAnchor ? cursorAnchor.x : (anchorX ?? 0)
+  const menuAnchorY = cursorAnchor ? cursorAnchor.y : (anchorY ?? 0)
+  const menuOriginX: OriginX = cursorAnchor ? 'left' : 'right'
 
   return (
     <>
@@ -216,6 +227,11 @@ function PlaylistRailItem({
         count={playlist.count}
         selected={selected}
         onClick={onSelect}
+        onContextMenu={event => {
+          event.preventDefault()
+          setCursorAnchor({ x: event.pageX, y: event.pageY })
+          openMenu(event)
+        }}
         actionsForceVisible={menuOpen}
         actions={
           <RailItemMenuButton
@@ -224,6 +240,7 @@ function PlaylistRailItem({
             title={t('replays.library.rail.playlistActions', 'Playlist actions')}
             onClick={event => {
               event.stopPropagation()
+              setCursorAnchor(undefined)
               openMenu(event)
             }}
           />
@@ -232,9 +249,9 @@ function PlaylistRailItem({
       <Popover
         open={menuOpen}
         onDismiss={closeMenu}
-        anchorX={anchorX ?? 0}
-        anchorY={anchorY ?? 0}
-        originX='right'
+        anchorX={menuAnchorX}
+        anchorY={menuAnchorY}
+        originX={menuOriginX}
         originY='top'>
         <MenuList dense={true}>
           <MenuItem

--- a/client/replays/replay-library-rail.tsx
+++ b/client/replays/replay-library-rail.tsx
@@ -5,14 +5,26 @@ import styled, { css, keyframes } from 'styled-components'
 import { ReplayBackfillProgress, ReplayPlaylist } from '../../common/replays-library'
 import { openDialog } from '../dialogs/action-creators'
 import { DialogType } from '../dialogs/dialog-type'
+import { useBreakpoint } from '../dom/dimension-hooks'
 import { MaterialIcon } from '../icons/material/material-icon'
 import { IconButton } from '../material/button'
 import { DestructiveMenuItem, MenuItem } from '../material/menu/item'
 import { MenuList } from '../material/menu/menu'
 import { OriginX, Popover, usePopoverController, useRefAnchorPosition } from '../material/popover'
+import { Tooltip } from '../material/tooltip'
 import { useAppDispatch } from '../redux-hooks'
 import { bodyMedium, labelMedium, singleLine } from '../styles/typography'
 import { LibraryView } from './replay-library-helpers'
+
+// The width at which the rail collapses to an icon-only strip, keyed to the ancestor
+// `replay-library-body` container's inline-size (set up in replay-library.tsx). This mirrors the
+// container query below via a ResizeObserver on the rail's own rendered width, rather than
+// duplicating the container breakpoint: 72px (collapsed) and 240px (expanded) sit well on either
+// side of the 100px threshold.
+const RAIL_COLLAPSE_BREAKPOINTS: Array<[minWidth: number, collapsed: boolean]> = [
+  [0, true],
+  [100, false],
+]
 
 const RailRoot = styled.div`
   display: flex;
@@ -26,6 +38,11 @@ const RailRoot = styled.div`
   top: 24px;
   max-height: calc(100vh - 96px);
   overflow-y: auto;
+  transition: width 125ms ease-out;
+
+  @container replay-library-body (width < 1100px) {
+    width: 72px;
+  }
 `
 
 const RailSection = styled.div`
@@ -45,6 +62,10 @@ const RailSectionTitle = styled.div`
   align-items: center;
 
   color: var(--theme-on-surface-variant);
+
+  @container replay-library-body (width < 1100px) {
+    display: none;
+  }
 `
 
 // A plain `div` (not `button`) so playlist rows can host a real, non-nested `<button>` for their
@@ -75,6 +96,14 @@ const RailItemRoot = styled.div<{ $selected: boolean }>`
     outline: 2px solid var(--theme-grey-blue);
     outline-offset: -2px;
   }
+
+  @container replay-library-body (width < 1100px) {
+    width: 40px;
+    height: 40px;
+    padding: 0;
+    justify-content: center;
+    margin: 0 auto;
+  }
 `
 
 const RailItemIcon = styled(MaterialIcon).attrs({ size: 18 })`
@@ -87,6 +116,10 @@ const RailItemLabel = styled.div`
   ${singleLine};
   flex-grow: 1;
   color: var(--theme-on-surface);
+
+  @container replay-library-body (width < 1100px) {
+    display: none;
+  }
 `
 
 const RailItemCount = styled.div<{ $hasActions: boolean; $hidden: boolean }>`
@@ -144,6 +177,12 @@ const RailItemEnd = styled.div`
   display: flex;
   align-items: center;
   justify-content: flex-end;
+
+  // Hides the count and the playlist row's hover-revealed overflow-menu button together — neither
+  // fits the icon-only strip, and the menu stays reachable via right-click regardless.
+  @container replay-library-body (width < 1100px) {
+    display: none;
+  }
 `
 
 function RailItem({
@@ -155,6 +194,7 @@ function RailItem({
   onContextMenu,
   actions,
   actionsForceVisible = false,
+  collapsed = false,
 }: {
   icon: string
   label: string
@@ -164,47 +204,60 @@ function RailItem({
   onContextMenu?: (event: React.MouseEvent) => void
   actions?: React.ReactNode
   actionsForceVisible?: boolean
+  /**
+   * Whether the rail is currently in its icon-only collapsed state. Shows a tooltip with `label`
+   * when true (the label text itself is hidden by the rail's container query at that point); the
+   * tooltip stays disabled in expanded mode since the label is already visible there.
+   */
+  collapsed?: boolean
 }) {
   const hasActions = actions !== undefined
 
   return (
-    <RailItemRoot
-      $selected={selected}
-      role='button'
-      tabIndex={0}
-      onClick={onClick}
-      onContextMenu={onContextMenu}
-      onKeyDown={event => {
-        if (event.key === 'Enter' || event.key === ' ') {
-          event.preventDefault()
-          onClick()
-        }
-      }}>
-      <RailItemIcon icon={icon} />
-      <RailItemLabel title={label}>{label}</RailItemLabel>
-      {count !== undefined || hasActions ? (
-        <RailItemEnd>
-          {count !== undefined ? (
-            <RailItemCount $hasActions={hasActions} $hidden={hasActions && actionsForceVisible}>
-              {count}
-            </RailItemCount>
-          ) : null}
-          {actions ? (
-            <RailItemActions $forceVisible={actionsForceVisible}>{actions}</RailItemActions>
-          ) : null}
-        </RailItemEnd>
-      ) : null}
-    </RailItemRoot>
+    <Tooltip text={label} position='right' disabled={!collapsed} tabIndex={-1}>
+      <RailItemRoot
+        $selected={selected}
+        role='button'
+        tabIndex={0}
+        /* The label is visually hidden in the collapsed icon-only strip, so the accessible name
+           can't rely on the text content alone. */
+        aria-label={label}
+        onClick={onClick}
+        onContextMenu={onContextMenu}
+        onKeyDown={event => {
+          if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault()
+            onClick()
+          }
+        }}>
+        <RailItemIcon icon={icon} />
+        <RailItemLabel title={label}>{label}</RailItemLabel>
+        {count !== undefined || hasActions ? (
+          <RailItemEnd>
+            {count !== undefined ? (
+              <RailItemCount $hasActions={hasActions} $hidden={hasActions && actionsForceVisible}>
+                {count}
+              </RailItemCount>
+            ) : null}
+            {actions ? (
+              <RailItemActions $forceVisible={actionsForceVisible}>{actions}</RailItemActions>
+            ) : null}
+          </RailItemEnd>
+        ) : null}
+      </RailItemRoot>
+    </Tooltip>
   )
 }
 
 function PlaylistRailItem({
   playlist,
   selected,
+  collapsed,
   onSelect,
 }: {
   playlist: ReplayPlaylist
   selected: boolean
+  collapsed: boolean
   onSelect: () => void
 }) {
   const { t } = useTranslation()
@@ -226,6 +279,7 @@ function PlaylistRailItem({
         label={playlist.name}
         count={playlist.count}
         selected={selected}
+        collapsed={collapsed}
         onClick={onSelect}
         onContextMenu={event => {
           event.preventDefault()
@@ -333,6 +387,10 @@ const BackfillLabel = styled.div`
   ${labelMedium};
   color: var(--theme-on-surface-variant);
   font-variant-numeric: tabular-nums;
+
+  @container replay-library-body (width < 1100px) {
+    display: none;
+  }
 `
 
 /**
@@ -396,9 +454,16 @@ export function ReplayLibraryRail({
 }: ReplayLibraryRailProps) {
   const { t } = useTranslation()
   const dispatch = useAppDispatch()
+  // Observes the rail's own rendered width so JS behavior (tooltips) follows the same collapse
+  // point as the CSS container query on `RailRoot`, without hardcoding the page-body breakpoint
+  // here too.
+  const [railRef, collapsed] = useBreakpoint<HTMLDivElement, boolean>(
+    RAIL_COLLAPSE_BREAKPOINTS,
+    false,
+  )
 
   return (
-    <RailRoot>
+    <RailRoot ref={railRef}>
       <RailSection>
         <RailSectionTitle>{t('replays.library.rail.library', 'Library')}</RailSectionTitle>
         <RailItem
@@ -406,6 +471,7 @@ export function ReplayLibraryRail({
           label={t('replays.library.rail.allReplays', 'All replays')}
           count={totalIndexed}
           selected={view.kind === 'all'}
+          collapsed={collapsed}
           onClick={() => onSelectView({ kind: 'all' })}
         />
         <RailItem
@@ -413,6 +479,7 @@ export function ReplayLibraryRail({
           label={t('replays.library.rail.bookmarked', 'Bookmarked')}
           count={bookmarkedCount}
           selected={view.kind === 'bookmarked'}
+          collapsed={collapsed}
           onClick={() => onSelectView({ kind: 'bookmarked' })}
         />
       </RailSection>
@@ -426,6 +493,7 @@ export function ReplayLibraryRail({
             key={p.id}
             playlist={p}
             selected={view.kind === 'playlist' && view.id === p.id}
+            collapsed={collapsed}
             onSelect={() => onSelectView({ kind: 'playlist', id: p.id })}
           />
         ))}
@@ -433,6 +501,7 @@ export function ReplayLibraryRail({
           icon='add'
           label={t('replays.library.rail.newPlaylist', 'New playlist')}
           selected={false}
+          collapsed={collapsed}
           onClick={() => {
             dispatch(
               openDialog({

--- a/client/replays/replay-library.tsx
+++ b/client/replays/replay-library.tsx
@@ -1,4 +1,5 @@
 import { debounce } from 'lodash-es'
+import * as React from 'react'
 import { useEffect, useEffectEvent, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { GroupedVirtuoso, GroupedVirtuosoHandle, Virtuoso, VirtuosoHandle } from 'react-virtuoso'
@@ -27,14 +28,23 @@ import {
   ReplayLibraryStatus,
   ReplayPlaylist,
 } from '../../common/replays-library'
-import { DayHeader, formatDayHeaderLabel, getDayBoundaries } from '../games/day-header'
+import { useContextMenu } from '../dom/use-context-menu'
+import {
+  DayHeader,
+  formatDayHeaderLabel,
+  getDayBoundaries,
+  resolveDateRangeMs,
+} from '../games/day-header'
 import { GameFilterBar } from '../games/game-filter-bar'
-import { GameListEntryLayout } from '../games/game-list-entry'
+import { GameListEntryLayout, SelectableRowContainer } from '../games/game-list-entry'
 import { PlayerTeamsDisplay } from '../games/player-teams-display'
 import { MaterialIcon } from '../icons/material/material-icon'
 import { useKeyListener } from '../keyboard/key-listener'
 import InfiniteScrollList from '../lists/infinite-scroll-list'
-import { ButtonStateStyleProps, IconButton, TextButton, useButtonState } from '../material/button'
+import { IconButton, TextButton, useButtonState } from '../material/button'
+import { MenuItem } from '../material/menu/item'
+import { MenuList } from '../material/menu/menu'
+import { Popover, usePopoverController } from '../material/popover'
 import { Ripple } from '../material/ripple'
 import { Tooltip } from '../material/tooltip'
 import { useLocationSearchParam } from '../navigation/router-hooks'
@@ -46,7 +56,7 @@ import { CenteredContentContainer } from '../styles/centered-container'
 import { styledWithAttrs } from '../styles/styled-with-attrs'
 import { bodyLarge, bodyMedium, singleLine, titleLarge, titleSmall } from '../styles/typography'
 import { startReplay } from './action-creators'
-import { ReplayInspector } from './replay-inspector'
+import { AddToPlaylistMenuItems, ReplayActionMenuItems, ReplayInspector } from './replay-inspector'
 import {
   encodeView,
   getReplayDisplayTeams,
@@ -96,21 +106,36 @@ function parseModeFilter(value: string): SupportedReplayGameType | 'others' | un
     : undefined
 }
 
-/**
- * Assembles the query filters (everything but paging) from the current view and filter/sort
- * values. `sort` is `undefined` in a playlist's manual order, which the query treats as "use the
- * playlist's arrangement".
- */
-function buildFilters(
-  view: LibraryView,
-  sort: GameSortOption | undefined,
-  mapName: string,
-  playerName: string,
-  gameType: number | 'others' | undefined,
-  duration: GameDurationFilter,
-  format: GameFormat | undefined,
-  matchup: EncodedMatchupString | undefined,
-): ReplayLibraryFilters {
+interface BuildFiltersParams {
+  view: LibraryView
+  /**
+   * `undefined` in a playlist's manual order, which the query treats as "use the playlist's
+   * arrangement".
+   */
+  sort: GameSortOption | undefined
+  mapName: string
+  playerName: string
+  gameType: number | 'others' | undefined
+  duration: GameDurationFilter
+  format: GameFormat | undefined
+  matchup: EncodedMatchupString | undefined
+  startDate: string
+  endDate: string
+}
+
+/** Assembles the query filters (everything but paging) from the current view and filter/sort values. */
+function buildFilters({
+  view,
+  sort,
+  mapName,
+  playerName,
+  gameType,
+  duration,
+  format,
+  matchup,
+  startDate,
+  endDate,
+}: BuildFiltersParams): ReplayLibraryFilters {
   const filters: ReplayLibraryFilters = {}
   if (view.kind === 'bookmarked') {
     filters.bookmarked = true
@@ -126,6 +151,9 @@ function buildFilters(
     filters.format = format
     if (matchup) filters.matchup = matchup
   }
+  const { startMs, endMs } = resolveDateRangeMs(startDate, endDate)
+  if (startMs !== undefined) filters.gameTimeFrom = startMs
+  if (endMs !== undefined) filters.gameTimeTo = endMs
   return filters
 }
 
@@ -207,25 +235,6 @@ export function ReplayLibraryUnavailable() {
 
 // ---- Row -------------------------------------------------------------------------------------
 
-const ReplayRowContainer = styled.div<ButtonStateStyleProps & { $selected: boolean }>`
-  position: relative;
-  width: 100%;
-
-  border-radius: 8px;
-  contain: content;
-  cursor: pointer;
-
-  background-color: ${props =>
-    props.$selected ? 'rgb(from var(--theme-on-surface) r g b / 0.1)' : 'transparent'};
-
-  &:hover {
-    background-color: ${props =>
-      props.$selected
-        ? 'rgb(from var(--theme-on-surface) r g b / 0.12)'
-        : 'rgb(from var(--theme-on-surface) r g b / 0.06)'};
-  }
-`
-
 const ParseErrorPlayers = styled.div`
   ${titleSmall};
 
@@ -269,6 +278,7 @@ interface ReplayListEntryProps {
   onSelect: (id: number) => void
   onWatch: (entry: ReplayLibraryEntry) => void
   onToggleBookmark: (entry: ReplayLibraryEntry) => void
+  onContextMenu: (entry: ReplayLibraryEntry, event: React.MouseEvent) => void
 }
 
 function ReplayListEntry({
@@ -281,6 +291,7 @@ function ReplayListEntry({
   onSelect,
   onWatch,
   onToggleBookmark,
+  onContextMenu,
 }: ReplayListEntryProps) {
   const { t } = useTranslation()
   const [buttonProps, rippleRef] = useButtonState({
@@ -319,7 +330,10 @@ function ReplayListEntry({
   )
 
   return (
-    <ReplayRowContainer {...buttonProps} $selected={selected}>
+    <SelectableRowContainer
+      {...buttonProps}
+      $selected={selected}
+      onContextMenu={event => onContextMenu(entry, event)}>
       <GameListEntryLayout
         fillPlayers={true}
         dense={true}
@@ -334,7 +348,7 @@ function ReplayListEntry({
         gameTypeLabel={entry.parseError ? '' : replayGameTypeToLabel(entry.gameType, t)}
       />
       <Ripple ref={rippleRef} />
-    </ReplayRowContainer>
+    </SelectableRowContainer>
   )
 }
 
@@ -364,6 +378,12 @@ export function ReplayLibrary() {
   const groupedRef = useRef<GroupedVirtuosoHandle>(null)
   const flatRef = useRef<VirtuosoHandle>(null)
 
+  // Right-click on a row selects it and opens this menu at the cursor, offering the same actions
+  // as the inspector's overflow menu.
+  const { onContextMenu: openRowContextMenu, contextMenuPopoverProps } = useContextMenu()
+  const [addToPlaylistMenuOpen, openAddToPlaylistMenu, closeAddToPlaylistMenu] =
+    usePopoverController()
+
   // Guards against IPC responses for a query that's since been superseded by a `reset()` (e.g. the
   // user changed filters while a request was in flight).
   const queryEpochRef = useRef(0)
@@ -376,6 +396,8 @@ export function ReplayLibrary() {
   const [matchupParam, setMatchupParam] = useLocationSearchParam('matchup')
   const [gameTypeParam, setGameTypeParam] = useLocationSearchParam('gameType')
   const [viewParam, setViewParam] = useLocationSearchParam('view')
+  const [startDate, setStartDateParam] = useLocationSearchParam('startDate')
+  const [endDate, setEndDateParam] = useLocationSearchParam('endDate')
 
   const duration = parseDuration(durationParam)
   const sort = parseSort(sortParam)
@@ -399,7 +421,9 @@ export function ReplayLibrary() {
     !!playerName ||
     !!format ||
     !!matchup ||
-    gameType !== undefined
+    gameType !== undefined ||
+    !!startDate ||
+    !!endDate
 
   const isDurationSort =
     sort === GameSortOption.ShortestFirst || sort === GameSortOption.LongestFirst
@@ -451,16 +475,18 @@ export function ReplayLibrary() {
 
     ipcRenderer
       .invoke('replayLibraryQuery', {
-        ...buildFilters(
+        ...buildFilters({
           view,
-          effectiveSort,
+          sort: effectiveSort,
           mapName,
           playerName,
           gameType,
           duration,
           format,
           matchup,
-        ),
+          startDate,
+          endDate,
+        }),
         offset: 0,
         limit,
       })
@@ -524,6 +550,11 @@ export function ReplayLibrary() {
   }
   const revealEntry = (entry: ReplayLibraryEntry) => {
     ipcRenderer.invoke('pathsShowItemInFolder', entry.path)?.catch(swallowNonBuiltins)
+  }
+
+  const handleRowContextMenu = (entry: ReplayLibraryEntry, event: React.MouseEvent) => {
+    setFocusedId(entry.id)
+    openRowContextMenu(event)
   }
 
   const toggleBookmark = (entry: ReplayLibraryEntry) => {
@@ -598,16 +629,18 @@ export function ReplayLibrary() {
 
     ipcRenderer
       .invoke('replayLibraryQuery', {
-        ...buildFilters(
+        ...buildFilters({
           view,
-          effectiveSort,
+          sort: effectiveSort,
           mapName,
           playerName,
           gameType,
           duration,
           format,
           matchup,
-        ),
+          startDate,
+          endDate,
+        }),
         offset: entries?.length ?? 0,
         limit: LOAD_CHUNK_SIZE,
       })
@@ -638,6 +671,8 @@ export function ReplayLibrary() {
     setFormatParam('')
     setMatchupParam('')
     setGameTypeParam('')
+    setStartDateParam('')
+    setEndDateParam('')
     reset()
     // `sort` is a view option (not a filter), so it's intentionally left untouched.
   }
@@ -723,6 +758,7 @@ export function ReplayLibrary() {
         onSelect={setFocusedId}
         onWatch={watchEntry}
         onToggleBookmark={toggleBookmark}
+        onContextMenu={handleRowContextMenu}
       />
     )
   }
@@ -778,7 +814,9 @@ export function ReplayLibrary() {
               'Replays you watch and play will show up here automatically.',
             )}
           </div>
-          {status?.watchedFolder ? <EmptyStatePath>{status.watchedFolder}</EmptyStatePath> : null}
+          {status?.watchedFolders.map(folder => (
+            <EmptyStatePath key={folder}>{folder}</EmptyStatePath>
+          ))}
         </CenteredState>
       )
     }
@@ -888,6 +926,16 @@ export function ReplayLibrary() {
           }}
           spoilerFree={spoilerFree}
           setSpoilerFree={setSpoilerFree}
+          startDate={startDate}
+          setStartDate={v => {
+            setStartDateParam(v)
+            reset()
+          }}
+          endDate={endDate}
+          setEndDate={v => {
+            setEndDateParam(v)
+            reset()
+          }}
         />
 
         <BodyRow>
@@ -922,7 +970,6 @@ export function ReplayLibrary() {
               alignWithFirstRow={!useFlatList}
               playlists={playlists}
               changeToken={changeToken}
-              spoilerFree={spoilerFree}
               inPlaylistView={view.kind === 'playlist'}
               canReorder={canReorder}
               canMoveUp={canMoveUp}
@@ -939,6 +986,61 @@ export function ReplayLibrary() {
             />
           ) : null}
         </BodyRow>
+
+        <Popover {...contextMenuPopoverProps}>
+          {focusedEntry ? (
+            <MenuList dense={true}>
+              <MenuItem
+                icon={<MaterialIcon icon='play_arrow' />}
+                text={t('replays.library.watchReplay', 'Watch replay')}
+                onClick={() => {
+                  contextMenuPopoverProps.onDismiss()
+                  watchEntry(focusedEntry)
+                }}
+              />
+              <MenuItem
+                icon={
+                  <MaterialIcon icon='bookmark' filled={focusedEntry.bookmarkedAt !== undefined} />
+                }
+                text={
+                  focusedEntry.bookmarkedAt !== undefined
+                    ? t('replays.library.removeBookmark', 'Remove bookmark')
+                    : t('replays.library.bookmark', 'Bookmark')
+                }
+                onClick={() => {
+                  contextMenuPopoverProps.onDismiss()
+                  toggleBookmark(focusedEntry)
+                }}
+              />
+              <ReplayActionMenuItems
+                entry={focusedEntry}
+                inPlaylistView={view.kind === 'playlist'}
+                closeMenu={contextMenuPopoverProps.onDismiss}
+                onOpenAddToPlaylist={openAddToPlaylistMenu}
+                onRemoveFromPlaylist={() => removeFromCurrentPlaylist(focusedEntry)}
+                onReveal={revealEntry}
+              />
+            </MenuList>
+          ) : null}
+        </Popover>
+        <Popover
+          open={addToPlaylistMenuOpen}
+          onDismiss={closeAddToPlaylistMenu}
+          anchorX={contextMenuPopoverProps.anchorX}
+          anchorY={contextMenuPopoverProps.anchorY}
+          originX={contextMenuPopoverProps.originX}
+          originY={contextMenuPopoverProps.originY}>
+          {focusedEntry ? (
+            <MenuList dense={true}>
+              <AddToPlaylistMenuItems
+                entry={focusedEntry}
+                playlists={playlists}
+                closeMenu={closeAddToPlaylistMenu}
+                onAddToPlaylist={addToPlaylist}
+              />
+            </MenuList>
+          ) : null}
+        </Popover>
       </PageColumn>
     </CenteredContentContainer>
   )

--- a/client/replays/replay-library.tsx
+++ b/client/replays/replay-library.tsx
@@ -418,8 +418,9 @@ export function ReplayLibrary() {
   const bookmarkTitle = t('replays.library.bookmark', 'Bookmark')
   const removeBookmarkTitle = t('replays.library.removeBookmark', 'Remove bookmark')
 
-  // Remembered per-user: hides the game length (a spoiler) from the list rows and the inspector.
-  const [spoilerFree, setSpoilerFree] = useUserLocalStorageValue('replaySpoilerFree', false)
+  // Remembered per-user, shared with the games and match history pages: hides the game length (a
+  // spoiler) from the list rows and the inspector.
+  const [spoilerFree, setSpoilerFree] = useUserLocalStorageValue('gamesSpoilerFree', false)
 
   // The view is navigation rather than a filter: it isn't included here, and clearing filters
   // leaves it alone.

--- a/client/replays/replay-library.tsx
+++ b/client/replays/replay-library.tsx
@@ -56,7 +56,11 @@ import { CenteredContentContainer } from '../styles/centered-container'
 import { styledWithAttrs } from '../styles/styled-with-attrs'
 import { bodyLarge, bodyMedium, singleLine, titleLarge, titleSmall } from '../styles/typography'
 import { startReplay } from './action-creators'
-import { AddToPlaylistMenuItems, ReplayActionMenuItems, ReplayInspector } from './replay-inspector'
+import {
+  getAddToPlaylistMenuItems,
+  getReplayActionMenuItems,
+  ReplayInspector,
+} from './replay-inspector'
 import {
   encodeView,
   getReplayDisplayTeams,
@@ -168,6 +172,12 @@ const PageColumn = styled.div`
 `
 
 const BodyRow = styled.div`
+  /*
+    Named container so descendants (e.g. the library rail) can adapt to the actual space this row
+    gets — which depends on the window size *and* the social sidebar — rather than the viewport.
+  */
+  container: replay-library-body / inline-size;
+
   display: flex;
   flex-direction: row;
   gap: 24px;
@@ -335,8 +345,6 @@ function ReplayListEntry({
       $selected={selected}
       onContextMenu={event => onContextMenu(entry, event)}>
       <GameListEntryLayout
-        fillPlayers={true}
-        dense={true}
         bookmark={bookmark}
         players={players}
         duration={
@@ -800,6 +808,18 @@ export function ReplayLibrary() {
           <div>{t('replays.library.playlistEmptyBody', 'Add replays to it from the library.')}</div>
         </CenteredState>
       )
+    } else if (status && status.watchedFolders.length === 0) {
+      listContent = (
+        <CenteredState>
+          <EmptyStateTitle>{t('replays.library.noFolders', 'No replay folders')}</EmptyStateTitle>
+          <div>
+            {t(
+              'replays.library.noFoldersBody',
+              'Add a folder in Settings > App > System to start indexing replays.',
+            )}
+          </div>
+        </CenteredState>
+      )
     } else if (backfill) {
       // A backfill is still populating the index (progress shows in the bar above); don't claim
       // there are no replays while it's just getting started.
@@ -1012,14 +1032,15 @@ export function ReplayLibrary() {
                   toggleBookmark(focusedEntry)
                 }}
               />
-              <ReplayActionMenuItems
-                entry={focusedEntry}
-                inPlaylistView={view.kind === 'playlist'}
-                closeMenu={contextMenuPopoverProps.onDismiss}
-                onOpenAddToPlaylist={openAddToPlaylistMenu}
-                onRemoveFromPlaylist={() => removeFromCurrentPlaylist(focusedEntry)}
-                onReveal={revealEntry}
-              />
+              {getReplayActionMenuItems({
+                entry: focusedEntry,
+                inPlaylistView: view.kind === 'playlist',
+                closeMenu: contextMenuPopoverProps.onDismiss,
+                onOpenAddToPlaylist: openAddToPlaylistMenu,
+                onRemoveFromPlaylist: () => removeFromCurrentPlaylist(focusedEntry),
+                onReveal: revealEntry,
+                t,
+              })}
             </MenuList>
           ) : null}
         </Popover>
@@ -1032,12 +1053,14 @@ export function ReplayLibrary() {
           originY={contextMenuPopoverProps.originY}>
           {focusedEntry ? (
             <MenuList dense={true}>
-              <AddToPlaylistMenuItems
-                entry={focusedEntry}
-                playlists={playlists}
-                closeMenu={closeAddToPlaylistMenu}
-                onAddToPlaylist={addToPlaylist}
-              />
+              {getAddToPlaylistMenuItems({
+                entry: focusedEntry,
+                playlists,
+                closeMenu: closeAddToPlaylistMenu,
+                onAddToPlaylist: addToPlaylist,
+                t,
+                dispatch,
+              })}
             </MenuList>
           ) : null}
         </Popover>

--- a/client/settings/app/system-settings.tsx
+++ b/client/settings/app/system-settings.tsx
@@ -1,5 +1,6 @@
 import { TFunction } from 'i18next'
 import { useAtomValue } from 'jotai'
+import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 import {
@@ -7,6 +8,7 @@ import {
   GameServerRegionId,
   GameServerRegionLatencies,
 } from '../../../common/game-server-regions'
+import { TypedIpcRenderer } from '../../../common/ipc'
 import { useForm, useFormCallbacks } from '../../forms/form-hook'
 import {
   gameServerRegionLatenciesAtom,
@@ -14,14 +16,37 @@ import {
 } from '../../game-server-regions/game-server-regions-atoms'
 import { getRegionDisplayName } from '../../game-server-regions/region-names'
 import { pickAutoRegion } from '../../game-server-regions/region-resolution'
+import { MaterialIcon } from '../../icons/material/material-icon'
+import logger from '../../logging/logger'
 import { isMatchmakingAtom, matchLaunchingAtom } from '../../matchmaking/matchmaking-atoms'
+import { IconButton, TextButton } from '../../material/button'
 import { CheckBox } from '../../material/check-box'
 import { SelectOption } from '../../material/select/option'
 import { Select } from '../../material/select/select'
+import { Tooltip } from '../../material/tooltip'
 import { useAppDispatch, useAppSelector } from '../../redux-hooks'
-import { bodySmall } from '../../styles/typography'
+import { bodyMedium, bodySmall, singleLine } from '../../styles/typography'
 import { mergeLocalSettings } from '../action-creators'
 import { FormContainer, SectionContainer, SectionOverline } from '../settings-content'
+
+const ipcRenderer = new TypedIpcRenderer()
+
+/**
+ * Removes duplicate folders case-insensitively (Windows paths compare case-insensitively), keeping
+ * the first occurrence's original casing.
+ */
+function dedupeFolders(folders: ReadonlyArray<string>): string[] {
+  const seen = new Set<string>()
+  const result: string[] = []
+  for (const folder of folders) {
+    const key = folder.toLowerCase()
+    if (!seen.has(key)) {
+      seen.add(key)
+      result.push(folder)
+    }
+  }
+  return result
+}
 
 const IndentedCheckBox = styled(CheckBox)`
   margin-left: 28px;
@@ -34,6 +59,49 @@ const NetworkOverline = styled(SectionOverline)`
 const RegionLockedText = styled.div`
   ${bodySmall};
   color: var(--theme-on-surface-variant);
+`
+
+const ReplayFoldersBlock = styled.div`
+  margin-top: 16px;
+
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+`
+
+const ReplayFoldersDescription = styled.div`
+  ${bodySmall};
+  color: var(--theme-on-surface-variant);
+`
+
+const FolderList = styled.div`
+  display: flex;
+  flex-direction: column;
+`
+
+const FolderRow = styled.div`
+  min-height: 40px;
+
+  display: flex;
+  align-items: center;
+  gap: 8px;
+`
+
+const FolderPath = styled.div`
+  ${bodyMedium};
+  ${singleLine};
+
+  flex: 1 1 auto;
+  min-width: 0;
+`
+
+const DefaultHint = styled.span`
+  ${bodySmall};
+  color: var(--theme-on-surface-variant);
+`
+
+const AddFolderButton = styled(TextButton)`
+  align-self: flex-start;
 `
 
 /**
@@ -133,6 +201,61 @@ export function AppSystemSettings() {
     },
   })
 
+  // The replay folders live outside the form model: they persist immediately on add/remove rather
+  // than being bound to a field that saves on change.
+  const configuredFolders = localSettings.replayLibraryFolders ?? []
+  const usingDefault = configuredFolders.length === 0
+  // The renderer can't compute the OS documents directory, so the main process resolves the default
+  // replay folder for display (and as the picker's starting location when nothing is configured).
+  const [defaultFolder, setDefaultFolder] = useState<string | undefined>(undefined)
+  useEffect(() => {
+    let active = true
+    ipcRenderer
+      .invoke('settingsGetDefaultReplayFolder')!
+      .then(folder => {
+        if (active) {
+          setDefaultFolder(folder)
+        }
+      })
+      .catch(err => {
+        logger.error(`Failed to get the default replay folder: ${err?.stack ?? err}`)
+      })
+    return () => {
+      active = false
+    }
+  }, [])
+
+  const saveFolders = (folders: ReadonlyArray<string>) => {
+    dispatch(
+      mergeLocalSettings(
+        { replayLibraryFolders: dedupeFolders(folders) },
+        { onSuccess: () => {}, onError: () => {} },
+      ),
+    )
+  }
+
+  const onAddFolderClick = () => {
+    Promise.resolve()
+      .then(async () => {
+        const selection = await ipcRenderer.invoke('settingsBrowseForFolder', {
+          title: t('settings.app.system.addReplayFolderTitle', 'Select a replay folder'),
+          defaultPath: configuredFolders[0] ?? defaultFolder,
+        })!
+        if (selection.canceled || selection.filePaths.length === 0) {
+          return
+        }
+        saveFolders([...configuredFolders, selection.filePaths[0]])
+      })
+      .catch(err => {
+        logger.error(`Failed to browse for a replay folder: ${err?.stack ?? err}`)
+      })
+  }
+
+  const onRemoveFolder = (folder: string) => {
+    // Removing the last explicit folder saves `[]`, which resolves back to the default folder.
+    saveFolders(configuredFolders.filter(f => f !== folder))
+  }
+
   return (
     <form noValidate={true} onSubmit={submit}>
       <FormContainer>
@@ -146,6 +269,49 @@ export function AppSystemSettings() {
             )}
             inputProps={{ tabIndex: 0 }}
           />
+
+          <ReplayFoldersBlock>
+            <SectionOverline>
+              {t('settings.app.system.replayFoldersTitle', 'Replay folders')}
+            </SectionOverline>
+            <ReplayFoldersDescription>
+              {t(
+                'settings.app.system.replayFoldersDescription',
+                'Folders indexed by your replay library. Removing a folder removes its replays from ' +
+                  'the library, including their bookmarks and playlist entries.',
+              )}
+            </ReplayFoldersDescription>
+
+            <FolderList>
+              {usingDefault ? (
+                <FolderRow>
+                  <FolderPath title={defaultFolder}>{defaultFolder ?? ''}</FolderPath>
+                  <DefaultHint>
+                    {t('settings.app.system.replayFolderDefaultHint', '(default)')}
+                  </DefaultHint>
+                </FolderRow>
+              ) : (
+                configuredFolders.map(folder => (
+                  <FolderRow key={folder}>
+                    <FolderPath title={folder}>{folder}</FolderPath>
+                    <Tooltip text={t('settings.app.system.removeReplayFolder', 'Remove folder')}>
+                      <IconButton
+                        icon={<MaterialIcon icon='delete' />}
+                        ariaLabel={t('settings.app.system.removeReplayFolder', 'Remove folder')}
+                        onClick={() => onRemoveFolder(folder)}
+                      />
+                    </Tooltip>
+                  </FolderRow>
+                ))
+              )}
+            </FolderList>
+
+            <AddFolderButton
+              label={t('settings.app.system.addReplayFolder', 'Add folder')}
+              iconStart={<MaterialIcon icon='add' />}
+              onClick={onAddFolderClick}
+            />
+          </ReplayFoldersBlock>
         </SectionContainer>
         <SectionContainer>
           <SectionOverline>{t('settings.app.system.startupOverline', 'Startup')}</SectionOverline>

--- a/client/settings/app/system-settings.tsx
+++ b/client/settings/app/system-settings.tsx
@@ -219,9 +219,9 @@ export function AppSystemSettings() {
   // The replay folders live outside the form model: they persist immediately on add/remove rather
   // than being bound to a field that saves on change.
   //
-  // `replayLibraryFolders` is materialized to a real list at first app boot, so it's normally
-  // defined here; the `undefined` fallback covers a renderer running before that migration and
-  // shows the resolved default folder as the sole (removable) entry.
+  // A user who has never configured folders has `replayLibraryFolders === undefined`; the
+  // fallback shows the resolved default folder as the sole, removable entry. Removing it saves
+  // `[]` (nothing indexed); adding a folder appends to whichever list is currently showing.
   const configuredFolders =
     localSettings.replayLibraryFolders ?? (defaultFolder !== undefined ? [defaultFolder] : [])
 
@@ -252,8 +252,8 @@ export function AppSystemSettings() {
   }
 
   const onRemoveFolder = (folder: string) => {
-    // Removing every folder saves `[]`, which empties the index for the current run; the app
-    // restores the default folder the next time it launches.
+    // Removing every folder saves `[]`, which persists: nothing is indexed until the user adds a
+    // folder again.
     saveFolders(configuredFolders.filter(f => f !== folder))
   }
 

--- a/client/settings/app/system-settings.tsx
+++ b/client/settings/app/system-settings.tsx
@@ -95,11 +95,6 @@ const FolderPath = styled.div`
   min-width: 0;
 `
 
-const DefaultHint = styled.span`
-  ${bodySmall};
-  color: var(--theme-on-surface-variant);
-`
-
 const AddFolderButton = styled(TextButton)`
   align-self: flex-start;
 `
@@ -201,10 +196,6 @@ export function AppSystemSettings() {
     },
   })
 
-  // The replay folders live outside the form model: they persist immediately on add/remove rather
-  // than being bound to a field that saves on change.
-  const configuredFolders = localSettings.replayLibraryFolders ?? []
-  const usingDefault = configuredFolders.length === 0
   // The renderer can't compute the OS documents directory, so the main process resolves the default
   // replay folder for display (and as the picker's starting location when nothing is configured).
   const [defaultFolder, setDefaultFolder] = useState<string | undefined>(undefined)
@@ -224,6 +215,15 @@ export function AppSystemSettings() {
       active = false
     }
   }, [])
+
+  // The replay folders live outside the form model: they persist immediately on add/remove rather
+  // than being bound to a field that saves on change.
+  //
+  // `replayLibraryFolders` is materialized to a real list at first app boot, so it's normally
+  // defined here; the `undefined` fallback covers a renderer running before that migration and
+  // shows the resolved default folder as the sole (removable) entry.
+  const configuredFolders =
+    localSettings.replayLibraryFolders ?? (defaultFolder !== undefined ? [defaultFolder] : [])
 
   const saveFolders = (folders: ReadonlyArray<string>) => {
     dispatch(
@@ -252,7 +252,7 @@ export function AppSystemSettings() {
   }
 
   const onRemoveFolder = (folder: string) => {
-    // Removing the last explicit folder saves `[]`, which resolves back to the default folder.
+    // Removing every folder saves `[]`, a valid state that indexes nothing.
     saveFolders(configuredFolders.filter(f => f !== folder))
   }
 
@@ -277,33 +277,25 @@ export function AppSystemSettings() {
             <ReplayFoldersDescription>
               {t(
                 'settings.app.system.replayFoldersDescription',
-                'Folders indexed by your replay library. Removing a folder removes its replays from ' +
-                  'the library, including their bookmarks and playlist entries.',
+                'Folders indexed by your replay library. The default StarCraft replay folder is ' +
+                  'added automatically. Removing a folder removes its replays from the library, ' +
+                  'including their bookmarks and playlist entries.',
               )}
             </ReplayFoldersDescription>
 
             <FolderList>
-              {usingDefault ? (
-                <FolderRow>
-                  <FolderPath title={defaultFolder}>{defaultFolder ?? ''}</FolderPath>
-                  <DefaultHint>
-                    {t('settings.app.system.replayFolderDefaultHint', '(default)')}
-                  </DefaultHint>
+              {configuredFolders.map(folder => (
+                <FolderRow key={folder}>
+                  <FolderPath title={folder}>{folder}</FolderPath>
+                  <Tooltip text={t('settings.app.system.removeReplayFolder', 'Remove folder')}>
+                    <IconButton
+                      icon={<MaterialIcon icon='delete' />}
+                      ariaLabel={t('settings.app.system.removeReplayFolder', 'Remove folder')}
+                      onClick={() => onRemoveFolder(folder)}
+                    />
+                  </Tooltip>
                 </FolderRow>
-              ) : (
-                configuredFolders.map(folder => (
-                  <FolderRow key={folder}>
-                    <FolderPath title={folder}>{folder}</FolderPath>
-                    <Tooltip text={t('settings.app.system.removeReplayFolder', 'Remove folder')}>
-                      <IconButton
-                        icon={<MaterialIcon icon='delete' />}
-                        ariaLabel={t('settings.app.system.removeReplayFolder', 'Remove folder')}
-                        onClick={() => onRemoveFolder(folder)}
-                      />
-                    </Tooltip>
-                  </FolderRow>
-                ))
-              )}
+              ))}
             </FolderList>
 
             <AddFolderButton

--- a/client/settings/app/system-settings.tsx
+++ b/client/settings/app/system-settings.tsx
@@ -252,7 +252,8 @@ export function AppSystemSettings() {
   }
 
   const onRemoveFolder = (folder: string) => {
-    // Removing every folder saves `[]`, a valid state that indexes nothing.
+    // Removing every folder saves `[]`, which empties the index for the current run; the app
+    // restores the default folder the next time it launches.
     saveFolders(configuredFolders.filter(f => f !== folder))
   }
 

--- a/client/users/match-history.tsx
+++ b/client/users/match-history.tsx
@@ -1,7 +1,6 @@
 import { useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
-import { ReadonlyDeep } from 'type-fest'
 import {
   ALL_GAME_FORMATS,
   decodeMatchup,
@@ -11,21 +10,17 @@ import {
   GameSortOption,
   makeEncodedMatchupString,
 } from '../../common/games/game-filters'
-import { GameRecordJson } from '../../common/games/games'
 import { SbUserId } from '../../common/users/sb-user-id'
 import { useContextMenu } from '../dom/use-context-menu'
 import { navigateToGameResults } from '../games/action-creators'
 import { renderGamesWithDayHeaders, resolveDateRangeMs } from '../games/day-header'
+import { GameContextMenuContent } from '../games/game-context-menu'
 import { GameFilterBar } from '../games/game-filter-bar'
 import { GameListEntry } from '../games/game-list-entry'
 import { GameRecordSidePanel } from '../games/game-record-side-panel'
 import { GameListSearchPage, useGameListSearch } from '../games/use-game-list-search'
-import { useGameReplayActions } from '../games/use-game-replay-actions'
 import { useKeyListener } from '../keyboard/key-listener'
 import InfiniteScrollList from '../lists/infinite-scroll-list'
-import { Divider } from '../material/menu/divider'
-import { MenuItem } from '../material/menu/item'
-import { MenuList } from '../material/menu/menu'
 import { Popover } from '../material/popover'
 import { useLocationSearchParam } from '../navigation/router-hooks'
 import { useAppDispatch } from '../redux-hooks'
@@ -97,52 +92,6 @@ function parseMatchup(
 /** A date-based sort groups games by calendar day; the duration sorts render as a flat list. */
 function isDateSort(sort: GameSortOption): boolean {
   return sort === GameSortOption.LatestFirst || sort === GameSortOption.OldestFirst
-}
-
-/**
- * Split out from the page so `useGameReplayActions` (which subscribes to this game's replay info)
- * only runs while the menu is actually open, rather than for every row on every render.
- */
-function MatchHistoryContextMenuContent({
-  game,
-  onDismiss,
-}: {
-  game: ReadonlyDeep<GameRecordJson>
-  onDismiss: () => void
-}) {
-  const { t } = useTranslation()
-  const { replayInfo, onWatchReplay, onSaveReplay } = useGameReplayActions(game)
-
-  return (
-    <MenuList dense={true}>
-      <MenuItem
-        text={t('games.sidePanel.viewFullResults', 'View full results')}
-        onClick={() => {
-          onDismiss()
-          navigateToGameResults(game.id)
-        }}
-      />
-      {IS_ELECTRON && replayInfo ? (
-        <>
-          <Divider $dense={true} />
-          <MenuItem
-            text={t('gameDetails.buttonWatchReplay', 'Watch replay')}
-            onClick={() => {
-              onDismiss()
-              onWatchReplay()
-            }}
-          />
-          <MenuItem
-            text={t('gameDetails.buttonSaveReplay', 'Save replay')}
-            onClick={() => {
-              onDismiss()
-              onSaveReplay()
-            }}
-          />
-        </>
-      ) : null}
-    </MenuList>
-  )
 }
 
 export function ConnectedMatchHistory({ userId }: { userId: SbUserId }) {
@@ -409,7 +358,7 @@ export function ConnectedMatchHistory({ userId }: { userId: SbUserId }) {
 
       {selectedGame ? (
         <Popover {...contextMenuPopoverProps}>
-          <MatchHistoryContextMenuContent
+          <GameContextMenuContent
             game={selectedGame}
             onDismiss={contextMenuPopoverProps.onDismiss}
           />

--- a/client/users/match-history.tsx
+++ b/client/users/match-history.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useRef, useState } from 'react'
+import { useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
+import { ReadonlyDeep } from 'type-fest'
 import {
   ALL_GAME_FORMATS,
   decodeMatchup,
@@ -10,14 +11,24 @@ import {
   GameSortOption,
   makeEncodedMatchupString,
 } from '../../common/games/game-filters'
+import { GameRecordJson } from '../../common/games/games'
 import { SbUserId } from '../../common/users/sb-user-id'
-import { renderGamesWithDayHeaders } from '../games/day-header'
+import { useContextMenu } from '../dom/use-context-menu'
+import { navigateToGameResults } from '../games/action-creators'
+import { renderGamesWithDayHeaders, resolveDateRangeMs } from '../games/day-header'
 import { GameFilterBar } from '../games/game-filter-bar'
 import { GameListEntry } from '../games/game-list-entry'
+import { GameRecordSidePanel } from '../games/game-record-side-panel'
+import { GameListSearchPage, useGameListSearch } from '../games/use-game-list-search'
+import { useGameReplayActions } from '../games/use-game-replay-actions'
+import { useKeyListener } from '../keyboard/key-listener'
 import InfiniteScrollList from '../lists/infinite-scroll-list'
+import { Divider } from '../material/menu/divider'
+import { MenuItem } from '../material/menu/item'
+import { MenuList } from '../material/menu/menu'
+import { Popover } from '../material/popover'
 import { useLocationSearchParam } from '../navigation/router-hooks'
-import { useRefreshToken } from '../network/refresh-token'
-import { useAppDispatch, useAppSelector } from '../redux-hooks'
+import { useAppDispatch } from '../redux-hooks'
 import { bodyLarge } from '../styles/typography'
 import { getMatchHistory } from './action-creators'
 
@@ -42,11 +53,15 @@ const MatchHistoryContainer = styled.div`
   gap: 16px;
 `
 
-const SearchResults = styled.div`
-  width: 100%;
-
+const BodyRow = styled.div`
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
+  gap: 24px;
+`
+
+const ListColumn = styled.div`
+  flex-grow: 1;
+  min-width: 0;
 `
 
 function parseDuration(value: string): GameDurationFilter {
@@ -79,6 +94,57 @@ function parseMatchup(
   return decodeMatchup(format, encoded) ? encoded : undefined
 }
 
+/** A date-based sort groups games by calendar day; the duration sorts render as a flat list. */
+function isDateSort(sort: GameSortOption): boolean {
+  return sort === GameSortOption.LatestFirst || sort === GameSortOption.OldestFirst
+}
+
+/**
+ * Split out from the page so `useGameReplayActions` (which subscribes to this game's replay info)
+ * only runs while the menu is actually open, rather than for every row on every render.
+ */
+function MatchHistoryContextMenuContent({
+  game,
+  onDismiss,
+}: {
+  game: ReadonlyDeep<GameRecordJson>
+  onDismiss: () => void
+}) {
+  const { t } = useTranslation()
+  const { replayInfo, onWatchReplay, onSaveReplay } = useGameReplayActions(game)
+
+  return (
+    <MenuList dense={true}>
+      <MenuItem
+        text={t('games.sidePanel.viewFullResults', 'View full results')}
+        onClick={() => {
+          onDismiss()
+          navigateToGameResults(game.id)
+        }}
+      />
+      {IS_ELECTRON && replayInfo ? (
+        <>
+          <Divider $dense={true} />
+          <MenuItem
+            text={t('gameDetails.buttonWatchReplay', 'Watch replay')}
+            onClick={() => {
+              onDismiss()
+              onWatchReplay()
+            }}
+          />
+          <MenuItem
+            text={t('gameDetails.buttonSaveReplay', 'Save replay')}
+            onClick={() => {
+              onDismiss()
+              onSaveReplay()
+            }}
+          />
+        </>
+      ) : null}
+    </MenuList>
+  )
+}
+
 export function ConnectedMatchHistory({ userId }: { userId: SbUserId }) {
   const { t } = useTranslation()
   const dispatch = useAppDispatch()
@@ -91,6 +157,8 @@ export function ConnectedMatchHistory({ userId }: { userId: SbUserId }) {
   const [playerName, setPlayerNameParam] = useLocationSearchParam('playerName')
   const [formatParam, setFormatParam] = useLocationSearchParam('format')
   const [matchupParam, setMatchupParam] = useLocationSearchParam('matchup')
+  const [startDateParam, setStartDateParam] = useLocationSearchParam('startDate')
+  const [endDateParam, setEndDateParam] = useLocationSearchParam('endDate')
 
   const ranked = rankedParam === 'true'
   const custom = customParam === 'true'
@@ -99,76 +167,115 @@ export function ConnectedMatchHistory({ userId }: { userId: SbUserId }) {
   const format = parseFormat(formatParam)
   const matchup = parseMatchup(matchupParam, format)
 
-  const [gameIds, setGameIds] = useState<string[]>()
-  const [hasMoreGames, setHasMoreGames] = useState(true)
-  const [isLoadingMoreGames, setIsLoadingMoreGames] = useState(false)
-  const [searchError, setSearchError] = useState<Error>()
-  const abortControllerRef = useRef<AbortController>(undefined)
-  const [refreshToken, triggerRefresh] = useRefreshToken()
+  const [selectedId, setSelectedId] = useState<string>()
+  const rowElemsRef = useRef(new Map<string, HTMLDivElement>())
 
-  // NOTE(2Pac): We select the (stable) map and derive the list in render rather than mapping inside
-  // the selector, which would return a fresh array on every store update and re-render the whole
-  // list on any Redux action. react-compiler memoizes the derivation below.
-  const gamesById = useAppSelector(s => s.games.byId)
-  const games = gameIds?.map(id => gamesById.get(id)!) ?? []
+  const { onContextMenu, contextMenuPopoverProps } = useContextMenu()
 
-  const reset = () => {
-    abortControllerRef.current?.abort()
-    setGameIds(undefined)
-    setHasMoreGames(true)
-    setIsLoadingMoreGames(false)
-    setSearchError(undefined)
-    triggerRefresh()
+  const loadPage = (offset: number, signal: AbortSignal): Promise<GameListSearchPage> => {
+    const { startMs, endMs } = resolveDateRangeMs(startDateParam, endDateParam)
+    return new Promise((resolve, reject) => {
+      dispatch(
+        getMatchHistory(
+          userId,
+          {
+            ranked: ranked || undefined,
+            custom: custom || undefined,
+            duration: duration === GameDurationFilter.All ? undefined : duration,
+            sort: sort === GameSortOption.LatestFirst ? undefined : sort,
+            mapName: mapName || undefined,
+            playerName: playerName || undefined,
+            format,
+            matchup,
+            startDate: startMs,
+            endDate: endMs,
+            offset,
+          },
+          {
+            signal,
+            onSuccess: result => {
+              resolve({ gameIds: result.games.map(g => g.id), hasMoreGames: result.hasMoreGames })
+            },
+            onError: err => reject(err),
+          },
+        ),
+      )
+    })
   }
 
-  const onLoadMoreGames = () => {
-    setIsLoadingMoreGames(true)
+  const { games, hasMoreGames, isLoadingMore, searchError, refreshToken, reset, onLoadMore } =
+    useGameListSearch(loadPage)
 
-    abortControllerRef.current?.abort()
-    abortControllerRef.current = new AbortController()
+  const selectedGame = games.find(g => g.id === selectedId) ?? games[0]
+  const selectedIndex = selectedGame ? games.findIndex(g => g.id === selectedGame.id) : -1
+  const sortIsDateBased = isDateSort(sort)
 
-    dispatch(
-      getMatchHistory(
-        userId,
-        {
-          ranked: ranked || undefined,
-          custom: custom || undefined,
-          duration: duration === GameDurationFilter.All ? undefined : duration,
-          sort: sort === GameSortOption.LatestFirst ? undefined : sort,
-          mapName: mapName || undefined,
-          playerName: playerName || undefined,
-          format,
-          matchup,
-          offset: gameIds?.length ?? 0,
-        },
-        {
-          signal: abortControllerRef.current.signal,
-          onSuccess: data => {
-            setIsLoadingMoreGames(false)
-            // A newly-completed game by this user shifts the window between page loads, so a later
-            // page can re-serve rows from an earlier one. Dedupe on concat to avoid duplicate React
-            // keys / repeated rows.
-            setGameIds(prev => {
-              const existingIds = new Set(prev ?? [])
-              return (prev ?? []).concat(
-                data.games.map(g => g.id).filter(id => !existingIds.has(id)),
-              )
-            })
-            setHasMoreGames(data.hasMoreGames)
-            setSearchError(undefined)
-          },
-          onError: err => {
-            setIsLoadingMoreGames(false)
-            setSearchError(err)
-          },
-        },
-      ),
-    )
+  const selectIndex = (index: number) => {
+    if (index < 0 || index >= games.length) return
+    const game = games[index]
+    setSelectedId(game.id)
+    rowElemsRef.current.get(game.id)?.scrollIntoView({ block: 'nearest' })
+  }
+  const moveSelection = (delta: number) => {
+    if (games.length === 0) return
+    const base = selectedIndex < 0 ? 0 : selectedIndex
+    const next = Math.min(Math.max(base + delta, 0), games.length - 1)
+    selectIndex(next)
   }
 
-  useEffect(() => {
-    return () => abortControllerRef.current?.abort()
-  }, [])
+  useKeyListener({
+    onKeyDown: (event: KeyboardEvent) => {
+      // Every key here acts on the match history list, but this page's key listener boundary is
+      // shared with other UI (e.g. the social sidebar's chat input, whose keydowns bubble to the
+      // document). While a text-entry element has focus, the keystroke belongs to it instead.
+      const target = event.target
+      if (
+        target instanceof HTMLElement &&
+        (target.tagName === 'INPUT' ||
+          target.tagName === 'TEXTAREA' ||
+          target.tagName === 'SELECT' ||
+          target.isContentEditable)
+      ) {
+        return false
+      }
+
+      switch (event.code) {
+        case 'ArrowUp':
+          moveSelection(-1)
+          return true
+        case 'ArrowDown':
+          moveSelection(1)
+          return true
+        case 'PageUp':
+          moveSelection(-10)
+          return true
+        case 'PageDown':
+          moveSelection(10)
+          return true
+        case 'Home':
+          selectIndex(0)
+          return true
+        case 'End':
+          selectIndex(games.length - 1)
+          return true
+        case 'Enter':
+        case 'NumpadEnter': {
+          const active = document.activeElement
+          // If the user is on an interactive control (e.g. a focused button), let it handle Enter.
+          if (
+            active instanceof HTMLElement &&
+            (active.tagName === 'BUTTON' || active.tagName === 'A')
+          ) {
+            return false
+          }
+          if (selectedGame) navigateToGameResults(selectedGame.id)
+          return true
+        }
+      }
+
+      return false
+    },
+  })
 
   const filterBar = (
     <GameFilterBar
@@ -215,45 +322,99 @@ export function ConnectedMatchHistory({ userId }: { userId: SbUserId }) {
         setMatchupParam(v ?? '')
         reset()
       }}
+      startDate={startDateParam}
+      setStartDate={v => {
+        setStartDateParam(v)
+        reset()
+      }}
+      endDate={endDateParam}
+      setEndDate={v => {
+        setEndDateParam(v)
+        reset()
+      }}
     />
   )
 
+  // A page load that's returned at least once with nothing left to fetch is a confirmed empty
+  // result; until then (including the very first, still in-flight page) we render the list shell so
+  // its own loading indicator can show, matching how this page behaved before it was rewired onto
+  // `useGameListSearch`.
+  const confirmedEmpty = !hasMoreGames && games.length === 0
+
+  let listBody: React.ReactNode
   if (searchError) {
-    return (
-      <MatchHistoryContainer>
-        {filterBar}
-        <ErrorText>
-          {t(
-            'user.matchHistory.retrievingError',
-            'There was an error retrieving the match history.',
-          )}
-        </ErrorText>
-      </MatchHistoryContainer>
+    listBody = (
+      <ErrorText>
+        {t('user.matchHistory.retrievingError', 'There was an error retrieving the match history.')}
+      </ErrorText>
     )
-  } else if (gameIds?.length === 0) {
-    return (
-      <MatchHistoryContainer>
-        {filterBar}
-        <NoResults>{t('user.matchHistory.noMatchingGames', 'No matching games.')}</NoResults>
-      </MatchHistoryContainer>
-    )
+  } else if (confirmedEmpty) {
+    listBody = <NoResults>{t('user.matchHistory.noMatchingGames', 'No matching games.')}</NoResults>
   } else {
     const gameItems = renderGamesWithDayHeaders(games, sort, t, game => (
-      <GameListEntry key={game.id} game={game} showResult={true} forUserId={userId} />
+      <GameListEntry
+        key={game.id}
+        game={game}
+        showResult={true}
+        forUserId={userId}
+        selected={game.id === selectedGame?.id}
+        onClick={setSelectedId}
+        onDoubleClick={gameId => navigateToGameResults(gameId)}
+        onContextMenu={(gameId, event) => {
+          setSelectedId(gameId)
+          onContextMenu(event)
+        }}
+        ref={el => {
+          if (el) {
+            rowElemsRef.current.set(game.id, el)
+          } else {
+            rowElemsRef.current.delete(game.id)
+          }
+        }}
+      />
     ))
 
-    return (
+    listBody = (
       <InfiniteScrollList
         nextLoadingEnabled={true}
-        isLoadingNext={isLoadingMoreGames}
+        isLoadingNext={isLoadingMore}
         hasNextData={hasMoreGames}
         refreshToken={refreshToken}
-        onLoadNextData={onLoadMoreGames}>
-        <MatchHistoryContainer>
-          {filterBar}
-          <SearchResults>{gameItems}</SearchResults>
-        </MatchHistoryContainer>
+        onLoadNextData={onLoadMore}>
+        {gameItems}
       </InfiniteScrollList>
     )
   }
+
+  // Mirrors the replay library's inspector: dropped entirely once there are confirmed to be no
+  // results, rather than showing an empty "select a game" placeholder beside the empty-state message.
+  const showPanel = !confirmedEmpty && !searchError
+
+  return (
+    <MatchHistoryContainer>
+      {filterBar}
+
+      <BodyRow>
+        <ListColumn>{listBody}</ListColumn>
+
+        {showPanel ? (
+          <GameRecordSidePanel
+            game={selectedGame}
+            forUserId={userId}
+            alignWithFirstRow={sortIsDateBased}
+            onViewResults={gameId => navigateToGameResults(gameId)}
+          />
+        ) : null}
+      </BodyRow>
+
+      {selectedGame ? (
+        <Popover {...contextMenuPopoverProps}>
+          <MatchHistoryContextMenuContent
+            game={selectedGame}
+            onDismiss={contextMenuPopoverProps.onDismiss}
+          />
+        </Popover>
+      ) : null}
+    </MatchHistoryContainer>
+  )
 }

--- a/client/users/match-history.tsx
+++ b/client/users/match-history.tsx
@@ -23,6 +23,7 @@ import { useKeyListener } from '../keyboard/key-listener'
 import InfiniteScrollList from '../lists/infinite-scroll-list'
 import { Popover } from '../material/popover'
 import { useLocationSearchParam } from '../navigation/router-hooks'
+import { useUserLocalStorageValue } from '../react/state-hooks'
 import { useAppDispatch } from '../redux-hooks'
 import { bodyLarge } from '../styles/typography'
 import { getMatchHistory } from './action-creators'
@@ -118,6 +119,10 @@ export function ConnectedMatchHistory({ userId }: { userId: SbUserId }) {
 
   const [selectedId, setSelectedId] = useState<string>()
   const rowElemsRef = useRef(new Map<string, HTMLDivElement>())
+
+  // Remembered per-user, shared with the replay library and games page: hides the game length and
+  // match result (both spoilers) from the list rows.
+  const [spoilerFree, setSpoilerFree] = useUserLocalStorageValue('gamesSpoilerFree', false)
 
   const { onContextMenu, contextMenuPopoverProps } = useContextMenu()
 
@@ -271,6 +276,8 @@ export function ConnectedMatchHistory({ userId }: { userId: SbUserId }) {
         setMatchupParam(v ?? '')
         reset()
       }}
+      spoilerFree={spoilerFree}
+      setSpoilerFree={setSpoilerFree}
       startDate={startDateParam}
       setStartDate={v => {
         setStartDateParam(v)
@@ -306,6 +313,7 @@ export function ConnectedMatchHistory({ userId }: { userId: SbUserId }) {
         game={game}
         showResult={true}
         forUserId={userId}
+        spoilerFree={spoilerFree}
         selected={game.id === selectedGame?.id}
         onClick={setSelectedId}
         onDoubleClick={gameId => navigateToGameResults(gameId)}

--- a/common/constants.ts
+++ b/common/constants.ts
@@ -20,6 +20,13 @@ export const CHANNEL_MAXLENGTH = 64
 
 export const STARCRAFT_DOWNLOAD_URL = 'https://download.battle.net/desktop'
 
+/**
+ * The largest millisecond timestamp representable by a JavaScript `Date` (±8.64e15, per ECMA-262).
+ * Timestamps taken from user input should be capped to this during validation: anything past it
+ * constructs an `Invalid Date`, which throws when serialized (e.g. by the DB driver).
+ */
+export const MAX_DATE_TIMESTAMP = 8640000000000000
+
 export function isValidUsername(username: string): boolean {
   return !!(
     username &&

--- a/common/games/games.ts
+++ b/common/games/games.ts
@@ -157,6 +157,10 @@ export interface GetGamesQueryParams {
   matchup?: EncodedMatchupString
   sort?: GameSortOption
   offset?: number
+  /** Inclusive lower bound (unix ms) on the game's start time. */
+  startDate?: number
+  /** Inclusive upper bound (unix ms) on the game's start time. */
+  endDate?: number
 }
 
 export interface GetGamesResponse {

--- a/common/ipc.ts
+++ b/common/ipc.ts
@@ -257,6 +257,16 @@ interface IpcInvokeables {
   settingsBrowseForStarcraft: (
     defaultPath: string,
   ) => Promise<{ canceled: boolean; filePaths: string[] }>
+  /** Opens a generic folder-picker dialog. */
+  settingsBrowseForFolder: (options: {
+    title?: string
+    defaultPath?: string
+  }) => Promise<{ canceled: boolean; filePaths: string[] }>
+  /**
+   * Returns the default replay folder path (`Documents/Starcraft/maps/replays`), since the
+   * renderer can't compute the OS documents directory itself.
+   */
+  settingsGetDefaultReplayFolder: () => Promise<string>
   settingsGetPrimaryResolution: () => Promise<{ width: number; height: number }>
   settingsGetMonitorInfo: () => Promise<{ primary: Display; monitors: Display[] }>
   settingsOverwriteBlizzardFile: () => void

--- a/common/replays-library.ts
+++ b/common/replays-library.ts
@@ -90,6 +90,10 @@ export interface ReplayLibraryFilters {
   offset?: number
   /** Maximum number of entries to return. When omitted, all matches are returned. */
   limit?: number
+  /** Inclusive lower bound (unix ms) on `gameTime`. */
+  gameTimeFrom?: number
+  /** Inclusive upper bound (unix ms) on `gameTime`. */
+  gameTimeTo?: number
 }
 
 /**
@@ -110,6 +114,6 @@ export interface ReplayLibraryStatus {
   bookmarkedCount: number
   /** Present while an initial/ongoing backfill is running. */
   backfill?: ReplayBackfillProgress
-  /** The absolute path of the folder being indexed. */
-  watchedFolder: string
+  /** The absolute paths of the folders being indexed. */
+  watchedFolders: string[]
 }

--- a/common/settings/default-settings.ts
+++ b/common/settings/default-settings.ts
@@ -41,6 +41,7 @@ export const DEFAULT_LOCAL_SETTINGS: ReadonlyDeep<
   useCustomCursorSize: false,
   customCursorSize: 0.25,
   gameServerRegion: undefined,
+  replayLibraryFolders: undefined,
 }
 
 export const DEFAULT_SCR_SETTINGS: ReadonlyDeep<Omit<ScrSettings, 'version'>> = {

--- a/common/settings/local-settings.ts
+++ b/common/settings/local-settings.ts
@@ -211,11 +211,11 @@ export interface LocalSettings extends ShieldBatteryAppSettings {
   launch64Bit?: boolean
 
   /**
-   * Absolute paths of the folders indexed by the replay library. Materialized to a non-empty list
-   * at every app boot: a missing or empty value is replaced with the default folder,
-   * `Documents/Starcraft/maps/replays`, added as a regular first entry. An empty array can exist
-   * only transiently, between the user removing every configured folder in the settings UI and the
-   * app's next launch.
+   * Absolute paths of the folders indexed by the replay library. `undefined` means the user has
+   * never configured folders: the default folder, `Documents/Starcraft/maps/replays`, is used and
+   * presented as a regular (removable) entry. An empty array means the user removed every
+   * configured folder: nothing is indexed, and the setting persists across launches until a folder
+   * is added again.
    */
   replayLibraryFolders?: ReadonlyArray<string>
 }

--- a/common/settings/local-settings.ts
+++ b/common/settings/local-settings.ts
@@ -209,6 +209,12 @@ export interface LocalSettings extends ShieldBatteryAppSettings {
   visualizeNetworkStalls?: boolean
   disableHd?: boolean
   launch64Bit?: boolean
+
+  /**
+   * Absolute paths of the folders indexed by the replay library. Absent or empty means the default
+   * folder (`Documents/Starcraft/maps/replays`).
+   */
+  replayLibraryFolders?: ReadonlyArray<string>
 }
 
 export interface ScrSettings {

--- a/common/settings/local-settings.ts
+++ b/common/settings/local-settings.ts
@@ -211,8 +211,11 @@ export interface LocalSettings extends ShieldBatteryAppSettings {
   launch64Bit?: boolean
 
   /**
-   * Absolute paths of the folders indexed by the replay library. Absent or empty means the default
-   * folder (`Documents/Starcraft/maps/replays`).
+   * Absolute paths of the folders indexed by the replay library. Materialized to a concrete list at
+   * first app boot (the default folder, `Documents/Starcraft/maps/replays`, is added as a regular
+   * first entry), so this is normally defined; an explicit empty array means nothing is indexed. An
+   * absent (`undefined`) value only occurs before that first-boot migration runs and falls back to
+   * the default folder defensively.
    */
   replayLibraryFolders?: ReadonlyArray<string>
 }

--- a/common/settings/local-settings.ts
+++ b/common/settings/local-settings.ts
@@ -211,11 +211,11 @@ export interface LocalSettings extends ShieldBatteryAppSettings {
   launch64Bit?: boolean
 
   /**
-   * Absolute paths of the folders indexed by the replay library. Materialized to a concrete list at
-   * first app boot (the default folder, `Documents/Starcraft/maps/replays`, is added as a regular
-   * first entry), so this is normally defined; an explicit empty array means nothing is indexed. An
-   * absent (`undefined`) value only occurs before that first-boot migration runs and falls back to
-   * the default folder defensively.
+   * Absolute paths of the folders indexed by the replay library. Materialized to a non-empty list
+   * at every app boot: a missing or empty value is replaced with the default folder,
+   * `Documents/Starcraft/maps/replays`, added as a regular first entry. An empty array can exist
+   * only transiently, between the user removing every configured folder in the settings UI and the
+   * app's next launch.
    */
   replayLibraryFolders?: ReadonlyArray<string>
 }

--- a/common/users/user-network.ts
+++ b/common/users/user-network.ts
@@ -90,6 +90,10 @@ export interface GetMatchHistoryQueryParams {
   matchup?: EncodedMatchupString
   sort?: GameSortOption
   offset?: number
+  /** Inclusive lower bound (unix ms) on the game's start time. */
+  startDate?: number
+  /** Inclusive upper bound (unix ms) on the game's start time. */
+  endDate?: number
 }
 
 /**

--- a/server/lib/games/game-api.ts
+++ b/server/lib/games/game-api.ts
@@ -239,7 +239,7 @@ export class GameApi {
   @httpBefore(throttleMiddleware(gamesListThrottle, ctx => String(ctx.session?.user?.id ?? ctx.ip)))
   async getGamesList(ctx: RouterContext): Promise<GetGamesResponse> {
     const {
-      query: { duration, mapName, playerName, format, matchup, sort, offset },
+      query: { duration, mapName, playerName, format, matchup, sort, offset, startDate, endDate },
     } = validateRequest(ctx, {
       query: Joi.object<GetGamesQueryParams>({
         duration: Joi.string().valid(...Object.values(GameDurationFilter)),
@@ -252,6 +252,8 @@ export class GameApi {
         // sort) an unbounded number of rows. `.integer()` is needed because Joi otherwise accepts
         // e.g. `1.5`, which produces an invalid `OFFSET 1.5` and 500s on the bigint cast.
         offset: Joi.number().integer().min(0).max(MAX_GAMES_OFFSET),
+        startDate: Joi.number().integer().min(0),
+        endDate: Joi.number().integer().min(0),
       }),
     })
 
@@ -266,6 +268,8 @@ export class GameApi {
       format,
       matchup: decodedMatchup,
       sort,
+      startDate,
+      endDate,
     })
 
     const uniqueUsers = new Set<SbUserId>()

--- a/server/lib/games/game-api.ts
+++ b/server/lib/games/game-api.ts
@@ -5,6 +5,7 @@ import Koa from 'koa'
 import { Readable } from 'stream'
 import { container, singleton } from 'tsyringe'
 import { assertUnreachable } from '../../../common/assert-unreachable'
+import { MAX_DATE_TIMESTAMP } from '../../../common/constants'
 import {
   ALL_GAME_FORMATS,
   decodeMatchup,
@@ -252,8 +253,8 @@ export class GameApi {
         // sort) an unbounded number of rows. `.integer()` is needed because Joi otherwise accepts
         // e.g. `1.5`, which produces an invalid `OFFSET 1.5` and 500s on the bigint cast.
         offset: Joi.number().integer().min(0).max(MAX_GAMES_OFFSET),
-        startDate: Joi.number().integer().min(0),
-        endDate: Joi.number().integer().min(0),
+        startDate: Joi.number().integer().min(0).max(MAX_DATE_TIMESTAMP),
+        endDate: Joi.number().integer().min(0).max(MAX_DATE_TIMESTAMP),
       }),
     })
 

--- a/server/lib/games/game-models.test.ts
+++ b/server/lib/games/game-models.test.ts
@@ -148,6 +148,32 @@ describe('games/game-models/getGames', () => {
     const template = query.mock.calls[0][0]
     expect(template.text).toContain("(g.config->>'resultsExempt')::boolean IS NOT TRUE")
   })
+
+  test('omits the start_time bounds when startDate/endDate are not given', async () => {
+    const query = mockDbClient([])
+
+    await getGames({ limit: 10, offset: 0 })
+
+    expect(query).toHaveBeenCalledTimes(1)
+    const template = query.mock.calls[0][0]
+    expect(template.text).not.toContain('g.start_time >=')
+    expect(template.text).not.toContain('g.start_time <=')
+  })
+
+  test('filters on start_time when startDate/endDate are given', async () => {
+    const query = mockDbClient([])
+    const startDate = Date.parse('2026-07-01T00:00:00.000Z')
+    const endDate = Date.parse('2026-07-21T23:59:59.999Z')
+
+    await getGames({ limit: 10, offset: 0, startDate, endDate })
+
+    expect(query).toHaveBeenCalledTimes(1)
+    const template = query.mock.calls[0][0]
+    expect(template.text).toContain('g.start_time >=')
+    expect(template.text).toContain('g.start_time <=')
+    expect(template.values).toContainEqual(new Date(startDate))
+    expect(template.values).toContainEqual(new Date(endDate))
+  })
 })
 
 describe('games/game-models/getGamesForUser', () => {
@@ -160,6 +186,34 @@ describe('games/game-models/getGamesForUser', () => {
     expect(query).toHaveBeenCalledTimes(1)
     const template = query.mock.calls[0][0]
     expect(template.text).toContain("(g.config->>'resultsExempt')::boolean IS NOT TRUE")
+  })
+
+  test('omits the start_time bounds when startDate/endDate are not given', async () => {
+    const query = mockDbClient([])
+    const userId = makeSbUserId(1)
+
+    await getGamesForUser({ userId, limit: 10, offset: 0 })
+
+    expect(query).toHaveBeenCalledTimes(1)
+    const template = query.mock.calls[0][0]
+    expect(template.text).not.toContain('g.start_time >=')
+    expect(template.text).not.toContain('g.start_time <=')
+  })
+
+  test('filters on start_time when startDate/endDate are given', async () => {
+    const query = mockDbClient([])
+    const userId = makeSbUserId(1)
+    const startDate = Date.parse('2026-07-01T00:00:00.000Z')
+    const endDate = Date.parse('2026-07-21T23:59:59.999Z')
+
+    await getGamesForUser({ userId, limit: 10, offset: 0, startDate, endDate })
+
+    expect(query).toHaveBeenCalledTimes(1)
+    const template = query.mock.calls[0][0]
+    expect(template.text).toContain('g.start_time >=')
+    expect(template.text).toContain('g.start_time <=')
+    expect(template.values).toContainEqual(new Date(startDate))
+    expect(template.values).toContainEqual(new Date(endDate))
   })
 })
 

--- a/server/lib/games/game-models.ts
+++ b/server/lib/games/game-models.ts
@@ -288,10 +288,23 @@ export async function getGames(
     format?: GameFormat
     matchup?: MatchupFilter
     sort?: GameSortOption
+    startDate?: number
+    endDate?: number
   },
   withClient?: DbClient,
 ): Promise<GameRecord[]> {
-  const { limit, offset, duration, mapName, playerName, format, matchup, sort } = params
+  const {
+    limit,
+    offset,
+    duration,
+    mapName,
+    playerName,
+    format,
+    matchup,
+    sort,
+    startDate,
+    endDate,
+  } = params
 
   const { client, done } = await db(withClient)
   try {
@@ -353,6 +366,14 @@ export async function getGames(
         const matchupStrings = expandMatchupFilter(matchup)
         whereClauses.push(sql`g.assigned_matchup = ANY(${matchupStrings})`)
       }
+    }
+
+    if (startDate !== undefined) {
+      whereClauses.push(sql`g.start_time >= ${new Date(startDate)}`)
+    }
+
+    if (endDate !== undefined) {
+      whereClauses.push(sql`g.start_time <= ${new Date(endDate)}`)
     }
 
     // NOTE(2Pac): All of these include `g.id` as a final tiebreaker so the ordering is fully
@@ -423,6 +444,8 @@ export async function getGamesForUser(
     format?: GameFormat
     matchup?: MatchupFilter
     sort?: GameSortOption
+    startDate?: number
+    endDate?: number
   },
   withClient?: DbClient,
 ): Promise<GameRecord[]> {
@@ -438,6 +461,8 @@ export async function getGamesForUser(
     format,
     matchup,
     sort,
+    startDate,
+    endDate,
   } = params
 
   const { client, done } = await db(withClient)
@@ -509,6 +534,14 @@ export async function getGamesForUser(
         const matchupStrings = expandMatchupFilter(matchup)
         whereClauses.push(sql`g.assigned_matchup = ANY(${matchupStrings})`)
       }
+    }
+
+    if (startDate !== undefined) {
+      whereClauses.push(sql`g.start_time >= ${new Date(startDate)}`)
+    }
+
+    if (endDate !== undefined) {
+      whereClauses.push(sql`g.start_time <= ${new Date(endDate)}`)
     }
 
     // NOTE(2Pac): All of these include `g.id` as a final tiebreaker so the ordering is fully

--- a/server/lib/users/user-api.ts
+++ b/server/lib/users/user-api.ts
@@ -685,7 +685,19 @@ export class UserApi {
   async getMatchHistory(ctx: RouterContext): Promise<GetMatchHistoryResponse> {
     const {
       params,
-      query: { ranked, custom, duration, mapName, playerName, format, matchup, sort, offset },
+      query: {
+        ranked,
+        custom,
+        duration,
+        mapName,
+        playerName,
+        format,
+        matchup,
+        sort,
+        offset,
+        startDate,
+        endDate,
+      },
     } = validateRequest(ctx, {
       params: Joi.object<{ id: SbUserId }>({
         id: joiUserId().required(),
@@ -703,6 +715,8 @@ export class UserApi {
         // `OFFSET 1.5` and 500s on the bigint cast. The max keeps a hand-crafted request from
         // forcing the DB to produce (and sort) an unbounded number of rows.
         offset: Joi.number().integer().min(0).max(MAX_GAMES_OFFSET),
+        startDate: Joi.number().integer().min(0),
+        endDate: Joi.number().integer().min(0),
       }),
     })
 
@@ -725,6 +739,8 @@ export class UserApi {
       format,
       matchup: decodedMatchup,
       sort,
+      startDate,
+      endDate,
     })
     const uniqueUsers = new Set<SbUserId>()
     const uniqueMaps = new Set<SbMapId>()

--- a/server/lib/users/user-api.ts
+++ b/server/lib/users/user-api.ts
@@ -7,6 +7,7 @@ import mime from 'mime'
 import { container } from 'tsyringe'
 import { assertUnreachable } from '../../../common/assert-unreachable'
 import {
+  MAX_DATE_TIMESTAMP,
   PASSWORD_MINLENGTH,
   USERNAME_MAXLENGTH,
   USERNAME_MINLENGTH,
@@ -715,8 +716,8 @@ export class UserApi {
         // `OFFSET 1.5` and 500s on the bigint cast. The max keeps a hand-crafted request from
         // forcing the DB to produce (and sort) an unbounded number of rows.
         offset: Joi.number().integer().min(0).max(MAX_GAMES_OFFSET),
-        startDate: Joi.number().integer().min(0),
-        endDate: Joi.number().integer().min(0),
+        startDate: Joi.number().integer().min(0).max(MAX_DATE_TIMESTAMP),
+        endDate: Joi.number().integer().min(0).max(MAX_DATE_TIMESTAMP),
       }),
     })
 

--- a/server/public/locales/en/global.json
+++ b/server/public/locales/en/global.json
@@ -1272,6 +1272,8 @@
       "moveDown": "Move down",
       "moveUp": "Move up",
       "newPlaylistMenu": "New playlist…",
+      "noFolders": "No replay folders",
+      "noFoldersBody": "Add a folder in Settings > App > System to start indexing replays.",
       "noMatches": "No replays match",
       "playlist": {
         "createError": "Error creating playlist: {{errorMessage}}",
@@ -1346,8 +1348,7 @@
         "filesOverline": "Files",
         "networkOverline": "Network",
         "removeReplayFolder": "Remove folder",
-        "replayFolderDefaultHint": "(default)",
-        "replayFoldersDescription": "Folders indexed by your replay library. Removing a folder removes its replays from the library, including their bookmarks and playlist entries.",
+        "replayFoldersDescription": "Folders indexed by your replay library. The default StarCraft replay folder is added automatically. Removing a folder removes its replays from the library, including their bookmarks and playlist entries.",
         "replayFoldersTitle": "Replay folders",
         "replayQuickOpen": "Launch replays opened with ShieldBattery immediately without previewing",
         "runOnStartup": "Run ShieldBattery on system startup",

--- a/server/public/locales/en/global.json
+++ b/server/public/locales/en/global.json
@@ -455,6 +455,17 @@
     "filters": {
       "advanced": "Advanced",
       "custom": "Custom",
+      "date": "Date",
+      "dateFrom": "From",
+      "datePast3Months": "Past 3 months",
+      "datePastMonth": "Past month",
+      "datePastWeek": "Past week",
+      "datePastYear": "Past year",
+      "datePresets": "Quick ranges",
+      "dateRangeBetween": "{{start}} – {{end}}",
+      "dateRangeFrom": "From {{date}}",
+      "dateRangeUntil": "Until {{date}}",
+      "dateTo": "To",
       "duration": {
         "10to20": "10-20min",
         "20to30": "20-30min",
@@ -653,6 +664,10 @@
     "reporting": {
       "actionedNotification": "Action was taken against a player you reported. Thanks for helping keep the community fair.",
       "pointsRefundedNotification": "Ranked points you lost in a game have been refunded to you after the game was reviewed."
+    },
+    "sidePanel": {
+      "empty": "Select a game to see its details",
+      "viewFullResults": "View full results"
     }
   },
   "gameServerRegions": {
@@ -1141,6 +1156,9 @@
     }
   },
   "material": {
+    "dateTextField": {
+      "pickerButtonLabel": "Show picker"
+    },
     "datetimeTextField": {
       "pickerButtonLabel": "Show picker"
     },
@@ -1323,8 +1341,14 @@
         "title": "Sound"
       },
       "system": {
+        "addReplayFolder": "Add folder",
+        "addReplayFolderTitle": "Select a replay folder",
         "filesOverline": "Files",
         "networkOverline": "Network",
+        "removeReplayFolder": "Remove folder",
+        "replayFolderDefaultHint": "(default)",
+        "replayFoldersDescription": "Folders indexed by your replay library. Removing a folder removes its replays from the library, including their bookmarks and playlist entries.",
+        "replayFoldersTitle": "Replay folders",
         "replayQuickOpen": "Launch replays opened with ShieldBattery immediately without previewing",
         "runOnStartup": "Run ShieldBattery on system startup",
         "serverRegion": {


### PR DESCRIPTION
Restyles the global games page and the user match-history page to the replay library's layout and interaction model, and adds a few features on top.

## Page redesign

- Both pages now show a sticky detail panel (new shared `GameRecordSidePanel`, built on `GameSidePanel`) on the right: map hero, game-type chip, date, roster (with W/L coloring on match history), and View full results / Watch replay / Save replay actions.
- Rows are selectable like replay library rows: **click selects** into the panel, **double-click** (or Enter) navigates to the full results page. Keyboard navigation (arrows / PageUp/Down / Home / End) and right-click context menus work the same as in the library.
- The games page goes full-bleed (`$fullWidth` + `data-content-fullbleed`) like the library; match history stays inside the profile's centered container. The live-games strip is unchanged.
- Refactors: the two pages' duplicated offset-paging fetch logic is extracted into `useGameListSearch`, and the watch/save-replay handlers into `useGameReplayActions`. The library's row container moved to `game-list-entry.tsx` as the shared `SelectableRowContainer`. Layout shells stay deliberately per-page.

## Date-range filter (all three pages)

- New Date chip in the shared `GameFilterBar`: quick presets (Past week/month/3 months/year) plus custom From/To fields (new `DateTextField` using the native picker), draft state + Apply like the Advanced panel, URL-persisted as `startDate`/`endDate` (`yyyy-mm-dd`, resolved to local-day boundaries).
- `/games/list` and `/users/:id/match-history` accept validated `startDate`/`endDate` unix-ms bounds on `start_time`; the replay index gets `gameTimeFrom`/`gameTimeTo` on the already-indexed `game_time` column (a date filter counts as a value filter, so unreadable replays are excluded).

## Configurable replay library folders

- `LocalSettings.replayLibraryFolders` (absent/empty ⇒ the current default `Documents/Starcraft/maps/replays`), edited via a new **Settings > App > System > Replay folders** block (list + browse-to-add + remove, with a hint that removing a folder drops those replays' bookmarks/playlist entries).
- `ReplayWatcher` watches/scans multiple roots and reacts to settings changes at runtime (no app restart). Pruning is per-root: rows are only removed when their root was removed from settings, or when a root that scanned successfully no longer contains them — so a temporarily unreadable root (e.g. an offline drive) never wipes its rows' curation. Saved replays go to the first configured folder.

## Other

- Removed the game/replay duration from the side panels (inspector included) — it stays in the table rows. The inspector's now-dead `spoilerFree` prop is gone (the row/list spoiler behavior is unchanged).
- Replay library rows and rail playlists get right-click context menus, sharing the inspector's menu items (`ReplayActionMenuItems`/`AddToPlaylistMenuItems`).

## Testing

- Unit: date-boundary helpers (local-time parsing incl. rollover rejection), SQL builders on both servers (`game-models`) and the replay index (`replay-queries`), and the pure per-root prune/containment logic (`replay-watcher-paths`, 19 cases). Full suite: 107 files / 1507 tests green; typecheck + lint clean.
- Live-verified in the Electron app against a real 11k-replay index: selection/keyboard/double-click/context menus on both pages, date filtering on all three pages (server + local index, boundary-inclusive), inspector date-only subline, playlist add/remove via context menu, rail right-click, and the full folder pipeline — settings change → watcher swap → index grows/shrinks live, with garbage/unreadable folder paths degrading to warnings without touching the index.