### PR TITLE
Remove the lobby name character restriction

### DIFF
--- a/client/lobbies/create-lobby.tsx
+++ b/client/lobbies/create-lobby.tsx
@@ -4,7 +4,7 @@ import React, { useEffect, useImperativeHandle, useMemo, useRef, useState } from
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 import { ReadonlyDeep } from 'type-fest'
-import { LOBBY_NAME_MAXLENGTH, LOBBY_NAME_PATTERN } from '../../common/constants'
+import { LOBBY_NAME_MAXLENGTH } from '../../common/constants'
 import { ALL_GAME_TYPES, GameType, gameTypeToLabel, isTeamType } from '../../common/games/game-type'
 import { LobbyCreateErrorCode } from '../../common/lobbies/lobby-network'
 import { SbLobbyId } from '../../common/lobbies/sb-lobby-id'
@@ -14,7 +14,7 @@ import { useTrackPageView } from '../analytics/analytics'
 import { openSimpleDialog } from '../dialogs/action-creators'
 import { useForm, useFormCallbacks, Validator } from '../forms/form-hook'
 import { SubmitOnEnter } from '../forms/submit-on-enter'
-import { composeValidators, maxLength, regex, required } from '../forms/validators'
+import { composeValidators, maxLength, required } from '../forms/validators'
 import { MaterialIcon } from '../icons/material/material-icon'
 import { BrowseLocalMaps } from '../maps/browse-local-maps'
 import { BrowseServerMaps } from '../maps/browse-server-maps'
@@ -103,9 +103,6 @@ interface CreateLobbyModel {
 const lobbyNameValidator = composeValidators(
   required(t => t('lobbies.createLobby.lobbyNameRequired', 'Enter a lobby name')),
   maxLength(LOBBY_NAME_MAXLENGTH),
-  regex(LOBBY_NAME_PATTERN, t =>
-    t('lobbies.createLobby.lobbyNameInvalidCharacters', 'Lobby name contains invalid characters'),
-  ),
 )
 const mapSelectionValidator: Validator<MapSelectionValue, CreateLobbyModel> = (
   value,

--- a/client/lobbies/lobby-url.test.ts
+++ b/client/lobbies/lobby-url.test.ts
@@ -36,6 +36,10 @@ describe('lobbies/lobby-url', () => {
       vi.doUnmock('slug')
       vi.resetModules()
     })
+
+    test('strips characters that are unsafe in a route param', () => {
+      expect(lobbySlug('100% @home ♥')).not.toMatch(/[%@]/)
+    })
   })
 
   describe('urlForLobby', () => {

--- a/common/constants.ts
+++ b/common/constants.ts
@@ -5,7 +5,6 @@ export const EMAIL_MINLENGTH = 3
 export const EMAIL_MAXLENGTH = 100
 
 export const LOBBY_NAME_MAXLENGTH = 50
-export const LOBBY_NAME_PATTERN = /^[^%@]+$/
 
 export const PASSWORD_MINLENGTH = 6
 

--- a/server/lib/wsapi/lobbies.ts
+++ b/server/lib/wsapi/lobbies.ts
@@ -5,7 +5,7 @@ import { container } from 'tsyringe'
 import { ReadonlyDeep } from 'type-fest'
 import createDeferred, { Deferred } from '../../../common/async/deferred'
 import swallowNonBuiltins from '../../../common/async/swallow-non-builtins'
-import { isValidLobbyName, LOBBY_NAME_PATTERN, validRace } from '../../../common/constants'
+import { isValidLobbyName, validRace } from '../../../common/constants'
 import { GameServerRegion, GameServerRegionId } from '../../../common/game-server-regions'
 import { GameConfig, GameSource } from '../../../common/games/configuration'
 import { GameType, isValidGameSubType, isValidGameType } from '../../../common/games/game-type'
@@ -226,10 +226,6 @@ export class LobbyApi {
     const client = this.getClient(data)
 
     const hostRegion = await this._resolveRegion(region)
-
-    if (!LOBBY_NAME_PATTERN.test(name)) {
-      throw new errors.BadRequest('lobby name contains invalid characters')
-    }
 
     let mapInfo = (await getMapInfos([map]))[0]
     if (!mapInfo) {

--- a/server/public/locales/en/global.json
+++ b/server/public/locales/en/global.json
@@ -897,7 +897,6 @@
       "gameSubTypeOptionTvB": "{{topSlots}} vs {{bottomSlots}}",
       "gameTypeHeader": "Game type",
       "lobbyName": "Lobby name",
-      "lobbyNameInvalidCharacters": "Lobby name contains invalid characters",
       "lobbyNameRequired": "Enter a lobby name",
       "mapRequired": "Select a map to play",
       "selectMap": "Select map",

--- a/server/public/locales/es/global.json
+++ b/server/public/locales/es/global.json
@@ -880,7 +880,6 @@
       "gameSubTypeOptionTvB": "{{topSlots}} contra {{bottomSlots}}",
       "gameTypeHeader": "Tipo de juego",
       "lobbyName": "Nombre del lobby",
-      "lobbyNameInvalidCharacters": "El nombre del lobby contiene caracteres no válidos",
       "lobbyNameRequired": "Ingrese un nombre de lobby",
       "mapRequired": "Selecciona un mapa para jugar",
       "selectMap": "Seleccionar mapa",

--- a/server/public/locales/ko/global.json
+++ b/server/public/locales/ko/global.json
@@ -874,7 +874,6 @@
       "gameSubTypeOptionTvB": "{{topSlots}} 대 {{bottomSlots}}",
       "gameTypeHeader": "게임 모드",
       "lobbyName": "로비 이름",
-      "lobbyNameInvalidCharacters": "로비 이름에 사용할 수 없는 문자가 포함되어 있어요",
       "lobbyNameRequired": "로비 이름을 입력해 주세요",
       "mapRequired": "플레이할 맵을 선택해 주세요",
       "selectMap": "맵 선택",

--- a/server/public/locales/ru/global.json
+++ b/server/public/locales/ru/global.json
@@ -883,7 +883,6 @@
       "gameSubTypeOptionTvB": "{{topSlots}} против {{bottomSlots}}",
       "gameTypeHeader": "Тип игры",
       "lobbyName": "Название лобби",
-      "lobbyNameInvalidCharacters": "Название лобби содержит недопустимые символы",
       "lobbyNameRequired": "Введите название лобби",
       "mapRequired": "Выберите карту для игры",
       "selectMap": "Выберите карту",

--- a/server/public/locales/zh-Hans/global.json
+++ b/server/public/locales/zh-Hans/global.json
@@ -874,7 +874,6 @@
       "gameSubTypeOptionTvB": "{{topSlots}}对{{bottomSlots}}",
       "gameTypeHeader": "游戏类型",
       "lobbyName": "房间名称",
-      "lobbyNameInvalidCharacters": "房间名称包含无效字符",
       "lobbyNameRequired": "输入房间名称",
       "mapRequired": "选择要玩的地图",
       "selectMap": "选择地图",


### PR DESCRIPTION
Lobby identity is a generated id (#1373), so names are display-only — they never appear in lookups or route params (URL slugs are derived and never decoded). The `%`/`@` denylist was only ever a workaround for wouter mis-decoding those characters in the old name-based route param (aa2ca80a5, #1114), so `LOBBY_NAME_PATTERN`, its client validator, the server-side create check, and the now-unused error string (removed from all five locale catalogs) can all go. Names remain limited to non-empty and 50 characters max.

Tested:
- Live-verified: created a lobby named `100% @home ♥` — it slugs to `100-home` and renders correctly everywhere (list, lobby view, URL)
