### PR TITLE
Polish the replay browser map preview + replay folders settings

### DIFF
--- a/client/games/game-side-panel.tsx
+++ b/client/games/game-side-panel.tsx
@@ -80,6 +80,10 @@ const GameSidePanelMapSkeleton = styled.div`
       transparent
     );
     animation: ${mapSkeletonShimmer} 1.5s ease-in-out infinite;
+
+    @media (prefers-reduced-motion: reduce) {
+      animation: none;
+    }
   }
 `
 

--- a/client/games/game-side-panel.tsx
+++ b/client/games/game-side-panel.tsx
@@ -1,7 +1,7 @@
 // Generic sticky detail panel used by game/replay list pages (e.g. the replay library, and
 // future side panels on the games and match-history pages) to show the currently selected entry.
 import * as React from 'react'
-import styled from 'styled-components'
+import styled, { keyframes } from 'styled-components'
 import { ReadonlyDeep } from 'type-fest'
 import { MapInfoJson } from '../../common/maps'
 import { MapNoImage } from '../maps/map-image'
@@ -49,6 +49,38 @@ const GameSidePanelMapPlaceholder = styled.div`
 
   border-radius: 8px;
   contain: content;
+`
+
+const mapSkeletonShimmer = keyframes`
+  0% { transform: translateX(-100%); }
+  100% { transform: translateX(100%); }
+`
+
+// A quiet placeholder for the hero image while the selected entry's map is still being fetched.
+// Shown instead of the "no map" tile so rapidly moving through the list (e.g. holding the down
+// arrow) doesn't flash "map preview not available" before each image resolves.
+const GameSidePanelMapSkeleton = styled.div`
+  position: relative;
+  width: 100%;
+  aspect-ratio: 1;
+
+  border-radius: 8px;
+  background-color: var(--theme-container);
+  overflow: hidden;
+
+  &::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    transform: translateX(-100%);
+    background: linear-gradient(
+      90deg,
+      transparent,
+      rgb(from var(--theme-skeleton) r g b / 0.24),
+      transparent
+    );
+    animation: ${mapSkeletonShimmer} 1.5s ease-in-out infinite;
+  }
 `
 
 const GameSidePanelEmptyText = styled.div`
@@ -105,6 +137,11 @@ export const GameSidePanelActions = styled.div`
 export interface GameSidePanelProps {
   /** Map shown as the panel's hero image; a placeholder tile is shown when undefined. */
   map?: ReadonlyDeep<MapInfoJson>
+  /**
+   * When true and no `map` is resolved yet, shows a loading skeleton instead of the "no preview"
+   * placeholder — avoids flashing "not available" while the map is still being fetched.
+   */
+  isMapLoading?: boolean
   /** True when the adjacent list is day-grouped, so the panel's top aligns with the first row. */
   alignWithFirstRow?: boolean
   className?: string
@@ -113,24 +150,34 @@ export interface GameSidePanelProps {
 
 export function GameSidePanel({
   map,
+  isMapLoading = false,
   alignWithFirstRow = false,
   className,
   children,
 }: GameSidePanelProps) {
+  let hero: React.ReactNode
+  if (map) {
+    hero = (
+      <GameSidePanelMapThumbnail
+        key={map.hash}
+        mapId={map.id}
+        forceAspectRatio={1}
+        showInfoLayer={true}
+      />
+    )
+  } else if (isMapLoading) {
+    hero = <GameSidePanelMapSkeleton />
+  } else {
+    hero = (
+      <GameSidePanelMapPlaceholder>
+        <MapNoImage />
+      </GameSidePanelMapPlaceholder>
+    )
+  }
+
   return (
     <GameSidePanelRoot $alignWithFirstRow={alignWithFirstRow} className={className}>
-      {map ? (
-        <GameSidePanelMapThumbnail
-          key={map.hash}
-          mapId={map.id}
-          forceAspectRatio={1}
-          showInfoLayer={true}
-        />
-      ) : (
-        <GameSidePanelMapPlaceholder>
-          <MapNoImage />
-        </GameSidePanelMapPlaceholder>
-      )}
+      {hero}
 
       {children}
     </GameSidePanelRoot>

--- a/client/replays/replay-hooks.test.tsx
+++ b/client/replays/replay-hooks.test.tsx
@@ -6,6 +6,7 @@ import type { GameRecordJson } from '../../common/games/games'
 import type { MapInfoJson } from '../../common/maps'
 import createStore from '../create-store'
 import type { RequestHandlingSpec } from '../network/abortable-thunk'
+import { FetchError } from '../network/fetch-errors'
 import {
   MAP_FETCH_COALESCE_MS as COALESCE_MS,
   resetSbGameMapStateForTests,
@@ -60,10 +61,15 @@ function advance(ms: number) {
   })
 }
 
-function failLatest(gameId: string) {
+function failLatest(gameId: string, err: Error = new Error('fetch failed')) {
   act(() => {
-    latestSpec(gameId).onError(new Error('fetch failed'))
+    latestSpec(gameId).onError(err)
   })
+}
+
+/** Builds the error `fetchJson` throws for a non-ok response with the given status. */
+function fetchError(status: number): FetchError {
+  return new FetchError(new Response('', { status, statusText: `status ${status}` }), '')
 }
 
 // Seeds the store as a `@games/getGameRecord` fetch would, so the game and its map are already
@@ -188,5 +194,49 @@ describe('client/replays/replay-hooks/useSbGameMap', () => {
     // When the shared in-flight request finally resolves, the re-attached mount reflects it.
     failLatest('shared')
     expect(result.current.status).toBe('unavailable')
+  })
+
+  test('never refetches a game the server says has no viewable record', () => {
+    const { result, rerender } = renderMap('gone')
+    expect(specCountFor('gone')).toBe(1)
+
+    failLatest('gone', fetchError(404))
+    expect(result.current.status).toBe('unavailable')
+
+    // Navigating away and back doesn't refetch — a 4xx verdict won't change within the session.
+    rerender({ gameId: 'other' })
+    advance(COALESCE_MS)
+    rerender({ gameId: 'gone' })
+    advance(COALESCE_MS)
+    expect(specCountFor('gone')).toBe(1)
+    expect(result.current.status).toBe('unavailable')
+  })
+
+  test('treats a 429 as transient: returning to the replay refetches', () => {
+    const { rerender } = renderMap('limited')
+    expect(specCountFor('limited')).toBe(1)
+    failLatest('limited', fetchError(429))
+
+    rerender({ gameId: 'other' })
+    advance(COALESCE_MS)
+    rerender({ gameId: 'limited' })
+    advance(COALESCE_MS)
+    expect(specCountFor('limited')).toBe(2)
+  })
+
+  test('refetches on return when a fetch fails after the user has already moved on', () => {
+    const { result, rerender } = renderMap('slow')
+    expect(specCountFor('slow')).toBe(1)
+
+    // Move on while the request is in flight, then let it fail with nobody watching.
+    rerender({ gameId: 'other' })
+    advance(COALESCE_MS)
+    failLatest('slow')
+
+    // Returning shows the loading skeleton (not a stale placeholder) and refetches.
+    rerender({ gameId: 'slow' })
+    expect(result.current.status).toBe('loading')
+    advance(COALESCE_MS)
+    expect(specCountFor('slow')).toBe(2)
   })
 })

--- a/client/replays/replay-hooks.test.tsx
+++ b/client/replays/replay-hooks.test.tsx
@@ -1,0 +1,170 @@
+import { act, renderHook } from '@testing-library/react'
+import { ReactNode } from 'react'
+import { Provider as ReduxProvider } from 'react-redux'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import createStore from '../create-store'
+import type { RequestHandlingSpec } from '../network/abortable-thunk'
+import { FetchError } from '../network/fetch-errors'
+import { useSbGameMap } from './replay-hooks'
+
+// Mock out the real game fetch so tests drive its outcome by hand. The mock records each spec so a
+// test can resolve/reject the "request" whenever it likes, and returns a harmless thunk.
+const { viewGameMock, specsByGame } = vi.hoisted(() => {
+  const specsByGame = new Map<string, Array<RequestHandlingSpec<unknown>>>()
+  const viewGameMock = vi.fn((gameId: string, spec: RequestHandlingSpec<unknown>) => {
+    const specs = specsByGame.get(gameId) ?? []
+    specs.push(spec)
+    specsByGame.set(gameId, specs)
+    return () => {}
+  })
+  return { viewGameMock, specsByGame }
+})
+
+vi.mock('../games/action-creators', () => ({
+  viewGame: viewGameMock,
+}))
+
+// Kept in sync with replay-hooks.ts (not exported from there).
+const DEBOUNCE_MS = 150
+const RETRY_MS = 2000
+
+let store: ReturnType<typeof createStore>
+
+function wrapper({ children }: { children: ReactNode }) {
+  return <ReduxProvider store={store}>{children}</ReduxProvider>
+}
+
+function renderMap(gameId: string | undefined) {
+  return renderHook(({ gameId }: { gameId: string | undefined }) => useSbGameMap(gameId), {
+    initialProps: { gameId },
+    wrapper,
+  })
+}
+
+function specCountFor(gameId: string): number {
+  return specsByGame.get(gameId)?.length ?? 0
+}
+
+function latestSpec(gameId: string): RequestHandlingSpec<unknown> {
+  const specs = specsByGame.get(gameId)
+  if (!specs?.length) {
+    throw new Error(`no viewGame call recorded for ${gameId}`)
+  }
+  return specs[specs.length - 1]
+}
+
+function advance(ms: number) {
+  act(() => {
+    vi.advanceTimersByTime(ms)
+  })
+}
+
+function failLatest(gameId: string, status: number) {
+  act(() => {
+    latestSpec(gameId).onError(new FetchError(new Response(null, { status }), ''))
+  })
+}
+
+describe('client/replays/replay-hooks/useSbGameMap', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    specsByGame.clear()
+    viewGameMock.mockClear()
+    store = createStore()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  test('debounces so intermediate selections do not each fire a request', () => {
+    const { rerender } = renderMap('skip-1')
+    advance(DEBOUNCE_MS - 50)
+    rerender({ gameId: 'skip-2' })
+    advance(DEBOUNCE_MS - 50)
+    rerender({ gameId: 'land' })
+    advance(DEBOUNCE_MS)
+
+    expect(specCountFor('skip-1')).toBe(0)
+    expect(specCountFor('skip-2')).toBe(0)
+    expect(specCountFor('land')).toBe(1)
+  })
+
+  test('resolves to unavailable on a terminal 4xx without retrying', () => {
+    const { result } = renderMap('terminal-game')
+    expect(result.current.status).toBe('loading')
+
+    advance(DEBOUNCE_MS)
+    expect(specCountFor('terminal-game')).toBe(1)
+
+    failLatest('terminal-game', 404)
+    expect(result.current.status).toBe('unavailable')
+
+    advance(RETRY_MS * 4)
+    expect(specCountFor('terminal-game')).toBe(1)
+  })
+
+  test('retries a transient failure with exponential backoff', () => {
+    const { result } = renderMap('flaky-game')
+
+    advance(DEBOUNCE_MS)
+    expect(specCountFor('flaky-game')).toBe(1)
+
+    failLatest('flaky-game', 429)
+    expect(result.current.status).toBe('loading')
+
+    // First retry after ~2s.
+    advance(RETRY_MS)
+    expect(specCountFor('flaky-game')).toBe(2)
+
+    failLatest('flaky-game', 500)
+    // Backoff doubles to ~4s, so nothing fires at 2s...
+    advance(RETRY_MS)
+    expect(specCountFor('flaky-game')).toBe(2)
+    // ...and the next attempt lands by 4s.
+    advance(RETRY_MS)
+    expect(specCountFor('flaky-game')).toBe(3)
+  })
+
+  test('refetches when returning to a replay whose fetch failed after moving on', () => {
+    const first = renderMap('left-game')
+    advance(DEBOUNCE_MS)
+    expect(specCountFor('left-game')).toBe(1)
+
+    // Navigate away entirely before the request resolves, then let it fail transiently with nobody
+    // mounted to hear it.
+    first.unmount()
+    failLatest('left-game', 429)
+
+    // Coming back mounts fresh and fetches again rather than sticking on the skeleton forever.
+    const second = renderMap('left-game')
+    expect(second.result.current.status).toBe('loading')
+    advance(DEBOUNCE_MS)
+    expect(specCountFor('left-game')).toBe(2)
+  })
+
+  test('recovers when re-attaching to an in-flight fetch that then fails transiently', () => {
+    const { result, rerender } = renderMap('reattach-game')
+
+    // Kick off the fetch for the first selection and leave it in flight.
+    advance(DEBOUNCE_MS)
+    expect(specCountFor('reattach-game')).toBe(1)
+
+    // Arrow to another replay and back while the first request is still outstanding.
+    rerender({ gameId: 'other-game' })
+    advance(DEBOUNCE_MS)
+    rerender({ gameId: 'reattach-game' })
+
+    // Re-attached to the still-'pending' fetch: no duplicate request, still showing the skeleton.
+    expect(result.current.status).toBe('loading')
+    expect(specCountFor('reattach-game')).toBe(1)
+
+    // The original in-flight request finally fails transiently. The re-attached mount — not the
+    // original, canceled requester — must own the retry, or the panel is stranded on 'loading'.
+    failLatest('reattach-game', 429)
+    expect(result.current.status).toBe('loading')
+
+    advance(RETRY_MS)
+    expect(specCountFor('reattach-game')).toBe(2)
+  })
+})

--- a/client/replays/replay-hooks.test.tsx
+++ b/client/replays/replay-hooks.test.tsx
@@ -8,7 +8,7 @@ import createStore from '../create-store'
 import type { RequestHandlingSpec } from '../network/abortable-thunk'
 import { FetchError } from '../network/fetch-errors'
 import {
-  MAP_FETCH_DEBOUNCE_MS as DEBOUNCE_MS,
+  MAP_FETCH_COALESCE_MS as COALESCE_MS,
   MAP_FETCH_MAX_ATTEMPTS as MAX_ATTEMPTS,
   MAP_FETCH_RETRY_MAX_MS as RETRY_MAX_MS,
   MAP_FETCH_RETRY_MS as RETRY_MS,
@@ -112,7 +112,7 @@ describe('client/replays/replay-hooks/useSbGameMap', () => {
     expect(result.current.status).toBe('unavailable')
     expect(result.current.map).toBeUndefined()
 
-    advance(DEBOUNCE_MS * 2)
+    advance(COALESCE_MS * 2)
     expect(viewGameMock).not.toHaveBeenCalled()
   })
 
@@ -123,17 +123,33 @@ describe('client/replays/replay-hooks/useSbGameMap', () => {
     expect(result.current.status).toBe('loaded')
     expect(result.current.map?.id).toBe('cached-map')
 
-    advance(DEBOUNCE_MS * 2)
+    advance(COALESCE_MS * 2)
     expect(specCountFor('cached-game')).toBe(0)
   })
 
-  test('debounces so intermediate selections do not each fire a request', () => {
-    const { rerender } = renderMap('skip-1')
-    advance(DEBOUNCE_MS - 50)
+  test('fetches a settled selection immediately, with no artificial loading delay', () => {
+    const { result } = renderMap('picked')
+
+    // Leading edge: nothing was fetched recently, so a deliberate selection loads at once — no timer
+    // advance needed.
+    expect(specCountFor('picked')).toBe(1)
+    expect(result.current.status).toBe('loading')
+  })
+
+  test('coalesces a fast scroll to the replay landed on, without fetching intermediates', () => {
+    // A first deliberate selection fetches immediately (leading edge)...
+    const { rerender } = renderMap('warm')
+    expect(specCountFor('warm')).toBe(1)
+
+    // ...then a scroll whose selections change faster than the coalesce window fetches only the row
+    // it settles on, not each intermediate one.
+    const step = Math.floor(COALESCE_MS / 3)
+    rerender({ gameId: 'skip-1' })
+    advance(step)
     rerender({ gameId: 'skip-2' })
-    advance(DEBOUNCE_MS - 50)
+    advance(step)
     rerender({ gameId: 'land' })
-    advance(DEBOUNCE_MS)
+    advance(COALESCE_MS)
 
     expect(specCountFor('skip-1')).toBe(0)
     expect(specCountFor('skip-2')).toBe(0)
@@ -144,7 +160,7 @@ describe('client/replays/replay-hooks/useSbGameMap', () => {
     const { result } = renderMap('terminal-game')
     expect(result.current.status).toBe('loading')
 
-    advance(DEBOUNCE_MS)
+    advance(COALESCE_MS)
     expect(specCountFor('terminal-game')).toBe(1)
 
     failLatest('terminal-game', 404)
@@ -157,7 +173,7 @@ describe('client/replays/replay-hooks/useSbGameMap', () => {
   test('retries a transient failure with exponential backoff', () => {
     const { result } = renderMap('flaky-game')
 
-    advance(DEBOUNCE_MS)
+    advance(COALESCE_MS)
     expect(specCountFor('flaky-game')).toBe(1)
 
     failLatest('flaky-game', 429)
@@ -178,7 +194,7 @@ describe('client/replays/replay-hooks/useSbGameMap', () => {
 
   test('refetches when returning to a replay whose fetch failed after moving on', () => {
     const first = renderMap('left-game')
-    advance(DEBOUNCE_MS)
+    advance(COALESCE_MS)
     expect(specCountFor('left-game')).toBe(1)
 
     // Navigate away entirely before the request resolves, then let it fail transiently with nobody
@@ -191,7 +207,7 @@ describe('client/replays/replay-hooks/useSbGameMap', () => {
     // rather than resetting to the initial debounce.
     const second = renderMap('left-game')
     expect(second.result.current.status).toBe('loading')
-    advance(DEBOUNCE_MS)
+    advance(COALESCE_MS)
     expect(specCountFor('left-game')).toBe(1)
     advance(RETRY_MS)
     expect(specCountFor('left-game')).toBe(2)
@@ -199,7 +215,7 @@ describe('client/replays/replay-hooks/useSbGameMap', () => {
 
   test('holds the retry backoff across arrowing off the replay and back', () => {
     const { rerender } = renderMap('storm-game')
-    advance(DEBOUNCE_MS)
+    advance(COALESCE_MS)
     expect(specCountFor('storm-game')).toBe(1)
 
     // Two transient failures grow the backoff to ~4s (2s doubled).
@@ -211,7 +227,7 @@ describe('client/replays/replay-hooks/useSbGameMap', () => {
     // Arrow away and back while backed off. The backoff is per-game module state, so it must persist
     // rather than resetting to the initial 2s.
     rerender({ gameId: 'elsewhere' })
-    advance(DEBOUNCE_MS)
+    advance(COALESCE_MS)
     rerender({ gameId: 'storm-game' })
 
     // Still backed off: nothing refires at 2s...
@@ -224,7 +240,7 @@ describe('client/replays/replay-hooks/useSbGameMap', () => {
 
   test('clears all backoff on a successful fetch so a backed-off game refetches promptly', () => {
     const { rerender } = renderMap('backed-off')
-    advance(DEBOUNCE_MS)
+    advance(COALESCE_MS)
     expect(specCountFor('backed-off')).toBe(1)
 
     // Two failures grow this game's backoff to ~4s.
@@ -235,12 +251,12 @@ describe('client/replays/replay-hooks/useSbGameMap', () => {
 
     // A different game's fetch then succeeds — the limiter clearly isn't blocking anymore.
     rerender({ gameId: 'ok-game' })
-    advance(DEBOUNCE_MS)
+    advance(COALESCE_MS)
     succeedLatest('ok-game')
 
     // Returning to the backed-off game now fetches on the debounce, not the stale ~4s backoff.
     rerender({ gameId: 'backed-off' })
-    advance(DEBOUNCE_MS)
+    advance(COALESCE_MS)
     expect(specCountFor('backed-off')).toBe(3)
   })
 
@@ -248,7 +264,7 @@ describe('client/replays/replay-hooks/useSbGameMap', () => {
   // doubling backoff, capped — derived from the same constants (and formula) the hook uses so it
   // can't drift out of sync with them.
   const ATTEMPT_DELAYS = Array.from({ length: MAX_ATTEMPTS }, (_, i) =>
-    i === 0 ? DEBOUNCE_MS : Math.min(RETRY_MS * 2 ** (i - 1), RETRY_MAX_MS),
+    i === 0 ? COALESCE_MS : Math.min(RETRY_MS * 2 ** (i - 1), RETRY_MAX_MS),
   )
 
   function exhaustRetries(gameId: string, result: { current: { status: string } }) {
@@ -278,13 +294,13 @@ describe('client/replays/replay-hooks/useSbGameMap', () => {
 
     // A later fetch on another game succeeds — proof the limiter/network recovered.
     gaveUp.rerender({ gameId: 'healthy' })
-    advance(DEBOUNCE_MS)
+    advance(COALESCE_MS)
     succeedLatest('healthy')
 
     // Returning to the gave-up game now refetches instead of staying stuck on the placeholder.
     gaveUp.rerender({ gameId: 'gave-up' })
     expect(gaveUp.result.current.status).toBe('loading')
-    advance(DEBOUNCE_MS)
+    advance(COALESCE_MS)
     expect(specCountFor('gave-up')).toBe(MAX_ATTEMPTS + 1)
   })
 
@@ -292,12 +308,12 @@ describe('client/replays/replay-hooks/useSbGameMap', () => {
     const { result, rerender } = renderMap('reattach-game')
 
     // Kick off the fetch for the first selection and leave it in flight.
-    advance(DEBOUNCE_MS)
+    advance(COALESCE_MS)
     expect(specCountFor('reattach-game')).toBe(1)
 
     // Arrow to another replay and back while the first request is still outstanding.
     rerender({ gameId: 'other-game' })
-    advance(DEBOUNCE_MS)
+    advance(COALESCE_MS)
     rerender({ gameId: 'reattach-game' })
 
     // Re-attached to the still-'pending' fetch: no duplicate request, still showing the skeleton.

--- a/client/replays/replay-hooks.test.tsx
+++ b/client/replays/replay-hooks.test.tsx
@@ -152,6 +152,28 @@ describe('client/replays/replay-hooks/useSbGameMap', () => {
     expect(specCountFor('land')).toBe(1)
   })
 
+  test('a sustained scroll fires nothing for skipped rows, however long it lasts', () => {
+    const { rerender } = renderMap('start')
+    expect(specCountFor('start')).toBe(1)
+
+    // Hold the arrow for many times the coalesce window: every change lands within the window of
+    // the previous one, so the whole run keeps deferring — no periodic leading-edge fetches leak
+    // out mid-scroll.
+    const step = Math.floor(COALESCE_MS / 3)
+    for (let i = 0; i < 20; i++) {
+      rerender({ gameId: `skipped-${i}` })
+      advance(step)
+    }
+    rerender({ gameId: 'landed' })
+    advance(COALESCE_MS)
+
+    for (let i = 0; i < 20; i++) {
+      expect(specCountFor(`skipped-${i}`)).toBe(0)
+    }
+    expect(specCountFor('landed')).toBe(1)
+    expect(viewGameMock).toHaveBeenCalledTimes(2)
+  })
+
   test('shows unavailable on a fetch error and does not retry', () => {
     const { result } = renderMap('broken')
     expect(specCountFor('broken')).toBe(1)

--- a/client/replays/replay-hooks.test.tsx
+++ b/client/replays/replay-hooks.test.tsx
@@ -205,23 +205,52 @@ describe('client/replays/replay-hooks/useSbGameMap', () => {
     expect(specCountFor('backed-off')).toBe(3)
   })
 
-  test('gives up and settles to unavailable after exhausting transient retries', () => {
-    const { result } = renderMap('doomed')
-    // The wait before each attempt: debounce, then the doubling backoff, capped.
-    const delays = [DEBOUNCE_MS, RETRY_MS, RETRY_MS * 2, RETRY_MS * 4, RETRY_MS * 8, RETRY_MAX_MS]
+  // The wait before each successive attempt on a game that keeps failing: debounce, then the
+  // doubling backoff, capped.
+  const ATTEMPT_DELAYS = [
+    DEBOUNCE_MS,
+    RETRY_MS,
+    RETRY_MS * 2,
+    RETRY_MS * 4,
+    RETRY_MS * 8,
+    RETRY_MAX_MS,
+  ]
 
+  function exhaustRetries(gameId: string, result: { current: { status: string } }) {
     for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
-      advance(delays[attempt - 1])
-      expect(specCountFor('doomed')).toBe(attempt)
+      advance(ATTEMPT_DELAYS[attempt - 1])
+      expect(specCountFor(gameId)).toBe(attempt)
       expect(result.current.status).toBe('loading')
-      failLatest('doomed', 429)
+      failLatest(gameId, 429)
     }
+  }
+
+  test('gives up to unavailable after exhausting transient retries, and stops polling', () => {
+    const { result } = renderMap('doomed')
+    exhaustRetries('doomed', result)
 
     // The final failure exhausts the cap: the hero stops shimmering and falls back to unavailable...
     expect(result.current.status).toBe('unavailable')
     // ...and there are no further retries, however long the panel stays open.
     advance(RETRY_MAX_MS * 2)
     expect(specCountFor('doomed')).toBe(MAX_ATTEMPTS)
+  })
+
+  test('reopens a gave-up game after a later successful fetch, rather than stranding it', () => {
+    const gaveUp = renderMap('gave-up')
+    exhaustRetries('gave-up', gaveUp.result)
+    expect(gaveUp.result.current.status).toBe('unavailable')
+
+    // A later fetch on another game succeeds — proof the limiter/network recovered.
+    gaveUp.rerender({ gameId: 'healthy' })
+    advance(DEBOUNCE_MS)
+    succeedLatest('healthy')
+
+    // Returning to the gave-up game now refetches instead of staying stuck on the placeholder.
+    gaveUp.rerender({ gameId: 'gave-up' })
+    expect(gaveUp.result.current.status).toBe('loading')
+    advance(DEBOUNCE_MS)
+    expect(specCountFor('gave-up')).toBe(MAX_ATTEMPTS + 1)
   })
 
   test('recovers when re-attaching to an in-flight fetch that then fails transiently', () => {

--- a/client/replays/replay-hooks.test.tsx
+++ b/client/replays/replay-hooks.test.tsx
@@ -6,12 +6,8 @@ import type { GameRecordJson } from '../../common/games/games'
 import type { MapInfoJson } from '../../common/maps'
 import createStore from '../create-store'
 import type { RequestHandlingSpec } from '../network/abortable-thunk'
-import { FetchError } from '../network/fetch-errors'
 import {
   MAP_FETCH_COALESCE_MS as COALESCE_MS,
-  MAP_FETCH_MAX_ATTEMPTS as MAX_ATTEMPTS,
-  MAP_FETCH_RETRY_MAX_MS as RETRY_MAX_MS,
-  MAP_FETCH_RETRY_MS as RETRY_MS,
   resetSbGameMapStateForTests,
   useSbGameMap,
 } from './replay-hooks'
@@ -64,15 +60,9 @@ function advance(ms: number) {
   })
 }
 
-function failLatest(gameId: string, status: number) {
+function failLatest(gameId: string) {
   act(() => {
-    latestSpec(gameId).onError(new FetchError(new Response(null, { status }), ''))
-  })
-}
-
-function succeedLatest(gameId: string) {
-  act(() => {
-    latestSpec(gameId).onSuccess(undefined)
+    latestSpec(gameId).onError(new Error('fetch failed'))
   })
 }
 
@@ -98,7 +88,7 @@ describe('client/replays/replay-hooks/useSbGameMap', () => {
     specsByGame.clear()
     viewGameMock.mockClear()
     // The hook's fetch bookkeeping is module-level and deliberately outlives a mount, so reset it
-    // between cases — otherwise markers/backoff/listeners leak from one test into the next.
+    // between cases — otherwise markers/listeners leak from one test into the next.
     resetSbGameMapStateForTests()
     store = createStore()
   })
@@ -156,176 +146,47 @@ describe('client/replays/replay-hooks/useSbGameMap', () => {
     expect(specCountFor('land')).toBe(1)
   })
 
-  test('resolves to unavailable on a terminal 4xx without retrying', () => {
-    const { result } = renderMap('terminal-game')
+  test('shows unavailable on a fetch error and does not retry', () => {
+    const { result } = renderMap('broken')
+    expect(specCountFor('broken')).toBe(1)
     expect(result.current.status).toBe('loading')
 
-    advance(COALESCE_MS)
-    expect(specCountFor('terminal-game')).toBe(1)
-
-    failLatest('terminal-game', 404)
+    failLatest('broken')
     expect(result.current.status).toBe('unavailable')
 
-    advance(RETRY_MS * 4)
-    expect(specCountFor('terminal-game')).toBe(1)
+    // No retry, however long the panel stays open.
+    advance(COALESCE_MS * 20)
+    expect(specCountFor('broken')).toBe(1)
   })
 
-  test('retries a transient failure with exponential backoff', () => {
-    const { result } = renderMap('flaky-game')
+  test('refetches when returning to a replay whose earlier fetch failed', () => {
+    const { rerender } = renderMap('flappy')
+    expect(specCountFor('flappy')).toBe(1)
+    failLatest('flappy')
+    expect(specCountFor('flappy')).toBe(1)
 
+    // Navigate away and back. Leaving drops the settled marker, so returning refetches rather than
+    // showing the placeholder for the rest of the session.
+    rerender({ gameId: 'other' })
     advance(COALESCE_MS)
-    expect(specCountFor('flaky-game')).toBe(1)
+    rerender({ gameId: 'flappy' })
+    advance(COALESCE_MS)
+    expect(specCountFor('flappy')).toBe(2)
+  })
 
-    failLatest('flaky-game', 429)
+  test('re-attaches to an in-flight fetch rather than starting a duplicate', () => {
+    const { result, rerender } = renderMap('shared')
+    expect(specCountFor('shared')).toBe(1)
+
+    // Arrow away and back while the request is still in flight — no duplicate fetch, still loading.
+    rerender({ gameId: 'other' })
+    advance(COALESCE_MS)
+    rerender({ gameId: 'shared' })
     expect(result.current.status).toBe('loading')
+    expect(specCountFor('shared')).toBe(1)
 
-    // First retry after ~2s.
-    advance(RETRY_MS)
-    expect(specCountFor('flaky-game')).toBe(2)
-
-    failLatest('flaky-game', 500)
-    // Backoff doubles to ~4s, so nothing fires at 2s...
-    advance(RETRY_MS)
-    expect(specCountFor('flaky-game')).toBe(2)
-    // ...and the next attempt lands by 4s.
-    advance(RETRY_MS)
-    expect(specCountFor('flaky-game')).toBe(3)
-  })
-
-  test('refetches when returning to a replay whose fetch failed after moving on', () => {
-    const first = renderMap('left-game')
-    advance(COALESCE_MS)
-    expect(specCountFor('left-game')).toBe(1)
-
-    // Navigate away entirely before the request resolves, then let it fail transiently with nobody
-    // mounted to hear it.
-    first.unmount()
-    failLatest('left-game', 429)
-
-    // Coming back mounts fresh and fetches again rather than sticking on the skeleton forever. The
-    // transient failure while away left a live backoff for this game, so the return waits it out
-    // rather than resetting to the initial debounce.
-    const second = renderMap('left-game')
-    expect(second.result.current.status).toBe('loading')
-    advance(COALESCE_MS)
-    expect(specCountFor('left-game')).toBe(1)
-    advance(RETRY_MS)
-    expect(specCountFor('left-game')).toBe(2)
-  })
-
-  test('holds the retry backoff across arrowing off the replay and back', () => {
-    const { rerender } = renderMap('storm-game')
-    advance(COALESCE_MS)
-    expect(specCountFor('storm-game')).toBe(1)
-
-    // Two transient failures grow the backoff to ~4s (2s doubled).
-    failLatest('storm-game', 429)
-    advance(RETRY_MS)
-    expect(specCountFor('storm-game')).toBe(2)
-    failLatest('storm-game', 429)
-
-    // Arrow away and back while backed off. The backoff is per-game module state, so it must persist
-    // rather than resetting to the initial 2s.
-    rerender({ gameId: 'elsewhere' })
-    advance(COALESCE_MS)
-    rerender({ gameId: 'storm-game' })
-
-    // Still backed off: nothing refires at 2s...
-    advance(RETRY_MS)
-    expect(specCountFor('storm-game')).toBe(2)
-    // ...but the next attempt lands by the held ~4s backoff.
-    advance(RETRY_MS)
-    expect(specCountFor('storm-game')).toBe(3)
-  })
-
-  test('clears all backoff on a successful fetch so a backed-off game refetches promptly', () => {
-    const { rerender } = renderMap('backed-off')
-    advance(COALESCE_MS)
-    expect(specCountFor('backed-off')).toBe(1)
-
-    // Two failures grow this game's backoff to ~4s.
-    failLatest('backed-off', 429)
-    advance(RETRY_MS)
-    expect(specCountFor('backed-off')).toBe(2)
-    failLatest('backed-off', 429)
-
-    // A different game's fetch then succeeds — the limiter clearly isn't blocking anymore.
-    rerender({ gameId: 'ok-game' })
-    advance(COALESCE_MS)
-    succeedLatest('ok-game')
-
-    // Returning to the backed-off game now fetches on the debounce, not the stale ~4s backoff.
-    rerender({ gameId: 'backed-off' })
-    advance(COALESCE_MS)
-    expect(specCountFor('backed-off')).toBe(3)
-  })
-
-  // The wait before each successive attempt on a game that keeps failing — debounce, then the
-  // doubling backoff, capped — derived from the same constants (and formula) the hook uses so it
-  // can't drift out of sync with them.
-  const ATTEMPT_DELAYS = Array.from({ length: MAX_ATTEMPTS }, (_, i) =>
-    i === 0 ? COALESCE_MS : Math.min(RETRY_MS * 2 ** (i - 1), RETRY_MAX_MS),
-  )
-
-  function exhaustRetries(gameId: string, result: { current: { status: string } }) {
-    for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
-      advance(ATTEMPT_DELAYS[attempt - 1])
-      expect(specCountFor(gameId)).toBe(attempt)
-      expect(result.current.status).toBe('loading')
-      failLatest(gameId, 429)
-    }
-  }
-
-  test('gives up to unavailable after exhausting transient retries, and stops polling', () => {
-    const { result } = renderMap('doomed')
-    exhaustRetries('doomed', result)
-
-    // The final failure exhausts the cap: the hero stops shimmering and falls back to unavailable...
+    // When the shared in-flight request finally resolves, the re-attached mount reflects it.
+    failLatest('shared')
     expect(result.current.status).toBe('unavailable')
-    // ...and there are no further retries, however long the panel stays open.
-    advance(RETRY_MAX_MS * 2)
-    expect(specCountFor('doomed')).toBe(MAX_ATTEMPTS)
-  })
-
-  test('reopens a gave-up game after a later successful fetch, rather than stranding it', () => {
-    const gaveUp = renderMap('gave-up')
-    exhaustRetries('gave-up', gaveUp.result)
-    expect(gaveUp.result.current.status).toBe('unavailable')
-
-    // A later fetch on another game succeeds — proof the limiter/network recovered.
-    gaveUp.rerender({ gameId: 'healthy' })
-    advance(COALESCE_MS)
-    succeedLatest('healthy')
-
-    // Returning to the gave-up game now refetches instead of staying stuck on the placeholder.
-    gaveUp.rerender({ gameId: 'gave-up' })
-    expect(gaveUp.result.current.status).toBe('loading')
-    advance(COALESCE_MS)
-    expect(specCountFor('gave-up')).toBe(MAX_ATTEMPTS + 1)
-  })
-
-  test('recovers when re-attaching to an in-flight fetch that then fails transiently', () => {
-    const { result, rerender } = renderMap('reattach-game')
-
-    // Kick off the fetch for the first selection and leave it in flight.
-    advance(COALESCE_MS)
-    expect(specCountFor('reattach-game')).toBe(1)
-
-    // Arrow to another replay and back while the first request is still outstanding.
-    rerender({ gameId: 'other-game' })
-    advance(COALESCE_MS)
-    rerender({ gameId: 'reattach-game' })
-
-    // Re-attached to the still-'pending' fetch: no duplicate request, still showing the skeleton.
-    expect(result.current.status).toBe('loading')
-    expect(specCountFor('reattach-game')).toBe(1)
-
-    // The original in-flight request finally fails transiently. The re-attached mount — not the
-    // original, canceled requester — must own the retry, or the panel is stranded on 'loading'.
-    failLatest('reattach-game', 429)
-    expect(result.current.status).toBe('loading')
-
-    advance(RETRY_MS)
-    expect(specCountFor('reattach-game')).toBe(2)
   })
 })

--- a/client/replays/replay-hooks.test.tsx
+++ b/client/replays/replay-hooks.test.tsx
@@ -2,10 +2,19 @@ import { act, renderHook } from '@testing-library/react'
 import { ReactNode } from 'react'
 import { Provider as ReduxProvider } from 'react-redux'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import type { GameRecordJson } from '../../common/games/games'
+import type { MapInfoJson } from '../../common/maps'
 import createStore from '../create-store'
 import type { RequestHandlingSpec } from '../network/abortable-thunk'
 import { FetchError } from '../network/fetch-errors'
-import { resetSbGameMapStateForTests, useSbGameMap } from './replay-hooks'
+import {
+  MAP_FETCH_DEBOUNCE_MS as DEBOUNCE_MS,
+  MAP_FETCH_MAX_ATTEMPTS as MAX_ATTEMPTS,
+  MAP_FETCH_RETRY_MAX_MS as RETRY_MAX_MS,
+  MAP_FETCH_RETRY_MS as RETRY_MS,
+  resetSbGameMapStateForTests,
+  useSbGameMap,
+} from './replay-hooks'
 
 // Mock out the real game fetch so tests drive its outcome by hand. The mock records each spec so a
 // test can resolve/reject the "request" whenever it likes, and returns a harmless thunk.
@@ -23,12 +32,6 @@ const { viewGameMock, specsByGame } = vi.hoisted(() => {
 vi.mock('../games/action-creators', () => ({
   viewGame: viewGameMock,
 }))
-
-// Kept in sync with replay-hooks.ts (not exported from there).
-const DEBOUNCE_MS = 150
-const RETRY_MS = 2000
-const RETRY_MAX_MS = 30000
-const MAX_ATTEMPTS = 6
 
 let store: ReturnType<typeof createStore>
 
@@ -73,6 +76,22 @@ function succeedLatest(gameId: string) {
   })
 }
 
+// Seeds the store as a `@games/getGameRecord` fetch would, so the game and its map are already
+// present (the cached, no-fetch-needed path). Only the fields the hook reads are set.
+function seedGameWithMap(gameId: string, mapId: string) {
+  act(() => {
+    store.dispatch({
+      type: '@games/getGameRecord',
+      payload: {
+        game: { id: gameId, mapId } as GameRecordJson,
+        map: { id: mapId } as MapInfoJson,
+        users: [],
+        mmrChanges: [],
+      },
+    })
+  })
+}
+
 describe('client/replays/replay-hooks/useSbGameMap', () => {
   beforeEach(() => {
     vi.useFakeTimers()
@@ -86,6 +105,26 @@ describe('client/replays/replay-hooks/useSbGameMap', () => {
 
   afterEach(() => {
     vi.useRealTimers()
+  })
+
+  test('is unavailable and fetches nothing for a replay with no linked game', () => {
+    const { result } = renderMap(undefined)
+    expect(result.current.status).toBe('unavailable')
+    expect(result.current.map).toBeUndefined()
+
+    advance(DEBOUNCE_MS * 2)
+    expect(viewGameMock).not.toHaveBeenCalled()
+  })
+
+  test('reports loaded from the store without fetching when the game is already cached', () => {
+    seedGameWithMap('cached-game', 'cached-map')
+
+    const { result } = renderMap('cached-game')
+    expect(result.current.status).toBe('loaded')
+    expect(result.current.map?.id).toBe('cached-map')
+
+    advance(DEBOUNCE_MS * 2)
+    expect(specCountFor('cached-game')).toBe(0)
   })
 
   test('debounces so intermediate selections do not each fire a request', () => {
@@ -205,16 +244,12 @@ describe('client/replays/replay-hooks/useSbGameMap', () => {
     expect(specCountFor('backed-off')).toBe(3)
   })
 
-  // The wait before each successive attempt on a game that keeps failing: debounce, then the
-  // doubling backoff, capped.
-  const ATTEMPT_DELAYS = [
-    DEBOUNCE_MS,
-    RETRY_MS,
-    RETRY_MS * 2,
-    RETRY_MS * 4,
-    RETRY_MS * 8,
-    RETRY_MAX_MS,
-  ]
+  // The wait before each successive attempt on a game that keeps failing — debounce, then the
+  // doubling backoff, capped — derived from the same constants (and formula) the hook uses so it
+  // can't drift out of sync with them.
+  const ATTEMPT_DELAYS = Array.from({ length: MAX_ATTEMPTS }, (_, i) =>
+    i === 0 ? DEBOUNCE_MS : Math.min(RETRY_MS * 2 ** (i - 1), RETRY_MAX_MS),
+  )
 
   function exhaustRetries(gameId: string, result: { current: { status: string } }) {
     for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {

--- a/client/replays/replay-hooks.test.tsx
+++ b/client/replays/replay-hooks.test.tsx
@@ -5,7 +5,7 @@ import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import createStore from '../create-store'
 import type { RequestHandlingSpec } from '../network/abortable-thunk'
 import { FetchError } from '../network/fetch-errors'
-import { useSbGameMap } from './replay-hooks'
+import { resetSbGameMapStateForTests, useSbGameMap } from './replay-hooks'
 
 // Mock out the real game fetch so tests drive its outcome by hand. The mock records each spec so a
 // test can resolve/reject the "request" whenever it likes, and returns a harmless thunk.
@@ -27,6 +27,8 @@ vi.mock('../games/action-creators', () => ({
 // Kept in sync with replay-hooks.ts (not exported from there).
 const DEBOUNCE_MS = 150
 const RETRY_MS = 2000
+const RETRY_MAX_MS = 30000
+const MAX_ATTEMPTS = 6
 
 let store: ReturnType<typeof createStore>
 
@@ -65,11 +67,20 @@ function failLatest(gameId: string, status: number) {
   })
 }
 
+function succeedLatest(gameId: string) {
+  act(() => {
+    latestSpec(gameId).onSuccess(undefined)
+  })
+}
+
 describe('client/replays/replay-hooks/useSbGameMap', () => {
   beforeEach(() => {
     vi.useFakeTimers()
     specsByGame.clear()
     viewGameMock.mockClear()
+    // The hook's fetch bookkeeping is module-level and deliberately outlives a mount, so reset it
+    // between cases — otherwise markers/backoff/listeners leak from one test into the next.
+    resetSbGameMapStateForTests()
     store = createStore()
   })
 
@@ -170,6 +181,47 @@ describe('client/replays/replay-hooks/useSbGameMap', () => {
     // ...but the next attempt lands by the held ~4s backoff.
     advance(RETRY_MS)
     expect(specCountFor('storm-game')).toBe(3)
+  })
+
+  test('clears all backoff on a successful fetch so a backed-off game refetches promptly', () => {
+    const { rerender } = renderMap('backed-off')
+    advance(DEBOUNCE_MS)
+    expect(specCountFor('backed-off')).toBe(1)
+
+    // Two failures grow this game's backoff to ~4s.
+    failLatest('backed-off', 429)
+    advance(RETRY_MS)
+    expect(specCountFor('backed-off')).toBe(2)
+    failLatest('backed-off', 429)
+
+    // A different game's fetch then succeeds — the limiter clearly isn't blocking anymore.
+    rerender({ gameId: 'ok-game' })
+    advance(DEBOUNCE_MS)
+    succeedLatest('ok-game')
+
+    // Returning to the backed-off game now fetches on the debounce, not the stale ~4s backoff.
+    rerender({ gameId: 'backed-off' })
+    advance(DEBOUNCE_MS)
+    expect(specCountFor('backed-off')).toBe(3)
+  })
+
+  test('gives up and settles to unavailable after exhausting transient retries', () => {
+    const { result } = renderMap('doomed')
+    // The wait before each attempt: debounce, then the doubling backoff, capped.
+    const delays = [DEBOUNCE_MS, RETRY_MS, RETRY_MS * 2, RETRY_MS * 4, RETRY_MS * 8, RETRY_MAX_MS]
+
+    for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+      advance(delays[attempt - 1])
+      expect(specCountFor('doomed')).toBe(attempt)
+      expect(result.current.status).toBe('loading')
+      failLatest('doomed', 429)
+    }
+
+    // The final failure exhausts the cap: the hero stops shimmering and falls back to unavailable...
+    expect(result.current.status).toBe('unavailable')
+    // ...and there are no further retries, however long the panel stays open.
+    advance(RETRY_MAX_MS * 2)
+    expect(specCountFor('doomed')).toBe(MAX_ATTEMPTS)
   })
 
   test('recovers when re-attaching to an in-flight fetch that then fails transiently', () => {

--- a/client/replays/replay-hooks.test.tsx
+++ b/client/replays/replay-hooks.test.tsx
@@ -136,11 +136,40 @@ describe('client/replays/replay-hooks/useSbGameMap', () => {
     first.unmount()
     failLatest('left-game', 429)
 
-    // Coming back mounts fresh and fetches again rather than sticking on the skeleton forever.
+    // Coming back mounts fresh and fetches again rather than sticking on the skeleton forever. The
+    // transient failure while away left a live backoff for this game, so the return waits it out
+    // rather than resetting to the initial debounce.
     const second = renderMap('left-game')
     expect(second.result.current.status).toBe('loading')
     advance(DEBOUNCE_MS)
+    expect(specCountFor('left-game')).toBe(1)
+    advance(RETRY_MS)
     expect(specCountFor('left-game')).toBe(2)
+  })
+
+  test('holds the retry backoff across arrowing off the replay and back', () => {
+    const { rerender } = renderMap('storm-game')
+    advance(DEBOUNCE_MS)
+    expect(specCountFor('storm-game')).toBe(1)
+
+    // Two transient failures grow the backoff to ~4s (2s doubled).
+    failLatest('storm-game', 429)
+    advance(RETRY_MS)
+    expect(specCountFor('storm-game')).toBe(2)
+    failLatest('storm-game', 429)
+
+    // Arrow away and back while backed off. The backoff is per-game module state, so it must persist
+    // rather than resetting to the initial 2s.
+    rerender({ gameId: 'elsewhere' })
+    advance(DEBOUNCE_MS)
+    rerender({ gameId: 'storm-game' })
+
+    // Still backed off: nothing refires at 2s...
+    advance(RETRY_MS)
+    expect(specCountFor('storm-game')).toBe(2)
+    // ...but the next attempt lands by the held ~4s backoff.
+    advance(RETRY_MS)
+    expect(specCountFor('storm-game')).toBe(3)
   })
 
   test('recovers when re-attaching to an in-flight fetch that then fails transiently', () => {

--- a/client/replays/replay-hooks.ts
+++ b/client/replays/replay-hooks.ts
@@ -17,17 +17,20 @@ export interface SbGameMapResult {
   status: SbGameMapStatus
 }
 
+// Exported for the hook's tests, which assert the debounce/backoff/give-up timings and would
+// silently drift if they hardcoded their own copies.
+
 /** How long a selection must hold still before we fetch its game (see the debounce in the effect). */
-const MAP_FETCH_DEBOUNCE_MS = 150
+export const MAP_FETCH_DEBOUNCE_MS = 150
 /** Base backoff before the first retry of a transiently-failed fetch (rate-limited / 5xx / network). */
-const MAP_FETCH_RETRY_MS = 2000
+export const MAP_FETCH_RETRY_MS = 2000
 /** Backoff ceiling: a sustained failure polls at most this often while the panel stays open. */
-const MAP_FETCH_RETRY_MAX_MS = 30000
+export const MAP_FETCH_RETRY_MAX_MS = 30000
 /**
  * Transient failures a fetch may take before it gives up (see `gaveUp`) rather than shimmering and
  * polling forever. With the backoff above, ~a minute.
  */
-const MAP_FETCH_MAX_ATTEMPTS = 6
+export const MAP_FETCH_MAX_ATTEMPTS = 6
 
 /**
  * Fetch outcome per game id, tracked at module scope so it survives the hook unmounting/remounting as

--- a/client/replays/replay-hooks.ts
+++ b/client/replays/replay-hooks.ts
@@ -2,6 +2,7 @@ import { useEffect, useSyncExternalStore } from 'react'
 import { ReadonlyDeep } from 'type-fest'
 import { MapInfoJson } from '../../common/maps'
 import { viewGame } from '../games/action-creators'
+import { isFetchError } from '../network/fetch-errors'
 import { useAppDispatch, useAppSelector } from '../redux-hooks'
 
 export type SbGameMapStatus = 'loading' | 'loaded' | 'unavailable'
@@ -28,16 +29,18 @@ export const MAP_FETCH_COALESCE_MS = 150
  * Per-game fetch outcome, tracked at module scope so it survives the hook re-rendering as the user
  * arrows between replays. Lets the hook tell "still loading" apart from "no map to show" even for a
  * game absent from the Redux store (a genuinely missing game is also simply absent from it):
- * `pending` while a request is in flight, `settled` once it has resolved — loaded, no map, or a
- * failed fetch (all of which show the placeholder rather than shimmering).
+ * `pending` while a request is in flight, `settled` once it has resolved (loaded, no map, or a
+ * transient failure — all of which show the placeholder rather than shimmering), `terminal` when
+ * the server answered with a 4xx: no viewable record exists, so the game is never refetched within
+ * the session.
  *
- * A `settled` marker is dropped when the user navigates away (see the cleanup effect below), so
- * returning to a replay whose fetch failed transiently refetches rather than showing the placeholder
- * for the rest of the session. Read through `useSyncExternalStore` (not a `forceUpdate` reading this
- * map during render) so the React Compiler can't memoize the derived `status` on its reactive inputs
- * and skip a status-only change.
+ * A `settled` marker is dropped when the user navigates away (see the cleanup effect below) or when
+ * the fetch resolves after they already have, so returning to a replay whose fetch failed
+ * transiently refetches rather than showing the placeholder for the rest of the session. Read
+ * through `useSyncExternalStore` (not a `forceUpdate` reading this map during render) so the React
+ * Compiler can't memoize the derived `status` on its reactive inputs and skip a status-only change.
  */
-const gameFetchStatus = new Map<string, 'pending' | 'settled'>()
+const gameFetchStatus = new Map<string, 'pending' | 'settled' | 'terminal'>()
 
 /**
  * `Date.now()` when the last fetch was kicked off, across all games — used to tell a deliberate
@@ -62,7 +65,9 @@ function subscribeToGameFetch(gameId: string | undefined, onChange: () => void):
   }
 }
 
-function getGameFetchStatus(gameId: string | undefined): 'pending' | 'settled' | undefined {
+function getGameFetchStatus(
+  gameId: string | undefined,
+): 'pending' | 'settled' | 'terminal' | undefined {
   return gameId ? gameFetchStatus.get(gameId) : undefined
 }
 
@@ -94,6 +99,18 @@ export function useSbGameMap(gameId: string | undefined): SbGameMapResult {
     if (!gameId || game || gameFetchStatus.has(gameId)) return () => {}
 
     let canceled = false
+    const settle = (outcome: 'settled' | 'terminal') => {
+      if (outcome === 'settled' && !gameFetchListeners.has(gameId)) {
+        // The result arrived after the user moved on (the cleanup effect below already ran while
+        // the fetch was pending, so nothing else will evict this marker). Leave none: a success is
+        // cached in the store regardless, and a failure should refetch when the replay is next
+        // shown rather than showing a stale placeholder.
+        gameFetchStatus.delete(gameId)
+      } else {
+        gameFetchStatus.set(gameId, outcome)
+        notifyGameFetchListeners(gameId)
+      }
+    }
     const attempt = () => {
       if (canceled || gameFetchStatus.has(gameId)) return
       lastFetchStartedAt = Date.now()
@@ -103,16 +120,17 @@ export function useSbGameMap(gameId: string | undefined): SbGameMapResult {
       // store is the point.
       dispatch(
         viewGame(gameId, {
-          onSuccess: () => {
-            gameFetchStatus.set(gameId, 'settled')
-            notifyGameFetchListeners(gameId)
-          },
-          onError: () => {
-            // Any failure (no viewable record, a 429, a 5xx, a network blip) settles to the
-            // placeholder — like every other panel, a failed fetch just shows the empty state. No
-            // retry; the cleanup effect lets a later reselect try again.
-            gameFetchStatus.set(gameId, 'settled')
-            notifyGameFetchListeners(gameId)
+          onSuccess: () => settle('settled'),
+          onError: err => {
+            // A 4xx (other than 429) is the server's verdict that there's no viewable record here,
+            // which won't change within the session — never refetch it. Anything else (429
+            // rate-limiting, a 5xx, a network blip) settles to the placeholder like every other
+            // panel, but only for as long as this replay stays selected: a reselect retries.
+            settle(
+              isFetchError(err) && err.status >= 400 && err.status < 500 && err.status !== 429
+                ? 'terminal'
+                : 'settled',
+            )
           },
         }),
       )
@@ -139,8 +157,9 @@ export function useSbGameMap(gameId: string | undefined): SbGameMapResult {
   useEffect(() => {
     return () => {
       // On leaving this replay, drop a settled marker so returning refetches — a transient failure
-      // shouldn't strand the preview for the session (a success is cached in the store regardless). A
-      // still-pending fetch is left in place so a quick return re-attaches to it.
+      // shouldn't strand the preview for the session (a success is cached in the store regardless).
+      // A still-pending fetch is left in place so a quick return re-attaches to it, and a terminal
+      // outcome is kept so a game with no viewable record isn't refetched on every reselect.
       if (gameId !== undefined && gameFetchStatus.get(gameId) === 'settled') {
         gameFetchStatus.delete(gameId)
       }
@@ -150,9 +169,10 @@ export function useSbGameMap(gameId: string | undefined): SbGameMapResult {
   let status: SbGameMapStatus
   if (map) {
     status = 'loaded'
-  } else if (gameId && !game && fetchStatus !== 'settled') {
+  } else if (gameId && !game && (fetchStatus === undefined || fetchStatus === 'pending')) {
     // Still on the way (coalescing / in flight): assume a map is coming rather than flashing the
-    // placeholder. A settled outcome (loaded, no map, or a failed fetch) falls through to unavailable.
+    // placeholder. A resolved outcome (loaded, no map, or a failed fetch) falls through to
+    // unavailable.
     status = 'loading'
   } else {
     status = 'unavailable'

--- a/client/replays/replay-hooks.ts
+++ b/client/replays/replay-hooks.ts
@@ -1,36 +1,104 @@
-import { useEffect } from 'react'
+import { useEffect, useReducer } from 'react'
 import { ReadonlyDeep } from 'type-fest'
 import { MapInfoJson } from '../../common/maps'
 import { viewGame } from '../games/action-creators'
 import { isFetchError } from '../network/fetch-errors'
 import { useAppDispatch, useAppSelector } from '../redux-hooks'
 
-/** Game ids we've already tried to fetch this session, so unmount/remount cycles from the
- * virtualized list (and genuine 404s for games the server no longer knows) don't refetch.
- * Non-4xx failures (network blips, 5xx) are evicted on error so a later mount can retry them. */
-const requestedGameIds = new Set<string>()
+export type SbGameMapStatus = 'loading' | 'loaded' | 'unavailable'
 
-export function useSbGameMap(gameId: string | undefined): ReadonlyDeep<MapInfoJson> | undefined {
+export interface SbGameMapResult {
+  map: ReadonlyDeep<MapInfoJson> | undefined
+  /**
+   * `loading` while the backing game (and thus its map) is still being fetched, `loaded` once the
+   * map is resolved, `unavailable` when there's genuinely no map to show (a replay with no linked
+   * SB game, or a game whose map has been deleted / can't be found).
+   */
+  status: SbGameMapStatus
+}
+
+/** How long a selection must hold still before we fetch its game — see the debounce note below. */
+const MAP_FETCH_DEBOUNCE_MS = 150
+/** Backoff before retrying a game fetch that failed transiently (rate-limited / 5xx / network). */
+const MAP_FETCH_RETRY_MS = 2000
+
+/**
+ * Outcome of each game fetch, tracked across the mount/unmount churn of navigating between replays:
+ * `pending` while a request is in flight, `settled` once it has succeeded or terminally failed (a
+ * 4xx other than 429 we won't retry). This lets the hook tell "still loading" apart from "no map to
+ * show" even for a game the Redux store doesn't have — a distinction the store alone can't make,
+ * since a game that's genuinely missing on the server is also simply absent from it.
+ *
+ * Transient failures (429 rate-limiting, 5xx, network blips) drop their entry so a retry can run.
+ */
+const gameFetchStatus = new Map<string, 'pending' | 'settled'>()
+
+export function useSbGameMap(gameId: string | undefined): SbGameMapResult {
   const dispatch = useAppDispatch()
   const game = useAppSelector(s => (gameId ? s.games.byId.get(gameId) : undefined))
   const map = useAppSelector(s => (game?.mapId ? s.maps.byId.get(game.mapId) : undefined))
+  // A terminal fetch failure only updates the module-level bookkeeping above (the store is left
+  // untouched), so it wouldn't trigger a render on its own; this forces one so `status` recomputes.
+  const forceUpdate = useReducer(x => x + 1, 0)[1]
 
   useEffect(() => {
-    if (!gameId || game || requestedGameIds.has(gameId)) return
-    requestedGameIds.add(gameId)
-    // Deliberately no abort on unmount: the response is tiny and caching it in the store is the
-    // point. Errors fall back to the placeholder tile.
-    dispatch(
-      viewGame(gameId, {
-        onSuccess: () => {},
-        onError: err => {
-          if (!isFetchError(err) || err.status < 400 || err.status >= 500) {
-            requestedGameIds.delete(gameId)
-          }
-        },
-      }),
-    )
-  }, [gameId, game, dispatch])
+    if (!gameId || game || gameFetchStatus.has(gameId)) return () => {}
 
-  return map
+    let canceled = false
+    let retryTimer: ReturnType<typeof setTimeout> | undefined
+
+    const attempt = () => {
+      if (canceled || gameFetchStatus.has(gameId)) return
+      gameFetchStatus.set(gameId, 'pending')
+      // Deliberately no abort on unmount/reselection: the response is tiny and caching it in the
+      // store is the point. `canceled` just stops us scheduling further retries once we've moved on.
+      dispatch(
+        viewGame(gameId, {
+          onSuccess: () => {
+            gameFetchStatus.set(gameId, 'settled')
+          },
+          onError: err => {
+            const status = isFetchError(err) ? err.status : undefined
+            if (status !== undefined && status >= 400 && status < 500 && status !== 429) {
+              // Terminal: the game genuinely has no viewable record, so settle and show the
+              // placeholder rather than retrying forever.
+              gameFetchStatus.set(gameId, 'settled')
+              forceUpdate()
+            } else if (!canceled) {
+              // Transient (429 rate-limiting, 5xx, network blip): drop the marker and retry after a
+              // backoff so a rate-limited selection resolves on its own instead of sticking on the
+              // skeleton.
+              gameFetchStatus.delete(gameId)
+              retryTimer = setTimeout(attempt, MAP_FETCH_RETRY_MS)
+            }
+          },
+        }),
+      )
+    }
+
+    // Debounce the first attempt so holding the arrow key through the list doesn't fire a request
+    // per intermediate selection — each is a different game, so request coalescing can't help (it
+    // only dedupes concurrent requests for the *same* game), and the burst trips the server's rate
+    // limiter. Cached games skip this entirely: they return above with the map already resolved.
+    const debounceTimer = setTimeout(attempt, MAP_FETCH_DEBOUNCE_MS)
+
+    return () => {
+      canceled = true
+      clearTimeout(debounceTimer)
+      if (retryTimer) clearTimeout(retryTimer)
+    }
+  }, [gameId, game, dispatch, forceUpdate])
+
+  let status: SbGameMapStatus
+  if (map) {
+    status = 'loaded'
+  } else if (gameId && !game && gameFetchStatus.get(gameId) !== 'settled') {
+    // The game (and its map) is still on the way — debouncing, in flight, or awaiting a retry.
+    // Assume a map is coming rather than flashing the "no map" placeholder.
+    status = 'loading'
+  } else {
+    status = 'unavailable'
+  }
+
+  return { map, status }
 }

--- a/client/replays/replay-hooks.ts
+++ b/client/replays/replay-hooks.ts
@@ -28,41 +28,49 @@ const MAP_FETCH_RETRY_MS = 2000
  */
 const MAP_FETCH_RETRY_MAX_MS = 30000
 /**
- * How many times a single game fetch may fail transiently before we give up and settle to
- * `unavailable`. Without a cap a *persistently* failing fetch — a long outage, or a non-`FetchError`
+ * How many times a single game fetch may fail transiently before we stop retrying and show the
+ * placeholder. Without a cap a *persistently* failing fetch — a long outage, or a non-`FetchError`
  * thrown while dispatching (which has no status and so is treated as transient) — would shimmer the
  * hero and poll forever with no terminal fallback. With the backoff above, six attempts span roughly
- * a minute before giving up.
+ * a minute before giving up. Giving up is *recoverable*, not permanent — see `gaveUp` below.
  */
 const MAP_FETCH_MAX_ATTEMPTS = 6
 
 /**
- * Outcome of each game fetch, tracked across the mount/unmount churn of navigating between replays:
- * `pending` while a request is in flight, `settled` once it has succeeded or terminally failed (a
- * 4xx other than 429 we won't retry). This lets the hook tell "still loading" apart from "no map to
- * show" even for a game the Redux store doesn't have — a distinction the store alone can't make,
- * since a game that's genuinely missing on the server is also simply absent from it.
+ * Outcome of each game fetch, tracked across the mount/unmount churn of navigating between replays.
+ * This lets the hook tell "still loading" apart from "no map to show" even for a game the Redux store
+ * doesn't have — a distinction the store alone can't make, since a game that's genuinely missing on
+ * the server is also simply absent from it.
  *
- * A transient failure (429 rate-limiting, 5xx, network blip) deletes the entry so the fetch can be
- * retried; a terminal outcome writes `settled` so revisiting the replay won't refetch it.
+ * - `pending`: a request is in flight.
+ * - `settled`: terminally resolved — the game loaded, or it 4xx'd (other than 429), so there's
+ *   genuinely no viewable record. Revisiting won't refetch.
+ * - `gaveUp`: exhausted its transient retries (`MAP_FETCH_MAX_ATTEMPTS`). Shown as unavailable and no
+ *   longer polled, but — unlike `settled` — *not* permanent: a transient outage shouldn't strand the
+ *   preview for the rest of the session. Any later successful fetch (proof the limiter/network
+ *   recovered) clears every `gaveUp` marker so those games refetch when next shown.
+ *
+ * A transient failure short of the cap deletes the entry instead, so the fetch is retried.
  *
  * This is an external store rather than Redux/component state so the outcome survives a hook
  * unmounting and remounting (arrowing off a replay and back), and it's read through
  * `useSyncExternalStore` below — not a `forceUpdate` reading this map during render — so the React
  * Compiler can't memoize the derived `status` on its reactive inputs and skip a status-only change.
  */
-const gameFetchStatus = new Map<string, 'pending' | 'settled'>()
+const gameFetchStatus = new Map<string, 'pending' | 'settled' | 'gaveUp'>()
 
 /**
- * Number of times each not-yet-settled game fetch has failed transiently. Kept at module scope,
+ * Number of times each not-yet-resolved game fetch has failed transiently. Kept at module scope,
  * keyed by game id, so it *holds* across the hook remounting: arrowing off a rate-limited replay and
  * back derives the same backoff instead of resetting to the initial 2s, so a sustained 429 keeps
- * backing off toward the cap rather than restarting the poll on every visit. Also drives the
- * attempt cap above.
+ * backing off toward the cap rather than restarting the poll on every visit. Also drives the attempt
+ * cap above.
  *
- * Cleared for a game once its fetch settles terminally; cleared *entirely* on any successful fetch —
- * a success proves the limiter/network isn't blocking, so every game's stale backoff is void and a
- * game we back off from won't stall on a long-expired 30s delay when revisited.
+ * Cleared *entirely* on any successful fetch — a success proves the limiter/network isn't blocking,
+ * so every game's accrued backoff is void (a game we backed off from won't stall on a long-expired
+ * 30s delay when revisited). That a concurrent success also resets a still-failing game's count is
+ * intended: the cap is a safety net for a *sustained* no-success outage, not a limiter on a burst
+ * that's already clearing.
  */
 const gameFetchRetries = new Map<string, number>()
 
@@ -82,7 +90,9 @@ function subscribeToGameFetch(gameId: string | undefined, onChange: () => void):
   }
 }
 
-function getGameFetchStatus(gameId: string | undefined): 'pending' | 'settled' | undefined {
+function getGameFetchStatus(
+  gameId: string | undefined,
+): 'pending' | 'settled' | 'gaveUp' | undefined {
   return gameId ? gameFetchStatus.get(gameId) : undefined
 }
 
@@ -110,9 +120,10 @@ export function useSbGameMap(gameId: string | undefined): SbGameMapResult {
 
   useEffect(() => {
     // Nothing to fetch: no selection, or the game (and thus its map) is already in the store. Also
-    // bail while a request is in flight or has settled — the subscription above delivers its outcome
-    // and re-renders us, so scheduling here too would just duplicate the request. Re-running on a
-    // transient failure (which deletes the marker) is what schedules the retry.
+    // bail on any tracked outcome — a request in flight (`pending`), a terminal one (`settled`), or a
+    // gave-up one (`gaveUp`): the subscription above delivers a `pending` request's result and
+    // re-renders us, and the resolved/gave-up states shouldn't refetch. Re-running on a transient
+    // failure (which deletes the marker) is what schedules the retry.
     if (!gameId || game || gameFetchStatus.has(gameId)) return () => {}
 
     let canceled = false
@@ -137,9 +148,16 @@ export function useSbGameMap(gameId: string | undefined): SbGameMapResult {
         viewGame(gameId, {
           onSuccess: () => {
             gameFetchStatus.set(gameId, 'settled')
-            // A success proves the limiter/network isn't blocking, so drop every game's accrued
-            // backoff — not just this one's — so a game we backed off from doesn't stall on a stale
-            // 30s delay when revisited.
+            // A success proves the limiter/network recovered, so let every game that gave up try
+            // again (dropping its marker means the next time it's shown it refetches) and void every
+            // game's accrued backoff — otherwise a game we backed off from would stall on a stale 30s
+            // delay, or a gave-up game would stay "unavailable" for the rest of the session.
+            for (const id of [...gameFetchStatus.keys()]) {
+              if (gameFetchStatus.get(id) === 'gaveUp') {
+                gameFetchStatus.delete(id)
+                notifyGameFetchListeners(id)
+              }
+            }
             gameFetchRetries.clear()
             notifyGameFetchListeners(gameId)
           },
@@ -148,12 +166,16 @@ export function useSbGameMap(gameId: string | undefined): SbGameMapResult {
             const terminal4xx =
               status !== undefined && status >= 400 && status < 500 && status !== 429
             const attempts = (gameFetchRetries.get(gameId) ?? 0) + 1
-            if (terminal4xx || attempts >= MAP_FETCH_MAX_ATTEMPTS) {
-              // Give up: either the game genuinely has no viewable record (a 4xx other than 429), or
-              // we've exhausted our transient retries (a sustained outage / rate-limit / persistently
-              // throwing fetch). Settle so we show the placeholder rather than shimmering — and
-              // polling — forever.
+            if (terminal4xx) {
+              // Terminal: the game genuinely has no viewable record, so settle permanently and show
+              // the placeholder rather than retrying.
               gameFetchStatus.set(gameId, 'settled')
+              gameFetchRetries.delete(gameId)
+            } else if (attempts >= MAP_FETCH_MAX_ATTEMPTS) {
+              // Exhausted our transient retries (a sustained outage / rate-limit / persistently
+              // throwing fetch): stop shimmering — and polling — and show the placeholder. Recoverable
+              // rather than permanent (see `gaveUp`): a later successful fetch reopens it.
+              gameFetchStatus.set(gameId, 'gaveUp')
               gameFetchRetries.delete(gameId)
             } else {
               // Transient (429 rate-limiting, 5xx, network blip, non-`FetchError` throw): drop the
@@ -180,9 +202,10 @@ export function useSbGameMap(gameId: string | undefined): SbGameMapResult {
   let status: SbGameMapStatus
   if (map) {
     status = 'loaded'
-  } else if (gameId && !game && fetchStatus !== 'settled') {
+  } else if (gameId && !game && (fetchStatus === undefined || fetchStatus === 'pending')) {
     // The game (and its map) is still on the way — debouncing, in flight, or awaiting a retry.
-    // Assume a map is coming rather than flashing the "no map" placeholder.
+    // Assume a map is coming rather than flashing the "no map" placeholder. Once the fetch resolves
+    // (`settled`) or gives up (`gaveUp`), fall through to the placeholder.
     status = 'loading'
   } else {
     status = 'unavailable'

--- a/client/replays/replay-hooks.ts
+++ b/client/replays/replay-hooks.ts
@@ -2,7 +2,6 @@ import { useEffect, useSyncExternalStore } from 'react'
 import { ReadonlyDeep } from 'type-fest'
 import { MapInfoJson } from '../../common/maps'
 import { viewGame } from '../games/action-creators'
-import { isFetchError } from '../network/fetch-errors'
 import { useAppDispatch, useAppSelector } from '../redux-hooks'
 
 export type SbGameMapStatus = 'loading' | 'loaded' | 'unavailable'
@@ -12,13 +11,10 @@ export interface SbGameMapResult {
   /**
    * `loading` while the backing game (and thus its map) is still being fetched, `loaded` once the
    * map is resolved, `unavailable` when there's genuinely no map to show (a replay with no linked
-   * SB game, or a game whose map has been deleted / can't be found).
+   * SB game, a game whose map has been deleted / can't be found, or a fetch that failed).
    */
   status: SbGameMapStatus
 }
-
-// Exported for the hook's tests, which assert the coalesce/backoff/give-up timings and would
-// silently drift if they hardcoded their own copies.
 
 /**
  * Coalescing window for rapid selection changes. A deliberate selection fetches immediately (leading
@@ -27,49 +23,31 @@ export interface SbGameMapResult {
  * so an intermediate replay you blow past doesn't fire its own request.
  */
 export const MAP_FETCH_COALESCE_MS = 150
-/** Base backoff before the first retry of a transiently-failed fetch (rate-limited / 5xx / network). */
-export const MAP_FETCH_RETRY_MS = 2000
-/** Backoff ceiling: a sustained failure polls at most this often while the panel stays open. */
-export const MAP_FETCH_RETRY_MAX_MS = 30000
-/**
- * Transient failures a fetch may take before it gives up (see `gaveUp`) rather than shimmering and
- * polling forever. With the backoff above, ~a minute.
- */
-export const MAP_FETCH_MAX_ATTEMPTS = 6
 
 /**
- * Fetch outcome per game id, tracked at module scope so it survives the hook unmounting/remounting as
- * the user arrows between replays. Lets the hook distinguish "still loading" from "no map" even for a
- * game absent from the Redux store (a genuinely missing game is also simply absent from it).
+ * Per-game fetch outcome, tracked at module scope so it survives the hook re-rendering as the user
+ * arrows between replays. Lets the hook tell "still loading" apart from "no map to show" even for a
+ * game absent from the Redux store (a genuinely missing game is also simply absent from it):
+ * `pending` while a request is in flight, `settled` once it has resolved — loaded, no map, or a
+ * failed fetch (all of which show the placeholder rather than shimmering).
  *
- * - `pending`: a request is in flight.
- * - `settled`: terminally resolved — loaded, or a 4xx (other than 429) with no viewable record.
- *   Permanent; revisiting won't refetch.
- * - `gaveUp`: exhausted its transient retries. Shown as unavailable and no longer polled, but — unlike
- *   `settled` — recoverable: any later successful fetch clears every `gaveUp`, so a transient outage
- *   doesn't strand the preview for the rest of the session.
- *
- * A transient failure short of the cap deletes the entry instead, so the fetch is retried.
+ * A `settled` marker is dropped when the user navigates away (see the cleanup effect below), so
+ * returning to a replay whose fetch failed transiently refetches rather than showing the placeholder
+ * for the rest of the session. Read through `useSyncExternalStore` (not a `forceUpdate` reading this
+ * map during render) so the React Compiler can't memoize the derived `status` on its reactive inputs
+ * and skip a status-only change.
  */
-const gameFetchStatus = new Map<string, 'pending' | 'settled' | 'gaveUp'>()
+const gameFetchStatus = new Map<string, 'pending' | 'settled'>()
 
 /**
- * Transient-failure count per not-yet-resolved game, driving both the backoff delay and the attempt
- * cap. At module scope so the backoff holds across remounts (arrowing away and back doesn't reset it
- * to 2s). Cleared entirely on any success — proof the limiter/network recovered — which voids stale
- * backoffs and keeps the cap a safety net for a sustained outage, not a limiter on a clearing burst.
- */
-const gameFetchRetries = new Map<string, number>()
-
-/** Hooks subscribed to a given game id's fetch outcome, notified whenever it changes. */
-const gameFetchListeners = new Map<string, Set<() => void>>()
-
-/**
- * `Date.now()` when the last fetch was kicked off, across all games. Used to tell a deliberate
+ * `Date.now()` when the last fetch was kicked off, across all games — used to tell a deliberate
  * selection (fetch immediately) from one made mid-scroll, still within `MAP_FETCH_COALESCE_MS` of the
  * previous fetch (debounce it so a fast scroll only fetches the row it lands on).
  */
 let lastFetchStartedAt = 0
+
+/** Hooks subscribed to a given game id's fetch outcome, notified whenever it changes. */
+const gameFetchListeners = new Map<string, Set<() => void>>()
 
 function subscribeToGameFetch(gameId: string | undefined, onChange: () => void): () => void {
   if (!gameId) return () => {}
@@ -84,9 +62,7 @@ function subscribeToGameFetch(gameId: string | undefined, onChange: () => void):
   }
 }
 
-function getGameFetchStatus(
-  gameId: string | undefined,
-): 'pending' | 'settled' | 'gaveUp' | undefined {
+function getGameFetchStatus(gameId: string | undefined): 'pending' | 'settled' | undefined {
   return gameId ? gameFetchStatus.get(gameId) : undefined
 }
 
@@ -112,9 +88,9 @@ export function useSbGameMap(gameId: string | undefined): SbGameMapResult {
   )
 
   useEffect(() => {
-    // Nothing to schedule: no selection, the game is already in the store, or the fetch has a tracked
-    // outcome (a `pending` request delivers its result via the subscription; `settled`/`gaveUp` don't
-    // refetch). A transient failure deletes the marker, and re-running here is what retries.
+    // Nothing to schedule: no selection, the game is already in the store, or a fetch is in flight /
+    // has settled (the subscription above delivers a pending fetch's result; a settled one shouldn't
+    // refetch while it's shown — the cleanup effect reopens it on the way out).
     if (!gameId || game || gameFetchStatus.has(gameId)) return () => {}
 
     let canceled = false
@@ -129,74 +105,54 @@ export function useSbGameMap(gameId: string | undefined): SbGameMapResult {
         viewGame(gameId, {
           onSuccess: () => {
             gameFetchStatus.set(gameId, 'settled')
-            // Recovery: a success proves the limiter/network is back, so reopen every gave-up game
-            // (deleting its marker → refetches when next shown) and void all accrued backoff.
-            for (const id of [...gameFetchStatus.keys()]) {
-              if (gameFetchStatus.get(id) === 'gaveUp') {
-                gameFetchStatus.delete(id)
-                notifyGameFetchListeners(id)
-              }
-            }
-            gameFetchRetries.clear()
             notifyGameFetchListeners(gameId)
           },
-          onError: err => {
-            const status = isFetchError(err) ? err.status : undefined
-            const terminal4xx =
-              status !== undefined && status >= 400 && status < 500 && status !== 429
-            const attempts = (gameFetchRetries.get(gameId) ?? 0) + 1
-            if (terminal4xx) {
-              // No viewable record — settle permanently.
-              gameFetchStatus.set(gameId, 'settled')
-              gameFetchRetries.delete(gameId)
-            } else if (attempts >= MAP_FETCH_MAX_ATTEMPTS) {
-              // Retries exhausted — give up (recoverable): stop shimmering and polling.
-              gameFetchStatus.set(gameId, 'gaveUp')
-              gameFetchRetries.delete(gameId)
-            } else {
-              // Transient (429 / 5xx / network / non-`FetchError` throw): drop the marker and bump the
-              // count. Notifying lets whichever hook is *currently* mounted own the retry, so a fetch
-              // started by a since-abandoned selection still recovers on a returning mount rather than
-              // stranding it on the skeleton.
-              gameFetchStatus.delete(gameId)
-              gameFetchRetries.set(gameId, attempts)
-            }
+          onError: () => {
+            // Any failure (no viewable record, a 429, a 5xx, a network blip) settles to the
+            // placeholder — like every other panel, a failed fetch just shows the empty state. No
+            // retry; the cleanup effect lets a later reselect try again.
+            gameFetchStatus.set(gameId, 'settled')
             notifyGameFetchListeners(gameId)
           },
         }),
       )
     }
 
-    const retries = gameFetchRetries.get(gameId) ?? 0
-    let timer: ReturnType<typeof setTimeout> | undefined
-    if (retries > 0) {
-      // Awaiting a retry: wait out the (persisted) exponential backoff.
-      timer = setTimeout(
-        attempt,
-        Math.min(MAP_FETCH_RETRY_MS * 2 ** (retries - 1), MAP_FETCH_RETRY_MAX_MS),
-      )
-    } else if (Date.now() - lastFetchStartedAt >= MAP_FETCH_COALESCE_MS) {
+    if (Date.now() - lastFetchStartedAt >= MAP_FETCH_COALESCE_MS) {
       // Leading edge: nothing's been fetched within the coalesce window, so this is a deliberate
       // selection — fetch at once, no artificial delay.
       attempt()
-    } else {
-      // Trailing edge: selections are changing faster than the coalesce window (a fast scroll), so
-      // wait for this one to settle, coalescing the run down to the row landed on.
-      timer = setTimeout(attempt, MAP_FETCH_COALESCE_MS)
+      return () => {
+        canceled = true
+      }
     }
 
+    // Trailing edge: selections are changing faster than the coalesce window (a fast scroll), so wait
+    // for this one to settle, coalescing the run down to the row landed on.
+    const timer = setTimeout(attempt, MAP_FETCH_COALESCE_MS)
     return () => {
       canceled = true
-      if (timer) clearTimeout(timer)
+      clearTimeout(timer)
     }
   }, [gameId, game, dispatch, fetchStatus])
+
+  useEffect(() => {
+    return () => {
+      // On leaving this replay, drop a settled marker so returning refetches — a transient failure
+      // shouldn't strand the preview for the session (a success is cached in the store regardless). A
+      // still-pending fetch is left in place so a quick return re-attaches to it.
+      if (gameId !== undefined && gameFetchStatus.get(gameId) === 'settled') {
+        gameFetchStatus.delete(gameId)
+      }
+    }
+  }, [gameId])
 
   let status: SbGameMapStatus
   if (map) {
     status = 'loaded'
-  } else if (gameId && !game && (fetchStatus === undefined || fetchStatus === 'pending')) {
-    // Still on the way (coalescing / in flight / awaiting retry): assume a map is coming rather than
-    // flashing the placeholder. `settled`/`gaveUp` fall through to unavailable.
+  } else if (gameId && !game && fetchStatus !== 'settled') {
+    // Still on the way (coalescing / in flight): assume a map is coming rather than flashing the
+    // placeholder. A settled outcome (loaded, no map, or a failed fetch) falls through to unavailable.
     status = 'loading'
   } else {
     status = 'unavailable'
@@ -207,11 +163,10 @@ export function useSbGameMap(gameId: string | undefined): SbGameMapResult {
 
 /**
  * Clears the module-level fetch bookkeeping. Exported for tests only — the state deliberately outlives
- * a hook mount, so it must be reset between cases to stop markers/counts/listeners leaking.
+ * a hook mount, so it must be reset between cases to stop markers and listeners leaking.
  */
 export function resetSbGameMapStateForTests() {
   gameFetchStatus.clear()
-  gameFetchRetries.clear()
   gameFetchListeners.clear()
   lastFetchStartedAt = 0
 }

--- a/client/replays/replay-hooks.ts
+++ b/client/replays/replay-hooks.ts
@@ -35,34 +35,62 @@ const MAP_FETCH_RETRY_MAX_MS = 30000
  * show" even for a game the Redux store doesn't have — a distinction the store alone can't make,
  * since a game that's genuinely missing on the server is also simply absent from it.
  *
- * Transient failures (429 rate-limiting, 5xx, network blips) drop their entry so a retry can run.
+ * A transient failure (429 rate-limiting, 5xx, network blip) deletes the entry so the fetch can be
+ * retried; a terminal outcome writes `settled` so revisiting the replay won't refetch it.
  */
 const gameFetchStatus = new Map<string, 'pending' | 'settled'>()
+
+/**
+ * Hooks currently mounted for a given game id. When a fetch changes `gameFetchStatus` above it
+ * notifies these, so every mounted hook re-renders (recomputing `status`) and — on a transient
+ * failure — whichever hook is still mounted owns the retry.
+ *
+ * This is what lets a selection that *re-attaches* to an already in-flight fetch recover. Arrowing
+ * off a replay and back before its request resolves leaves the marker `pending`, so the returning
+ * mount parks here instead of starting its own request; if that request then fails transiently, the
+ * notification — not the original requester's by-then-canceled closure — is what re-renders it and
+ * schedules the retry. Without this the panel would stay stuck on the loading skeleton for the rest
+ * of the session, precisely in the fast-scroll / 429 scenario the debounce exists to handle.
+ */
+const gameFetchListeners = new Map<string, Set<() => void>>()
+
+function notifyGameFetchListeners(gameId: string) {
+  const listeners = gameFetchListeners.get(gameId)
+  if (!listeners) return
+  // Copy first: a listener may (un)subscribe as a side effect of the re-render it triggers.
+  for (const listener of [...listeners]) {
+    listener()
+  }
+}
 
 export function useSbGameMap(gameId: string | undefined): SbGameMapResult {
   const dispatch = useAppDispatch()
   const game = useAppSelector(s => (gameId ? s.games.byId.get(gameId) : undefined))
   const map = useAppSelector(s => (game?.mapId ? s.maps.byId.get(game.mapId) : undefined))
-  // A terminal fetch failure only updates the module-level bookkeeping above (the store is left
-  // untouched), so it wouldn't trigger a render on its own; this forces one so `status` recomputes.
+  // Fetch outcomes update the module-level bookkeeping above rather than the store, so they wouldn't
+  // trigger a render on their own; this forces one so `status` recomputes.
   const forceUpdate = useReducer(x => x + 1, 0)[1]
 
   useEffect(() => {
-    if (!gameId || game || gameFetchStatus.has(gameId)) return () => {}
+    if (!gameId || game) return () => {}
 
     let canceled = false
-    let retryTimer: ReturnType<typeof setTimeout> | undefined
+    let timer: ReturnType<typeof setTimeout> | undefined
     let retryDelay = MAP_FETCH_RETRY_MS
 
     const attempt = () => {
+      // A fetch for this game is already in flight or settled (started by our own earlier attempt,
+      // an earlier selection of the same replay, or another mount): don't duplicate it — the
+      // listener below delivers its outcome.
       if (canceled || gameFetchStatus.has(gameId)) return
       gameFetchStatus.set(gameId, 'pending')
       // Deliberately no abort on unmount/reselection: the response is tiny and caching it in the
-      // store is the point. `canceled` just stops us scheduling further retries once we've moved on.
+      // store is the point.
       dispatch(
         viewGame(gameId, {
           onSuccess: () => {
             gameFetchStatus.set(gameId, 'settled')
+            notifyGameFetchListeners(gameId)
           },
           onError: err => {
             const status = isFetchError(err) ? err.status : undefined
@@ -70,34 +98,53 @@ export function useSbGameMap(gameId: string | undefined): SbGameMapResult {
               // Terminal: the game genuinely has no viewable record, so settle and show the
               // placeholder rather than retrying forever.
               gameFetchStatus.set(gameId, 'settled')
-              forceUpdate()
             } else {
-              // Transient (429 rate-limiting, 5xx, network blip): drop the marker unconditionally so
-              // a later mount can retry (a failure that lands after we've moved on must not leave the
-              // entry stuck at 'pending', which would strand a returning selection on the skeleton),
-              // and only schedule our own retry if we're still the active selection. Back off
-              // exponentially so a sustained rate-limit resolves on its own without hammering.
+              // Transient (429 rate-limiting, 5xx, network blip): drop the marker so the fetch can be
+              // retried. We don't schedule the retry here — the notification lets whichever hook is
+              // *currently* mounted own it, which matters when this request was started by a
+              // selection the user has since navigated away from (this closure is canceled and would
+              // schedule nothing, stranding a returning mount on the skeleton).
               gameFetchStatus.delete(gameId)
-              if (!canceled) {
-                retryTimer = setTimeout(attempt, retryDelay)
-                retryDelay = Math.min(retryDelay * 2, MAP_FETCH_RETRY_MAX_MS)
-              }
             }
+            notifyGameFetchListeners(gameId)
           },
         }),
       )
     }
 
+    const onFetchStatusChange = () => {
+      if (canceled) return
+      forceUpdate()
+      // A transient failure cleared the marker and we still need the map: own the retry, backing off
+      // exponentially so a sustained rate-limit settles into an occasional poll rather than a fixed
+      // 0.5 req/s hammer for as long as the panel stays open.
+      if (!gameFetchStatus.has(gameId)) {
+        if (timer) clearTimeout(timer)
+        timer = setTimeout(attempt, retryDelay)
+        retryDelay = Math.min(retryDelay * 2, MAP_FETCH_RETRY_MAX_MS)
+      }
+    }
+
+    const listeners = gameFetchListeners.get(gameId) ?? new Set<() => void>()
+    gameFetchListeners.set(gameId, listeners)
+    listeners.add(onFetchStatusChange)
+
     // Debounce the first attempt so holding the arrow key through the list doesn't fire a request
     // per intermediate selection — each is a different game, so request coalescing can't help (it
     // only dedupes concurrent requests for the *same* game), and the burst trips the server's rate
-    // limiter. Cached games skip this entirely: they return above with the map already resolved.
-    const debounceTimer = setTimeout(attempt, MAP_FETCH_DEBOUNCE_MS)
+    // limiter. Skipped when a fetch is already in flight/settled for this game (a cached game returns
+    // above with the map resolved; a re-attaching selection waits for the listener's outcome).
+    if (!gameFetchStatus.has(gameId)) {
+      timer = setTimeout(attempt, MAP_FETCH_DEBOUNCE_MS)
+    }
 
     return () => {
       canceled = true
-      clearTimeout(debounceTimer)
-      if (retryTimer) clearTimeout(retryTimer)
+      if (timer) clearTimeout(timer)
+      listeners.delete(onFetchStatusChange)
+      if (listeners.size === 0) {
+        gameFetchListeners.delete(gameId)
+      }
     }
   }, [gameId, game, dispatch, forceUpdate])
 

--- a/client/replays/replay-hooks.ts
+++ b/client/replays/replay-hooks.ts
@@ -19,8 +19,14 @@ export interface SbGameMapResult {
 
 /** How long a selection must hold still before we fetch its game — see the debounce note below. */
 const MAP_FETCH_DEBOUNCE_MS = 150
-/** Backoff before retrying a game fetch that failed transiently (rate-limited / 5xx / network). */
+/** Initial backoff before retrying a game fetch that failed transiently (rate-limited / 5xx / network). */
 const MAP_FETCH_RETRY_MS = 2000
+/**
+ * Ceiling for the retry backoff. Each transient failure doubles the delay up to this cap, so a
+ * sustained 429 settles into an occasional poll rather than a fixed 0.5 req/s hammer for as long as
+ * the panel stays open, while still self-healing once the rate limit clears.
+ */
+const MAP_FETCH_RETRY_MAX_MS = 30000
 
 /**
  * Outcome of each game fetch, tracked across the mount/unmount churn of navigating between replays:
@@ -46,6 +52,7 @@ export function useSbGameMap(gameId: string | undefined): SbGameMapResult {
 
     let canceled = false
     let retryTimer: ReturnType<typeof setTimeout> | undefined
+    let retryDelay = MAP_FETCH_RETRY_MS
 
     const attempt = () => {
       if (canceled || gameFetchStatus.has(gameId)) return
@@ -64,12 +71,17 @@ export function useSbGameMap(gameId: string | undefined): SbGameMapResult {
               // placeholder rather than retrying forever.
               gameFetchStatus.set(gameId, 'settled')
               forceUpdate()
-            } else if (!canceled) {
-              // Transient (429 rate-limiting, 5xx, network blip): drop the marker and retry after a
-              // backoff so a rate-limited selection resolves on its own instead of sticking on the
-              // skeleton.
+            } else {
+              // Transient (429 rate-limiting, 5xx, network blip): drop the marker unconditionally so
+              // a later mount can retry (a failure that lands after we've moved on must not leave the
+              // entry stuck at 'pending', which would strand a returning selection on the skeleton),
+              // and only schedule our own retry if we're still the active selection. Back off
+              // exponentially so a sustained rate-limit resolves on its own without hammering.
               gameFetchStatus.delete(gameId)
-              retryTimer = setTimeout(attempt, MAP_FETCH_RETRY_MS)
+              if (!canceled) {
+                retryTimer = setTimeout(attempt, retryDelay)
+                retryDelay = Math.min(retryDelay * 2, MAP_FETCH_RETRY_MAX_MS)
+              }
             }
           },
         }),

--- a/client/replays/replay-hooks.ts
+++ b/client/replays/replay-hooks.ts
@@ -18,10 +18,11 @@ export interface SbGameMapResult {
 }
 
 /**
- * Coalescing window for rapid selection changes. A deliberate selection fetches immediately (leading
- * edge — no artificial delay on the normal click-through-the-list case); only while selections keep
- * changing faster than this (a fast scroll / held arrow) does the fetch wait for the list to settle,
- * so an intermediate replay you blow past doesn't fire its own request.
+ * Coalescing window for rapid selection changes, measured between selection *changes*. A deliberate
+ * selection fetches immediately (leading edge — no artificial delay on the normal
+ * click-through-the-list case); only while selections keep changing faster than this (a fast
+ * scroll / held arrow) does the fetch wait for the list to settle, so a scroll fires no requests
+ * for the replays it blows past, however long it goes on.
  */
 export const MAP_FETCH_COALESCE_MS = 150
 
@@ -43,11 +44,14 @@ export const MAP_FETCH_COALESCE_MS = 150
 const gameFetchStatus = new Map<string, 'pending' | 'settled' | 'terminal'>()
 
 /**
- * `Date.now()` when the last fetch was kicked off, across all games — used to tell a deliberate
- * selection (fetch immediately) from one made mid-scroll, still within `MAP_FETCH_COALESCE_MS` of the
- * previous fetch (debounce it so a fast scroll only fetches the row it lands on).
+ * The last selection seen and when it changed, across all mounts — used to tell a deliberate
+ * selection (made a while after the previous one; fetch immediately) from one made mid-scroll,
+ * within `MAP_FETCH_COALESCE_MS` of the previous *change*. Keyed on change rather than on the last
+ * fetch so a sustained scroll keeps deferring for as long as it goes on, instead of leaking a
+ * leading-edge fetch every time a window elapses mid-scroll.
  */
-let lastFetchStartedAt = 0
+let lastSelectedGameId: string | undefined
+let lastSelectionChangedAt = 0
 
 /** Hooks subscribed to a given game id's fetch outcome, notified whenever it changes. */
 const gameFetchListeners = new Map<string, Set<() => void>>()
@@ -93,6 +97,16 @@ export function useSbGameMap(gameId: string | undefined): SbGameMapResult {
   )
 
   useEffect(() => {
+    // Tracked before the early returns so rows needing no fetch still count as selection changes,
+    // and only on a genuine change so a re-run for the same selection (a store or fetch-status
+    // update) can't reset — or re-enter — the coalescing window.
+    const sinceSelectionChange =
+      gameId === lastSelectedGameId ? Infinity : Date.now() - lastSelectionChangedAt
+    if (gameId !== lastSelectedGameId) {
+      lastSelectedGameId = gameId
+      lastSelectionChangedAt = Date.now()
+    }
+
     // Nothing to schedule: no selection, the game is already in the store, or a fetch is in flight /
     // has settled (the subscription above delivers a pending fetch's result; a settled one shouldn't
     // refetch while it's shown — the cleanup effect reopens it on the way out).
@@ -113,7 +127,6 @@ export function useSbGameMap(gameId: string | undefined): SbGameMapResult {
     }
     const attempt = () => {
       if (canceled || gameFetchStatus.has(gameId)) return
-      lastFetchStartedAt = Date.now()
       gameFetchStatus.set(gameId, 'pending')
       notifyGameFetchListeners(gameId)
       // Deliberately no abort on unmount/reselection: the response is tiny and caching it in the
@@ -136,9 +149,9 @@ export function useSbGameMap(gameId: string | undefined): SbGameMapResult {
       )
     }
 
-    if (Date.now() - lastFetchStartedAt >= MAP_FETCH_COALESCE_MS) {
-      // Leading edge: nothing's been fetched within the coalesce window, so this is a deliberate
-      // selection — fetch at once, no artificial delay.
+    if (sinceSelectionChange >= MAP_FETCH_COALESCE_MS) {
+      // Leading edge: the selection hasn't changed within the coalesce window, so this is a
+      // deliberate one — fetch at once, no artificial delay.
       attempt()
       return () => {
         canceled = true
@@ -188,5 +201,6 @@ export function useSbGameMap(gameId: string | undefined): SbGameMapResult {
 export function resetSbGameMapStateForTests() {
   gameFetchStatus.clear()
   gameFetchListeners.clear()
-  lastFetchStartedAt = 0
+  lastSelectedGameId = undefined
+  lastSelectionChangedAt = 0
 }

--- a/client/replays/replay-hooks.ts
+++ b/client/replays/replay-hooks.ts
@@ -1,4 +1,4 @@
-import { useEffect, useReducer } from 'react'
+import { useEffect, useSyncExternalStore } from 'react'
 import { ReadonlyDeep } from 'type-fest'
 import { MapInfoJson } from '../../common/maps'
 import { viewGame } from '../games/action-creators'
@@ -37,22 +37,42 @@ const MAP_FETCH_RETRY_MAX_MS = 30000
  *
  * A transient failure (429 rate-limiting, 5xx, network blip) deletes the entry so the fetch can be
  * retried; a terminal outcome writes `settled` so revisiting the replay won't refetch it.
+ *
+ * This is an external store rather than Redux/component state so the outcome survives a hook
+ * unmounting and remounting (arrowing off a replay and back), and it's read through
+ * `useSyncExternalStore` below — not a `forceUpdate` reading this map during render — so the React
+ * Compiler can't memoize the derived `status` on its reactive inputs and skip a status-only change.
  */
 const gameFetchStatus = new Map<string, 'pending' | 'settled'>()
 
 /**
- * Hooks currently mounted for a given game id. When a fetch changes `gameFetchStatus` above it
- * notifies these, so every mounted hook re-renders (recomputing `status`) and — on a transient
- * failure — whichever hook is still mounted owns the retry.
- *
- * This is what lets a selection that *re-attaches* to an already in-flight fetch recover. Arrowing
- * off a replay and back before its request resolves leaves the marker `pending`, so the returning
- * mount parks here instead of starting its own request; if that request then fails transiently, the
- * notification — not the original requester's by-then-canceled closure — is what re-renders it and
- * schedules the retry. Without this the panel would stay stuck on the loading skeleton for the rest
- * of the session, precisely in the fast-scroll / 429 scenario the debounce exists to handle.
+ * Current retry backoff (ms) for each game that has failed transiently and not yet settled. Kept at
+ * module scope, keyed by game id, so the backoff *holds* across the hook remounting: arrowing off a
+ * rate-limited replay and back doesn't reset it to the initial 2s, so a sustained 429 keeps backing
+ * off toward the cap instead of restarting the poll from scratch on every visit. Cleared once the
+ * fetch settles (success or terminal failure).
  */
+const gameFetchBackoff = new Map<string, number>()
+
+/** Hooks subscribed to a given game id's fetch outcome, notified whenever it changes. */
 const gameFetchListeners = new Map<string, Set<() => void>>()
+
+function subscribeToGameFetch(gameId: string | undefined, onChange: () => void): () => void {
+  if (!gameId) return () => {}
+  const listeners = gameFetchListeners.get(gameId) ?? new Set<() => void>()
+  gameFetchListeners.set(gameId, listeners)
+  listeners.add(onChange)
+  return () => {
+    listeners.delete(onChange)
+    if (listeners.size === 0) {
+      gameFetchListeners.delete(gameId)
+    }
+  }
+}
+
+function getGameFetchStatus(gameId: string | undefined): 'pending' | 'settled' | undefined {
+  return gameId ? gameFetchStatus.get(gameId) : undefined
+}
 
 function notifyGameFetchListeners(gameId: string) {
   const listeners = gameFetchListeners.get(gameId)
@@ -67,29 +87,41 @@ export function useSbGameMap(gameId: string | undefined): SbGameMapResult {
   const dispatch = useAppDispatch()
   const game = useAppSelector(s => (gameId ? s.games.byId.get(gameId) : undefined))
   const map = useAppSelector(s => (game?.mapId ? s.maps.byId.get(game.mapId) : undefined))
-  // Fetch outcomes update the module-level bookkeeping above rather than the store, so they wouldn't
-  // trigger a render on their own; this forces one so `status` recomputes.
-  const forceUpdate = useReducer(x => x + 1, 0)[1]
+  // The fetch outcome lives in the module-level store above rather than Redux, so it's read here as
+  // an external store. This (not a forceUpdate) is what keeps `status` correct under the React
+  // Compiler: `fetchStatus` is a tracked reactive input, so the compiler can't memoize the `status`
+  // derivation on `[map, gameId, game]` and skip recomputing it when only the fetch outcome changed.
+  const fetchStatus = useSyncExternalStore(
+    onChange => subscribeToGameFetch(gameId, onChange),
+    () => getGameFetchStatus(gameId),
+  )
 
   useEffect(() => {
-    if (!gameId || game) return () => {}
+    // Nothing to fetch: no selection, or the game (and thus its map) is already in the store. Also
+    // bail while a request is in flight or has settled — the subscription above delivers its outcome
+    // and re-renders us, so scheduling here too would just duplicate the request. Re-running on a
+    // transient failure (which deletes the marker) is what schedules the retry.
+    if (!gameId || game || gameFetchStatus.has(gameId)) return () => {}
 
     let canceled = false
-    let timer: ReturnType<typeof setTimeout> | undefined
-    let retryDelay = MAP_FETCH_RETRY_MS
-
-    const attempt = () => {
-      // A fetch for this game is already in flight or settled (started by our own earlier attempt,
-      // an earlier selection of the same replay, or another mount): don't duplicate it — the
-      // listener below delivers its outcome.
+    // A fresh selection is debounced so holding the arrow key through the list doesn't fire a request
+    // per intermediate selection — each is a different game, so request coalescing can't help (it
+    // only dedupes concurrent requests for the *same* game), and the burst trips the server's rate
+    // limiter. A game that failed transiently instead waits its persisted backoff, so a returning or
+    // re-attaching selection retries no faster than the backoff, rather than resetting to the
+    // debounce.
+    const delay = gameFetchBackoff.get(gameId) ?? MAP_FETCH_DEBOUNCE_MS
+    const timer = setTimeout(() => {
       if (canceled || gameFetchStatus.has(gameId)) return
       gameFetchStatus.set(gameId, 'pending')
+      notifyGameFetchListeners(gameId)
       // Deliberately no abort on unmount/reselection: the response is tiny and caching it in the
       // store is the point.
       dispatch(
         viewGame(gameId, {
           onSuccess: () => {
             gameFetchStatus.set(gameId, 'settled')
+            gameFetchBackoff.delete(gameId)
             notifyGameFetchListeners(gameId)
           },
           onError: err => {
@@ -98,60 +130,38 @@ export function useSbGameMap(gameId: string | undefined): SbGameMapResult {
               // Terminal: the game genuinely has no viewable record, so settle and show the
               // placeholder rather than retrying forever.
               gameFetchStatus.set(gameId, 'settled')
+              gameFetchBackoff.delete(gameId)
             } else {
               // Transient (429 rate-limiting, 5xx, network blip): drop the marker so the fetch can be
-              // retried. We don't schedule the retry here — the notification lets whichever hook is
-              // *currently* mounted own it, which matters when this request was started by a
-              // selection the user has since navigated away from (this closure is canceled and would
-              // schedule nothing, stranding a returning mount on the skeleton).
+              // retried, and grow the backoff toward the cap. Notifying re-renders whichever hook is
+              // *currently* mounted for this game; that hook's effect re-runs and owns the retry — so
+              // a request started by a selection the user has since navigated away from still recovers
+              // on a returning mount, instead of stranding it on the loading skeleton.
               gameFetchStatus.delete(gameId)
+              const prev = gameFetchBackoff.get(gameId)
+              gameFetchBackoff.set(
+                gameId,
+                prev === undefined
+                  ? MAP_FETCH_RETRY_MS
+                  : Math.min(prev * 2, MAP_FETCH_RETRY_MAX_MS),
+              )
             }
             notifyGameFetchListeners(gameId)
           },
         }),
       )
-    }
-
-    const onFetchStatusChange = () => {
-      if (canceled) return
-      forceUpdate()
-      // A transient failure cleared the marker and we still need the map: own the retry, backing off
-      // exponentially so a sustained rate-limit settles into an occasional poll rather than a fixed
-      // 0.5 req/s hammer for as long as the panel stays open.
-      if (!gameFetchStatus.has(gameId)) {
-        if (timer) clearTimeout(timer)
-        timer = setTimeout(attempt, retryDelay)
-        retryDelay = Math.min(retryDelay * 2, MAP_FETCH_RETRY_MAX_MS)
-      }
-    }
-
-    const listeners = gameFetchListeners.get(gameId) ?? new Set<() => void>()
-    gameFetchListeners.set(gameId, listeners)
-    listeners.add(onFetchStatusChange)
-
-    // Debounce the first attempt so holding the arrow key through the list doesn't fire a request
-    // per intermediate selection — each is a different game, so request coalescing can't help (it
-    // only dedupes concurrent requests for the *same* game), and the burst trips the server's rate
-    // limiter. Skipped when a fetch is already in flight/settled for this game (a cached game returns
-    // above with the map resolved; a re-attaching selection waits for the listener's outcome).
-    if (!gameFetchStatus.has(gameId)) {
-      timer = setTimeout(attempt, MAP_FETCH_DEBOUNCE_MS)
-    }
+    }, delay)
 
     return () => {
       canceled = true
-      if (timer) clearTimeout(timer)
-      listeners.delete(onFetchStatusChange)
-      if (listeners.size === 0) {
-        gameFetchListeners.delete(gameId)
-      }
+      clearTimeout(timer)
     }
-  }, [gameId, game, dispatch, forceUpdate])
+  }, [gameId, game, dispatch, fetchStatus])
 
   let status: SbGameMapStatus
   if (map) {
     status = 'loaded'
-  } else if (gameId && !game && gameFetchStatus.get(gameId) !== 'settled') {
+  } else if (gameId && !game && fetchStatus !== 'settled') {
     // The game (and its map) is still on the way — debouncing, in flight, or awaiting a retry.
     // Assume a map is coming rather than flashing the "no map" placeholder.
     status = 'loading'

--- a/client/replays/replay-hooks.ts
+++ b/client/replays/replay-hooks.ts
@@ -17,11 +17,16 @@ export interface SbGameMapResult {
   status: SbGameMapStatus
 }
 
-// Exported for the hook's tests, which assert the debounce/backoff/give-up timings and would
+// Exported for the hook's tests, which assert the coalesce/backoff/give-up timings and would
 // silently drift if they hardcoded their own copies.
 
-/** How long a selection must hold still before we fetch its game (see the debounce in the effect). */
-export const MAP_FETCH_DEBOUNCE_MS = 150
+/**
+ * Coalescing window for rapid selection changes. A deliberate selection fetches immediately (leading
+ * edge — no artificial delay on the normal click-through-the-list case); only while selections keep
+ * changing faster than this (a fast scroll / held arrow) does the fetch wait for the list to settle,
+ * so an intermediate replay you blow past doesn't fire its own request.
+ */
+export const MAP_FETCH_COALESCE_MS = 150
 /** Base backoff before the first retry of a transiently-failed fetch (rate-limited / 5xx / network). */
 export const MAP_FETCH_RETRY_MS = 2000
 /** Backoff ceiling: a sustained failure polls at most this often while the panel stays open. */
@@ -58,6 +63,13 @@ const gameFetchRetries = new Map<string, number>()
 
 /** Hooks subscribed to a given game id's fetch outcome, notified whenever it changes. */
 const gameFetchListeners = new Map<string, Set<() => void>>()
+
+/**
+ * `Date.now()` when the last fetch was kicked off, across all games. Used to tell a deliberate
+ * selection (fetch immediately) from one made mid-scroll, still within `MAP_FETCH_COALESCE_MS` of the
+ * previous fetch (debounce it so a fast scroll only fetches the row it lands on).
+ */
+let lastFetchStartedAt = 0
 
 function subscribeToGameFetch(gameId: string | undefined, onChange: () => void): () => void {
   if (!gameId) return () => {}
@@ -106,17 +118,9 @@ export function useSbGameMap(gameId: string | undefined): SbGameMapResult {
     if (!gameId || game || gameFetchStatus.has(gameId)) return () => {}
 
     let canceled = false
-    // Debounce a fresh selection so holding the arrow key doesn't fire a request per intermediate
-    // replay (each is a different game, so request coalescing can't help). A game that's already
-    // failed waits its backoff instead, so a returning/re-attaching selection retries no faster than
-    // the backoff.
-    const retries = gameFetchRetries.get(gameId) ?? 0
-    const delay =
-      retries === 0
-        ? MAP_FETCH_DEBOUNCE_MS
-        : Math.min(MAP_FETCH_RETRY_MS * 2 ** (retries - 1), MAP_FETCH_RETRY_MAX_MS)
-    const timer = setTimeout(() => {
+    const attempt = () => {
       if (canceled || gameFetchStatus.has(gameId)) return
+      lastFetchStartedAt = Date.now()
       gameFetchStatus.set(gameId, 'pending')
       notifyGameFetchListeners(gameId)
       // Deliberately no abort on unmount/reselection: the response is tiny and caching it in the
@@ -161,11 +165,29 @@ export function useSbGameMap(gameId: string | undefined): SbGameMapResult {
           },
         }),
       )
-    }, delay)
+    }
+
+    const retries = gameFetchRetries.get(gameId) ?? 0
+    let timer: ReturnType<typeof setTimeout> | undefined
+    if (retries > 0) {
+      // Awaiting a retry: wait out the (persisted) exponential backoff.
+      timer = setTimeout(
+        attempt,
+        Math.min(MAP_FETCH_RETRY_MS * 2 ** (retries - 1), MAP_FETCH_RETRY_MAX_MS),
+      )
+    } else if (Date.now() - lastFetchStartedAt >= MAP_FETCH_COALESCE_MS) {
+      // Leading edge: nothing's been fetched within the coalesce window, so this is a deliberate
+      // selection — fetch at once, no artificial delay.
+      attempt()
+    } else {
+      // Trailing edge: selections are changing faster than the coalesce window (a fast scroll), so
+      // wait for this one to settle, coalescing the run down to the row landed on.
+      timer = setTimeout(attempt, MAP_FETCH_COALESCE_MS)
+    }
 
     return () => {
       canceled = true
-      clearTimeout(timer)
+      if (timer) clearTimeout(timer)
     }
   }, [gameId, game, dispatch, fetchStatus])
 
@@ -173,7 +195,7 @@ export function useSbGameMap(gameId: string | undefined): SbGameMapResult {
   if (map) {
     status = 'loaded'
   } else if (gameId && !game && (fetchStatus === undefined || fetchStatus === 'pending')) {
-    // Still on the way (debouncing / in flight / awaiting retry): assume a map is coming rather than
+    // Still on the way (coalescing / in flight / awaiting retry): assume a map is coming rather than
     // flashing the placeholder. `settled`/`gaveUp` fall through to unavailable.
     status = 'loading'
   } else {
@@ -191,4 +213,5 @@ export function resetSbGameMapStateForTests() {
   gameFetchStatus.clear()
   gameFetchRetries.clear()
   gameFetchListeners.clear()
+  lastFetchStartedAt = 0
 }

--- a/client/replays/replay-hooks.ts
+++ b/client/replays/replay-hooks.ts
@@ -17,60 +17,39 @@ export interface SbGameMapResult {
   status: SbGameMapStatus
 }
 
-/** How long a selection must hold still before we fetch its game — see the debounce note below. */
+/** How long a selection must hold still before we fetch its game (see the debounce in the effect). */
 const MAP_FETCH_DEBOUNCE_MS = 150
-/** Base backoff before the first retry of a game fetch that failed transiently (rate-limited / 5xx / network). */
+/** Base backoff before the first retry of a transiently-failed fetch (rate-limited / 5xx / network). */
 const MAP_FETCH_RETRY_MS = 2000
-/**
- * Ceiling for the retry backoff. Each transient failure doubles the delay up to this cap, so a
- * sustained 429 settles into an occasional poll rather than a fixed 0.5 req/s hammer for as long as
- * the panel stays open, while still self-healing once the rate limit clears.
- */
+/** Backoff ceiling: a sustained failure polls at most this often while the panel stays open. */
 const MAP_FETCH_RETRY_MAX_MS = 30000
 /**
- * How many times a single game fetch may fail transiently before we stop retrying and show the
- * placeholder. Without a cap a *persistently* failing fetch — a long outage, or a non-`FetchError`
- * thrown while dispatching (which has no status and so is treated as transient) — would shimmer the
- * hero and poll forever with no terminal fallback. With the backoff above, six attempts span roughly
- * a minute before giving up. Giving up is *recoverable*, not permanent — see `gaveUp` below.
+ * Transient failures a fetch may take before it gives up (see `gaveUp`) rather than shimmering and
+ * polling forever. With the backoff above, ~a minute.
  */
 const MAP_FETCH_MAX_ATTEMPTS = 6
 
 /**
- * Outcome of each game fetch, tracked across the mount/unmount churn of navigating between replays.
- * This lets the hook tell "still loading" apart from "no map to show" even for a game the Redux store
- * doesn't have — a distinction the store alone can't make, since a game that's genuinely missing on
- * the server is also simply absent from it.
+ * Fetch outcome per game id, tracked at module scope so it survives the hook unmounting/remounting as
+ * the user arrows between replays. Lets the hook distinguish "still loading" from "no map" even for a
+ * game absent from the Redux store (a genuinely missing game is also simply absent from it).
  *
  * - `pending`: a request is in flight.
- * - `settled`: terminally resolved — the game loaded, or it 4xx'd (other than 429), so there's
- *   genuinely no viewable record. Revisiting won't refetch.
- * - `gaveUp`: exhausted its transient retries (`MAP_FETCH_MAX_ATTEMPTS`). Shown as unavailable and no
- *   longer polled, but — unlike `settled` — *not* permanent: a transient outage shouldn't strand the
- *   preview for the rest of the session. Any later successful fetch (proof the limiter/network
- *   recovered) clears every `gaveUp` marker so those games refetch when next shown.
+ * - `settled`: terminally resolved — loaded, or a 4xx (other than 429) with no viewable record.
+ *   Permanent; revisiting won't refetch.
+ * - `gaveUp`: exhausted its transient retries. Shown as unavailable and no longer polled, but — unlike
+ *   `settled` — recoverable: any later successful fetch clears every `gaveUp`, so a transient outage
+ *   doesn't strand the preview for the rest of the session.
  *
  * A transient failure short of the cap deletes the entry instead, so the fetch is retried.
- *
- * This is an external store rather than Redux/component state so the outcome survives a hook
- * unmounting and remounting (arrowing off a replay and back), and it's read through
- * `useSyncExternalStore` below — not a `forceUpdate` reading this map during render — so the React
- * Compiler can't memoize the derived `status` on its reactive inputs and skip a status-only change.
  */
 const gameFetchStatus = new Map<string, 'pending' | 'settled' | 'gaveUp'>()
 
 /**
- * Number of times each not-yet-resolved game fetch has failed transiently. Kept at module scope,
- * keyed by game id, so it *holds* across the hook remounting: arrowing off a rate-limited replay and
- * back derives the same backoff instead of resetting to the initial 2s, so a sustained 429 keeps
- * backing off toward the cap rather than restarting the poll on every visit. Also drives the attempt
- * cap above.
- *
- * Cleared *entirely* on any successful fetch — a success proves the limiter/network isn't blocking,
- * so every game's accrued backoff is void (a game we backed off from won't stall on a long-expired
- * 30s delay when revisited). That a concurrent success also resets a still-failing game's count is
- * intended: the cap is a safety net for a *sustained* no-success outage, not a limiter on a burst
- * that's already clearing.
+ * Transient-failure count per not-yet-resolved game, driving both the backoff delay and the attempt
+ * cap. At module scope so the backoff holds across remounts (arrowing away and back doesn't reset it
+ * to 2s). Cleared entirely on any success — proof the limiter/network recovered — which voids stale
+ * backoffs and keeps the cap a safety net for a sustained outage, not a limiter on a clearing burst.
  */
 const gameFetchRetries = new Map<string, number>()
 
@@ -109,30 +88,25 @@ export function useSbGameMap(gameId: string | undefined): SbGameMapResult {
   const dispatch = useAppDispatch()
   const game = useAppSelector(s => (gameId ? s.games.byId.get(gameId) : undefined))
   const map = useAppSelector(s => (game?.mapId ? s.maps.byId.get(game.mapId) : undefined))
-  // The fetch outcome lives in the module-level store above rather than Redux, so it's read here as
-  // an external store. This (not a forceUpdate) is what keeps `status` correct under the React
-  // Compiler: `fetchStatus` is a tracked reactive input, so the compiler can't memoize the `status`
-  // derivation on `[map, gameId, game]` and skip recomputing it when only the fetch outcome changed.
+  // Read the module-level outcome as an external store. useSyncExternalStore (a tracked reactive
+  // input) rather than a forceUpdate keeps `status` correct under the React Compiler, which could
+  // otherwise memoize the derivation on `[map, gameId, game]` and skip a status-only change.
   const fetchStatus = useSyncExternalStore(
     onChange => subscribeToGameFetch(gameId, onChange),
     () => getGameFetchStatus(gameId),
   )
 
   useEffect(() => {
-    // Nothing to fetch: no selection, or the game (and thus its map) is already in the store. Also
-    // bail on any tracked outcome — a request in flight (`pending`), a terminal one (`settled`), or a
-    // gave-up one (`gaveUp`): the subscription above delivers a `pending` request's result and
-    // re-renders us, and the resolved/gave-up states shouldn't refetch. Re-running on a transient
-    // failure (which deletes the marker) is what schedules the retry.
+    // Nothing to schedule: no selection, the game is already in the store, or the fetch has a tracked
+    // outcome (a `pending` request delivers its result via the subscription; `settled`/`gaveUp` don't
+    // refetch). A transient failure deletes the marker, and re-running here is what retries.
     if (!gameId || game || gameFetchStatus.has(gameId)) return () => {}
 
     let canceled = false
-    // A fresh selection is debounced so holding the arrow key through the list doesn't fire a request
-    // per intermediate selection — each is a different game, so request coalescing can't help (it
-    // only dedupes concurrent requests for the *same* game), and the burst trips the server's rate
-    // limiter. A game that has already failed transiently instead waits an exponential backoff
-    // derived from its (persisted) failure count, so a returning or re-attaching selection retries no
-    // faster than the backoff, rather than resetting to the debounce.
+    // Debounce a fresh selection so holding the arrow key doesn't fire a request per intermediate
+    // replay (each is a different game, so request coalescing can't help). A game that's already
+    // failed waits its backoff instead, so a returning/re-attaching selection retries no faster than
+    // the backoff.
     const retries = gameFetchRetries.get(gameId) ?? 0
     const delay =
       retries === 0
@@ -148,10 +122,8 @@ export function useSbGameMap(gameId: string | undefined): SbGameMapResult {
         viewGame(gameId, {
           onSuccess: () => {
             gameFetchStatus.set(gameId, 'settled')
-            // A success proves the limiter/network recovered, so let every game that gave up try
-            // again (dropping its marker means the next time it's shown it refetches) and void every
-            // game's accrued backoff — otherwise a game we backed off from would stall on a stale 30s
-            // delay, or a gave-up game would stay "unavailable" for the rest of the session.
+            // Recovery: a success proves the limiter/network is back, so reopen every gave-up game
+            // (deleting its marker → refetches when next shown) and void all accrued backoff.
             for (const id of [...gameFetchStatus.keys()]) {
               if (gameFetchStatus.get(id) === 'gaveUp') {
                 gameFetchStatus.delete(id)
@@ -167,23 +139,18 @@ export function useSbGameMap(gameId: string | undefined): SbGameMapResult {
               status !== undefined && status >= 400 && status < 500 && status !== 429
             const attempts = (gameFetchRetries.get(gameId) ?? 0) + 1
             if (terminal4xx) {
-              // Terminal: the game genuinely has no viewable record, so settle permanently and show
-              // the placeholder rather than retrying.
+              // No viewable record — settle permanently.
               gameFetchStatus.set(gameId, 'settled')
               gameFetchRetries.delete(gameId)
             } else if (attempts >= MAP_FETCH_MAX_ATTEMPTS) {
-              // Exhausted our transient retries (a sustained outage / rate-limit / persistently
-              // throwing fetch): stop shimmering — and polling — and show the placeholder. Recoverable
-              // rather than permanent (see `gaveUp`): a later successful fetch reopens it.
+              // Retries exhausted — give up (recoverable): stop shimmering and polling.
               gameFetchStatus.set(gameId, 'gaveUp')
               gameFetchRetries.delete(gameId)
             } else {
-              // Transient (429 rate-limiting, 5xx, network blip, non-`FetchError` throw): drop the
-              // marker so the fetch can be retried, and bump the failure count (which grows the
-              // backoff toward the cap). Notifying re-renders whichever hook is *currently* mounted
-              // for this game; that hook's effect re-runs and owns the retry — so a request started by
-              // a selection the user has since navigated away from still recovers on a returning
-              // mount, instead of stranding it on the loading skeleton.
+              // Transient (429 / 5xx / network / non-`FetchError` throw): drop the marker and bump the
+              // count. Notifying lets whichever hook is *currently* mounted own the retry, so a fetch
+              // started by a since-abandoned selection still recovers on a returning mount rather than
+              // stranding it on the skeleton.
               gameFetchStatus.delete(gameId)
               gameFetchRetries.set(gameId, attempts)
             }
@@ -203,9 +170,8 @@ export function useSbGameMap(gameId: string | undefined): SbGameMapResult {
   if (map) {
     status = 'loaded'
   } else if (gameId && !game && (fetchStatus === undefined || fetchStatus === 'pending')) {
-    // The game (and its map) is still on the way — debouncing, in flight, or awaiting a retry.
-    // Assume a map is coming rather than flashing the "no map" placeholder. Once the fetch resolves
-    // (`settled`) or gives up (`gaveUp`), fall through to the placeholder.
+    // Still on the way (debouncing / in flight / awaiting retry): assume a map is coming rather than
+    // flashing the placeholder. `settled`/`gaveUp` fall through to unavailable.
     status = 'loading'
   } else {
     status = 'unavailable'
@@ -215,9 +181,8 @@ export function useSbGameMap(gameId: string | undefined): SbGameMapResult {
 }
 
 /**
- * Clears the module-level fetch bookkeeping. Exported for tests only, so each case starts from a
- * clean slate instead of leaking `pending`/`settled` markers, backoff counts, and listeners into the
- * next one (the state deliberately outlives any single hook mount, so it isn't reset otherwise).
+ * Clears the module-level fetch bookkeeping. Exported for tests only — the state deliberately outlives
+ * a hook mount, so it must be reset between cases to stop markers/counts/listeners leaking.
  */
 export function resetSbGameMapStateForTests() {
   gameFetchStatus.clear()

--- a/client/replays/replay-hooks.ts
+++ b/client/replays/replay-hooks.ts
@@ -19,7 +19,7 @@ export interface SbGameMapResult {
 
 /** How long a selection must hold still before we fetch its game — see the debounce note below. */
 const MAP_FETCH_DEBOUNCE_MS = 150
-/** Initial backoff before retrying a game fetch that failed transiently (rate-limited / 5xx / network). */
+/** Base backoff before the first retry of a game fetch that failed transiently (rate-limited / 5xx / network). */
 const MAP_FETCH_RETRY_MS = 2000
 /**
  * Ceiling for the retry backoff. Each transient failure doubles the delay up to this cap, so a
@@ -27,6 +27,14 @@ const MAP_FETCH_RETRY_MS = 2000
  * the panel stays open, while still self-healing once the rate limit clears.
  */
 const MAP_FETCH_RETRY_MAX_MS = 30000
+/**
+ * How many times a single game fetch may fail transiently before we give up and settle to
+ * `unavailable`. Without a cap a *persistently* failing fetch — a long outage, or a non-`FetchError`
+ * thrown while dispatching (which has no status and so is treated as transient) — would shimmer the
+ * hero and poll forever with no terminal fallback. With the backoff above, six attempts span roughly
+ * a minute before giving up.
+ */
+const MAP_FETCH_MAX_ATTEMPTS = 6
 
 /**
  * Outcome of each game fetch, tracked across the mount/unmount churn of navigating between replays:
@@ -46,13 +54,17 @@ const MAP_FETCH_RETRY_MAX_MS = 30000
 const gameFetchStatus = new Map<string, 'pending' | 'settled'>()
 
 /**
- * Current retry backoff (ms) for each game that has failed transiently and not yet settled. Kept at
- * module scope, keyed by game id, so the backoff *holds* across the hook remounting: arrowing off a
- * rate-limited replay and back doesn't reset it to the initial 2s, so a sustained 429 keeps backing
- * off toward the cap instead of restarting the poll from scratch on every visit. Cleared once the
- * fetch settles (success or terminal failure).
+ * Number of times each not-yet-settled game fetch has failed transiently. Kept at module scope,
+ * keyed by game id, so it *holds* across the hook remounting: arrowing off a rate-limited replay and
+ * back derives the same backoff instead of resetting to the initial 2s, so a sustained 429 keeps
+ * backing off toward the cap rather than restarting the poll on every visit. Also drives the
+ * attempt cap above.
+ *
+ * Cleared for a game once its fetch settles terminally; cleared *entirely* on any successful fetch —
+ * a success proves the limiter/network isn't blocking, so every game's stale backoff is void and a
+ * game we back off from won't stall on a long-expired 30s delay when revisited.
  */
-const gameFetchBackoff = new Map<string, number>()
+const gameFetchRetries = new Map<string, number>()
 
 /** Hooks subscribed to a given game id's fetch outcome, notified whenever it changes. */
 const gameFetchListeners = new Map<string, Set<() => void>>()
@@ -107,10 +119,14 @@ export function useSbGameMap(gameId: string | undefined): SbGameMapResult {
     // A fresh selection is debounced so holding the arrow key through the list doesn't fire a request
     // per intermediate selection — each is a different game, so request coalescing can't help (it
     // only dedupes concurrent requests for the *same* game), and the burst trips the server's rate
-    // limiter. A game that failed transiently instead waits its persisted backoff, so a returning or
-    // re-attaching selection retries no faster than the backoff, rather than resetting to the
-    // debounce.
-    const delay = gameFetchBackoff.get(gameId) ?? MAP_FETCH_DEBOUNCE_MS
+    // limiter. A game that has already failed transiently instead waits an exponential backoff
+    // derived from its (persisted) failure count, so a returning or re-attaching selection retries no
+    // faster than the backoff, rather than resetting to the debounce.
+    const retries = gameFetchRetries.get(gameId) ?? 0
+    const delay =
+      retries === 0
+        ? MAP_FETCH_DEBOUNCE_MS
+        : Math.min(MAP_FETCH_RETRY_MS * 2 ** (retries - 1), MAP_FETCH_RETRY_MAX_MS)
     const timer = setTimeout(() => {
       if (canceled || gameFetchStatus.has(gameId)) return
       gameFetchStatus.set(gameId, 'pending')
@@ -121,30 +137,33 @@ export function useSbGameMap(gameId: string | undefined): SbGameMapResult {
         viewGame(gameId, {
           onSuccess: () => {
             gameFetchStatus.set(gameId, 'settled')
-            gameFetchBackoff.delete(gameId)
+            // A success proves the limiter/network isn't blocking, so drop every game's accrued
+            // backoff — not just this one's — so a game we backed off from doesn't stall on a stale
+            // 30s delay when revisited.
+            gameFetchRetries.clear()
             notifyGameFetchListeners(gameId)
           },
           onError: err => {
             const status = isFetchError(err) ? err.status : undefined
-            if (status !== undefined && status >= 400 && status < 500 && status !== 429) {
-              // Terminal: the game genuinely has no viewable record, so settle and show the
-              // placeholder rather than retrying forever.
+            const terminal4xx =
+              status !== undefined && status >= 400 && status < 500 && status !== 429
+            const attempts = (gameFetchRetries.get(gameId) ?? 0) + 1
+            if (terminal4xx || attempts >= MAP_FETCH_MAX_ATTEMPTS) {
+              // Give up: either the game genuinely has no viewable record (a 4xx other than 429), or
+              // we've exhausted our transient retries (a sustained outage / rate-limit / persistently
+              // throwing fetch). Settle so we show the placeholder rather than shimmering — and
+              // polling — forever.
               gameFetchStatus.set(gameId, 'settled')
-              gameFetchBackoff.delete(gameId)
+              gameFetchRetries.delete(gameId)
             } else {
-              // Transient (429 rate-limiting, 5xx, network blip): drop the marker so the fetch can be
-              // retried, and grow the backoff toward the cap. Notifying re-renders whichever hook is
-              // *currently* mounted for this game; that hook's effect re-runs and owns the retry — so
-              // a request started by a selection the user has since navigated away from still recovers
-              // on a returning mount, instead of stranding it on the loading skeleton.
+              // Transient (429 rate-limiting, 5xx, network blip, non-`FetchError` throw): drop the
+              // marker so the fetch can be retried, and bump the failure count (which grows the
+              // backoff toward the cap). Notifying re-renders whichever hook is *currently* mounted
+              // for this game; that hook's effect re-runs and owns the retry — so a request started by
+              // a selection the user has since navigated away from still recovers on a returning
+              // mount, instead of stranding it on the loading skeleton.
               gameFetchStatus.delete(gameId)
-              const prev = gameFetchBackoff.get(gameId)
-              gameFetchBackoff.set(
-                gameId,
-                prev === undefined
-                  ? MAP_FETCH_RETRY_MS
-                  : Math.min(prev * 2, MAP_FETCH_RETRY_MAX_MS),
-              )
+              gameFetchRetries.set(gameId, attempts)
             }
             notifyGameFetchListeners(gameId)
           },
@@ -170,4 +189,15 @@ export function useSbGameMap(gameId: string | undefined): SbGameMapResult {
   }
 
   return { map, status }
+}
+
+/**
+ * Clears the module-level fetch bookkeeping. Exported for tests only, so each case starts from a
+ * clean slate instead of leaking `pending`/`settled` markers, backoff counts, and listeners into the
+ * next one (the state deliberately outlives any single hook mount, so it isn't reset otherwise).
+ */
+export function resetSbGameMapStateForTests() {
+  gameFetchStatus.clear()
+  gameFetchRetries.clear()
+  gameFetchListeners.clear()
 }

--- a/client/replays/replay-inspector.tsx
+++ b/client/replays/replay-inspector.tsx
@@ -324,7 +324,7 @@ export function ReplayInspector({
   const [anchor, anchorX, anchorY, refreshAnchorPos] = useRefAnchorPosition('right', 'bottom')
   const [menuOpen, openMenu, closeMenu] = usePopoverController({ refreshAnchorPos })
   const [addMenuOpen, openAddMenu, closeAddMenu] = usePopoverController({ refreshAnchorPos })
-  const map = useSbGameMap(entry?.sbGameId)
+  const { map, status: mapStatus } = useSbGameMap(entry?.sbGameId)
 
   const entryId = entry?.id
   // Tagged with the entry id it was fetched for, so a stale response (or a fetch that hasn't
@@ -484,7 +484,10 @@ export function ReplayInspector({
   )
 
   return (
-    <GameSidePanel map={map} alignWithFirstRow={alignWithFirstRow}>
+    <GameSidePanel
+      map={map}
+      isMapLoading={mapStatus === 'loading'}
+      alignWithFirstRow={alignWithFirstRow}>
       {entry.parseError ? (
         <>
           <GameSidePanelHeader>
@@ -502,7 +505,13 @@ export function ReplayInspector({
         <>
           <GameSidePanelHeader>
             {chips}
-            {!map ? (
+            {/*
+              The map thumbnail renders its own name label, so a title here would duplicate it once
+              loaded. Show the name as text only when there's genuinely no thumbnail coming (no
+              linked map) — not while it's still loading, which would otherwise shift the header's
+              height when the title is dropped on load.
+            */}
+            {mapStatus === 'unavailable' ? (
               <GameSidePanelTitle>{filterColorCodes(entry.mapName)}</GameSidePanelTitle>
             ) : null}
             <GameSidePanelSubline>{longTimestamp.format(entry.gameTime)}</GameSidePanelSubline>

--- a/client/settings/app/system-settings.tsx
+++ b/client/settings/app/system-settings.tsx
@@ -19,15 +19,20 @@ import { pickAutoRegion } from '../../game-server-regions/region-resolution'
 import { MaterialIcon } from '../../icons/material/material-icon'
 import logger from '../../logging/logger'
 import { isMatchmakingAtom, matchLaunchingAtom } from '../../matchmaking/matchmaking-atoms'
-import { IconButton, TextButton } from '../../material/button'
+import { IconButton, OutlinedButton } from '../../material/button'
 import { CheckBox } from '../../material/check-box'
 import { SelectOption } from '../../material/select/option'
 import { Select } from '../../material/select/select'
 import { Tooltip } from '../../material/tooltip'
 import { useAppDispatch, useAppSelector } from '../../redux-hooks'
-import { bodyMedium, bodySmall, singleLine } from '../../styles/typography'
+import { bodySmall, singleLine, titleSmall } from '../../styles/typography'
 import { mergeLocalSettings } from '../action-creators'
-import { FormContainer, SectionContainer, SectionOverline } from '../settings-content'
+import {
+  FormContainer,
+  SectionContainer,
+  SettingsSectionDescription,
+  SettingsSectionHeader,
+} from '../settings-content'
 
 const ipcRenderer = new TypedIpcRenderer()
 
@@ -48,12 +53,19 @@ function dedupeFolders(folders: ReadonlyArray<string>): string[] {
   return result
 }
 
+/**
+ * The final path segment (folder name) of an absolute path, used as the row's prominent label with
+ * the full path shown beneath it. Handles both `\` (Windows) and `/` separators and any trailing
+ * separator; falls back to the whole (trimmed) path for something without a separator (e.g. a drive
+ * root).
+ */
+function folderDisplayName(folder: string): string {
+  const trimmed = folder.replace(/[/\\]+$/, '')
+  return trimmed.replace(/^.*[/\\]/, '') || trimmed
+}
+
 const IndentedCheckBox = styled(CheckBox)`
   margin-left: 28px;
-`
-
-const NetworkOverline = styled(SectionOverline)`
-  margin-bottom: 8px;
 `
 
 const RegionLockedText = styled.div`
@@ -61,42 +73,64 @@ const RegionLockedText = styled.div`
   color: var(--theme-on-surface-variant);
 `
 
-const ReplayFoldersBlock = styled.div`
-  margin-top: 16px;
-
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-`
-
-const ReplayFoldersDescription = styled.div`
-  ${bodySmall};
-  color: var(--theme-on-surface-variant);
-`
-
 const FolderList = styled.div`
   display: flex;
   flex-direction: column;
+  gap: 4px;
 `
 
 const FolderRow = styled.div`
-  min-height: 40px;
+  min-height: 56px;
+  padding: 8px 8px 8px 12px;
 
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 12px;
+
+  border-radius: 8px;
+
+  &:hover {
+    background-color: rgb(from var(--theme-on-surface) r g b / 0.08);
+  }
+`
+
+const FolderIconTile = styled.div`
+  flex-shrink: 0;
+  width: 40px;
+  height: 40px;
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  border-radius: 8px;
+  background-color: var(--theme-container-high);
+  color: var(--theme-on-surface-variant);
+`
+
+const FolderText = styled.div`
+  flex: 1 1 auto;
+  min-width: 0;
+
+  display: flex;
+  flex-direction: column;
+`
+
+const FolderName = styled.div`
+  ${titleSmall};
+  ${singleLine};
 `
 
 const FolderPath = styled.div`
-  ${bodyMedium};
+  ${bodySmall};
   ${singleLine};
 
-  flex: 1 1 auto;
-  min-width: 0;
+  color: var(--theme-on-surface-variant);
 `
 
-const AddFolderButton = styled(TextButton)`
+const AddFolderButton = styled(OutlinedButton)`
   align-self: flex-start;
+  margin-top: 12px;
 `
 
 /**
@@ -257,11 +291,15 @@ export function AppSystemSettings() {
     saveFolders(configuredFolders.filter(f => f !== folder))
   }
 
+  const removeFolderLabel = t('settings.app.system.removeReplayFolder', 'Remove folder')
+
   return (
     <form noValidate={true} onSubmit={submit}>
       <FormContainer>
         <SectionContainer>
-          <SectionOverline>{t('settings.app.system.filesOverline', 'Files')}</SectionOverline>
+          <SettingsSectionHeader>
+            {t('settings.app.system.filesOverline', 'Files')}
+          </SettingsSectionHeader>
           <CheckBox
             {...bindCheckable('quickOpenReplays')}
             label={t(
@@ -270,44 +308,52 @@ export function AppSystemSettings() {
             )}
             inputProps={{ tabIndex: 0 }}
           />
+        </SectionContainer>
 
-          <ReplayFoldersBlock>
-            <SectionOverline>
-              {t('settings.app.system.replayFoldersTitle', 'Replay folders')}
-            </SectionOverline>
-            <ReplayFoldersDescription>
-              {t(
-                'settings.app.system.replayFoldersDescription',
-                'Folders indexed by your replay library. The default StarCraft replay folder is ' +
-                  'added automatically. Removing a folder removes its replays from the library, ' +
-                  'including their bookmarks and playlist entries.',
-              )}
-            </ReplayFoldersDescription>
+        <SectionContainer>
+          <SettingsSectionHeader>
+            {t('settings.app.system.replayFoldersTitle', 'Replay folders')}
+          </SettingsSectionHeader>
+          <SettingsSectionDescription>
+            {t(
+              'settings.app.system.replayFoldersDescription',
+              'Folders indexed by your replay library. The default StarCraft replay folder is ' +
+                'added automatically. Removing a folder removes its replays from the library, ' +
+                'including their bookmarks and playlist entries.',
+            )}
+          </SettingsSectionDescription>
 
-            <FolderList>
-              {configuredFolders.map(folder => (
-                <FolderRow key={folder}>
+          <FolderList>
+            {configuredFolders.map(folder => (
+              <FolderRow key={folder}>
+                <FolderIconTile>
+                  <MaterialIcon icon='folder' />
+                </FolderIconTile>
+                <FolderText>
+                  <FolderName title={folder}>{folderDisplayName(folder)}</FolderName>
                   <FolderPath title={folder}>{folder}</FolderPath>
-                  <Tooltip text={t('settings.app.system.removeReplayFolder', 'Remove folder')}>
-                    <IconButton
-                      icon={<MaterialIcon icon='delete' />}
-                      ariaLabel={t('settings.app.system.removeReplayFolder', 'Remove folder')}
-                      onClick={() => onRemoveFolder(folder)}
-                    />
-                  </Tooltip>
-                </FolderRow>
-              ))}
-            </FolderList>
+                </FolderText>
+                <Tooltip text={removeFolderLabel}>
+                  <IconButton
+                    icon={<MaterialIcon icon='delete' />}
+                    ariaLabel={removeFolderLabel}
+                    onClick={() => onRemoveFolder(folder)}
+                  />
+                </Tooltip>
+              </FolderRow>
+            ))}
+          </FolderList>
 
-            <AddFolderButton
-              label={t('settings.app.system.addReplayFolder', 'Add folder')}
-              iconStart={<MaterialIcon icon='add' />}
-              onClick={onAddFolderClick}
-            />
-          </ReplayFoldersBlock>
+          <AddFolderButton
+            label={t('settings.app.system.addReplayFolder', 'Add folder')}
+            iconStart={<MaterialIcon icon='add' />}
+            onClick={onAddFolderClick}
+          />
         </SectionContainer>
         <SectionContainer>
-          <SectionOverline>{t('settings.app.system.startupOverline', 'Startup')}</SectionOverline>
+          <SettingsSectionHeader>
+            {t('settings.app.system.startupOverline', 'Startup')}
+          </SettingsSectionHeader>
           <CheckBox
             {...bindCheckable('runAppAtSystemStart')}
             label={t('settings.app.system.runOnStartup', 'Run ShieldBattery on system startup')}
@@ -322,7 +368,9 @@ export function AppSystemSettings() {
         </SectionContainer>
         {regions.length > 0 ? (
           <SectionContainer>
-            <NetworkOverline>{t('settings.app.system.networkOverline', 'Network')}</NetworkOverline>
+            <SettingsSectionHeader>
+              {t('settings.app.system.networkOverline', 'Network')}
+            </SettingsSectionHeader>
             <Select
               {...bindCustom('gameServerRegion')}
               label={t('settings.app.system.serverRegion.label', 'Server region')}

--- a/server/lib/games/game-api.ts
+++ b/server/lib/games/game-api.ts
@@ -67,8 +67,8 @@ import { deriveResultSubmission } from './raw-results'
 const MAX_REPLAY_SIZE_BYTES = 5 * 1024 * 1024
 
 const throttle = createThrottle('games', {
-  rate: 20,
-  burst: 40,
+  rate: 40,
+  burst: 80,
   window: 60000,
 })
 

--- a/server/lib/games/game-api.ts
+++ b/server/lib/games/game-api.ts
@@ -67,6 +67,16 @@ import { deriveResultSubmission } from './raw-results'
 const MAX_REPLAY_SIZE_BYTES = 5 * 1024 * 1024
 
 const throttle = createThrottle('games', {
+  rate: 20,
+  burst: 40,
+  window: 60000,
+})
+
+// A looser limit just for the read-only single-game fetch (the map preview + game view), which a
+// user legitimately hits far more often than the lifecycle writes above — selecting distinct
+// replays while browsing the library is a read per selection. Kept separate from `throttle` so
+// loosening the read path doesn't also loosen the subscribe/unsubscribe/status writes.
+const gameInfoThrottle = createThrottle('gameInfo', {
   rate: 40,
   burst: 80,
   window: 60000,
@@ -268,7 +278,7 @@ export class GameApi {
   }
 
   @httpGet('/:gameId')
-  @httpBefore(throttleMiddleware(throttle, ctx => String(ctx.session?.user?.id ?? ctx.ip)))
+  @httpBefore(throttleMiddleware(gameInfoThrottle, ctx => String(ctx.session?.user?.id ?? ctx.ip)))
   async getGame(ctx: RouterContext): Promise<GetGameResponse> {
     const {
       params: { gameId },

--- a/vitest-client-setup.ts
+++ b/vitest-client-setup.ts
@@ -1,9 +1,15 @@
 // Run before any client/ vitest tests, use to set up the environment with any necessary globals
 import { cleanup } from '@testing-library/react'
+import { enableArrayMethods, enableMapSet } from 'immer'
 import { afterEach, vi } from 'vitest'
 
 // This is just to stop prettier from stripping all the comments for some reason?
 {
+  // The app enables these Immer plugins at startup (see client/index.jsx); reducers store Maps/Sets,
+  // so any test that dispatches through a real reducer needs them enabled too.
+  enableMapSet()
+  enableArrayMethods()
+
   // Generally this is what we want, as it maximizes the amount of code that can be run/tested. If you
   // want a particular test to run as if in a browser, you can set this differently in the test
   // probably


### PR DESCRIPTION
Addresses two pieces of UI feedback on the replay browser.

## Map preview loading (replay inspector)

The side panel's map hero flashed **"Map preview not available"** the instant you
selected a replay, before its SB game/map had loaded — worst when holding the
down arrow through the list, and it'll be more noticeable on a non-localhost
server.

- `useSbGameMap` now returns `{ map, status }` where `status` is
  `loading | loaded | unavailable`, tracking each game fetch's outcome so it can
  tell "still loading" apart from "genuinely no map" even across the
  mount/unmount churn of arrowing between replays.
- `GameSidePanel` takes an `isMapLoading` prop and shows a subtle shimmer
  skeleton (same square footprint as the thumbnail/placeholder) while loading,
  instead of the "not available" tile.
- **Header height jump fixed:** the map-name title in the header is now shown
  only when the map is genuinely unavailable (a B.NET replay or a deleted map).
  On the normal loading→loaded path the title is absent in both states — and all
  three hero states are the same `aspect-ratio: 1` box — so there's no layout
  shift when the map loads.

### Rate limiting on fast scroll

Holding the arrow key fired a `viewGame` request per intermediate selection.
Each is a *different* game, so request coalescing (same-id dedupe) can't help,
and the burst tripped the server's rate limiter (429). Three independent changes
harden this:

- **Leading-edge fetch (client).** A deliberate selection fetches its game
  immediately — no artificial delay on the normal click-through-the-list case.
  The coalescing window (150ms) only kicks in while selections keep changing
  faster than it (a fast scroll / held arrow), collapsing that burst down to the
  row you land on. Cached games resolve instantly from the store and never fetch.
- **Empty state on failure (client).** A failed fetch settles to the
  placeholder — the same empty state every other panel shows — rather than
  retrying. Transient failures (429/5xx/network) are forgotten when you leave the
  replay (or immediately, if the response lands after you've already moved on),
  so reselecting refetches. A terminal 4xx — the server says there's no viewable
  record — is pinned for the session so reselecting a dead replay doesn't
  re-request it (as on master, except a 429 no longer counts as terminal).
- **Higher read limit (server).** `GET /games/:gameId` gets its own `gameInfo`
  throttle (rate 40 / burst 80 per 60s) instead of sharing the `games` throttle —
  selecting ~40 distinct never-before-viewed replays within a minute or two is
  reachable just by browsing, so the old burst was too low. The shared `games`
  throttle (and the subscribe/unsubscribe/status write endpoints it guards) is
  unchanged.

> Note: batch-prefetching the loaded rows' game/map info (the way the
> games/match-history lists bundle maps) would make selection cache-instant, but
> it needs a new `games/batch-info` endpoint. Deferred — the changes above
> resolve the reported burst, and a prefetch can land later without conflict.

## Replay folders settings redesign (App > System)

Brought the section up to the modern settings pattern (as used in Social):

- Sections use `titleLarge` headers + `bodyLarge` descriptions instead of small
  overlines; "Replay folders" is now its own top-level section.
- Each folder is a proper list row — folder-icon tile, folder name over its full
  path, hover state — rather than plain text with an icon button off to the side.
- "Add folder" is an outlined button.

No new translation strings.

## Verification

Typecheck and ESLint clean; `gen-translations` is a no-op. `useSbGameMap` has unit
coverage for the leading-edge/coalesce, empty-state-on-failure, refetch-on-return,
re-attach, terminal-4xx pinning, and failure-after-moving-on paths
(`client/replays/replay-hooks.test.tsx`).

Not yet re-verified live: the header-jump and rate-limit fixes were made in
response to interactive testing that surfaced those issues, so the fixes
themselves still want an in-app pass (map skeleton on a throttled/remote fetch,
no height shift on load, no 429s browsing the library, and the settings layout).
