### PR TITLE
Add unlisted lobbies, invite links, and an observers toggle

### DIFF
--- a/client/lobbies/action-creators.js
+++ b/client/lobbies/action-creators.js
@@ -48,7 +48,7 @@ const ipcRenderer = new TypedIpcRenderer()
 // be awaited here and handed to the `onSuccess`/`onError` callbacks.
 export const createLobby =
   (
-    { name, map, gameType, gameSubType, useLegacyLimits, allowObservers = true },
+    { name, map, gameType, gameSubType, useLegacyLimits, allowObservers, visibility },
     { onSuccess, onError } = {},
   ) =>
   dispatch => {
@@ -70,6 +70,7 @@ export const createLobby =
         gameSubType,
         useLegacyLimits,
         allowObservers,
+        visibility,
         region: desiredRegion?.region,
         // `rttMs` is nullable on `DesiredRegion` (a manual pick can be unmeasured); the wire
         // format only distinguishes "present" from "absent", so a null rtt is sent as absent.

--- a/client/lobbies/create-lobby.tsx
+++ b/client/lobbies/create-lobby.tsx
@@ -6,6 +6,7 @@ import styled from 'styled-components'
 import { ReadonlyDeep } from 'type-fest'
 import { LOBBY_NAME_MAXLENGTH, LOBBY_NAME_PATTERN } from '../../common/constants'
 import { ALL_GAME_TYPES, GameType, gameTypeToLabel, isTeamType } from '../../common/games/game-type'
+import { LobbyVisibility } from '../../common/lobbies'
 import { LobbyCreateErrorCode } from '../../common/lobbies/lobby-network'
 import { SbLobbyId } from '../../common/lobbies/sb-lobby-id'
 import { SbMapId } from '../../common/maps'
@@ -22,6 +23,7 @@ import { MapSelect, MapSelectionValue } from '../maps/map-select'
 import { useAutoFocusRef } from '../material/auto-focus'
 import { FilledButton, TextButton } from '../material/button'
 import { CheckBox } from '../material/check-box'
+import { RadioButton, RadioGroup } from '../material/radio'
 import { ScrollDivider, useScrollIndicatorState } from '../material/scroll-indicator'
 import { SelectOption } from '../material/select/option'
 import { Select } from '../material/select/select'
@@ -29,7 +31,7 @@ import { TextField } from '../material/text-field'
 import { LoadingDotsArea } from '../progress/dots'
 import { useStableCallback } from '../react/state-hooks'
 import { useAppDispatch, useAppSelector } from '../redux-hooks'
-import { bodyLarge, titleLarge } from '../styles/typography'
+import { bodyLarge, bodySmall, titleLarge } from '../styles/typography'
 import { createLobby, getLobbyPreferences, updateLobbyPreferences } from './action-creators'
 import { navigateToLobby } from './lobby-url'
 
@@ -82,6 +84,11 @@ const GameTypeAndSubType = styled.div`
   }
 `
 
+const VisibilitySettings = styled.div`
+  max-width: 400px;
+  margin-top: 32px;
+`
+
 const AdvancedSettings = styled.div`
   max-width: 320px;
   margin-top: 32px;
@@ -92,12 +99,25 @@ const SectionHeader = styled.div`
   margin: 16px 0;
 `
 
+// Spans rather than divs: these render inside a <label>, which only accepts phrasing content.
+const VisibilityOptionName = styled.span`
+  display: block;
+`
+
+const VisibilityOptionDescription = styled.span`
+  ${bodySmall};
+  display: block;
+  color: var(--theme-on-surface-variant);
+`
+
 interface CreateLobbyModel {
   name: string
   mapSelection: MapSelectionValue
   gameType: GameType
   gameSubType: number
   useLegacyLimits: boolean
+  visibility: LobbyVisibility
+  allowObservers: boolean
 }
 
 const lobbyNameValidator = composeValidators(
@@ -297,6 +317,46 @@ function CreateLobbyForm({
         numRecentMaps={NUM_RECENT_MAPS}
       />
 
+      <VisibilitySettings>
+        <SectionHeader>{t('lobbies.createLobby.visibility', 'Visibility')}</SectionHeader>
+        <RadioGroup {...bindInput('visibility')}>
+          <RadioButton
+            value='listed'
+            disabled={disabled}
+            label={
+              <>
+                <VisibilityOptionName>
+                  {t('lobbies.createLobby.visibilityListed', 'Public')}
+                </VisibilityOptionName>
+                <VisibilityOptionDescription>
+                  {t(
+                    'lobbies.createLobby.visibilityListedDescription',
+                    'Shown in the lobby list for anyone to join',
+                  )}
+                </VisibilityOptionDescription>
+              </>
+            }
+          />
+          <RadioButton
+            value='unlisted'
+            disabled={disabled}
+            label={
+              <>
+                <VisibilityOptionName>
+                  {t('lobbies.createLobby.visibilityUnlisted', 'Unlisted')}
+                </VisibilityOptionName>
+                <VisibilityOptionDescription>
+                  {t(
+                    'lobbies.createLobby.visibilityUnlistedDescription',
+                    'Only people you share the link with can join',
+                  )}
+                </VisibilityOptionDescription>
+              </>
+            }
+          />
+        </RadioGroup>
+      </VisibilitySettings>
+
       <AdvancedSettings>
         <SectionHeader>
           {t('lobbies.createLobby.advancedSettings', 'Advanced settings')}
@@ -305,6 +365,12 @@ function CreateLobbyForm({
           {...bindCheckable('useLegacyLimits')}
           label={t('lobbies.createLobby.useLegacyLimits', 'Use legacy unit limit')}
           disabled={disabled}
+          inputProps={{ tabIndex: 0 }}
+        />
+        <CheckBox
+          {...bindCheckable('allowObservers')}
+          label={t('lobbies.createLobby.allowObservers', 'Allow observers')}
+          disabled={disabled || getInputValue('gameType') !== GameType.Melee}
           inputProps={{ tabIndex: 0 }}
         />
       </AdvancedSettings>
@@ -333,6 +399,8 @@ export function CreateLobby(props: CreateLobbyProps) {
   const gameType = useAppSelector(s => s.lobbyPreferences.gameType)
   const gameSubType = useAppSelector(s => s.lobbyPreferences.gameSubType)
   const useLegacyLimits = useAppSelector(s => s.lobbyPreferences.useLegacyLimits)
+  const prefsVisibility = useAppSelector(s => s.lobbyPreferences.visibility)
+  const prefsAllowObservers = useAppSelector(s => s.lobbyPreferences.allowObservers)
 
   const storeSelectedMap = useAppSelector(s => s.lobbyPreferences.selectedMap)
   const storeRecentMaps = useAppSelector(s => s.lobbyPreferences.recentMaps)
@@ -350,8 +418,19 @@ export function CreateLobby(props: CreateLobbyProps) {
           recentMaps: storeRecentMaps.toArray(),
         },
         useLegacyLimits: useLegacyLimits ?? false,
+        visibility: prefsVisibility ?? 'listed',
+        allowObservers: prefsAllowObservers ?? true,
       }) satisfies CreateLobbyModel,
-    [initialName, gameType, gameSubType, storeSelectedMap, storeRecentMaps, useLegacyLimits],
+    [
+      initialName,
+      gameType,
+      gameSubType,
+      storeSelectedMap,
+      storeRecentMaps,
+      useLegacyLimits,
+      prefsVisibility,
+      prefsAllowObservers,
+    ],
   )
 
   const formRef = useRef<CreateLobbyFormHandle>(null)
@@ -370,6 +449,8 @@ export function CreateLobby(props: CreateLobbyProps) {
           gameType: model.gameType,
           gameSubType: model.gameSubType,
           useLegacyLimits: model.useLegacyLimits,
+          visibility: model.visibility,
+          allowObservers: model.allowObservers,
         }),
       )
     }, 200),
@@ -448,6 +529,8 @@ export function CreateLobby(props: CreateLobbyProps) {
                   gameSubType,
                   mapSelection: { mapId, recentMaps },
                   useLegacyLimits,
+                  visibility,
+                  allowObservers,
                 } = model
                 const subType = isTeamType(gameType) ? gameSubType : undefined
 
@@ -460,6 +543,8 @@ export function CreateLobby(props: CreateLobbyProps) {
                       gameType,
                       gameSubType: subType,
                       useLegacyLimits,
+                      visibility,
+                      allowObservers,
                     },
                     {
                       onSuccess: (result: { id: SbLobbyId }) => navigateToLobby(result.id, name),
@@ -497,6 +582,8 @@ export function CreateLobby(props: CreateLobbyProps) {
                     gameType: model.gameType,
                     gameSubType: model.gameSubType,
                     useLegacyLimits: model.useLegacyLimits,
+                    visibility: model.visibility,
+                    allowObservers: model.allowObservers,
                   }),
                 )
               }}

--- a/client/lobbies/lobby-preferences-reducer.ts
+++ b/client/lobbies/lobby-preferences-reducer.ts
@@ -1,5 +1,6 @@
 import { List, Record } from 'immutable'
 import { GameType } from '../../common/games/game-type'
+import { LobbyVisibility } from '../../common/lobbies'
 import { MapInfoJson, SbMapId } from '../../common/maps'
 import {
   LOBBY_PREFERENCES_GET,
@@ -15,6 +16,8 @@ export class LobbyPreferences extends Record({
   recentMaps: List<SbMapId>(),
   selectedMap: undefined as SbMapId | undefined,
   useLegacyLimits: undefined as boolean | undefined,
+  visibility: undefined as LobbyVisibility | undefined,
+  allowObservers: undefined as boolean | undefined,
 
   isRequesting: false,
   hasLoaded: false,

--- a/client/lobbies/lobby.tsx
+++ b/client/lobbies/lobby.tsx
@@ -1,6 +1,6 @@
 import { List } from 'immutable'
-import React from 'react'
-import { WithTranslation, withTranslation } from 'react-i18next'
+import React, { useRef, useState } from 'react'
+import { useTranslation, WithTranslation, withTranslation } from 'react-i18next'
 import styled from 'styled-components'
 import { ReadonlyDeep } from 'type-fest'
 import { assertUnreachable } from '../../common/assert-unreachable'
@@ -17,13 +17,16 @@ import {
 import { Slot, SlotType } from '../../common/lobbies/slot'
 import { RaceChar } from '../../common/races'
 import { SelfUserJson } from '../../common/users/sb-user'
+import { MaterialIcon } from '../icons/material/material-icon'
+import logger from '../logging/logger'
 import { ReduxMapThumbnail } from '../maps/map-thumbnail'
-import { FilledButton } from '../material/button'
+import { FilledButton, TextButton } from '../material/button'
 import { Card } from '../material/card'
 import { elevationPlus1 } from '../material/shadows'
 import { Chat } from '../messaging/chat'
 import { MessageComponentProps } from '../messaging/message-list'
 import { SbMessage } from '../messaging/message-records'
+import { makeServerUrl } from '../network/server-url'
 import { headlineMedium, labelLarge, labelMedium } from '../styles/typography'
 import { ClosedSlot } from './closed-slot'
 import { LobbyUserMenu } from './lobby-menu-items'
@@ -41,6 +44,7 @@ import {
 } from './lobby-message-layout'
 import { LobbyMessageType } from './lobby-message-records'
 import { LobbyLoadingState } from './lobby-reducer'
+import { urlForLobby } from './lobby-url'
 import { OpenSlot } from './open-slot'
 import { PlayerSlot } from './player-slot'
 import { ObserverSlots, RegularSlots, TeamName } from './slot'
@@ -90,6 +94,12 @@ const Info = styled.div`
   flex-shrink: 0;
 `
 
+const InfoActions = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+`
+
 const StyledMapThumbnail = styled(ReduxMapThumbnail)`
   ${elevationPlus1};
   width: 256px;
@@ -122,6 +132,43 @@ const Countdown = styled.div`
   ${headlineMedium};
   margin: 16px 0;
 `
+
+/**
+ * A button that copies a shareable link to this lobby. The lobby's id is what actually grants
+ * access, so this is the only way to invite someone into a lobby that isn't publicly listed.
+ */
+function CopyInviteLinkButton({ lobby }: { lobby: Lobby }) {
+  const { t } = useTranslation()
+  const [copied, setCopied] = useState(false)
+  const timeoutRef = useRef<ReturnType<typeof setTimeout>>(undefined)
+
+  return (
+    <TextButton
+      label={
+        copied
+          ? t('lobbies.lobby.copiedInviteLink', 'Copied!')
+          : t('lobbies.lobby.copyInviteLink', 'Copy invite link')
+      }
+      iconStart={<MaterialIcon icon='link' />}
+      onClick={() => {
+        if (timeoutRef.current) {
+          clearTimeout(timeoutRef.current)
+        }
+
+        navigator.clipboard
+          .writeText(makeServerUrl(urlForLobby(lobby.id, lobby.name)))
+          .catch(err => logger.error('Error writing to clipboard: ' + (err?.stack ?? err)))
+        setCopied(true)
+
+        timeoutRef.current = setTimeout(() => {
+          timeoutRef.current = undefined
+          setCopied(false)
+        }, 2000)
+      }}
+      testName='copy-invite-link-button'
+    />
+  )
+}
 
 function LobbyChatMessage({ message }: MessageComponentProps) {
   // Cast to just lobby messages so we can check for exhaustiveness, even though this won't
@@ -353,15 +400,26 @@ class LobbyComponent extends React.Component<LobbyProps & WithTranslation> {
           />
         </Left>
         <Info>
-          <FilledButton
-            label={t('lobbies.lobby.leaveLobby', 'Leave lobby')}
-            onClick={onLeaveLobbyClick}
-            testName='leave-lobby-button'
-          />
+          <InfoActions>
+            <FilledButton
+              label={t('lobbies.lobby.leaveLobby', 'Leave lobby')}
+              onClick={onLeaveLobbyClick}
+              testName='leave-lobby-button'
+            />
+            <CopyInviteLinkButton lobby={lobby} />
+          </InfoActions>
           <StyledMapThumbnail mapId={lobby.map!.id} showInfoLayer />
           <InfoItem>
             <InfoLabel as='span'>{t('lobbies.lobby.gameType', 'Game type')}</InfoLabel>
             <InfoValue as='span'>{gameTypeToLabel(lobby.gameType, t)}</InfoValue>
+          </InfoItem>
+          <InfoItem>
+            <InfoLabel as='span'>{t('lobbies.lobby.visibility', 'Visibility')}</InfoLabel>
+            <InfoValue as='span'>
+              {lobby.visibility === 'unlisted'
+                ? t('lobbies.lobby.visibilityUnlisted', 'Unlisted')
+                : t('lobbies.lobby.visibilityListed', 'Public')}
+            </InfoValue>
           </InfoItem>
           <InfoItem>
             <InfoLabel as='span'>{t('lobbies.lobby.unitLimit', 'Unit limit')}</InfoLabel>

--- a/client/lobbies/lobby.tsx
+++ b/client/lobbies/lobby.tsx
@@ -26,7 +26,7 @@ import { Chat } from '../messaging/chat'
 import { MessageComponentProps } from '../messaging/message-list'
 import { SbMessage } from '../messaging/message-records'
 import { useLinkCopier } from '../navigation/copy-link-button'
-import { makeServerUrl } from '../network/server-url'
+import { getServerOrigin } from '../network/server-url'
 import { headlineMedium, labelLarge, labelMedium } from '../styles/typography'
 import { ClosedSlot } from './closed-slot'
 import { LobbyUserMenu } from './lobby-menu-items'
@@ -139,7 +139,9 @@ const Countdown = styled.div`
  */
 function CopyInviteLinkButton({ lobby }: { lobby: Lobby }) {
   const { t } = useTranslation()
-  const [copied, copyLink] = useLinkCopier(() => makeServerUrl(urlForLobby(lobby.id, lobby.name)))
+  const [copied, copyLink] = useLinkCopier(
+    () => getServerOrigin() + urlForLobby(lobby.id, lobby.name),
+  )
 
   return (
     <TextButton

--- a/client/lobbies/lobby.tsx
+++ b/client/lobbies/lobby.tsx
@@ -1,5 +1,5 @@
 import { List } from 'immutable'
-import React, { useRef, useState } from 'react'
+import React from 'react'
 import { useTranslation, WithTranslation, withTranslation } from 'react-i18next'
 import styled from 'styled-components'
 import { ReadonlyDeep } from 'type-fest'
@@ -18,7 +18,6 @@ import { Slot, SlotType } from '../../common/lobbies/slot'
 import { RaceChar } from '../../common/races'
 import { SelfUserJson } from '../../common/users/sb-user'
 import { MaterialIcon } from '../icons/material/material-icon'
-import logger from '../logging/logger'
 import { ReduxMapThumbnail } from '../maps/map-thumbnail'
 import { FilledButton, TextButton } from '../material/button'
 import { Card } from '../material/card'
@@ -26,6 +25,7 @@ import { elevationPlus1 } from '../material/shadows'
 import { Chat } from '../messaging/chat'
 import { MessageComponentProps } from '../messaging/message-list'
 import { SbMessage } from '../messaging/message-records'
+import { useLinkCopier } from '../navigation/copy-link-button'
 import { makeServerUrl } from '../network/server-url'
 import { headlineMedium, labelLarge, labelMedium } from '../styles/typography'
 import { ClosedSlot } from './closed-slot'
@@ -139,8 +139,7 @@ const Countdown = styled.div`
  */
 function CopyInviteLinkButton({ lobby }: { lobby: Lobby }) {
   const { t } = useTranslation()
-  const [copied, setCopied] = useState(false)
-  const timeoutRef = useRef<ReturnType<typeof setTimeout>>(undefined)
+  const [copied, copyLink] = useLinkCopier(() => makeServerUrl(urlForLobby(lobby.id, lobby.name)))
 
   return (
     <TextButton
@@ -150,21 +149,7 @@ function CopyInviteLinkButton({ lobby }: { lobby: Lobby }) {
           : t('lobbies.lobby.copyInviteLink', 'Copy invite link')
       }
       iconStart={<MaterialIcon icon='link' />}
-      onClick={() => {
-        if (timeoutRef.current) {
-          clearTimeout(timeoutRef.current)
-        }
-
-        navigator.clipboard
-          .writeText(makeServerUrl(urlForLobby(lobby.id, lobby.name)))
-          .catch(err => logger.error('Error writing to clipboard: ' + (err?.stack ?? err)))
-        setCopied(true)
-
-        timeoutRef.current = setTimeout(() => {
-          timeoutRef.current = undefined
-          setCopied(false)
-        }, 2000)
-      }}
+      onClick={copyLink}
       testName='copy-invite-link-button'
     />
   )

--- a/client/navigation/copy-link-button.tsx
+++ b/client/navigation/copy-link-button.tsx
@@ -6,7 +6,6 @@ import logger from '../logging/logger'
 import { IconButton } from '../material/button'
 import { Tooltip, TooltipPosition } from '../material/tooltip'
 import { makeServerUrl } from '../network/server-url'
-import { useStableCallback } from '../react/state-hooks'
 
 const StyledIconButton = styled(IconButton)`
   color: var(--theme-on-surface-variant);
@@ -24,6 +23,34 @@ function getCurrentUrl() {
   }
 }
 
+/**
+ * Shared clipboard-write behavior for "copy link" style buttons: writes the URL returned by
+ * `getUrl` to the clipboard and reports `copied` as true for 2 seconds afterward, so callers can
+ * swap in "Copied!" style feedback.
+ */
+export function useLinkCopier(getUrl: () => string): [copied: boolean, copyLink: () => void] {
+  const [copied, setCopied] = useState(false)
+  const timeoutRef = useRef<ReturnType<typeof setTimeout>>(undefined)
+
+  function copyLink() {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current)
+    }
+
+    navigator.clipboard
+      .writeText(getUrl())
+      .catch(err => logger.error('Error writing to clipboard: ' + (err?.stack ?? err)))
+    setCopied(true)
+
+    timeoutRef.current = setTimeout(() => {
+      timeoutRef.current = undefined
+      setCopied(false)
+    }, 2000)
+  }
+
+  return [copied, copyLink]
+}
+
 export interface CopyLinkButtonProps {
   className?: string
   tooltipPosition?: TooltipPosition
@@ -37,31 +64,14 @@ export function CopyLinkButton({
   startingText = i18n.t('navigation.copyLink.defaultText', 'Copy link'),
   copiedText = i18n.t('navigation.copyLink.copiedText', 'Copied!'),
 }: CopyLinkButtonProps) {
-  const [text, setText] = useState(startingText)
-  const timeoutRef = useRef<ReturnType<typeof setTimeout>>(undefined)
-
-  const onClick = useStableCallback(() => {
-    if (timeoutRef.current) {
-      clearTimeout(timeoutRef.current)
-    }
-
-    navigator.clipboard
-      .writeText(getCurrentUrl())
-      .catch(err => logger.error('Error writing to clipboard: ' + (err?.stack ?? err)))
-    setText(copiedText)
-
-    timeoutRef.current = setTimeout(() => {
-      timeoutRef.current = undefined
-      setText(startingText)
-    }, 2000)
-  })
+  const [copied, copyLink] = useLinkCopier(getCurrentUrl)
 
   return (
-    <Tooltip text={text} position={tooltipPosition}>
+    <Tooltip text={copied ? copiedText : startingText} position={tooltipPosition}>
       <StyledIconButton
         className={className}
         icon={<MaterialIcon icon='link' />}
-        onClick={onClick}
+        onClick={copyLink}
       />
     </Tooltip>
   )

--- a/common/lobbies/index.ts
+++ b/common/lobbies/index.ts
@@ -15,6 +15,14 @@ export const MAX_OBSERVERS = 4
 /** States that a lobby can be in. These are the possible return values of `getLobbyState`. */
 export type LobbyState = 'nonexistent' | 'exists' | 'countingDown' | 'hasStarted'
 
+/**
+ * How discoverable a lobby is. `listed` lobbies are published on the public lobby list; `unlisted`
+ * ones never are, so they can only be reached by someone who has been given their id.
+ */
+export type LobbyVisibility = 'listed' | 'unlisted'
+
+export const ALL_LOBBY_VISIBILITIES: ReadonlyArray<LobbyVisibility> = ['listed', 'unlisted']
+
 export class Team extends Record({
   name: '',
   teamId: 0,
@@ -40,6 +48,7 @@ export class Lobby extends Record({
   teams: List<Team>(),
   host: new Slot(),
   useLegacyLimits: false,
+  visibility: 'listed' as LobbyVisibility,
 }) {}
 
 export function isUms(gameType: GameType): gameType is GameType.UseMapSettings {

--- a/migrations/20260729120000_add_lobby_preferences_visibility_observers.sql
+++ b/migrations/20260729120000_add_lobby_preferences_visibility_observers.sql
@@ -1,0 +1,9 @@
+-- Remembers the create-lobby form's visibility ('listed'/'unlisted') and observer toggle, so a host
+-- gets their last-used settings back instead of the defaults on every visit.
+--
+-- Both nullable with no default: an absent value means the user has never touched the control, and
+-- the client applies its own default ('listed' / observers allowed).
+
+ALTER TABLE lobby_preferences
+  ADD COLUMN visibility text CHECK (visibility IN ('listed', 'unlisted')),
+  ADD COLUMN allow_observers boolean;

--- a/server/lib/api/lobbyPreferences.js
+++ b/server/lib/api/lobbyPreferences.js
@@ -31,7 +31,16 @@ export default function (router) {
 }
 
 async function upsertPreferences(ctx, next) {
-  const { name, gameType, gameSubType, recentMaps, selectedMap, useLegacyLimits } = ctx.request.body
+  const {
+    name,
+    gameType,
+    gameSubType,
+    recentMaps,
+    selectedMap,
+    useLegacyLimits,
+    visibility,
+    allowObservers,
+  } = ctx.request.body
 
   if (name && !isValidLobbyName(name)) {
     throw new httpErrors.BadRequest('invalid lobby name')
@@ -45,6 +54,10 @@ async function upsertPreferences(ctx, next) {
     throw new httpErrors.BadRequest('invalid selected map')
   } else if (useLegacyLimits && typeof useLegacyLimits !== 'boolean') {
     throw new httpErrors.BadRequest('invalid use legacy limits')
+  } else if (visibility !== undefined && visibility !== 'listed' && visibility !== 'unlisted') {
+    throw new httpErrors.BadRequest('invalid visibility')
+  } else if (allowObservers !== undefined && typeof allowObservers !== 'boolean') {
+    throw new httpErrors.BadRequest('invalid allow observers')
   }
 
   const preferences = await upsertLobbyPreferences(ctx.session.user.id, {
@@ -54,6 +67,8 @@ async function upsertPreferences(ctx, next) {
     recentMaps: recentMaps.slice(0, 5),
     selectedMap,
     useLegacyLimits,
+    visibility,
+    allowObservers,
   })
   const recentMapInfos = await getMapInfos(preferences.recentMaps)
   ctx.body = {

--- a/server/lib/api/lobbyPreferences.js
+++ b/server/lib/api/lobbyPreferences.js
@@ -1,6 +1,7 @@
 import httpErrors from 'http-errors'
 import { isValidLobbyName } from '../../../common/constants'
 import { isValidGameSubType, isValidGameType } from '../../../common/games/game-type'
+import { ALL_LOBBY_VISIBILITIES } from '../../../common/lobbies'
 import { toMapInfoJson } from '../../../common/maps'
 import { getLobbyPreferences, upsertLobbyPreferences } from '../lobbies/lobby-preferences-models'
 import { getMapInfos } from '../maps/map-models'
@@ -54,7 +55,7 @@ async function upsertPreferences(ctx, next) {
     throw new httpErrors.BadRequest('invalid selected map')
   } else if (useLegacyLimits && typeof useLegacyLimits !== 'boolean') {
     throw new httpErrors.BadRequest('invalid use legacy limits')
-  } else if (visibility !== undefined && visibility !== 'listed' && visibility !== 'unlisted') {
+  } else if (visibility !== undefined && !ALL_LOBBY_VISIBILITIES.includes(visibility)) {
     throw new httpErrors.BadRequest('invalid visibility')
   } else if (allowObservers !== undefined && typeof allowObservers !== 'boolean') {
     throw new httpErrors.BadRequest('invalid allow observers')

--- a/server/lib/lobbies/lobby-preferences-models.ts
+++ b/server/lib/lobbies/lobby-preferences-models.ts
@@ -1,4 +1,5 @@
 import { ReadonlyDeep } from 'type-fest'
+import { LobbyVisibility } from '../../../common/lobbies'
 import { SbUserId } from '../../../common/users/sb-user-id'
 import db from '../db'
 import { sql } from '../db/sql'
@@ -12,6 +13,8 @@ export interface LobbyPreferences {
   recentMaps?: string[]
   selectedMap?: string
   useLegacyLimits?: boolean
+  visibility?: LobbyVisibility
+  allowObservers?: boolean
 }
 
 type DbLobbyPreferences = Dbify<LobbyPreferences>
@@ -25,6 +28,8 @@ function fromDbLobbyPreferences(prefs: DbLobbyPreferences): LobbyPreferences {
     recentMaps: prefs.recent_maps !== null ? prefs.recent_maps : undefined,
     selectedMap: prefs.selected_map !== null ? prefs.selected_map : undefined,
     useLegacyLimits: prefs.use_legacy_limits !== null ? prefs.use_legacy_limits : undefined,
+    visibility: prefs.visibility !== null ? prefs.visibility : undefined,
+    allowObservers: prefs.allow_observers !== null ? prefs.allow_observers : undefined,
   }
 }
 
@@ -37,6 +42,8 @@ export async function upsertLobbyPreferences(
     recentMaps,
     selectedMap,
     useLegacyLimits,
+    visibility,
+    allowObservers,
   }: ReadonlyDeep<LobbyPreferences>,
 ): Promise<LobbyPreferences> {
   const { client, done } = await db()
@@ -44,9 +51,10 @@ export async function upsertLobbyPreferences(
   try {
     const result = await client.query<DbLobbyPreferences>(sql`
       INSERT INTO lobby_preferences
-        (user_id, name, game_type, game_sub_type, recent_maps, selected_map, use_legacy_limits)
+        (user_id, name, game_type, game_sub_type, recent_maps, selected_map, use_legacy_limits,
+          visibility, allow_observers)
       VALUES (${userId}, ${name}, ${gameType}, ${gameSubType}, ${recentMaps}, ${selectedMap},
-        ${useLegacyLimits})
+        ${useLegacyLimits}, ${visibility}, ${allowObservers})
       ON CONFLICT (user_id)
       DO UPDATE SET
         name = ${name},
@@ -54,7 +62,9 @@ export async function upsertLobbyPreferences(
         game_sub_type = ${gameSubType},
         recent_maps = ${recentMaps},
         selected_map = ${selectedMap},
-        use_legacy_limits = ${useLegacyLimits}
+        use_legacy_limits = ${useLegacyLimits},
+        visibility = ${visibility},
+        allow_observers = ${allowObservers}
       WHERE lobby_preferences.user_id = ${userId}
       RETURNING *;
     `)

--- a/server/lib/lobbies/lobby.test.ts
+++ b/server/lib/lobbies/lobby.test.ts
@@ -153,6 +153,43 @@ describe('Lobbies - melee', () => {
     expect(BOXER_LOBBY.host.region).toBeUndefined()
   })
 
+  test('defaults to being listed publicly', () => {
+    expect(BOXER_LOBBY.visibility).toBe('listed')
+  })
+
+  test('keeps a requested unlisted visibility', () => {
+    const lobby = createLobby({
+      name: 'Secret Squirrel',
+      map: BigGameHunters,
+      gameType: GameType.Melee,
+      gameSubType: 0,
+      numSlots: 4,
+      hostUserId: HOST_USER_ID,
+      allowObservers: false,
+      visibility: 'unlisted',
+    })
+
+    expect(lobby.visibility).toBe('unlisted')
+  })
+
+  test('leaves visibility out of the summarized JSON', () => {
+    // Summaries only ever describe listed lobbies, so nothing downstream should be able to key off
+    // a visibility that is always the same value.
+    const unlisted = createLobby({
+      name: 'Secret Squirrel',
+      map: BigGameHunters,
+      gameType: GameType.Melee,
+      gameSubType: 0,
+      numSlots: 4,
+      hostUserId: HOST_USER_ID,
+      allowObservers: false,
+      visibility: 'unlisted',
+    })
+
+    expect(toSummaryJson(BOXER_LOBBY)).not.toHaveProperty('visibility')
+    expect(toSummaryJson(unlisted)).not.toHaveProperty('visibility')
+  })
+
   test('should find available slot', () => {
     const [t1, s1] = findAvailableSlot(BOXER_LOBBY)
     expect(t1).toBe(0)

--- a/server/lib/lobbies/lobby.ts
+++ b/server/lib/lobbies/lobby.ts
@@ -4,6 +4,7 @@ import { GameServerRegionId } from '../../../common/game-server-regions'
 import { GameType, isTeamType } from '../../../common/games/game-type'
 import {
   Lobby,
+  LobbyVisibility,
   MAX_OBSERVERS,
   Team,
   canAddObservers,
@@ -233,6 +234,7 @@ export function createLobby({
   hostRegion,
   allowObservers,
   useLegacyLimits = false,
+  visibility = 'listed',
 }: {
   name: string
   map: MapInfo
@@ -245,6 +247,7 @@ export function createLobby({
   hostRegion?: GameServerRegionId
   allowObservers: boolean
   useLegacyLimits?: boolean
+  visibility?: LobbyVisibility
 }) {
   let teams = createInitialTeams(map, gameType, gameSubType, numSlots)
   if (gameType === GameType.Melee && allowObservers) {
@@ -272,6 +275,7 @@ export function createLobby({
     teams,
     host: new Slot(),
     useLegacyLimits,
+    visibility,
   })
   let host
   const [hostTeamIndex, hostSlotIndex, hostSlot] = getLobbySlotsWithIndexes(lobby)

--- a/server/lib/wsapi/lobbies.test.ts
+++ b/server/lib/wsapi/lobbies.test.ts
@@ -255,6 +255,32 @@ describe('wsapi/lobbies/visibility', () => {
     expect(listPublishes()).toEqual([])
   })
 
+  test('joining an unlisted lobby does not publish an update to the list', async () => {
+    const { id } = await createLobby(host, 'Unlisted lobby', 'unlisted')
+    fakeNydus.publish.mockClear()
+
+    await lobbyApi.join(apiData(joiner, { id }), NOOP_NEXT)
+
+    // The occupants still see the new player; only the public list is kept in the dark.
+    expect(
+      fakeNydus.publish.mock.calls.some(
+        ([path, data]) => path === `/lobbies/${id}` && data?.type === 'diff',
+      ),
+    ).toBe(true)
+    expect(listPublishes()).toEqual([])
+  })
+
+  test('joining a listed lobby publishes an update to the list', async () => {
+    const { id } = await createLobby(host, 'Listed lobby', 'listed')
+    fakeNydus.publish.mockClear()
+
+    await lobbyApi.join(apiData(joiner, { id }), NOOP_NEXT)
+
+    expect(listPublishes()).toEqual([
+      { action: 'update', payload: expect.objectContaining({ name: 'Listed lobby' }) },
+    ])
+  })
+
   test('creating a listed lobby with a name matching an existing listed lobby fails', async () => {
     await createLobby(host, 'Duplicate name', 'listed')
 

--- a/server/lib/wsapi/lobbies.test.ts
+++ b/server/lib/wsapi/lobbies.test.ts
@@ -1,6 +1,32 @@
-import { describe, expect, test } from 'vitest'
+import { Map as IMap } from 'immutable'
+import { NydusServer } from 'nydus'
+import { container } from 'tsyringe'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { GameServerRegion, makeGameServerRegionId } from '../../../common/game-server-regions'
-import { knownRegionOrUndefined } from './lobbies'
+import { GameType } from '../../../common/games/game-type'
+import { LobbySummaryJson } from '../../../common/lobbies/lobby-network'
+import { makeSbMapId, MapInfo, MapVisibility, Tileset } from '../../../common/maps'
+import { asMockedFunction } from '../../../common/testing/mocks'
+import { SbUser } from '../../../common/users/sb-user'
+import { makeSbUserId } from '../../../common/users/sb-user-id'
+import { GameServerRegionsService } from '../game-server-regions/game-server-regions-service'
+import { GameLoader } from '../games/game-loader'
+import { GameplayActivityRegistry } from '../games/gameplay-activity-registry'
+import { getMapInfos } from '../maps/map-models'
+import { reparseMapsAsNeeded } from '../maps/map-operations'
+import { NetcodeV2Service } from '../netcode-v2/netcode-v2-service'
+import { RestrictionService } from '../users/restriction-service'
+import { findUsersById } from '../users/user-model'
+import { RequestSessionLookup } from '../websockets/session-lookup'
+import { ClientSocketsManager, UserSocketsManager } from '../websockets/socket-groups'
+import {
+  clearTestLogs,
+  createFakeNydusServer,
+  FakeNydusServer,
+  InspectableNydusClient,
+  NydusConnector,
+} from '../websockets/testing/websockets'
+import { knownRegionOrUndefined, LobbyApi } from './lobbies'
 
 function region(id: string): GameServerRegion {
   return {
@@ -32,5 +58,200 @@ describe('wsapi/lobbies/knownRegionOrUndefined', () => {
 
   test('drops any region when the live list is empty', () => {
     expect(knownRegionOrUndefined(makeGameServerRegionId('us-east'), [])).toBeUndefined()
+  })
+})
+
+const BIG_GAME_HUNTERS: MapInfo = {
+  id: makeSbMapId('big-game-hunters'),
+  hash: 'deadbeef',
+  name: 'Big Game Hunters',
+  description: '',
+  uploadedBy: makeSbUserId(1),
+  uploadDate: new Date(0),
+  visibility: MapVisibility.Official,
+  mapData: {
+    format: 'scm',
+    tileset: Tileset.Jungle,
+    originalName: 'Big Game Hunters',
+    originalDescription: '',
+    slots: 8,
+    umsSlots: 8,
+    umsForces: [{ name: 'team', teamId: 0, players: [] }],
+    width: 256,
+    height: 256,
+    isEud: false,
+    parserVersion: 1,
+  },
+  imageVersion: 1,
+}
+
+vi.mock('../maps/map-models', async () => {
+  const actual = await vi.importActual<typeof import('../maps/map-models')>('../maps/map-models')
+  return { ...actual, getMapInfos: vi.fn() }
+})
+vi.mock('../maps/map-operations', async () => {
+  const actual =
+    await vi.importActual<typeof import('../maps/map-operations')>('../maps/map-operations')
+  return { ...actual, reparseMapsAsNeeded: vi.fn() }
+})
+vi.mock('../users/user-model', async () => {
+  const actual = await vi.importActual<typeof import('../users/user-model')>('../users/user-model')
+  return { ...actual, findUsersById: vi.fn() }
+})
+
+const HOST_USER: SbUser = { id: makeSbUserId(1), name: 'HostUser' } as SbUser
+const JOINER_USER: SbUser = { id: makeSbUserId(2), name: 'JoinerUser' } as SbUser
+const OTHER_HOST_USER: SbUser = { id: makeSbUserId(3), name: 'OtherHostUser' } as SbUser
+const LISTER_USER: SbUser = { id: makeSbUserId(4), name: 'ListerUser' } as SbUser
+
+const NOOP_NEXT = async () => {}
+
+describe('wsapi/lobbies/visibility', () => {
+  let nydus: NydusServer
+  let fakeNydus: FakeNydusServer
+  let lobbyApi: LobbyApi
+  let connector: NydusConnector
+
+  let host: InspectableNydusClient
+  let joiner: InspectableNydusClient
+  let otherHost: InspectableNydusClient
+  let lister: InspectableNydusClient
+
+  function apiData(client: InspectableNydusClient, body: Record<string, any> = {}) {
+    return IMap<string, any>({ client, body })
+  }
+
+  /** Returns the data published on the public lobby list channel, in order. */
+  function listPublishes(): Array<{ action: string; payload: any }> {
+    return fakeNydus.publish.mock.calls
+      .filter(([path]) => path === '/lobbies')
+      .map(([, data]) => data)
+  }
+
+  /** Returns the most recently published open-lobby count, or undefined if none was published. */
+  function latestLobbiesCount(): number | undefined {
+    const counts = fakeNydus.publish.mock.calls.filter(([path]) => path === '/lobbiesCount')
+    return counts.length ? counts[counts.length - 1][1].count : undefined
+  }
+
+  async function createLobby(
+    client: InspectableNydusClient,
+    name: string,
+    visibility?: 'listed' | 'unlisted',
+  ) {
+    return (await lobbyApi.create(
+      apiData(client, {
+        name,
+        map: BIG_GAME_HUNTERS.id,
+        gameType: GameType.Melee,
+        visibility,
+      }),
+      NOOP_NEXT,
+    )) as { id: string }
+  }
+
+  beforeEach(() => {
+    container.registerInstance(GameplayActivityRegistry, new GameplayActivityRegistry())
+    container.registerInstance(GameLoader, {} as unknown as GameLoader)
+    container.registerInstance(RestrictionService, {
+      isRestricted: async () => false,
+    } as unknown as RestrictionService)
+    container.registerInstance(GameServerRegionsService, {
+      getRegions: async () => [],
+    } as unknown as GameServerRegionsService)
+    container.registerInstance(NetcodeV2Service, {
+      warmRegions: () => {},
+    } as unknown as NetcodeV2Service)
+
+    nydus = createFakeNydusServer()
+    fakeNydus = nydus as unknown as FakeNydusServer
+    const sessionLookup = new RequestSessionLookup()
+    const clientSockets = new ClientSocketsManager(nydus, sessionLookup)
+    const userSockets = new UserSocketsManager(nydus, sessionLookup, async () => {})
+    lobbyApi = new LobbyApi(nydus, userSockets, clientSockets)
+    connector = new NydusConnector(nydus, sessionLookup)
+
+    asMockedFunction(getMapInfos).mockResolvedValue([BIG_GAME_HUNTERS])
+    asMockedFunction(reparseMapsAsNeeded).mockResolvedValue([BIG_GAME_HUNTERS])
+    asMockedFunction(findUsersById).mockResolvedValue([])
+
+    host = connector.connectClient(HOST_USER, 'HOST_CLIENT')
+    joiner = connector.connectClient(JOINER_USER, 'JOINER_CLIENT')
+    otherHost = connector.connectClient(OTHER_HOST_USER, 'OTHER_HOST_CLIENT')
+    lister = connector.connectClient(LISTER_USER, 'LISTER_CLIENT')
+
+    clearTestLogs(nydus)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  test('creating a listed lobby publishes it to the list and counts it', async () => {
+    await createLobby(host, 'Listed lobby', 'listed')
+
+    expect(listPublishes()).toEqual([
+      { action: 'add', payload: expect.objectContaining({ name: 'Listed lobby' }) },
+    ])
+    expect(latestLobbiesCount()).toBe(1)
+  })
+
+  test('creating an unlisted lobby publishes nothing to the list and is not counted', async () => {
+    await createLobby(host, 'Unlisted lobby', 'unlisted')
+
+    expect(listPublishes()).toEqual([])
+    expect(latestLobbiesCount()).toBe(0)
+  })
+
+  test("a new subscriber's initial snapshot omits unlisted lobbies", async () => {
+    await createLobby(host, 'Unlisted lobby', 'unlisted')
+    await createLobby(otherHost, 'Listed lobby', 'listed')
+
+    await lobbyApi.subscribe(apiData(lister), NOOP_NEXT)
+
+    const subscribeCall = fakeNydus.subscribeClient.mock.calls.find(
+      ([, path]) => path === '/lobbies',
+    )
+    const initialData = subscribeCall![2] as { action: string; payload: Iterable<LobbySummaryJson> }
+    expect(initialData.action).toBe('full')
+    expect(Array.from(initialData.payload).map(l => l.name)).toEqual(['Listed lobby'])
+  })
+
+  test('closing an unlisted lobby does not publish its id to the list', async () => {
+    await createLobby(host, 'Unlisted lobby', 'unlisted')
+    fakeNydus.publish.mockClear()
+
+    // The host is the only occupant, so leaving deletes the lobby.
+    await lobbyApi.leave(apiData(host), NOOP_NEXT)
+
+    expect(listPublishes()).toEqual([])
+  })
+
+  test('closing a listed lobby publishes its id to the list', async () => {
+    const { id } = await createLobby(host, 'Listed lobby', 'listed')
+    fakeNydus.publish.mockClear()
+
+    await lobbyApi.leave(apiData(host), NOOP_NEXT)
+
+    expect(listPublishes()).toEqual([{ action: 'delete', payload: id }])
+  })
+
+  test('starting the countdown in an unlisted lobby does not publish its id to the list', async () => {
+    const { id } = await createLobby(host, 'Unlisted lobby', 'unlisted')
+    await lobbyApi.join(apiData(joiner, { id }), NOOP_NEXT)
+    fakeNydus.publish.mockClear()
+
+    // Keeps the countdown from ever elapsing, so the test doesn't leave a game load in flight. The
+    // handler publishes everything we care about before it suspends on the timer.
+    vi.useFakeTimers()
+    lobbyApi.startCountdown(apiData(host), NOOP_NEXT).catch(() => {})
+
+    // The occupants still see the countdown; only the public list is kept in the dark.
+    expect(
+      fakeNydus.publish.mock.calls.some(
+        ([path, data]) => path === `/lobbies/${id}` && data?.type === 'startCountdown',
+      ),
+    ).toBe(true)
+    expect(listPublishes()).toEqual([])
   })
 })

--- a/server/lib/wsapi/lobbies.test.ts
+++ b/server/lib/wsapi/lobbies.test.ts
@@ -4,7 +4,7 @@ import { container } from 'tsyringe'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { GameServerRegion, makeGameServerRegionId } from '../../../common/game-server-regions'
 import { GameType } from '../../../common/games/game-type'
-import { LobbySummaryJson } from '../../../common/lobbies/lobby-network'
+import { LobbyCreateErrorCode, LobbySummaryJson } from '../../../common/lobbies/lobby-network'
 import { makeSbMapId, MapInfo, MapVisibility, Tileset } from '../../../common/maps'
 import { asMockedFunction } from '../../../common/testing/mocks'
 import { SbUser } from '../../../common/users/sb-user'
@@ -253,5 +253,25 @@ describe('wsapi/lobbies/visibility', () => {
       ),
     ).toBe(true)
     expect(listPublishes()).toEqual([])
+  })
+
+  test('creating a listed lobby with a name matching an existing listed lobby fails', async () => {
+    await createLobby(host, 'Duplicate name', 'listed')
+
+    await expect(createLobby(otherHost, 'Duplicate name', 'listed')).rejects.toMatchObject({
+      body: { code: LobbyCreateErrorCode.NameTaken },
+    })
+  })
+
+  test('creating a listed lobby with a name matching an existing unlisted lobby succeeds', async () => {
+    await createLobby(host, 'Duplicate name', 'unlisted')
+
+    await expect(createLobby(otherHost, 'Duplicate name', 'listed')).resolves.toBeDefined()
+  })
+
+  test('creating an unlisted lobby with a name matching an existing listed lobby succeeds', async () => {
+    await createLobby(host, 'Duplicate name', 'listed')
+
+    await expect(createLobby(otherHost, 'Duplicate name', 'unlisted')).resolves.toBeDefined()
   })
 })

--- a/server/lib/wsapi/lobbies.ts
+++ b/server/lib/wsapi/lobbies.ts
@@ -260,9 +260,17 @@ export class LobbyApi {
         numSlots = mapInfo.mapData.slots
     }
 
+    const lobbyVisibility = visibility ?? 'listed'
+
     // This check must not be separated from the inserts below by an await, or two in-flight
     // creates with the same name could both pass it.
-    if (this.lobbies.some(l => l.name === name)) {
+    // Name uniqueness only applies among listed lobbies: an unlisted lobby must never influence a
+    // publicly-observable outcome (a NameTaken error would reveal its existence), and names are
+    // display-only, so duplicates outside the public list are harmless.
+    if (
+      lobbyVisibility === 'listed' &&
+      this.lobbies.some(l => l.visibility === 'listed' && l.name === name)
+    ) {
       throw Object.assign(new errors.Conflict('already another lobby with that name'), {
         body: { code: LobbyCreateErrorCode.NameTaken },
       })
@@ -279,7 +287,7 @@ export class LobbyApi {
       hostRegion,
       allowObservers: allowObservers ?? false,
       useLegacyLimits,
-      visibility: visibility ?? 'listed',
+      visibility: lobbyVisibility,
     })
     if (!this.activityRegistry.registerActiveClient(user.userId, client)) {
       throw new errors.Conflict('user is already active in a gameplay activity')

--- a/server/lib/wsapi/lobbies.ts
+++ b/server/lib/wsapi/lobbies.ts
@@ -10,6 +10,7 @@ import { GameServerRegion, GameServerRegionId } from '../../../common/game-serve
 import { GameConfig, GameSource } from '../../../common/games/configuration'
 import { GameType, isValidGameSubType, isValidGameType } from '../../../common/games/game-type'
 import {
+  ALL_LOBBY_VISIBILITIES,
   findSlotById,
   findSlotByUserId,
   getHumanSlots,
@@ -20,12 +21,9 @@ import {
   hasOpposingSides,
   isUms,
   Lobby,
+  LobbyVisibility,
 } from '../../../common/lobbies'
-import {
-  LobbyCreateErrorCode,
-  LobbySlotCreateEvent,
-  LobbySummaryJson,
-} from '../../../common/lobbies/lobby-network'
+import { LobbyCreateErrorCode, LobbySlotCreateEvent } from '../../../common/lobbies/lobby-network'
 import { SbLobbyId } from '../../../common/lobbies/sb-lobby-id'
 import * as Slots from '../../../common/lobbies/slot'
 import { Slot } from '../../../common/lobbies/slot'
@@ -76,6 +74,8 @@ const isValidRttMs = (rttMs: unknown) =>
 const isValidNetcodeV2Pubkey = (pubkey: unknown) =>
   pubkey === undefined ||
   (typeof pubkey === 'string' && Buffer.from(pubkey, 'base64').length === 32)
+const isValidVisibility = (visibility: unknown) =>
+  visibility === undefined || ALL_LOBBY_VISIBILITIES.includes(visibility as LobbyVisibility)
 
 /**
  * Returns `region` only when it appears in `regions`, otherwise undefined. The region list can
@@ -152,7 +152,10 @@ export class LobbyApi {
       return
     }
 
-    const summary = this.lobbies.valueSeq().map(l => Lobbies.toSummaryJson(l))
+    const summary = this.lobbies
+      .valueSeq()
+      .filter(l => l.visibility === 'listed')
+      .map(l => Lobbies.toSummaryJson(l))
     this.nydus.subscribeClient(socket, MOUNT_BASE, { action: 'full', payload: summary })
 
     const onClose = () => {
@@ -194,7 +197,9 @@ export class LobbyApi {
       map: nonEmptyString,
       gameType: isValidGameType,
       gameSubType: isValidGameSubType,
+      allowObservers: (b: unknown) => b === undefined || b === true || b === false,
       useLegacyLimits: (b: unknown) => b === undefined || b === true || b === false,
+      visibility: isValidVisibility,
       region: isValidRegion,
       rttMs: isValidRttMs,
       clientPubkey: isValidNetcodeV2Pubkey,
@@ -208,6 +213,7 @@ export class LobbyApi {
       gameSubType,
       allowObservers,
       useLegacyLimits,
+      visibility,
       region,
       rttMs,
       clientPubkey,
@@ -218,6 +224,7 @@ export class LobbyApi {
       gameSubType?: number
       allowObservers?: boolean
       useLegacyLimits?: boolean
+      visibility?: LobbyVisibility
       region?: GameServerRegionId
       rttMs?: number
       clientPubkey?: string
@@ -272,6 +279,7 @@ export class LobbyApi {
       hostRegion,
       allowObservers: allowObservers ?? false,
       useLegacyLimits,
+      visibility: visibility ?? 'listed',
     })
     if (!this.activityRegistry.registerActiveClient(user.userId, client)) {
       throw new errors.Conflict('user is already active in a gameplay activity')
@@ -284,7 +292,7 @@ export class LobbyApi {
     }
     this._subscribeClientToLobby(lobby, user, client)
 
-    this._publishListChange('add', Lobbies.toSummaryJson(lobby))
+    this._publishListChange('add', lobby)
     this._warmLobbyRegions(lobby)
 
     return { id: lobby.id }
@@ -842,7 +850,7 @@ export class LobbyApi {
       this.lobbies = this.lobbies.delete(lobby.id)
       this.lobbyBannedUsers = this.lobbyBannedUsers.delete(lobby.id)
       this.lobbyPlayerNetwork.deleteLobby(lobby.id)
-      this._publishListChange('delete', lobby.id)
+      this._publishListChange('delete', lobby)
     } else {
       this.lobbies = this.lobbies.set(lobby.id, updatedLobby)
       this.lobbyPlayerNetwork.deleteUser(lobby.id, client.userId)
@@ -901,7 +909,7 @@ export class LobbyApi {
     )
 
     this._publishTo(lobby, { type: 'startCountdown' })
-    this._publishListChange('delete', lobby.id)
+    this._publishListChange('delete', lobby)
 
     const gameConfig: GameConfig = {
       gameType: lobby.gameType,
@@ -1012,7 +1020,7 @@ export class LobbyApi {
       usersAtFault,
     })
     if (!isLobbyEmpty) {
-      this._publishListChange('add', Lobbies.toSummaryJson(lobby))
+      this._publishListChange('add', lobby)
     }
   }
 
@@ -1052,7 +1060,7 @@ export class LobbyApi {
       type: 'cancelCountdown',
     })
     if (!isLobbyEmpty) {
-      this._publishListChange('add', Lobbies.toSummaryJson(lobby))
+      this._publishListChange('add', lobby)
     }
   }
 
@@ -1138,15 +1146,32 @@ export class LobbyApi {
 
   _getLobbiesCount() {
     // TODO(tec27): Ideally this would remove full lobbies?
-    return Math.max(this.lobbies.size - (this.lobbyCountdowns.size + this.loadingLobbies.size), 0)
+    return this.lobbies.count(
+      l =>
+        l.visibility === 'listed' &&
+        !this.lobbyCountdowns.has(l.id) &&
+        !this.loadingLobbies.has(l.id),
+    )
   }
 
   _publishLobbiesCount() {
     this.nydus.publish('/lobbiesCount', { count: this._getLobbiesCount() })
   }
 
-  _publishListChange(action: 'add' | 'delete' | 'update', summary: LobbySummaryJson | SbLobbyId) {
-    this.nydus.publish(MOUNT_BASE, { action, payload: summary })
+  /**
+   * Publishes a change to the public lobby list, and refreshes the open-lobby count for everyone.
+   *
+   * A lobby's id is the capability that lets someone join it, so nothing about an unlisted lobby
+   * (not even the bare id in a `delete`) may reach the public list channel. Every list publish must
+   * go through here so that filtering can't be forgotten at a callsite.
+   */
+  _publishListChange(action: 'add' | 'delete' | 'update', lobby: Lobby) {
+    if (lobby.visibility === 'listed') {
+      this.nydus.publish(MOUNT_BASE, {
+        action,
+        payload: action === 'delete' ? lobby.id : Lobbies.toSummaryJson(lobby),
+      })
+    }
     this._publishLobbiesCount()
   }
 
@@ -1296,7 +1321,7 @@ export class LobbyApi {
       })
     }
 
-    this._publishListChange('update', Lobbies.toSummaryJson(newLobby))
+    this._publishListChange('update', newLobby)
   }
 
   static _getPath(lobby: Lobby) {

--- a/server/public/locales/en/global.json
+++ b/server/public/locales/en/global.json
@@ -888,6 +888,7 @@
     },
     "createLobby": {
       "advancedSettings": "Advanced settings",
+      "allowObservers": "Allow observers",
       "backToList": "Back to list",
       "errorDialogTitle": "Error creating lobby",
       "errorGeneric": "Something went wrong while creating the lobby. Please try again.",
@@ -902,7 +903,12 @@
       "mapRequired": "Select a map to play",
       "selectMap": "Select map",
       "title": "Create lobby",
-      "useLegacyLimits": "Use legacy unit limit"
+      "useLegacyLimits": "Use legacy unit limit",
+      "visibility": "Visibility",
+      "visibilityListed": "Public",
+      "visibilityListedDescription": "Shown in the lobby list for anyone to join",
+      "visibilityUnlisted": "Unlisted",
+      "visibilityUnlistedDescription": "Only people you share the link with can join"
     },
     "errors": {
       "alreadyInLobby": "You're already in another lobby.",
@@ -923,12 +929,17 @@
       "title": "Join Lobby"
     },
     "lobby": {
+      "copiedInviteLink": "Copied!",
+      "copyInviteLink": "Copy invite link",
       "gameType": "Game type",
       "leaveLobby": "Leave lobby",
       "startGame": "Start game",
       "unitLimit": "Unit limit",
       "unitLimitExtended": "Extended",
-      "unitLimitLegacy": "Legacy"
+      "unitLimitLegacy": "Legacy",
+      "visibility": "Visibility",
+      "visibilityListed": "Public",
+      "visibilityUnlisted": "Unlisted"
     },
     "messageLayout": {
       "banPlayer": "<0><0></0></0> has been banned from the lobby",

--- a/server/public/locales/es/global.json
+++ b/server/public/locales/es/global.json
@@ -871,6 +871,7 @@
     },
     "createLobby": {
       "advancedSettings": "Ajustes avanzados",
+      "allowObservers": "Permitir observadores",
       "backToList": "Volver a la lista",
       "errorDialogTitle": "Error al crear el lobby",
       "errorGeneric": "Algo salió mal al crear el lobby. Intenta de nuevo.",
@@ -885,7 +886,12 @@
       "mapRequired": "Selecciona un mapa para jugar",
       "selectMap": "Seleccionar mapa",
       "title": "Crear lobby",
-      "useLegacyLimits": "Usar límite de unidad heredado"
+      "useLegacyLimits": "Usar límite de unidad heredado",
+      "visibility": "Visibilidad",
+      "visibilityListed": "Público",
+      "visibilityListedDescription": "Aparece en la lista de lobbies y cualquiera puede unirse",
+      "visibilityUnlisted": "No listado",
+      "visibilityUnlistedDescription": "Solo puede unirse quien tenga el enlace"
     },
     "errors": {
       "alreadyInLobby": "Ya estás en otro lobby.",
@@ -907,12 +913,17 @@
       "title": "Unirse al lobby"
     },
     "lobby": {
+      "copiedInviteLink": "¡Copiado!",
+      "copyInviteLink": "Copiar enlace de invitación",
       "gameType": "Tipo de juego",
       "leaveLobby": "Salir del lobby",
       "startGame": "Empezar juego",
       "unitLimit": "Límite de unidad",
       "unitLimitExtended": "Extendido",
-      "unitLimitLegacy": "Legado"
+      "unitLimitLegacy": "Legado",
+      "visibility": "Visibilidad",
+      "visibilityListed": "Público",
+      "visibilityUnlisted": "No listado"
     },
     "messageLayout": {
       "banPlayer": "<0><0></0></0> se prohibió del lobby",

--- a/server/public/locales/ko/global.json
+++ b/server/public/locales/ko/global.json
@@ -865,6 +865,7 @@
     },
     "createLobby": {
       "advancedSettings": "고급 설정",
+      "allowObservers": "관전자 허용",
       "backToList": "목록으로 돌아가기",
       "errorDialogTitle": "로비 생성 오류",
       "errorGeneric": "로비를 만드는 중 문제가 발생했습니다. 다시 시도해 주세요.",
@@ -879,7 +880,12 @@
       "mapRequired": "플레이할 맵을 선택해 주세요",
       "selectMap": "맵 선택",
       "title": "로비 만들기",
-      "useLegacyLimits": "옛 유닛 제한 사용"
+      "useLegacyLimits": "옛 유닛 제한 사용",
+      "visibility": "공개 범위",
+      "visibilityListed": "공개",
+      "visibilityListedDescription": "로비 목록에 표시되어 누구나 참여할 수 있습니다",
+      "visibilityUnlisted": "일부 공개",
+      "visibilityUnlistedDescription": "링크를 받은 사람만 참여할 수 있습니다"
     },
     "errors": {
       "alreadyInLobby": "이미 다른 로비에 참여 중입니다.",
@@ -899,12 +905,17 @@
       "title": "로비 참가"
     },
     "lobby": {
+      "copiedInviteLink": "복사되었습니다!",
+      "copyInviteLink": "초대 링크 복사",
       "gameType": "게임 방식",
       "leaveLobby": "로비 나가기",
       "startGame": "게임 시작",
       "unitLimit": "유닛 제한",
       "unitLimitExtended": "확장",
-      "unitLimitLegacy": "오리지널"
+      "unitLimitLegacy": "오리지널",
+      "visibility": "공개 범위",
+      "visibilityListed": "공개",
+      "visibilityUnlisted": "일부 공개"
     },
     "messageLayout": {
       "banPlayer": "<0><0></0></0>이(가) 로비에서 금지되었습니다",

--- a/server/public/locales/ru/global.json
+++ b/server/public/locales/ru/global.json
@@ -874,6 +874,7 @@
     },
     "createLobby": {
       "advancedSettings": "Расширенные настройки",
+      "allowObservers": "Разрешить зрителей",
       "backToList": "Обратно к списку",
       "errorDialogTitle": "Ошибка при создании лобби",
       "errorGeneric": "Что-то пошло не так при создании лобби. Пожалуйста, попробуйте ещё раз.",
@@ -888,7 +889,12 @@
       "mapRequired": "Выберите карту для игры",
       "selectMap": "Выберите карту",
       "title": "Создать лобби",
-      "useLegacyLimits": "Использовать классический лимит юнитов"
+      "useLegacyLimits": "Использовать классический лимит юнитов",
+      "visibility": "Видимость",
+      "visibilityListed": "Публичное",
+      "visibilityListedDescription": "Отображается в списке лобби, присоединиться может любой",
+      "visibilityUnlisted": "Доступ по ссылке",
+      "visibilityUnlistedDescription": "Присоединиться могут только те, у кого есть ссылка"
     },
     "errors": {
       "alreadyInLobby": "Вы уже находитесь в другом лобби.",
@@ -911,12 +917,17 @@
       "title": "Присоединиться к лобби"
     },
     "lobby": {
+      "copiedInviteLink": "Скопировано!",
+      "copyInviteLink": "Копировать ссылку-приглашение",
       "gameType": "Тип игры",
       "leaveLobby": "Выйти из лобби",
       "startGame": "Начать игру",
       "unitLimit": "Лимит единиц",
       "unitLimitExtended": "Расширенный",
-      "unitLimitLegacy": "Классический"
+      "unitLimitLegacy": "Классический",
+      "visibility": "Видимость",
+      "visibilityListed": "Публичное",
+      "visibilityUnlisted": "Доступ по ссылке"
     },
     "messageLayout": {
       "banPlayer": "<0><0></0></0> забанен в лобби",

--- a/server/public/locales/zh-Hans/global.json
+++ b/server/public/locales/zh-Hans/global.json
@@ -865,6 +865,7 @@
     },
     "createLobby": {
       "advancedSettings": "高级设置",
+      "allowObservers": "允许观战者",
       "backToList": "返回列表",
       "errorDialogTitle": "创建房间出错",
       "errorGeneric": "创建房间时出了点问题。请重试。",
@@ -879,7 +880,12 @@
       "mapRequired": "选择要玩的地图",
       "selectMap": "选择地图",
       "title": "创建房间",
-      "useLegacyLimits": "使用旧版单位数量限制"
+      "useLegacyLimits": "使用旧版单位数量限制",
+      "visibility": "可见性",
+      "visibilityListed": "公开",
+      "visibilityListedDescription": "显示在房间列表中，任何人都可以加入",
+      "visibilityUnlisted": "不公开列出",
+      "visibilityUnlistedDescription": "只有拿到链接的人才能加入"
     },
     "errors": {
       "alreadyInLobby": "您已经在另一个房间了。",
@@ -899,12 +905,17 @@
       "title": "加入房间"
     },
     "lobby": {
+      "copiedInviteLink": "已复制！",
+      "copyInviteLink": "复制邀请链接",
       "gameType": "游戏类型",
       "leaveLobby": "离开房间",
       "startGame": "开始游戏",
       "unitLimit": "单位数量限制",
       "unitLimitExtended": "扩展",
-      "unitLimitLegacy": "原版"
+      "unitLimitLegacy": "原版",
+      "visibility": "可见性",
+      "visibilityListed": "公开",
+      "visibilityUnlisted": "不公开列出"
     },
     "messageLayout": {
       "banPlayer": "<0><0></0></0>已被房间封禁",


### PR DESCRIPTION
Lobbies gain a visibility setting: **Public** (listed, as today) or **Unlisted**. Unlisted lobbies never reach the public lobby list or the open-lobby count — on any publish surface (create/close/countdown list diffs, the subscribe-time snapshot, and the count badge). They can only be joined by someone who has the lobby's id, so the random id from #1373 acts as the access capability. All list publishes now route through a single `_publishListChange(action, lobby)` chokepoint that takes the full lobby and filters unlisted ones, so a callsite can't forget to filter — even a bare id in a `delete` is treated as a capability and never published.

The lobby view gets a **"Copy invite link"** button (all lobbies, not just unlisted) that copies `https://<host>/lobbies/<id>/<slug>`.

The create form gets the visibility control plus an **"Allow observers"** checkbox — previously the client hardcoded observers on for every melee lobby. Both new settings persist in `lobby_preferences` (new nullable `visibility` + `allow_observers` columns; absent = client defaults).

`toSummaryJson` deliberately omits `visibility`: summaries only ever describe listed lobbies.

Tested:
- New wsapi test suite covering all four publish surfaces (create/close/countdown/snapshot + count), plus lobby-model tests for the visibility field
- Live 2-client verification: unlisted lobby absent from the other client's list and count badge, joinable via the pasted invite link, ban-free join flow intact; obs toggle on/off produces/omits the Observers team; preferences round-trip (form remembers last-used visibility + obs setting)