### PR TITLE
Give the game loader its own player type instead of lobby Slots

### DIFF
--- a/server/lib/games/game-loader.test.ts
+++ b/server/lib/games/game-loader.test.ts
@@ -366,15 +366,14 @@ describe('games/game-loader/GameLoader', () => {
     } as any)
 
     const request: GameLoadRequest = {
-      players: [player1.player, player2.player],
+      // p1 has a recorded rtt; p2 has none and must be sent without one.
+      players: [{ ...player1.player, rttMs: 42 }, player2.player],
       playerInfos: [player1.playerInfo, player2.playerInfo],
       mapId,
       gameConfig: lobbyConfig([
         [{ id: p1, race: 't', isComputer: false }],
         [{ id: p2, race: 'z', isComputer: false }],
       ]),
-      // p1 has a recorded rtt; p2 has none and must be sent without one.
-      rttMsByUserId: new Map([[p1, 42]]),
     }
 
     const resultPromise = gameLoader.loadGame(request)
@@ -419,16 +418,15 @@ describe('games/game-loader/GameLoader', () => {
     const pubkey1 = Buffer.alloc(32, 1).toString('base64')
     const pubkey2 = Buffer.alloc(32, 2).toString('base64')
     const request: GameLoadRequest = {
-      players: [player1.player, player2.player],
+      players: [
+        { ...player1.player, netcodeV2Pubkey: pubkey1 },
+        { ...player2.player, netcodeV2Pubkey: pubkey2 },
+      ],
       playerInfos: [player1.playerInfo, player2.playerInfo],
       mapId,
       gameConfig: lobbyConfig([
         [{ id: p1, race: 't', isComputer: false }],
         [{ id: p2, race: 'z', isComputer: false }],
-      ]),
-      netcodeV2PubkeyByUserId: new Map([
-        [p1, pubkey1],
-        [p2, pubkey2],
       ]),
     }
 

--- a/server/lib/games/game-loader.test.ts
+++ b/server/lib/games/game-loader.test.ts
@@ -4,7 +4,7 @@ import { makeGameServerRegionId } from '../../../common/game-server-regions'
 import { GameConfigPlayer, GameSource, LobbyGameConfig } from '../../../common/games/configuration'
 import { PlayerInfo } from '../../../common/games/game-launch-config'
 import { GameType } from '../../../common/games/game-type'
-import { createHuman, Slot, SlotType } from '../../../common/lobbies/slot'
+import { SlotType } from '../../../common/lobbies/slot'
 import { makeSbMapId, MapInfo, MapVisibility } from '../../../common/maps'
 import { BwUserLatency } from '../../../common/network'
 import { asMockedFunction } from '../../../common/testing/mocks'
@@ -13,7 +13,13 @@ import { makeSbUserId, SbUserId } from '../../../common/users/sb-user-id'
 import { getMapInfos } from '../maps/map-models'
 import { deleteUserRecordsForGame } from '../models/games-users'
 import { findUsersById } from '../users/user-model'
-import { BaseGameLoaderError, GameLoader, GameLoadErrorType, GameLoadRequest } from './game-loader'
+import {
+  BaseGameLoaderError,
+  GameLoader,
+  GameLoadErrorType,
+  GameLoadPlayer,
+  GameLoadRequest,
+} from './game-loader'
 import { deleteRecordForGame, updateGameConfig } from './game-models'
 import { registerGame } from './registration'
 
@@ -47,18 +53,17 @@ function lobbyConfig(teams: GameConfigPlayer[][]): LobbyGameConfig {
   }
 }
 
-function makePlayer(userId: SbUserId): { slot: Slot; playerInfo: PlayerInfo } {
-  const slot = createHuman(userId)
+function makePlayer(userId: SbUserId): { player: GameLoadPlayer; playerInfo: PlayerInfo } {
   return {
-    slot,
+    player: { userId, isObserver: false },
     playerInfo: {
-      id: slot.id,
+      id: `slot-${userId}`,
       userId,
-      race: slot.race,
-      playerId: slot.playerId,
+      race: 'r',
+      playerId: 0,
       teamId: 0,
       type: SlotType.Human,
-      typeId: slot.typeId,
+      typeId: 6,
     },
   }
 }
@@ -138,7 +143,7 @@ describe('games/game-loader/GameLoader', () => {
     )
   })
 
-  function registerActiveClients(players: Slot[]) {
+  function registerActiveClients(players: GameLoadPlayer[]) {
     activityRegistry.getClientForUser.mockImplementation((userId: SbUserId) =>
       players.some(p => p.userId === userId) ? makeClient(userId) : undefined,
     )
@@ -147,7 +152,7 @@ describe('games/game-loader/GameLoader', () => {
   test('fails immediately when a multi-human game loads and netcode v2 is not enabled', async () => {
     const player1 = makePlayer(p1)
     const player2 = makePlayer(p2)
-    registerActiveClients([player1.slot, player2.slot])
+    registerActiveClients([player1.player, player2.player])
     asMockedFunction(findUsersById).mockResolvedValue([makeUser(p1), makeUser(p2)])
     netcodeV2Service.isEnabled.mockReturnValue(false)
 
@@ -160,7 +165,7 @@ describe('games/game-loader/GameLoader', () => {
     } as any)
 
     const request: GameLoadRequest = {
-      players: [player1.slot, player2.slot],
+      players: [player1.player, player2.player],
       playerInfos: [player1.playerInfo, player2.playerInfo],
       mapId,
       gameConfig: lobbyConfig([
@@ -191,7 +196,7 @@ describe('games/game-loader/GameLoader', () => {
 
   test('loads a solo game without requiring netcode v2 to be enabled', async () => {
     const player1 = makePlayer(p1)
-    registerActiveClients([player1.slot])
+    registerActiveClients([player1.player])
     asMockedFunction(findUsersById).mockResolvedValue([makeUser(p1)])
     netcodeV2Service.isEnabled.mockReturnValue(false)
 
@@ -201,7 +206,7 @@ describe('games/game-loader/GameLoader', () => {
     } as any)
 
     const request: GameLoadRequest = {
-      players: [player1.slot],
+      players: [player1.player],
       playerInfos: [player1.playerInfo],
       mapId,
       gameConfig: lobbyConfig([[{ id: p1, race: 't', isComputer: false }]]),
@@ -238,7 +243,7 @@ describe('games/game-loader/GameLoader', () => {
   test('loads a multi-human game and persists useNetcodeV2 when netcode v2 is enabled', async () => {
     const player1 = makePlayer(p1)
     const player2 = makePlayer(p2)
-    registerActiveClients([player1.slot, player2.slot])
+    registerActiveClients([player1.player, player2.player])
     asMockedFunction(findUsersById).mockResolvedValue([makeUser(p1), makeUser(p2)])
     netcodeV2Service.isEnabled.mockReturnValue(true)
     netcodeV2Service.createSessionForGame.mockResolvedValue(
@@ -257,7 +262,7 @@ describe('games/game-loader/GameLoader', () => {
     } as any)
 
     const request: GameLoadRequest = {
-      players: [player1.slot, player2.slot],
+      players: [player1.player, player2.player],
       playerInfos: [player1.playerInfo, player2.playerInfo],
       mapId,
       gameConfig: lobbyConfig([
@@ -292,8 +297,8 @@ describe('games/game-loader/GameLoader', () => {
     const player1 = makePlayer(p1)
     const player2 = makePlayer(p2)
     // p1 joined with a region; p2 has none and must be sent region-less.
-    const slot1 = player1.slot.set('region', region)
-    registerActiveClients([slot1, player2.slot])
+    const player1WithRegion: GameLoadPlayer = { ...player1.player, region }
+    registerActiveClients([player1WithRegion, player2.player])
     asMockedFunction(findUsersById).mockResolvedValue([makeUser(p1), makeUser(p2)])
     netcodeV2Service.isEnabled.mockReturnValue(true)
     netcodeV2Service.createSessionForGame.mockResolvedValue(
@@ -312,7 +317,7 @@ describe('games/game-loader/GameLoader', () => {
     } as any)
 
     const request: GameLoadRequest = {
-      players: [slot1, player2.slot],
+      players: [player1WithRegion, player2.player],
       playerInfos: [player1.playerInfo, player2.playerInfo],
       mapId,
       gameConfig: lobbyConfig([
@@ -342,7 +347,7 @@ describe('games/game-loader/GameLoader', () => {
   test('threads each player measured rtt through to createSessionForGame', async () => {
     const player1 = makePlayer(p1)
     const player2 = makePlayer(p2)
-    registerActiveClients([player1.slot, player2.slot])
+    registerActiveClients([player1.player, player2.player])
     asMockedFunction(findUsersById).mockResolvedValue([makeUser(p1), makeUser(p2)])
     netcodeV2Service.isEnabled.mockReturnValue(true)
     netcodeV2Service.createSessionForGame.mockResolvedValue(
@@ -361,7 +366,7 @@ describe('games/game-loader/GameLoader', () => {
     } as any)
 
     const request: GameLoadRequest = {
-      players: [player1.slot, player2.slot],
+      players: [player1.player, player2.player],
       playerInfos: [player1.playerInfo, player2.playerInfo],
       mapId,
       gameConfig: lobbyConfig([
@@ -393,7 +398,7 @@ describe('games/game-loader/GameLoader', () => {
   test('threads each player netcode v2 pubkey through to createSessionForGame', async () => {
     const player1 = makePlayer(p1)
     const player2 = makePlayer(p2)
-    registerActiveClients([player1.slot, player2.slot])
+    registerActiveClients([player1.player, player2.player])
     asMockedFunction(findUsersById).mockResolvedValue([makeUser(p1), makeUser(p2)])
     netcodeV2Service.isEnabled.mockReturnValue(true)
     netcodeV2Service.createSessionForGame.mockResolvedValue(
@@ -414,7 +419,7 @@ describe('games/game-loader/GameLoader', () => {
     const pubkey1 = Buffer.alloc(32, 1).toString('base64')
     const pubkey2 = Buffer.alloc(32, 2).toString('base64')
     const request: GameLoadRequest = {
-      players: [player1.slot, player2.slot],
+      players: [player1.player, player2.player],
       playerInfos: [player1.playerInfo, player2.playerInfo],
       mapId,
       gameConfig: lobbyConfig([
@@ -448,7 +453,7 @@ describe('games/game-loader/GameLoader', () => {
   test('publishes a provisioning status to every player when the coordinator reports provisioning', async () => {
     const player1 = makePlayer(p1)
     const player2 = makePlayer(p2)
-    registerActiveClients([player1.slot, player2.slot])
+    registerActiveClients([player1.player, player2.player])
     asMockedFunction(findUsersById).mockResolvedValue([makeUser(p1), makeUser(p2)])
     netcodeV2Service.isEnabled.mockReturnValue(true)
     netcodeV2Service.createSessionForGame.mockImplementation(async ({ onProvisioning }) => {
@@ -468,7 +473,7 @@ describe('games/game-loader/GameLoader', () => {
     } as any)
 
     const request: GameLoadRequest = {
-      players: [player1.slot, player2.slot],
+      players: [player1.player, player2.player],
       playerInfos: [player1.playerInfo, player2.playerInfo],
       mapId,
       gameConfig: lobbyConfig([
@@ -499,7 +504,7 @@ describe('games/game-loader/GameLoader', () => {
     try {
       const player1 = makePlayer(p1)
       const player2 = makePlayer(p2)
-      registerActiveClients([player1.slot, player2.slot])
+      registerActiveClients([player1.player, player2.player])
       asMockedFunction(findUsersById).mockResolvedValue([makeUser(p1), makeUser(p2)])
       netcodeV2Service.isEnabled.mockReturnValue(true)
       netcodeV2Service.createSessionForGame.mockImplementation(async ({ onProvisioning }) => {
@@ -519,7 +524,7 @@ describe('games/game-loader/GameLoader', () => {
       } as any)
 
       const request: GameLoadRequest = {
-        players: [player1.slot, player2.slot],
+        players: [player1.player, player2.player],
         playerInfos: [player1.playerInfo, player2.playerInfo],
         mapId,
         gameConfig: lobbyConfig([

--- a/server/lib/games/game-loader.ts
+++ b/server/lib/games/game-loader.ts
@@ -4,10 +4,10 @@ import { singleton } from 'tsyringe'
 import { AsyncResult, Result } from 'typescript-result'
 import createDeferred, { Deferred } from '../../../common/async/deferred'
 import { extendableDeadline } from '../../../common/async/extendable-deadline'
+import { GameServerRegionId } from '../../../common/game-server-regions'
 import { GameConfig, GameSource } from '../../../common/games/configuration'
 import { GameSetup, PlayerInfo } from '../../../common/games/game-launch-config'
 import { GameLoaderEvent } from '../../../common/games/game-loader-network'
-import { Slot, SlotType } from '../../../common/lobbies/slot'
 import { MapInfo, SbMapId, toMapInfoJson } from '../../../common/maps'
 import { BwTurnRate, BwUserLatency } from '../../../common/network'
 import { urlPath } from '../../../common/urls'
@@ -84,9 +84,30 @@ export interface GameLoadResult {
   gameId: string
 }
 
+/**
+ * A human participant in a game being loaded. This is everything the loader itself needs to know
+ * about a player; whatever richer model a caller has (lobby slots, matchmaking entities, ...) is
+ * mapped into this at the call site. Per-slot data the game process needs but the loader only
+ * passes through lives on `GameLoadRequest.playerInfos` instead.
+ */
+export interface GameLoadPlayer {
+  /** The user occupying this spot in the game. */
+  readonly userId: SbUserId
+  /**
+   * Whether this player watches rather than plays. Observers load the game and get a netcode v2
+   * slot like anyone else, but are excluded from the relay's desync comparison.
+   */
+  readonly isObserver: boolean
+  /**
+   * The home game-server region this player selected, if any. Forwarded to the coordinator to home
+   * this player's netcode v2 relay; a player with none is placed region-blind.
+   */
+  readonly region?: GameServerRegionId
+}
+
 const createLoadingData = Record({
   gameSource: GameSource.Lobby,
-  players: ISet<Slot>(),
+  players: [] as ReadonlyArray<GameLoadPlayer>,
   finishedPlayers: ISet<SbUserId>(),
   abortController: null as unknown as AbortController,
   deferred: null as unknown as Deferred<Result<GameLoadResult, GameLoaderError>>,
@@ -99,7 +120,7 @@ type LoadingData = ReturnType<typeof createLoadingData>
 
 const LoadingDatas = {
   isAllFinished(loadingData: LoadingData) {
-    return loadingData.players.every(p => loadingData.finishedPlayers.has(p.userId!))
+    return loadingData.players.every(p => loadingData.finishedPlayers.has(p.userId))
   },
 }
 
@@ -108,10 +129,11 @@ const LoadingDatas = {
  */
 export interface GameLoadRequest {
   /**
-   * A list of players that should be created as human (or observer) type slots. At least one player
-   * should be present for things to work properly.
+   * The players that should be created as human (or observer) type slots. At least one player
+   * should be present for things to work properly. The order is preserved when assigning netcode v2
+   * slots (aside from the host, who is always moved to slot 0).
    */
-  players: Iterable<Slot>
+  players: ReadonlyArray<GameLoadPlayer>
   /**
    * A list of the info about each slot in the map/lobby. This is only really useful data for UMS
    * lobbies, where slots may have different types, there might be hidden computer slots, etc. For
@@ -134,17 +156,15 @@ export interface GameLoadRequest {
   ratings?: Array<[id: SbUserId, rating: number]>
   /**
    * Each player's measured round-trip time (ms) to their home region, keyed by user id. Read when
-   * building the netcode v2 session-create roster, alongside the region already carried on each
-   * player's `Slot`. Kept off `Slot` itself (rather than a field there, alongside `region`) because
-   * `Slot` is broadcast wholesale to lobby members and per-player rtt is not for peers' eyes; a
-   * user with no entry is forwarded to the coordinator without a latency sample.
+   * building the netcode v2 session-create roster, alongside the `region` carried on each
+   * `GameLoadPlayer`. A user with no entry is forwarded to the coordinator without a latency
+   * sample.
    */
   rttMsByUserId?: ReadonlyMap<SbUserId, number>
   /**
    * Each player's per-session netcode v2 public key (base64), keyed by user id. Threaded per-slot
    * into the netcode v2 session-create request. Required for every human slot of a multi-human
-   * (netcode v2) game — a missing entry fails the load fast rather than waiting. Kept off `Slot`
-   * (like `rttMsByUserId`) since no peer needs it.
+   * (netcode v2) game — a missing entry fails the load fast rather than waiting.
    */
   netcodeV2PubkeyByUserId?: ReadonlyMap<SbUserId, string>
   /** An `AbortSignal` that can be used to cancel the loading process midway through. */
@@ -284,7 +304,7 @@ export class GameLoader {
           gameId,
           createLoadingData({
             gameSource: gameConfig.gameSource,
-            players: ISet(players),
+            players: [...players],
             abortController,
             deferred: gameLoaded,
             signal: signal
@@ -315,12 +335,12 @@ export class GameLoader {
           }
 
           const unloaded = []
-          if (loadingData.finishedPlayers.size >= Math.floor(loadingData.players.size / 2)) {
+          if (loadingData.finishedPlayers.size >= Math.floor(loadingData.players.length / 2)) {
             // If at least half the players have finished loading, mark the rest of them as failed
             // since that can only really happen if some players failed to report a status or
             // crashed on game start.
             for (const p of loadingData.players) {
-              if (p.userId && !loadingData.finishedPlayers.has(p.userId)) {
+              if (!loadingData.finishedPlayers.has(p.userId)) {
                 unloaded.push(p.userId)
               }
             }
@@ -394,7 +414,7 @@ export class GameLoader {
     this.loadingGames = this.loadingGames.set(gameId, loadingData)
 
     if (LoadingDatas.isAllFinished(loadingData)) {
-      const allUserIds = loadingData.players.map(p => p.userId!).toArray()
+      const allUserIds = loadingData.players.map(p => p.userId)
       const activeClients = allUserIds
         .map(userId => this.activityRegistry.getClientForUser(userId))
         .filter(c => !!c)
@@ -447,7 +467,7 @@ export class GameLoader {
 
     const loadingData = this.loadingGames.get(gameId)!
 
-    const allUserIds = loadingData.players.map(p => p.userId!).toArray()
+    const allUserIds = loadingData.players.map(p => p.userId)
     const activeClients = allUserIds
       .map(userId => this.activityRegistry.getClientForUser(userId))
       .filter(c => !!c)
@@ -494,7 +514,7 @@ export class GameLoader {
 
     log.info(`game server still provisioning for ${gameId} in: ${regions.join(', ')}`)
     for (const player of loadingData.players) {
-      this.publisher.publish(gameUserPath(gameId, player.userId!), {
+      this.publisher.publish(gameUserPath(gameId, player.userId), {
         type: 'setLoadingStatus',
         gameId,
         status: 'provisioningGameServer',
@@ -544,7 +564,7 @@ export class GameLoader {
 
       const loadingData = this.loadingGames.get(gameId)!
       const { players, signal } = loadingData
-      const allUserIds = players.map(p => p.userId!).toArray()
+      const allUserIds = players.map(p => p.userId)
 
       const usersResult = Result.try(() => findUsersById(allUserIds))
       const chatRestrictedResult = Result.try(() =>
@@ -574,7 +594,7 @@ export class GameLoader {
       }
 
       const [users, usersError] = await usersResult.toTuple()
-      if (usersError || users.length !== players.size) {
+      if (usersError || users.length !== players.length) {
         return Result.error(
           new BaseGameLoaderError(
             GameLoadErrorType.Internal,
@@ -596,7 +616,7 @@ export class GameLoader {
         })
       }
 
-      const hasMultipleHumans = players.size > 1
+      const hasMultipleHumans = players.length > 1
       if (hasMultipleHumans && !this.netcodeV2Service.isEnabled()) {
         return Result.error(
           new BaseGameLoaderError(
@@ -670,7 +690,7 @@ export class GameLoader {
         userLatency: chosenUserLatency,
       })
       for (const player of players) {
-        const userId = player.userId!
+        const userId = player.userId
         this.publisher.publish(gameUserPath(gameId, userId), {
           type: 'setGameConfig',
           gameId,
@@ -690,21 +710,21 @@ export class GameLoader {
         // consumes this setup when its game init starts, so it must be published to every player
         // before they can proceed. A slot missing its pubkey fails the session create fast.
         //
-        // `players` includes observer slots alongside human slots (see `GameLoadRequest.players`'s
-        // doc comment), and `Slot.type` distinguishes them, so observer-ness is known here — mark
-        // it so the relay's desync comparator can exclude observers from the compared slot set.
+        // `players` includes observers alongside playing humans (see `GameLoadRequest.players`'s
+        // doc comment), and `GameLoadPlayer.isObserver` distinguishes them, so observer-ness is
+        // known here — mark it so the relay's desync comparator can exclude observers from the
+        // compared slot set.
         //
         // The host must land at rp2 slot 0: with native-lobby netcode v2, the host creates the
         // game's Storm session, and Storm always assigns its creator slot 0. The game DLL maps
         // BW Storm ids to rp2 slots by identity, so this roster has to agree the host is slot 0 or
         // that mapping breaks. Reuse the host already resolved for `generalSetup` (the same user
         // named in the published `GameSetup.host`) rather than re-deriving it here.
-        const playersArr = [...players]
         const hostUserId = generalSetup.host.userId
-        const hostPlayer = playersArr.find(p => p.userId === hostUserId)
-        let orderedPlayers: Slot[]
+        const hostPlayer = players.find(p => p.userId === hostUserId)
+        let orderedPlayers: ReadonlyArray<GameLoadPlayer>
         if (hostPlayer) {
-          orderedPlayers = [hostPlayer, ...playersArr.filter(p => p !== hostPlayer)]
+          orderedPlayers = [hostPlayer, ...players.filter(p => p !== hostPlayer)]
         } else {
           // Shouldn't happen — the host is always a human participant — but don't let it crash the
           // load, just fall back to the unordered assignment.
@@ -712,21 +732,21 @@ export class GameLoader {
             { gameId, hostUserId },
             'netcode v2: host not found among players, using unordered slot assignment',
           )
-          orderedPlayers = playersArr
+          orderedPlayers = players
         }
         const slots = orderedPlayers.map((p, slot) => ({
           slot,
-          userId: p.userId!,
-          observer: p.type === SlotType.Observer,
+          userId: p.userId,
+          observer: p.isObserver,
           // The region the player selected when they queued/joined, if any. Forwarded to the
           // coordinator to home this slot's relay; a slot with none falls back region-blind.
           region: p.region,
           // The player's measured round-trip time to that region, if recorded. Combined with every
           // other slot's region/rtt to estimate the session's worst pairwise latency.
-          rttMs: rttMsByUserId?.get(p.userId!),
+          rttMs: rttMsByUserId?.get(p.userId),
           // The player's per-session netcode v2 public key, submitted at queue/lobby-join time. The
           // coordinator embeds it in this slot's session token; a slot missing it fails create fast.
-          pubkey: netcodeV2PubkeyByUserId?.get(p.userId!),
+          pubkey: netcodeV2PubkeyByUserId?.get(p.userId),
         }))
         const [setups, setupsError] = (
           await Result.fromAsyncCatching(

--- a/server/lib/games/game-loader.ts
+++ b/server/lib/games/game-loader.ts
@@ -103,6 +103,18 @@ export interface GameLoadPlayer {
    * this player's netcode v2 relay; a player with none is placed region-blind.
    */
   readonly region?: GameServerRegionId
+  /**
+   * This player's measured round-trip time (ms) to their home region, if recorded. Read when
+   * building the netcode v2 session-create roster, alongside `region`. A player with no value is
+   * forwarded to the coordinator without a latency sample.
+   */
+  readonly rttMs?: number
+  /**
+   * This player's per-session netcode v2 public key (base64), submitted at queue/lobby-join time.
+   * Threaded per-slot into the netcode v2 session-create request. Required for every human slot of
+   * a multi-human (netcode v2) game — a missing value fails the load fast rather than waiting.
+   */
+  readonly netcodeV2Pubkey?: string
 }
 
 const createLoadingData = Record({
@@ -137,8 +149,8 @@ export interface GameLoadRequest {
   /**
    * A list of the info about each slot in the map/lobby. This is only really useful data for UMS
    * lobbies, where slots may have different types, there might be hidden computer slots, etc. For
-   * a lobby, see `getPlayerInfos(Lobby)`. For matchmaking this can just be created from `players`
-   * directly.
+   * a lobby, see `getPlayerInfos(Lobby)`. A caller with a richer player model (e.g. matchmaking's
+   * team assignments) builds `players` and `playerInfos` side by side from it.
    */
   playerInfos: PlayerInfo[]
   /**
@@ -154,19 +166,6 @@ export interface GameLoadRequest {
    * matchmaking games.
    */
   ratings?: Array<[id: SbUserId, rating: number]>
-  /**
-   * Each player's measured round-trip time (ms) to their home region, keyed by user id. Read when
-   * building the netcode v2 session-create roster, alongside the `region` carried on each
-   * `GameLoadPlayer`. A user with no entry is forwarded to the coordinator without a latency
-   * sample.
-   */
-  rttMsByUserId?: ReadonlyMap<SbUserId, number>
-  /**
-   * Each player's per-session netcode v2 public key (base64), keyed by user id. Threaded per-slot
-   * into the netcode v2 session-create request. Required for every human slot of a multi-human
-   * (netcode v2) game — a missing entry fails the load fast rather than waiting.
-   */
-  netcodeV2PubkeyByUserId?: ReadonlyMap<SbUserId, string>
   /** An `AbortSignal` that can be used to cancel the loading process midway through. */
   signal?: AbortSignal
 }
@@ -288,8 +287,6 @@ export class GameLoader {
     mapId,
     gameConfig,
     ratings,
-    rttMsByUserId,
-    netcodeV2PubkeyByUserId,
     signal,
   }: GameLoadRequest): AsyncResult<GameLoadResult, GameLoaderError> {
     const gameLoaded = createDeferred<Result<GameLoadResult, GameLoaderError>>()
@@ -321,8 +318,6 @@ export class GameLoader {
           resultCodes,
           playerInfos,
           ratings,
-          rttMsByUserId,
-          netcodeV2PubkeyByUserId,
         }).onFailure(err => {
           this.maybeCancelLoadingFromSystem(gameId, err)
         })
@@ -538,8 +533,6 @@ export class GameLoader {
     resultCodes,
     playerInfos,
     ratings,
-    rttMsByUserId,
-    netcodeV2PubkeyByUserId,
   }: {
     gameId: string
     mapId: SbMapId
@@ -547,8 +540,6 @@ export class GameLoader {
     resultCodes: Map<SbUserId, string>
     playerInfos: PlayerInfo[]
     ratings?: Array<[id: SbUserId, rating: number]>
-    rttMsByUserId?: ReadonlyMap<SbUserId, number>
-    netcodeV2PubkeyByUserId?: ReadonlyMap<SbUserId, string>
   }): AsyncResult<void, GameLoaderError> {
     return Result.fromAsync(async () => {
       if (!this.loadingGames.has(gameId)) {
@@ -743,10 +734,10 @@ export class GameLoader {
           region: p.region,
           // The player's measured round-trip time to that region, if recorded. Combined with every
           // other slot's region/rtt to estimate the session's worst pairwise latency.
-          rttMs: rttMsByUserId?.get(p.userId),
+          rttMs: p.rttMs,
           // The player's per-session netcode v2 public key, submitted at queue/lobby-join time. The
           // coordinator embeds it in this slot's session token; a slot missing it fails create fast.
-          pubkey: netcodeV2PubkeyByUserId?.get(p.userId),
+          pubkey: p.netcodeV2Pubkey,
         }))
         const [setups, setupsError] = (
           await Result.fromAsyncCatching(

--- a/server/lib/matchmaking/matchmaking-service.test.ts
+++ b/server/lib/matchmaking/matchmaking-service.test.ts
@@ -8,6 +8,7 @@ import {
   MatchmakingPreferences,
   MatchmakingType,
 } from '../../../common/matchmaking'
+import { RaceChar } from '../../../common/races'
 import { asMockedFunction } from '../../../common/testing/mocks'
 import { MatchFoundMessage } from '../../../common/typeshare'
 import { makeSbUserId, SbUserId } from '../../../common/users/sb-user-id'
@@ -152,6 +153,21 @@ describe('matchmaking/matchmaking-service', () => {
     prefs.matchmakingType = MatchmakingType.Match1v1
     ;(prefs as any).userId = userId
     await service.find(userId, clientId, [], [prefs], clientPubkey, desiredRegion)
+  }
+
+  /** Like `queuePlayer`, but with an explicit main race and alternate-race preference data. */
+  async function queuePlayerWithRacePrefs(
+    userId: SbUserId,
+    clientId: string,
+    race: RaceChar,
+    data: MatchmakingPreferences['data'],
+  ) {
+    const prefs = makePreferences()
+    prefs.matchmakingType = MatchmakingType.Match1v1
+    ;(prefs as any).userId = userId
+    prefs.race = race
+    prefs.data = data
+    await service.find(userId, clientId, [], [prefs], DEFAULT_PUBKEY)
   }
 
   async function queueMultiPlayer(
@@ -514,14 +530,12 @@ describe('matchmaking/matchmaking-service', () => {
     const slotForB = request.players.find((p: any) => p.userId === USER_B)
     expect(slotForA.region).toBe(REGION_US_EAST)
     expect(slotForB.region).toBeUndefined()
-    expect(request.rttMsByUserId).toEqual(new Map([[USER_A, 24]]))
-    // Both players submitted a pubkey when they queued; each reaches the loader keyed by user id.
-    expect(request.netcodeV2PubkeyByUserId).toEqual(
-      new Map([
-        [USER_A, DEFAULT_PUBKEY],
-        [USER_B, DEFAULT_PUBKEY],
-      ]),
-    )
+    expect(slotForA.rttMs).toBe(24)
+    expect(slotForB.rttMs).toBeUndefined()
+    // Both players submitted a pubkey when they queued; each reaches the loader on their own
+    // player entry.
+    expect(slotForA.netcodeV2Pubkey).toBe(DEFAULT_PUBKEY)
+    expect(slotForB.netcodeV2Pubkey).toBe(DEFAULT_PUBKEY)
   })
 
   test('preserves a queued player pubkey across a requeue', async () => {
@@ -579,7 +593,62 @@ describe('matchmaking/matchmaking-service', () => {
 
     expect(gameLoader.loadGame).toHaveBeenCalledTimes(1)
     const request = gameLoader.loadGame.mock.calls[0][0]
-    expect(request.netcodeV2PubkeyByUserId.get(USER_A)).toBe(pubkeyA)
+    const slotForA = request.players.find((p: any) => p.userId === USER_A)
+    expect(slotForA.netcodeV2Pubkey).toBe(pubkeyA)
+  })
+
+  test('builds playerInfos for the matched game, including the alternate-race branch', async () => {
+    asMockedFunction(getCurrentMapPool).mockResolvedValue({ maps: [MAP_ID] } as any)
+    asMockedFunction(getMapInfos).mockResolvedValue([{ id: MAP_ID } as any])
+    gameLoader.loadGame.mockResolvedValue(Result.ok({ gameId: GAME_ID }))
+
+    // Both queue the same main race, but only B opts into playing its alternate on the mirror
+    // matchup, so B (and only B) should land on its alternate race while A keeps its main one.
+    await queuePlayerWithRacePrefs(USER_A, CLIENT_A, 'z', {
+      useAlternateRace: false,
+      alternateRace: 't',
+    })
+    await queuePlayerWithRacePrefs(USER_B, CLIENT_B, 'z', {
+      useAlternateRace: true,
+      alternateRace: 't',
+    })
+
+    redisHandler({
+      type: 'matchFound',
+      data: {
+        mode: MatchmakingType.Match1v1,
+        teamA: [{ id: USER_A, ticket: 'ticket-a' }],
+        teamB: [{ id: USER_B, ticket: 'ticket-b' }],
+        quality: 12.5,
+        skillVariance: 30000,
+        winProbability: 0.42,
+        teamARating: 1500,
+        teamBRating: 1600,
+        maxLatency: 1,
+      },
+    })
+    await vi.advanceTimersByTimeAsync(0)
+
+    await service.accept(USER_A)
+    await service.accept(USER_B)
+    // Drain the runMatch promise chain (accept -> pickMap -> draft -> doGameLoad -> loadGame).
+    for (let i = 0; i < 20; i++) {
+      await vi.advanceTimersByTimeAsync(0)
+    }
+
+    expect(gameLoader.loadGame).toHaveBeenCalledTimes(1)
+    const request = gameLoader.loadGame.mock.calls[0][0]
+    const infoForA = request.playerInfos.find((p: any) => p.userId === USER_A)
+    const infoForB = request.playerInfos.find((p: any) => p.userId === USER_B)
+
+    for (const info of [infoForA, infoForB]) {
+      expect(info.typeId).toBe(6)
+      expect(info.playerId).toBe(0)
+      expect(info.type).toBe('human')
+    }
+    expect(infoForA.race).toBe('z')
+    // B opted into its alternate race for the mirror matchup; A did not, so A keeps its main race.
+    expect(infoForB.race).toBe('t')
   })
 
   test('records the match formation telemetry for a match that fails to start', async () => {

--- a/server/lib/matchmaking/matchmaking-service.ts
+++ b/server/lib/matchmaking/matchmaking-service.ts
@@ -19,7 +19,7 @@ import {
 } from '../../../common/games/configuration'
 import { PlayerInfo } from '../../../common/games/game-launch-config'
 import { GameType } from '../../../common/games/game-type'
-import { createHuman, Slot, SlotType } from '../../../common/lobbies/slot'
+import { SlotType } from '../../../common/lobbies/slot'
 import { MapInfo } from '../../../common/maps'
 import {
   getMatchmakingModeInfo,
@@ -38,7 +38,7 @@ import { MatchFoundMessage, PublishedMatchmakingMessage } from '../../../common/
 import { RestrictionKind } from '../../../common/users/restrictions'
 import { makeSbUserId, SbUserId } from '../../../common/users/sb-user-id'
 import { GameServerRegionsService } from '../game-server-regions/game-server-regions-service'
-import { GameLoader, GameLoadErrorType } from '../games/game-loader'
+import { GameLoader, GameLoadErrorType, GameLoadPlayer } from '../games/game-loader'
 import { GameplayActivityRegistry } from '../games/gameplay-activity-registry'
 import logger from '../logging/logger'
 import { getMapInfos } from '../maps/map-models'
@@ -1068,9 +1068,12 @@ export class MatchmakingService {
   }
 
   private async doGameLoad(match: Match, mapInfo: MapInfo) {
-    let slots: Slot[]
-    let playerInfos: PlayerInfo[]
-    let teams: GameConfigPlayer[][]
+    /**
+     * Each participant paired with the race they'll actually play, grouped into the game's teams.
+     * The shapes the game loader, the game process and the persisted game config each need are all
+     * derived from this below.
+     */
+    let playersInTeams: Array<Array<{ userId: SbUserId; race: RaceChar }>>
     const players = Array.from(match.players())
     const clients: ClientSocketsGroup[] = []
     let declined = false
@@ -1101,104 +1104,91 @@ export class MatchmakingService {
         // one of the players randomly to play their alternate race, leaving the other player to
         // play their main race.
         const randomPlayerIndex = randomInt(0, players.length)
-        slots = players.map((p, i) =>
-          createHuman(p.id, i === randomPlayerIndex ? p.preferenceData.alternateRace : p.race),
-        )
+        playersInTeams = [
+          players.map((p, i) => ({
+            userId: p.id,
+            // `alternateRace` is optional in stored preferences, so someone who asked for one
+            // without picking it plays random.
+            race: (i === randomPlayerIndex ? p.preferenceData.alternateRace : p.race) ?? 'r',
+          })),
+        ]
       } else if (
         playersHaveSameRace &&
         players.some(p => p.preferenceData.useAlternateRace === true)
       ) {
         // All players have the same main race and one of them wants to use an alternate race
-        slots = players.map(p =>
-          createHuman(
-            p.id,
-            p.preferenceData.useAlternateRace ? p.preferenceData.alternateRace : p.race,
-          ),
-        )
+        playersInTeams = [
+          players.map(p => ({
+            userId: p.id,
+            race:
+              (p.preferenceData.useAlternateRace ? p.preferenceData.alternateRace : p.race) ?? 'r',
+          })),
+        ]
       } else {
         // No alternate race selection, so everyone gets their selected race
-        slots = players.map(p => createHuman(p.id, p.race))
+        playersInTeams = [players.map(p => ({ userId: p.id, race: p.race }))]
       }
-
-      playerInfos = slots.map(s => ({
-        id: s.id,
-        userId: s.userId,
-        race: s.race,
-        playerId: s.playerId,
-        teamId: 0,
-        type: s.type,
-        typeId: s.typeId,
-      }))
-      teams = [
-        slots.map(s => ({
-          id: s.userId ?? makeSbUserId(0),
-          race: s.race,
-          isComputer: s.type === SlotType.Computer || s.type === SlotType.UmsComputer,
-        })),
-      ]
     } else {
       // For team modes, use draft results if available, otherwise use original race selections
       const draftState = match.getDraftState()
       const finalRaces = draftState?.getFinalRaces()
 
-      const slotsInTeams = match.teams.map(team =>
+      playersInTeams = match.teams.map(team =>
         team.flatMap(entity =>
-          Array.from(getPlayersFromEntity(entity), p =>
-            createHuman(p.id, finalRaces?.get(p.id) ?? p.race),
-          ),
+          Array.from(getPlayersFromEntity(entity), p => ({
+            userId: p.id,
+            race: finalRaces?.get(p.id) ?? p.race,
+          })),
         ),
       )
-      slots = slotsInTeams.flat()
-      playerInfos = slotsInTeams.flatMap((t, i) =>
-        t.map(s => ({
-          id: s.id,
-          userId: s.userId,
-          race: s.race,
-          playerId: s.playerId,
-          teamId: i,
-          type: s.type,
-          typeId: s.typeId,
-        })),
-      )
-      teams = slotsInTeams.map(t =>
-        t.map(s => ({
-          id: s.userId ?? makeSbUserId(0),
-          race: s.race,
-          isComputer: s.type === SlotType.Computer || s.type === SlotType.UmsComputer,
-        })),
-      )
     }
+
+    // Matchmaking games are always plain human players on a non-UMS map, so the UMS-only fields BW
+    // needs are their neutral values: `playerId` is unused outside UMS (BW takes the slot's index
+    // in this list), and 6 is the BW slot type id for a regular player.
+    const playerInfos: PlayerInfo[] = playersInTeams.flatMap((team, teamId) =>
+      team.map(p => ({
+        id: nanoid(),
+        userId: p.userId,
+        race: p.race,
+        playerId: 0,
+        teamId,
+        type: SlotType.Human,
+        typeId: 6,
+      })),
+    )
+    const teams: GameConfigPlayer[][] = playersInTeams.map(team =>
+      team.map(p => ({ id: p.userId, race: p.race, isComputer: false })),
+    )
 
     // Carry each player's queued home region through to the game loader, which forwards it to the
     // coordinator to place their relay. It was validated against the live region list when they
     // queued; a player with no recorded region is placed region-blind.
-    slots = slots.map(s =>
-      s.userId !== undefined
-        ? s.set('region', this.playerQueueData.get(s.userId)?.region?.region)
-        : s,
-    )
+    const gameLoadPlayers: GameLoadPlayer[] = playersInTeams.flat().map(p => ({
+      userId: p.userId,
+      isObserver: false,
+      region: this.playerQueueData.get(p.userId)?.region?.region,
+    }))
 
     // Each player's measured round-trip time to that region, carried to the game loader alongside
-    // `region` — but kept off the `Slot` itself (unlike `region`) since `rttMs` is never meant to
-    // reach another player.
+    // `region` — but keyed by user id rather than carried per-player, since `rttMs` is never meant
+    // to reach another player.
     const rttMsByUserId = new Map<SbUserId, number>()
-    for (const s of slots) {
-      const rttMs =
-        s.userId !== undefined ? this.playerQueueData.get(s.userId)?.region?.rttMs : undefined
+    for (const p of gameLoadPlayers) {
+      const rttMs = this.playerQueueData.get(p.userId)?.region?.rttMs
       if (rttMs !== undefined) {
-        rttMsByUserId.set(s.userId!, rttMs)
+        rttMsByUserId.set(p.userId, rttMs)
       }
     }
 
     // Each player's per-session netcode v2 public key, submitted when they queued and carried to the
-    // game loader to build the coordinator session token — kept off the `Slot` (like `rttMs`) since
-    // no peer needs it.
+    // game loader to build the coordinator session token — keyed by user id (like `rttMs`) since no
+    // peer needs it.
     const netcodeV2PubkeyByUserId = new Map<SbUserId, string>()
-    for (const s of slots) {
-      const pubkey =
-        s.userId !== undefined ? this.playerQueueData.get(s.userId)?.clientPubkey : undefined
+    for (const p of gameLoadPlayers) {
+      const pubkey = this.playerQueueData.get(p.userId)?.clientPubkey
       if (pubkey !== undefined) {
-        netcodeV2PubkeyByUserId.set(s.userId!, pubkey)
+        netcodeV2PubkeyByUserId.set(p.userId, pubkey)
       }
     }
 
@@ -1279,7 +1269,7 @@ export class MatchmakingService {
     }
 
     const loadResult = await this.gameLoader.loadGame({
-      players: slots,
+      players: gameLoadPlayers,
       playerInfos,
       mapId: chosenMap.id,
       gameConfig,

--- a/server/lib/matchmaking/matchmaking-service.ts
+++ b/server/lib/matchmaking/matchmaking-service.ts
@@ -1161,36 +1161,20 @@ export class MatchmakingService {
       team.map(p => ({ id: p.userId, race: p.race, isComputer: false })),
     )
 
-    // Carry each player's queued home region through to the game loader, which forwards it to the
-    // coordinator to place their relay. It was validated against the live region list when they
-    // queued; a player with no recorded region is placed region-blind.
+    // Carry each player's queued home region, measured round-trip time, and netcode v2 public key
+    // through to the game loader. Region is forwarded to the coordinator to place the player's
+    // relay and was validated against the live region list when they queued; a player with no
+    // recorded region is placed region-blind. rtt is combined with every other player's region/rtt
+    // to estimate the session's worst pairwise latency. The pubkey was submitted when the player
+    // queued and is required for every human slot of a multi-human (netcode v2) game — a missing
+    // one fails the load fast.
     const gameLoadPlayers: GameLoadPlayer[] = playersInTeams.flat().map(p => ({
       userId: p.userId,
       isObserver: false,
       region: this.playerQueueData.get(p.userId)?.region?.region,
+      rttMs: this.playerQueueData.get(p.userId)?.region?.rttMs,
+      netcodeV2Pubkey: this.playerQueueData.get(p.userId)?.clientPubkey,
     }))
-
-    // Each player's measured round-trip time to that region, carried to the game loader alongside
-    // `region` — but keyed by user id rather than carried per-player, since `rttMs` is never meant
-    // to reach another player.
-    const rttMsByUserId = new Map<SbUserId, number>()
-    for (const p of gameLoadPlayers) {
-      const rttMs = this.playerQueueData.get(p.userId)?.region?.rttMs
-      if (rttMs !== undefined) {
-        rttMsByUserId.set(p.userId, rttMs)
-      }
-    }
-
-    // Each player's per-session netcode v2 public key, submitted when they queued and carried to the
-    // game loader to build the coordinator session token — keyed by user id (like `rttMs`) since no
-    // peer needs it.
-    const netcodeV2PubkeyByUserId = new Map<SbUserId, string>()
-    for (const p of gameLoadPlayers) {
-      const pubkey = this.playerQueueData.get(p.userId)?.clientPubkey
-      if (pubkey !== undefined) {
-        netcodeV2PubkeyByUserId.set(p.userId, pubkey)
-      }
-    }
 
     const entities = match.teams.flat()
     const chosenMap = mapInfo
@@ -1274,8 +1258,6 @@ export class MatchmakingService {
       mapId: chosenMap.id,
       gameConfig,
       ratings,
-      rttMsByUserId,
-      netcodeV2PubkeyByUserId,
     })
 
     if (loadResult.isError()) {

--- a/server/lib/wsapi/lobbies.ts
+++ b/server/lib/wsapi/lobbies.ts
@@ -935,19 +935,8 @@ export class LobbyApi {
       const abortController = new AbortController()
       this.loadingLobbies = this.loadingLobbies.set(lobbyId, abortController)
 
-      // Split the occupants' collected network info into the two per-user maps the game loader
-      // takes: rtt for the latency estimate, pubkey for each slot's session token.
+      // Each occupant's collected network info, to merge into their `GameLoadPlayer`.
       const networkByUser = this.lobbyPlayerNetwork.getAll(lobbyId)
-      const rttMsByUserId = new global.Map<SbUserId, number>()
-      const netcodeV2PubkeyByUserId = new global.Map<SbUserId, string>()
-      for (const [userId, info] of networkByUser) {
-        if (info.rttMs !== undefined) {
-          rttMsByUserId.set(userId, info.rttMs)
-        }
-        if (info.netcodeV2Pubkey !== undefined) {
-          netcodeV2PubkeyByUserId.set(userId, info.netcodeV2Pubkey)
-        }
-      }
 
       const gameLoadResult = await this.gameLoader.loadGame({
         players: getHumanSlots(lobby)
@@ -955,13 +944,13 @@ export class LobbyApi {
             userId: s.userId!,
             isObserver: s.type === SlotType.Observer,
             region: s.region,
+            rttMs: networkByUser.get(s.userId!)?.rttMs,
+            netcodeV2Pubkey: networkByUser.get(s.userId!)?.netcodeV2Pubkey,
           }))
           .toArray(),
         playerInfos: getPlayerInfos(lobby),
         mapId: lobby.map!.id,
         gameConfig,
-        rttMsByUserId,
-        netcodeV2PubkeyByUserId,
         signal: abortController.signal,
       })
 

--- a/server/lib/wsapi/lobbies.ts
+++ b/server/lib/wsapi/lobbies.ts
@@ -28,7 +28,7 @@ import {
 } from '../../../common/lobbies/lobby-network'
 import { SbLobbyId } from '../../../common/lobbies/sb-lobby-id'
 import * as Slots from '../../../common/lobbies/slot'
-import { Slot } from '../../../common/lobbies/slot'
+import { Slot, SlotType } from '../../../common/lobbies/slot'
 import { SbMapId } from '../../../common/maps'
 import { isPrettyId } from '../../../common/pretty-id'
 import { urlPath } from '../../../common/urls'
@@ -950,7 +950,13 @@ export class LobbyApi {
       }
 
       const gameLoadResult = await this.gameLoader.loadGame({
-        players: getHumanSlots(lobby),
+        players: getHumanSlots(lobby)
+          .map(s => ({
+            userId: s.userId!,
+            isObserver: s.type === SlotType.Observer,
+            region: s.region,
+          }))
+          .toArray(),
         playerInfos: getPlayerInfos(lobby),
         mapId: lobby.map!.id,
         gameConfig,


### PR DESCRIPTION
`GameLoadRequest.players` was `Iterable<Slot>`, which coupled the game loader to the lobby's Immutable Record model: matchmaking had to manufacture fake Slots via `createHuman` just to satisfy the interface, and per-player load data (rtt, netcode pubkeys) kept getting parked in side maps because Slot is broadcast wholesale to lobby members. The loader only ever read userId, observer-ness, and region, so it now takes a plain `GameLoadPlayer { userId, isObserver, region? }` array; the lobby maps its slots into it at launch and matchmaking builds it directly.

No wire or persisted shape changes: `games.config` is derived solely from `gameConfig.teams`, the game process receives the already-plain `PlayerInfo[]` (matchmaking now writes `createHuman`'s exact literals into it directly), and the rally-point session roster is built identically. Player order into rp2 slots is now deterministic (insertion order, host forced to slot 0 as before); non-host order carries no meaning.

Context: discussed with tec27 (2026-07-30) — killing Slot as the loader mechanism keeps a future conversion of the lobby model off Immutable.js contained to lobby code.

Tested:
- Full unit suite green, including updated game-loader tests
- Verified byte-stability of the `games.config`, game-process, and rally-point shapes against master
- Not yet re-verified with a real game launch (same pending check as #1373)
