### PR TITLE
Show a lobby preview on the in-app join page and surface join failures

### DIFF
--- a/client/lobbies/action-creators.js
+++ b/client/lobbies/action-creators.js
@@ -89,21 +89,31 @@ export const createLobby =
     })
   }
 
-export const joinLobby = id => dispatch => {
-  Promise.all([
-    resolveDesiredRegion().catch(() => undefined),
-    Promise.resolve(ipcRenderer.invoke('activeGameGenNetcodeV2SessionKeys')).catch(() => undefined),
-  ]).then(([desiredRegion, clientPubkey]) => {
-    dispatch(
-      createSiteSocketAction(LOBBY_JOIN_BEGIN, LOBBY_JOIN, '/lobbies/join', {
+export const joinLobby =
+  (id, { onSuccess, onError } = {}) =>
+  dispatch => {
+    Promise.all([
+      resolveDesiredRegion().catch(() => undefined),
+      Promise.resolve(ipcRenderer.invoke('activeGameGenNetcodeV2SessionKeys')).catch(
+        () => undefined,
+      ),
+    ]).then(([desiredRegion, clientPubkey]) => {
+      const params = {
         id,
         region: desiredRegion?.region,
         rttMs: desiredRegion?.rttMs ?? undefined,
         clientPubkey,
-      }),
-    )
-  })
-}
+      }
+
+      dispatch({ type: LOBBY_JOIN_BEGIN, payload: params })
+      const result = siteSocket.invoke('/lobbies/join', params)
+      dispatch({ type: LOBBY_JOIN, payload: result, meta: params })
+      result.then(
+        payload => onSuccess?.(payload),
+        err => onError?.(err),
+      )
+    })
+  }
 
 export const addComputer = slotId =>
   createSiteSocketAction(LOBBY_ADD_COMPUTER_BEGIN, LOBBY_ADD_COMPUTER, '/lobbies/addComputer', {

--- a/client/lobbies/devonly/join-preview-test.tsx
+++ b/client/lobbies/devonly/join-preview-test.tsx
@@ -1,10 +1,9 @@
 import { useState } from 'react'
-import styled from 'styled-components'
 import { assertUnreachable } from '../../../common/assert-unreachable'
-import { labelSmall } from '../../styles/typography'
 import { LobbySummaryLoadState } from '../lobby-summary'
 import { JoinableLobbyContent } from '../view'
 import { MOCK_LOBBY_SUMMARY } from './lobby-landing-test'
+import { ScenarioPicker } from './scenario-picker'
 
 type Scenario = 'loading' | 'preview' | 'joining' | 'fetchError' | 'gone' | 'started'
 
@@ -56,57 +55,13 @@ function scenarioToProps(scenario: Scenario): {
   }
 }
 
-const ControlsLabel = styled.div`
-  ${labelSmall};
-  color: var(--theme-on-surface-variant);
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  margin: 16px 16px 8px;
-`
-
-const ScenarioButtons = styled.div`
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-  margin: 0 16px;
-`
-
-const ScenarioBtn = styled.button<{ $active: boolean }>`
-  ${labelSmall};
-  padding: 6px 14px;
-  border-radius: 20px;
-  border: 1px solid
-    ${props => (props.$active ? 'var(--theme-primary)' : 'var(--theme-outline-variant)')};
-  background: ${props =>
-    props.$active ? 'color-mix(in srgb, var(--theme-primary) 15%, transparent)' : 'transparent'};
-  color: ${props => (props.$active ? 'var(--theme-primary)' : 'var(--theme-on-surface-variant)')};
-  cursor: pointer;
-  transition:
-    background 150ms ease,
-    border-color 150ms ease,
-    color 150ms ease;
-
-  &:hover {
-    background: color-mix(in srgb, var(--theme-primary) 10%, transparent);
-    border-color: var(--theme-primary);
-    color: var(--theme-primary);
-  }
-`
-
 export function JoinPreviewTest() {
   const [scenario, setScenario] = useState<Scenario>('preview')
   const { summary, lobbyGone, lobbyStarted, isJoining } = scenarioToProps(scenario)
 
   return (
     <div>
-      <ControlsLabel>Scenario</ControlsLabel>
-      <ScenarioButtons>
-        {SCENARIOS.map(s => (
-          <ScenarioBtn key={s.id} $active={scenario === s.id} onClick={() => setScenario(s.id)}>
-            {s.label}
-          </ScenarioBtn>
-        ))}
-      </ScenarioButtons>
+      <ScenarioPicker scenarios={SCENARIOS} active={scenario} onChange={setScenario} />
       <JoinableLobbyContent
         summary={summary}
         lobbyGone={lobbyGone}

--- a/client/lobbies/devonly/join-preview-test.tsx
+++ b/client/lobbies/devonly/join-preview-test.tsx
@@ -1,0 +1,119 @@
+import { useState } from 'react'
+import styled from 'styled-components'
+import { assertUnreachable } from '../../../common/assert-unreachable'
+import { labelSmall } from '../../styles/typography'
+import { LobbySummaryLoadState } from '../lobby-summary'
+import { JoinableLobbyContent } from '../view'
+import { MOCK_LOBBY_SUMMARY } from './lobby-landing-test'
+
+type Scenario = 'loading' | 'preview' | 'joining' | 'fetchError' | 'gone' | 'started'
+
+const SCENARIOS: Array<{ id: Scenario; label: string }> = [
+  { id: 'loading', label: 'Loading' },
+  { id: 'preview', label: 'Preview' },
+  { id: 'joining', label: 'Preview (joining)' },
+  { id: 'fetchError', label: 'Fetch error' },
+  { id: 'gone', label: 'No longer open' },
+  { id: 'started', label: 'Started' },
+]
+
+function scenarioToProps(scenario: Scenario): {
+  summary: LobbySummaryLoadState | undefined
+  lobbyGone: boolean
+  lobbyStarted: boolean
+  isJoining: boolean
+} {
+  switch (scenario) {
+    case 'loading':
+      return { summary: undefined, lobbyGone: false, lobbyStarted: false, isJoining: false }
+    case 'preview':
+      return {
+        summary: { status: 'loaded', data: MOCK_LOBBY_SUMMARY },
+        lobbyGone: false,
+        lobbyStarted: false,
+        isJoining: false,
+      }
+    case 'joining':
+      return {
+        summary: { status: 'loaded', data: MOCK_LOBBY_SUMMARY },
+        lobbyGone: false,
+        lobbyStarted: false,
+        isJoining: true,
+      }
+    case 'fetchError':
+      return {
+        summary: { status: 'error' },
+        lobbyGone: false,
+        lobbyStarted: false,
+        isJoining: false,
+      }
+    case 'gone':
+      return { summary: undefined, lobbyGone: true, lobbyStarted: false, isJoining: false }
+    case 'started':
+      return { summary: undefined, lobbyGone: false, lobbyStarted: true, isJoining: false }
+    default:
+      return assertUnreachable(scenario)
+  }
+}
+
+const ControlsLabel = styled.div`
+  ${labelSmall};
+  color: var(--theme-on-surface-variant);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  margin: 16px 16px 8px;
+`
+
+const ScenarioButtons = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 0 16px;
+`
+
+const ScenarioBtn = styled.button<{ $active: boolean }>`
+  ${labelSmall};
+  padding: 6px 14px;
+  border-radius: 20px;
+  border: 1px solid
+    ${props => (props.$active ? 'var(--theme-primary)' : 'var(--theme-outline-variant)')};
+  background: ${props =>
+    props.$active ? 'color-mix(in srgb, var(--theme-primary) 15%, transparent)' : 'transparent'};
+  color: ${props => (props.$active ? 'var(--theme-primary)' : 'var(--theme-on-surface-variant)')};
+  cursor: pointer;
+  transition:
+    background 150ms ease,
+    border-color 150ms ease,
+    color 150ms ease;
+
+  &:hover {
+    background: color-mix(in srgb, var(--theme-primary) 10%, transparent);
+    border-color: var(--theme-primary);
+    color: var(--theme-primary);
+  }
+`
+
+export function JoinPreviewTest() {
+  const [scenario, setScenario] = useState<Scenario>('preview')
+  const { summary, lobbyGone, lobbyStarted, isJoining } = scenarioToProps(scenario)
+
+  return (
+    <div>
+      <ControlsLabel>Scenario</ControlsLabel>
+      <ScenarioButtons>
+        {SCENARIOS.map(s => (
+          <ScenarioBtn key={s.id} $active={scenario === s.id} onClick={() => setScenario(s.id)}>
+            {s.label}
+          </ScenarioBtn>
+        ))}
+      </ScenarioButtons>
+      <JoinableLobbyContent
+        summary={summary}
+        lobbyGone={lobbyGone}
+        lobbyStarted={lobbyStarted}
+        isJoining={isJoining}
+        onJoinClick={() => {}}
+      />
+    </div>
+  )
+}

--- a/client/lobbies/devonly/lobby-landing-test.tsx
+++ b/client/lobbies/devonly/lobby-landing-test.tsx
@@ -16,7 +16,7 @@ const MOCK_HOST: SbUser = { id: makeSbUserId(1), name: 'HostUser', created: 0 }
 
 const MOCK_LOBBY_ID = makeSbLobbyId(encodePrettyId('5eed0000-0000-0000-0000-000000000042'))
 
-const MOCK_SUMMARY: LobbySummaryResponse = {
+export const MOCK_LOBBY_SUMMARY: LobbySummaryResponse = {
   summary: {
     id: MOCK_LOBBY_ID,
     name: 'Fastest Game Ever',
@@ -51,7 +51,7 @@ function scenarioToState(scenario: Scenario): LobbySummaryLoadState | undefined 
     case 'error':
       return { status: 'error' }
     case 'loaded':
-      return { status: 'loaded', data: MOCK_SUMMARY }
+      return { status: 'loaded', data: MOCK_LOBBY_SUMMARY }
     default:
       return assertUnreachable(scenario)
   }

--- a/client/lobbies/devonly/lobby-landing-test.tsx
+++ b/client/lobbies/devonly/lobby-landing-test.tsx
@@ -1,5 +1,4 @@
 import { useState } from 'react'
-import styled from 'styled-components'
 import { assertUnreachable } from '../../../common/assert-unreachable'
 import { GameType } from '../../../common/games/game-type'
 import { LobbySummaryResponse } from '../../../common/lobbies/lobby-network'
@@ -8,9 +7,9 @@ import { makeSbMapId } from '../../../common/maps'
 import { encodePrettyId } from '../../../common/pretty-id'
 import { SbUser } from '../../../common/users/sb-user'
 import { makeSbUserId } from '../../../common/users/sb-user-id'
-import { labelSmall } from '../../styles/typography'
 import { LobbyLandingContent } from '../lobby-landing'
 import { LobbySummaryLoadState } from '../lobby-summary'
+import { ScenarioPicker } from './scenario-picker'
 
 const MOCK_HOST: SbUser = { id: makeSbUserId(1), name: 'HostUser', created: 0 }
 
@@ -57,56 +56,12 @@ function scenarioToState(scenario: Scenario): LobbySummaryLoadState | undefined 
   }
 }
 
-const ControlsLabel = styled.div`
-  ${labelSmall};
-  color: var(--theme-on-surface-variant);
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  margin: 16px 16px 8px;
-`
-
-const ScenarioButtons = styled.div`
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-  margin: 0 16px;
-`
-
-const ScenarioBtn = styled.button<{ $active: boolean }>`
-  ${labelSmall};
-  padding: 6px 14px;
-  border-radius: 20px;
-  border: 1px solid
-    ${props => (props.$active ? 'var(--theme-primary)' : 'var(--theme-outline-variant)')};
-  background: ${props =>
-    props.$active ? 'color-mix(in srgb, var(--theme-primary) 15%, transparent)' : 'transparent'};
-  color: ${props => (props.$active ? 'var(--theme-primary)' : 'var(--theme-on-surface-variant)')};
-  cursor: pointer;
-  transition:
-    background 150ms ease,
-    border-color 150ms ease,
-    color 150ms ease;
-
-  &:hover {
-    background: color-mix(in srgb, var(--theme-primary) 10%, transparent);
-    border-color: var(--theme-primary);
-    color: var(--theme-primary);
-  }
-`
-
 export function LobbyLandingTest() {
   const [scenario, setScenario] = useState<Scenario>('loaded')
 
   return (
     <div>
-      <ControlsLabel>Scenario</ControlsLabel>
-      <ScenarioButtons>
-        {SCENARIOS.map(s => (
-          <ScenarioBtn key={s.id} $active={scenario === s.id} onClick={() => setScenario(s.id)}>
-            {s.label}
-          </ScenarioBtn>
-        ))}
-      </ScenarioButtons>
+      <ScenarioPicker scenarios={SCENARIOS} active={scenario} onChange={setScenario} />
       <LobbyLandingContent state={scenarioToState(scenario)} />
     </div>
   )

--- a/client/lobbies/devonly/lobby-landing-test.tsx
+++ b/client/lobbies/devonly/lobby-landing-test.tsx
@@ -9,7 +9,8 @@ import { encodePrettyId } from '../../../common/pretty-id'
 import { SbUser } from '../../../common/users/sb-user'
 import { makeSbUserId } from '../../../common/users/sb-user-id'
 import { labelSmall } from '../../styles/typography'
-import { LobbyLandingContent, LobbyLandingState } from '../lobby-landing'
+import { LobbyLandingContent } from '../lobby-landing'
+import { LobbySummaryLoadState } from '../lobby-summary'
 
 const MOCK_HOST: SbUser = { id: makeSbUserId(1), name: 'HostUser', created: 0 }
 
@@ -41,7 +42,7 @@ const SCENARIOS: Array<{ id: Scenario; label: string }> = [
   { id: 'loaded', label: 'Loaded' },
 ]
 
-function scenarioToState(scenario: Scenario): LobbyLandingState | undefined {
+function scenarioToState(scenario: Scenario): LobbySummaryLoadState | undefined {
   switch (scenario) {
     case 'loading':
       return undefined

--- a/client/lobbies/devonly/routes.jsx
+++ b/client/lobbies/devonly/routes.jsx
@@ -1,5 +1,6 @@
 import { Component } from 'react'
 import { Link, Route, Switch } from 'wouter'
+import { JoinPreviewTest } from './join-preview-test'
 import { LobbyLandingTest } from './lobby-landing-test'
 import LobbyTest from './lobby-test'
 import RacePickerTest from './race-picker-test'
@@ -19,6 +20,9 @@ class DevLobbiesDashboard extends Component {
         <li>
           <Link href={`${BASE_URL}/lobby-landing`}>Lobby landing page</Link>
         </li>
+        <li>
+          <Link href={`${BASE_URL}/join-preview`}>Lobby join preview</Link>
+        </li>
       </ul>
     )
   }
@@ -30,6 +34,7 @@ export default () => {
       <Route path={`${BASE_URL}/lobby`} component={LobbyTest} />
       <Route path={`${BASE_URL}/race-picker`} component={RacePickerTest} />
       <Route path={`${BASE_URL}/lobby-landing`} component={LobbyLandingTest} />
+      <Route path={`${BASE_URL}/join-preview`} component={JoinPreviewTest} />
       <Route>
         <DevLobbiesDashboard />
       </Route>

--- a/client/lobbies/devonly/scenario-picker.tsx
+++ b/client/lobbies/devonly/scenario-picker.tsx
@@ -1,0 +1,65 @@
+import styled from 'styled-components'
+import { labelSmall } from '../../styles/typography'
+
+const ControlsLabel = styled.div`
+  ${labelSmall};
+  color: var(--theme-on-surface-variant);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  margin: 16px 16px 8px;
+`
+
+const ScenarioButtons = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 0 16px;
+`
+
+const ScenarioBtn = styled.button<{ $active: boolean }>`
+  ${labelSmall};
+  padding: 6px 14px;
+  border-radius: 20px;
+  border: 1px solid
+    ${props => (props.$active ? 'var(--theme-primary)' : 'var(--theme-outline-variant)')};
+  background: ${props =>
+    props.$active ? 'color-mix(in srgb, var(--theme-primary) 15%, transparent)' : 'transparent'};
+  color: ${props => (props.$active ? 'var(--theme-primary)' : 'var(--theme-on-surface-variant)')};
+  cursor: pointer;
+  transition:
+    background 150ms ease,
+    border-color 150ms ease,
+    color 150ms ease;
+
+  &:hover {
+    background: color-mix(in srgb, var(--theme-primary) 10%, transparent);
+    border-color: var(--theme-primary);
+    color: var(--theme-primary);
+  }
+`
+
+/**
+ * The shared scenario switcher for the lobby devonly test pages.
+ */
+export function ScenarioPicker<T extends string>({
+  scenarios,
+  active,
+  onChange,
+}: {
+  scenarios: ReadonlyArray<{ id: T; label: string }>
+  active: T
+  onChange: (scenario: T) => void
+}) {
+  return (
+    <>
+      <ControlsLabel>Scenario</ControlsLabel>
+      <ScenarioButtons>
+        {scenarios.map(s => (
+          <ScenarioBtn key={s.id} $active={active === s.id} onClick={() => onChange(s.id)}>
+            {s.label}
+          </ScenarioBtn>
+        ))}
+      </ScenarioButtons>
+    </>
+  )
+}

--- a/client/lobbies/join-lobby.tsx
+++ b/client/lobbies/join-lobby.tsx
@@ -14,12 +14,14 @@ import { isMatchmakingAtom } from '../matchmaking/matchmaking-atoms'
 import { FilledButton } from '../material/button'
 import siteSocket from '../network/site-socket'
 import { useAppDispatch, useAppSelector } from '../redux-hooks'
+import { useSnackbarController } from '../snackbars/snackbar-overlay'
 import { healthChecked } from '../starcraft/health-checked'
 import { FlexSpacer } from '../styles/flex-spacer'
 import { BodyLarge, BodyMedium, TitleLarge, TitleMedium } from '../styles/typography'
 import { joinLobby } from './action-creators'
 import { LobbySummary } from './lobby-list-reducer'
 import { navigateToLobby } from './lobby-url'
+import { lobbyJoinErrorMessage } from './view'
 
 const ListEntryRoot = styled.div`
   width: 100%;
@@ -172,6 +174,7 @@ function JoinLobby({ onNavigateToCreate }: JoinLobbyProps) {
 function LobbyList() {
   const { t } = useTranslation()
   const dispatch = useAppDispatch()
+  const snackbarController = useSnackbarController()
   const { byId, list } = useAppSelector(s => s.lobbyList)
 
   const isMatchmaking = useAtomValue(isMatchmakingAtom)
@@ -211,7 +214,13 @@ function LobbyList() {
                   )
                 } else {
                   healthChecked(() => {
-                    dispatch(joinLobby(lobby.id))
+                    dispatch(
+                      joinLobby(lobby.id, {
+                        onError: (err: unknown) => {
+                          snackbarController.showSnackbar(lobbyJoinErrorMessage(err, t))
+                        },
+                      }),
+                    )
                     navigateToLobby(lobby.id, lobby.name)
                   })()
                 }

--- a/client/lobbies/join-lobby.tsx
+++ b/client/lobbies/join-lobby.tsx
@@ -19,9 +19,9 @@ import { healthChecked } from '../starcraft/health-checked'
 import { FlexSpacer } from '../styles/flex-spacer'
 import { BodyLarge, BodyMedium, TitleLarge, TitleMedium } from '../styles/typography'
 import { joinLobby } from './action-creators'
+import { lobbyJoinErrorMessage } from './lobby-join-errors'
 import { LobbySummary } from './lobby-list-reducer'
 import { navigateToLobby } from './lobby-url'
-import { lobbyJoinErrorMessage } from './view'
 
 const ListEntryRoot = styled.div`
   width: 100%;

--- a/client/lobbies/lobby-join-errors.ts
+++ b/client/lobbies/lobby-join-errors.ts
@@ -1,0 +1,32 @@
+import { TFunction } from 'i18next'
+import { InvokeError } from 'nydus-client'
+import { LobbyJoinErrorCode } from '../../common/lobbies/lobby-network'
+
+/**
+ * Returns the user-facing message for a failed lobby join. Shared by every UI that dispatches
+ * `joinLobby` so the same failure reads the same everywhere. Kept in its own module so eagerly
+ * loaded callers (e.g. the lobby list) don't pull the code-split lobby view into their chunk.
+ */
+export function lobbyJoinErrorMessage(err: unknown, t: TFunction): string {
+  const code = err instanceof InvokeError ? err.body?.code : undefined
+  switch (code) {
+    case LobbyJoinErrorCode.NoLongerOpen:
+      return t('lobbies.summary.noLongerOpen', 'This lobby is no longer open.')
+    case LobbyJoinErrorCode.Full:
+      return t('lobbies.joinLobby.errorFull', 'This lobby is full.')
+    case LobbyJoinErrorCode.Banned:
+      return t('lobbies.joinLobby.errorBanned', "You've been banned from this lobby.")
+    case LobbyJoinErrorCode.AlreadyStarted:
+      return t('lobbies.state.started', 'This lobby has already started and cannot be joined.')
+    case LobbyJoinErrorCode.AlreadyInActivity:
+      return t(
+        'lobbies.joinLobby.errorAlreadyInActivity',
+        'You are already in a game, searching for a match, or in another lobby.',
+      )
+    default:
+      return t(
+        'lobbies.joinLobby.errorGeneric',
+        'Something went wrong while joining the lobby. Please try again.',
+      )
+  }
+}

--- a/client/lobbies/lobby-landing.tsx
+++ b/client/lobbies/lobby-landing.tsx
@@ -60,7 +60,7 @@ export interface LobbyLandingPageProps {
  */
 export function LobbyLandingPage({ params }: LobbyLandingPageProps) {
   const lobbyId = makeSbLobbyId(params.lobbyId)
-  const state = useLobbySummary(lobbyId)
+  const [state] = useLobbySummary(lobbyId)
 
   const lobbyName = state?.status === 'loaded' ? state.data.summary.name : undefined
   useCorrectLobbySlug(lobbyId, lobbyName)

--- a/client/lobbies/lobby-landing.tsx
+++ b/client/lobbies/lobby-landing.tsx
@@ -1,21 +1,15 @@
 import * as React from 'react'
-import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 import { assertUnreachable } from '../../common/assert-unreachable'
-import { gameTypeToLabel } from '../../common/games/game-type'
-import { LobbySummaryResponse } from '../../common/lobbies/lobby-network'
 import { makeSbLobbyId } from '../../common/lobbies/sb-lobby-id'
-import { apiUrl } from '../../common/urls'
 import { MaterialIcon } from '../icons/material/material-icon'
-import { MapThumbnail } from '../maps/map-thumbnail'
 import { FilledButton } from '../material/button'
 import { LinkButton } from '../material/link-button'
-import { fetchJson } from '../network/fetch'
-import { isFetchError } from '../network/fetch-errors'
 import { LoadingDotsArea } from '../progress/dots'
 import { CenteredContentContainer } from '../styles/centered-container'
-import { BodyLarge, BodyMedium, HeadlineMedium, bodyLarge, labelMedium } from '../styles/typography'
+import { BodyLarge, BodyMedium } from '../styles/typography'
+import { LobbySummaryDetails, LobbySummaryLoadState, useLobbySummary } from './lobby-summary'
 import { useCorrectLobbySlug } from './lobby-url'
 
 const Root = styled(CenteredContentContainer)`
@@ -38,55 +32,6 @@ const StateMessageIcon = styled(MaterialIcon).attrs({ size: 96, filled: false })
   color: var(--theme-on-surface-variant);
 `
 
-const LobbyName = styled(HeadlineMedium)`
-  margin-bottom: 24px;
-  text-align: center;
-  overflow-wrap: break-word;
-`
-
-const InfoLayout = styled.div`
-  display: flex;
-  flex-wrap: wrap;
-  align-items: flex-start;
-  justify-content: center;
-  gap: 24px;
-`
-
-const MAP_THUMBNAIL_SIZE = 208
-
-const MapThumbnailContainer = styled.div`
-  flex-shrink: 0;
-  width: ${MAP_THUMBNAIL_SIZE}px;
-`
-
-const DetailsList = styled.div`
-  flex-grow: 1;
-  margin-top: 8px;
-
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
-`
-
-const DetailRow = styled.div`
-  display: flex;
-  align-items: baseline;
-  gap: 16px;
-`
-
-const DetailLabel = styled.div`
-  ${labelMedium};
-  width: 88px;
-  flex-shrink: 0;
-
-  color: var(--theme-on-surface-variant);
-  text-align: right;
-`
-
-const DetailValue = styled.div`
-  ${bodyLarge};
-`
-
 const CtaLayout = styled.div`
   margin-top: 40px;
 
@@ -102,12 +47,6 @@ const AppHint = styled(BodyMedium)`
   text-align: center;
 `
 
-type LoadState =
-  { status: 'loaded'; data: LobbySummaryResponse } | { status: 'notFound' } | { status: 'error' }
-
-/** The load state driving {@link LobbyLandingContent}, exported for devonly test pages. */
-export type LobbyLandingState = LoadState
-
 export interface LobbyLandingPageProps {
   params: { lobbyId: string }
 }
@@ -121,37 +60,7 @@ export interface LobbyLandingPageProps {
  */
 export function LobbyLandingPage({ params }: LobbyLandingPageProps) {
   const lobbyId = makeSbLobbyId(params.lobbyId)
-
-  // Tagged with the lobby id it was resolved for, so a stale result from a previous id (e.g. if
-  // this route's params change without the component unmounting) doesn't get rendered as current --
-  // the state is treated as still-loading until a result tagged with the current id arrives.
-  const [result, setResult] = useState<{ lobbyId: string; state: LoadState }>()
-
-  useEffect(() => {
-    const controller = new AbortController()
-
-    fetchJson<LobbySummaryResponse>(apiUrl`lobbies/${lobbyId}/summary`, {
-      signal: controller.signal,
-    }).then(
-      data => {
-        setResult({ lobbyId, state: { status: 'loaded', data } })
-      },
-      err => {
-        if (controller.signal.aborted) {
-          return
-        }
-        setResult({
-          lobbyId,
-          state:
-            isFetchError(err) && err.status === 404 ? { status: 'notFound' } : { status: 'error' },
-        })
-      },
-    )
-
-    return () => controller.abort()
-  }, [lobbyId])
-
-  const state: LoadState | undefined = result?.lobbyId === lobbyId ? result.state : undefined
+  const state = useLobbySummary(lobbyId)
 
   const lobbyName = state?.status === 'loaded' ? state.data.summary.name : undefined
   useCorrectLobbySlug(lobbyId, lobbyName)
@@ -164,7 +73,7 @@ export function LobbyLandingPage({ params }: LobbyLandingPageProps) {
  * states without doing any fetching itself, so it can be driven directly (e.g. from a devonly test
  * page) without racing a real lobby.
  */
-export function LobbyLandingContent({ state }: { state: LobbyLandingState | undefined }) {
+export function LobbyLandingContent({ state }: { state: LobbySummaryLoadState | undefined }) {
   let content: React.ReactNode
   if (!state) {
     content = <LoadingDotsArea />
@@ -177,7 +86,12 @@ export function LobbyLandingContent({ state }: { state: LobbyLandingState | unde
         content = <ErrorState />
         break
       case 'loaded':
-        content = <LiveLobby summary={state.data} />
+        content = (
+          <>
+            <LobbySummaryDetails summary={state.data} />
+            <DownloadCta showAppHint={true} />
+          </>
+        )
         break
       default:
         content = assertUnreachable(state)
@@ -193,7 +107,7 @@ function NotFoundState() {
   return (
     <StateMessageLayout>
       <StateMessageIcon icon='other_houses' />
-      <BodyLarge>{t('lobbies.landing.notFound', 'This lobby is no longer open.')}</BodyLarge>
+      <BodyLarge>{t('lobbies.summary.noLongerOpen', 'This lobby is no longer open.')}</BodyLarge>
       <DownloadCta />
     </StateMessageLayout>
   )
@@ -210,46 +124,6 @@ function ErrorState() {
       </BodyLarge>
       <DownloadCta />
     </StateMessageLayout>
-  )
-}
-
-function LiveLobby({ summary }: { summary: LobbySummaryResponse }) {
-  const { t } = useTranslation()
-  const { summary: lobby, host } = summary
-
-  return (
-    <>
-      <LobbyName>{lobby.name}</LobbyName>
-      <InfoLayout>
-        <MapThumbnailContainer>
-          <MapThumbnail map={lobby.map} size={MAP_THUMBNAIL_SIZE} />
-        </MapThumbnailContainer>
-        <DetailsList>
-          <DetailRow>
-            <DetailLabel>{t('lobbies.landing.mapLabel', 'Map')}</DetailLabel>
-            <DetailValue>{lobby.map.name}</DetailValue>
-          </DetailRow>
-          <DetailRow>
-            <DetailLabel>{t('lobbies.landing.hostLabel', 'Host')}</DetailLabel>
-            <DetailValue>{host.name}</DetailValue>
-          </DetailRow>
-          <DetailRow>
-            <DetailLabel>{t('lobbies.landing.gameTypeLabel', 'Game type')}</DetailLabel>
-            <DetailValue>{gameTypeToLabel(lobby.gameType, t)}</DetailValue>
-          </DetailRow>
-          <DetailRow>
-            <DetailLabel>{t('lobbies.landing.slotsLabel', 'Slots')}</DetailLabel>
-            <DetailValue>
-              {t('lobbies.landing.openSlotCount', {
-                defaultValue: '{{count}} open',
-                count: lobby.openSlotCount,
-              })}
-            </DetailValue>
-          </DetailRow>
-        </DetailsList>
-      </InfoLayout>
-      <DownloadCta showAppHint={true} />
-    </>
   )
 }
 

--- a/client/lobbies/lobby-summary.tsx
+++ b/client/lobbies/lobby-summary.tsx
@@ -88,6 +88,9 @@ export function useLobbySummary(
       signal: controller.signal,
     }).then(
       data => {
+        if (controller.signal.aborted) {
+          return
+        }
         setResult({ lobbyId, state: { status: 'loaded', data } })
       },
       err => {

--- a/client/lobbies/lobby-summary.tsx
+++ b/client/lobbies/lobby-summary.tsx
@@ -67,14 +67,19 @@ export type LobbySummaryLoadState =
 
 /**
  * Fetches the unauthenticated lobby summary (`GET /api/1/lobbies/:lobbyId/summary`) for `lobbyId`.
- * Returns undefined while the fetch for the current `lobbyId` is in flight.
+ * Returns a tuple of the load state (undefined while the fetch for the current `lobbyId` is in
+ * flight) and a `refresh` function that re-runs the fetch for the current `lobbyId`.
  *
  * The result is tagged with the lobby id it was fetched for, so a stale result from a previous id
  * (e.g. if `lobbyId` changes without the caller unmounting) is never rendered as current -- the
- * state stays undefined until a result tagged with the current id arrives.
+ * state stays undefined until a result tagged with the current id arrives. A `refresh` doesn't
+ * clear the existing result, so the previous state remains rendered until the new one lands.
  */
-export function useLobbySummary(lobbyId: SbLobbyId): LobbySummaryLoadState | undefined {
+export function useLobbySummary(
+  lobbyId: SbLobbyId,
+): [state: LobbySummaryLoadState | undefined, refresh: () => void] {
   const [result, setResult] = useState<{ lobbyId: string; state: LobbySummaryLoadState }>()
+  const [refreshToken, setRefreshToken] = useState(0)
 
   useEffect(() => {
     const controller = new AbortController()
@@ -98,9 +103,11 @@ export function useLobbySummary(lobbyId: SbLobbyId): LobbySummaryLoadState | und
     )
 
     return () => controller.abort()
-  }, [lobbyId])
+  }, [lobbyId, refreshToken])
 
-  return result?.lobbyId === lobbyId ? result.state : undefined
+  const refresh = () => setRefreshToken(t => t + 1)
+
+  return [result?.lobbyId === lobbyId ? result.state : undefined, refresh]
 }
 
 /**

--- a/client/lobbies/lobby-summary.tsx
+++ b/client/lobbies/lobby-summary.tsx
@@ -60,8 +60,7 @@ const DetailValue = styled.div`
 `
 
 /**
- * The load state of a lobby summary fetch, tagged with the lobby id it belongs to (see
- * `useLobbySummary`).
+ * The load state of a lobby summary fetch (see `useLobbySummary`).
  */
 export type LobbySummaryLoadState =
   { status: 'loaded'; data: LobbySummaryResponse } | { status: 'notFound' } | { status: 'error' }

--- a/client/lobbies/lobby-summary.tsx
+++ b/client/lobbies/lobby-summary.tsx
@@ -73,7 +73,9 @@ export type LobbySummaryLoadState =
  * The result is tagged with the lobby id it was fetched for, so a stale result from a previous id
  * (e.g. if `lobbyId` changes without the caller unmounting) is never rendered as current -- the
  * state stays undefined until a result tagged with the current id arrives. A `refresh` doesn't
- * clear the existing result, so the previous state remains rendered until the new one lands.
+ * clear the existing result, so the previous state remains rendered until the new one lands. If a
+ * refresh fails for a reason other than a 404, the last successfully loaded summary is kept
+ * instead of being downgraded to the error state.
  */
 export function useLobbySummary(
   lobbyId: SbLobbyId,
@@ -97,11 +99,15 @@ export function useLobbySummary(
         if (controller.signal.aborted) {
           return
         }
-        setResult({
-          lobbyId,
-          state:
-            isFetchError(err) && err.status === 404 ? { status: 'notFound' } : { status: 'error' },
-        })
+        const state: LobbySummaryLoadState =
+          isFetchError(err) && err.status === 404 ? { status: 'notFound' } : { status: 'error' }
+        setResult(prev =>
+          // A lobby that's still loadable shouldn't lose its rendered details to a transient
+          // failure; only a 404 (definitively gone) replaces a loaded summary.
+          state.status === 'error' && prev?.lobbyId === lobbyId && prev.state.status === 'loaded'
+            ? prev
+            : { lobbyId, state },
+        )
       },
     )
 

--- a/client/lobbies/lobby-summary.tsx
+++ b/client/lobbies/lobby-summary.tsx
@@ -1,0 +1,148 @@
+import { useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import styled from 'styled-components'
+import { gameTypeToLabel } from '../../common/games/game-type'
+import { LobbySummaryResponse } from '../../common/lobbies/lobby-network'
+import { SbLobbyId } from '../../common/lobbies/sb-lobby-id'
+import { apiUrl } from '../../common/urls'
+import { MapThumbnail } from '../maps/map-thumbnail'
+import { fetchJson } from '../network/fetch'
+import { isFetchError } from '../network/fetch-errors'
+import { bodyLarge, HeadlineMedium, labelMedium } from '../styles/typography'
+
+const LobbyName = styled(HeadlineMedium)`
+  margin-bottom: 24px;
+  text-align: center;
+  overflow-wrap: break-word;
+`
+
+const InfoLayout = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  justify-content: center;
+  gap: 24px;
+`
+
+const MAP_THUMBNAIL_SIZE = 208
+
+const MapThumbnailContainer = styled.div`
+  flex-shrink: 0;
+  width: ${MAP_THUMBNAIL_SIZE}px;
+`
+
+const DetailsList = styled.div`
+  flex-grow: 1;
+  margin-top: 8px;
+
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+`
+
+const DetailRow = styled.div`
+  display: flex;
+  align-items: baseline;
+  gap: 16px;
+`
+
+const DetailLabel = styled.div`
+  ${labelMedium};
+  width: 88px;
+  flex-shrink: 0;
+
+  color: var(--theme-on-surface-variant);
+  text-align: right;
+`
+
+const DetailValue = styled.div`
+  ${bodyLarge};
+`
+
+/**
+ * The load state of a lobby summary fetch, tagged with the lobby id it belongs to (see
+ * `useLobbySummary`).
+ */
+export type LobbySummaryLoadState =
+  { status: 'loaded'; data: LobbySummaryResponse } | { status: 'notFound' } | { status: 'error' }
+
+/**
+ * Fetches the unauthenticated lobby summary (`GET /api/1/lobbies/:lobbyId/summary`) for `lobbyId`.
+ * Returns undefined while the fetch for the current `lobbyId` is in flight.
+ *
+ * The result is tagged with the lobby id it was fetched for, so a stale result from a previous id
+ * (e.g. if `lobbyId` changes without the caller unmounting) is never rendered as current -- the
+ * state stays undefined until a result tagged with the current id arrives.
+ */
+export function useLobbySummary(lobbyId: SbLobbyId): LobbySummaryLoadState | undefined {
+  const [result, setResult] = useState<{ lobbyId: string; state: LobbySummaryLoadState }>()
+
+  useEffect(() => {
+    const controller = new AbortController()
+
+    fetchJson<LobbySummaryResponse>(apiUrl`lobbies/${lobbyId}/summary`, {
+      signal: controller.signal,
+    }).then(
+      data => {
+        setResult({ lobbyId, state: { status: 'loaded', data } })
+      },
+      err => {
+        if (controller.signal.aborted) {
+          return
+        }
+        setResult({
+          lobbyId,
+          state:
+            isFetchError(err) && err.status === 404 ? { status: 'notFound' } : { status: 'error' },
+        })
+      },
+    )
+
+    return () => controller.abort()
+  }, [lobbyId])
+
+  return result?.lobbyId === lobbyId ? result.state : undefined
+}
+
+/**
+ * Renders a lobby's name and key details (map, host, game type, open slot count) from its
+ * unauthenticated summary. Shared by the logged-out web landing page and the in-app join preview.
+ */
+export function LobbySummaryDetails({ summary }: { summary: LobbySummaryResponse }) {
+  const { t } = useTranslation()
+  const { summary: lobby, host } = summary
+
+  return (
+    <>
+      <LobbyName>{lobby.name}</LobbyName>
+      <InfoLayout>
+        <MapThumbnailContainer>
+          <MapThumbnail map={lobby.map} size={MAP_THUMBNAIL_SIZE} />
+        </MapThumbnailContainer>
+        <DetailsList>
+          <DetailRow>
+            <DetailLabel>{t('lobbies.summary.mapLabel', 'Map')}</DetailLabel>
+            <DetailValue>{lobby.map.name}</DetailValue>
+          </DetailRow>
+          <DetailRow>
+            <DetailLabel>{t('lobbies.summary.hostLabel', 'Host')}</DetailLabel>
+            <DetailValue>{host.name}</DetailValue>
+          </DetailRow>
+          <DetailRow>
+            <DetailLabel>{t('lobbies.summary.gameTypeLabel', 'Game type')}</DetailLabel>
+            <DetailValue>{gameTypeToLabel(lobby.gameType, t)}</DetailValue>
+          </DetailRow>
+          <DetailRow>
+            <DetailLabel>{t('lobbies.summary.slotsLabel', 'Slots')}</DetailLabel>
+            <DetailValue>
+              {t('lobbies.summary.openSlotCount', {
+                defaultValue: '{{count}} open',
+                count: lobby.openSlotCount,
+              })}
+            </DetailValue>
+          </DetailRow>
+        </DetailsList>
+      </InfoLayout>
+    </>
+  )
+}

--- a/client/lobbies/view.tsx
+++ b/client/lobbies/view.tsx
@@ -371,6 +371,14 @@ function JoinableLobbyView({ routeLobbyId }: { routeLobbyId: SbLobbyId }) {
   const [lobbyGone, setLobbyGone] = useState(false)
   const [lobbyStarted, setLobbyStarted] = useState(false)
 
+  // The parent view can only correct the URL slug from the lobby name in the store, which isn't
+  // populated until the user is actually in the lobby -- the summary lets this page fix a stale or
+  // hand-edited slug the same way the logged-out landing page does.
+  useCorrectLobbySlug(
+    routeLobbyId,
+    summary?.status === 'loaded' ? summary.data.summary.name : undefined,
+  )
+
   const onJoinClick = () => {
     setIsJoining(true)
     dispatch(

--- a/client/lobbies/view.tsx
+++ b/client/lobbies/view.tsx
@@ -1,4 +1,3 @@
-import { TFunction } from 'i18next'
 import { InvokeError } from 'nydus-client'
 import * as React from 'react'
 import { useEffect, useState } from 'react'
@@ -41,6 +40,7 @@ import {
   startCountdown,
 } from './action-creators'
 import LobbyComponent from './lobby'
+import { lobbyJoinErrorMessage } from './lobby-join-errors'
 import { LobbySummaryDetails, LobbySummaryLoadState, useLobbySummary } from './lobby-summary'
 import { useCorrectLobbySlug } from './lobby-url'
 
@@ -355,34 +355,6 @@ const JoinPreviewLayout = styled.div`
   flex-direction: column;
   align-items: center;
 `
-
-/**
- * Returns the user-facing message for a failed lobby join. Shared by every UI that dispatches
- * `joinLobby` so the same failure reads the same everywhere.
- */
-export function lobbyJoinErrorMessage(err: unknown, t: TFunction): string {
-  const code = err instanceof InvokeError ? err.body?.code : undefined
-  switch (code) {
-    case LobbyJoinErrorCode.NoLongerOpen:
-      return t('lobbies.summary.noLongerOpen', 'This lobby is no longer open.')
-    case LobbyJoinErrorCode.Full:
-      return t('lobbies.joinLobby.errorFull', 'This lobby is full.')
-    case LobbyJoinErrorCode.Banned:
-      return t('lobbies.joinLobby.errorBanned', "You've been banned from this lobby.")
-    case LobbyJoinErrorCode.AlreadyStarted:
-      return t('lobbies.state.started', 'This lobby has already started and cannot be joined.')
-    case LobbyJoinErrorCode.AlreadyInActivity:
-      return t(
-        'lobbies.joinLobby.errorAlreadyInActivity',
-        'You are already in a game, searching for a match, or in another lobby.',
-      )
-    default:
-      return t(
-        'lobbies.joinLobby.errorGeneric',
-        'Something went wrong while joining the lobby. Please try again.',
-      )
-  }
-}
 
 /**
  * Renders the join interstitial for a lobby that isn't the current user's active lobby: a preview

--- a/client/lobbies/view.tsx
+++ b/client/lobbies/view.tsx
@@ -405,15 +405,15 @@ function JoinableLobbyView({ routeLobbyId }: { routeLobbyId: SbLobbyId }) {
     )
   }
 
-  // Every slot type counted by `openSlotCount` is joinable via the server's slot search, so a
-  // summary reporting 0 open slots means a join attempt is certain to fail with `Full`.
-  const isFull = summary?.status === 'loaded' && summary.data.summary.openSlotCount === 0
+  // NOTE: The button stays enabled even if the summary reports 0 open slots — the summary is a
+  // one-shot snapshot, so fullness may have changed since it loaded. The server arbitrates on
+  // click, and a still-full lobby gets the specific `Full` error below.
   const joinButton = (
     <StateMessageActionButton
       label={t('lobbies.joinLobby.action', 'Join lobby')}
       iconStart={<MaterialIcon icon='add' />}
       onClick={healthChecked(onJoinClick)}
-      disabled={isJoining || isFull}
+      disabled={isJoining}
       testName='join-lobby-button'
     />
   )

--- a/client/lobbies/view.tsx
+++ b/client/lobbies/view.tsx
@@ -1,10 +1,12 @@
+import { InvokeError } from 'nydus-client'
 import * as React from 'react'
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 import { Route, Switch } from 'wouter'
 import { assertUnreachable } from '../../common/assert-unreachable'
 import { LobbyState } from '../../common/lobbies'
+import { LobbyJoinErrorCode } from '../../common/lobbies/lobby-network'
 import { makeSbLobbyId, SbLobbyId } from '../../common/lobbies/sb-lobby-id'
 import { useRequireLogin, useSelfUser } from '../auth/auth-utils'
 import { navigateToGameResults } from '../games/action-creators'
@@ -13,9 +15,10 @@ import { MaterialIcon } from '../icons/material/material-icon'
 import { openMapPreviewDialog } from '../maps/action-creators'
 import { FilledButton } from '../material/button'
 import { push, replace } from '../navigation/routing'
-import LoadingIndicator from '../progress/dots'
+import LoadingIndicator, { LoadingDotsArea } from '../progress/dots'
 import { usePrevious } from '../react/state-hooks'
 import { useAppDispatch, useAppSelector } from '../redux-hooks'
+import { useSnackbarController } from '../snackbars/snackbar-overlay'
 import { BodyLarge } from '../styles/typography'
 import {
   activateLobby,
@@ -36,6 +39,7 @@ import {
   startCountdown,
 } from './action-creators'
 import LobbyComponent from './lobby'
+import { LobbySummaryDetails, useLobbySummary } from './lobby-summary'
 import { useCorrectLobbySlug } from './lobby-url'
 
 const LoadingArea = styled.div`
@@ -286,7 +290,6 @@ function LobbyStateContent({
   state: LobbyState
   routeLobbyId: SbLobbyId
 }) {
-  const dispatch = useAppDispatch()
   const { t } = useTranslation()
   switch (state) {
     case 'nonexistent':
@@ -305,28 +308,7 @@ function LobbyStateContent({
         </StateMessageLayout>
       )
     case 'exists':
-      // TODO(tec27): Show a preview of the lobby (like what's shown in the lobby list). We don't
-      // have a way to retrieve info about a single lobby in the lobby service and I don't want to
-      // change that a bunch right now (it needs replacing), so just taking the simple approach for
-      // now.
-      // TODO(tec27): Also handle join errors better, we have no real way of responding to failure
-      // here (like if the lobby is full)
-      return (
-        <StateMessageLayout>
-          <StateMessageIcon icon='meeting_room' />
-          <BodyLarge>
-            {t(
-              'lobbies.state.exists',
-              "You're not currently in this lobby. Would you like to join it?",
-            )}
-          </BodyLarge>
-          <StateMessageActionButton
-            label={t('lobbies.joinLobby.action', 'Join lobby')}
-            iconStart={<MaterialIcon icon='add' />}
-            onClick={() => dispatch(joinLobby(routeLobbyId))}
-          />
-        </StateMessageLayout>
-      )
+      return <JoinableLobbyView routeLobbyId={routeLobbyId} />
     case 'countingDown':
     case 'hasStarted':
       return (
@@ -340,4 +322,122 @@ function LobbyStateContent({
     default:
       return assertUnreachable(state)
   }
+}
+
+const JoinPreviewLayout = styled.div`
+  width: 100%;
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 16px 0;
+
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`
+
+/**
+ * Renders the join interstitial for a lobby that isn't the current user's active lobby: a preview
+ * of the lobby (fetched from the unauthenticated summary endpoint, same as the logged-out landing
+ * page) plus a button to join it. Falls back to a bare join prompt if the preview fails to load
+ * (the lobby may well still be joinable), and to a "no longer open" message if either the preview
+ * or the join attempt itself finds the lobby gone.
+ */
+function JoinableLobbyView({ routeLobbyId }: { routeLobbyId: SbLobbyId }) {
+  const dispatch = useAppDispatch()
+  const { t } = useTranslation()
+  const snackbarController = useSnackbarController()
+  const summary = useLobbySummary(routeLobbyId)
+  const [isJoining, setIsJoining] = useState(false)
+  const [lobbyGone, setLobbyGone] = useState(false)
+
+  const onJoinClick = () => {
+    setIsJoining(true)
+    dispatch(
+      joinLobby(routeLobbyId, {
+        onError: (err: unknown) => {
+          setIsJoining(false)
+
+          const code = err instanceof InvokeError ? err.body?.code : undefined
+          switch (code) {
+            case LobbyJoinErrorCode.NoLongerOpen:
+              setLobbyGone(true)
+              break
+            case LobbyJoinErrorCode.Full:
+              snackbarController.showSnackbar(
+                t('lobbies.joinLobby.errorFull', 'This lobby is full.'),
+              )
+              break
+            case LobbyJoinErrorCode.Banned:
+              snackbarController.showSnackbar(
+                t('lobbies.joinLobby.errorBanned', "You've been banned from this lobby."),
+              )
+              break
+            case LobbyJoinErrorCode.AlreadyStarted:
+              snackbarController.showSnackbar(
+                t('lobbies.state.started', 'This lobby has already started and cannot be joined.'),
+              )
+              break
+            default:
+              snackbarController.showSnackbar(
+                t(
+                  'lobbies.joinLobby.errorGeneric',
+                  'Something went wrong while joining the lobby. Please try again.',
+                ),
+              )
+              break
+          }
+        },
+      }),
+    )
+  }
+
+  const joinButton = (
+    <StateMessageActionButton
+      label={t('lobbies.joinLobby.action', 'Join lobby')}
+      iconStart={<MaterialIcon icon='add' />}
+      onClick={onJoinClick}
+      disabled={isJoining}
+      testName='join-lobby-button'
+    />
+  )
+
+  if (lobbyGone || summary?.status === 'notFound') {
+    return (
+      <StateMessageLayout>
+        <StateMessageIcon icon='other_houses' />
+        <BodyLarge>{t('lobbies.summary.noLongerOpen', 'This lobby is no longer open.')}</BodyLarge>
+        <StateMessageActionButton
+          label={t('lobbies.joinLobby.browseLobbies', 'Browse lobbies')}
+          iconStart={<MaterialIcon icon='list' />}
+          onClick={() => push('/play/lobbies')}
+        />
+      </StateMessageLayout>
+    )
+  }
+
+  if (!summary) {
+    return <LoadingDotsArea />
+  }
+
+  if (summary.status === 'error') {
+    return (
+      <StateMessageLayout>
+        <StateMessageIcon icon='meeting_room' />
+        <BodyLarge>
+          {t(
+            'lobbies.state.exists',
+            "You're not currently in this lobby. Would you like to join it?",
+          )}
+        </BodyLarge>
+        {joinButton}
+      </StateMessageLayout>
+    )
+  }
+
+  return (
+    <JoinPreviewLayout>
+      <LobbySummaryDetails summary={summary.data} />
+      {joinButton}
+    </JoinPreviewLayout>
+  )
 }

--- a/client/lobbies/view.tsx
+++ b/client/lobbies/view.tsx
@@ -1,3 +1,4 @@
+import { TFunction } from 'i18next'
 import { InvokeError } from 'nydus-client'
 import * as React from 'react'
 import { useEffect, useState } from 'react'
@@ -356,6 +357,34 @@ const JoinPreviewLayout = styled.div`
 `
 
 /**
+ * Returns the user-facing message for a failed lobby join. Shared by every UI that dispatches
+ * `joinLobby` so the same failure reads the same everywhere.
+ */
+export function lobbyJoinErrorMessage(err: unknown, t: TFunction): string {
+  const code = err instanceof InvokeError ? err.body?.code : undefined
+  switch (code) {
+    case LobbyJoinErrorCode.NoLongerOpen:
+      return t('lobbies.summary.noLongerOpen', 'This lobby is no longer open.')
+    case LobbyJoinErrorCode.Full:
+      return t('lobbies.joinLobby.errorFull', 'This lobby is full.')
+    case LobbyJoinErrorCode.Banned:
+      return t('lobbies.joinLobby.errorBanned', "You've been banned from this lobby.")
+    case LobbyJoinErrorCode.AlreadyStarted:
+      return t('lobbies.state.started', 'This lobby has already started and cannot be joined.')
+    case LobbyJoinErrorCode.AlreadyInActivity:
+      return t(
+        'lobbies.joinLobby.errorAlreadyInActivity',
+        'You are already in a game, searching for a match, or in another lobby.',
+      )
+    default:
+      return t(
+        'lobbies.joinLobby.errorGeneric',
+        'Something went wrong while joining the lobby. Please try again.',
+      )
+  }
+}
+
+/**
  * Renders the join interstitial for a lobby that isn't the current user's active lobby: a preview
  * of the lobby (fetched from the unauthenticated summary endpoint, same as the logged-out landing
  * page) plus a button to join it. Falls back to a bare join prompt if the preview fails to load
@@ -391,34 +420,11 @@ function JoinableLobbyView({ routeLobbyId }: { routeLobbyId: SbLobbyId }) {
             case LobbyJoinErrorCode.NoLongerOpen:
               setLobbyGone(true)
               break
-            case LobbyJoinErrorCode.Full:
-              snackbarController.showSnackbar(
-                t('lobbies.joinLobby.errorFull', 'This lobby is full.'),
-              )
-              break
-            case LobbyJoinErrorCode.Banned:
-              snackbarController.showSnackbar(
-                t('lobbies.joinLobby.errorBanned', "You've been banned from this lobby."),
-              )
-              break
             case LobbyJoinErrorCode.AlreadyStarted:
               setLobbyStarted(true)
               break
-            case LobbyJoinErrorCode.AlreadyInActivity:
-              snackbarController.showSnackbar(
-                t(
-                  'lobbies.joinLobby.errorAlreadyInActivity',
-                  'You are already in a game, searching for a match, or in another lobby.',
-                ),
-              )
-              break
             default:
-              snackbarController.showSnackbar(
-                t(
-                  'lobbies.joinLobby.errorGeneric',
-                  'Something went wrong while joining the lobby. Please try again.',
-                ),
-              )
+              snackbarController.showSnackbar(lobbyJoinErrorMessage(err, t))
               break
           }
 

--- a/client/lobbies/view.tsx
+++ b/client/lobbies/view.tsx
@@ -40,7 +40,7 @@ import {
   startCountdown,
 } from './action-creators'
 import LobbyComponent from './lobby'
-import { LobbySummaryDetails, useLobbySummary } from './lobby-summary'
+import { LobbySummaryDetails, LobbySummaryLoadState, useLobbySummary } from './lobby-summary'
 import { useCorrectLobbySlug } from './lobby-url'
 
 const LoadingArea = styled.div`
@@ -327,7 +327,20 @@ function LobbyStartedMessage() {
       <BodyLarge>
         {t('lobbies.state.started', 'This lobby has already started and cannot be joined.')}
       </BodyLarge>
+      <BrowseLobbiesButton />
     </StateMessageLayout>
+  )
+}
+
+function BrowseLobbiesButton() {
+  const { t } = useTranslation()
+
+  return (
+    <StateMessageActionButton
+      label={t('lobbies.joinLobby.browseLobbies', 'Browse lobbies')}
+      iconStart={<MaterialIcon icon='list' />}
+      onClick={() => push('/play/lobbies')}
+    />
   )
 }
 
@@ -353,7 +366,7 @@ function JoinableLobbyView({ routeLobbyId }: { routeLobbyId: SbLobbyId }) {
   const dispatch = useAppDispatch()
   const { t } = useTranslation()
   const snackbarController = useSnackbarController()
-  const summary = useLobbySummary(routeLobbyId)
+  const [summary, refreshSummary] = useLobbySummary(routeLobbyId)
   const [isJoining, setIsJoining] = useState(false)
   const [lobbyGone, setLobbyGone] = useState(false)
   const [lobbyStarted, setLobbyStarted] = useState(false)
@@ -400,19 +413,52 @@ function JoinableLobbyView({ routeLobbyId }: { routeLobbyId: SbLobbyId }) {
               )
               break
           }
+
+          refreshSummary()
         },
       }),
     )
   }
 
+  return (
+    <JoinableLobbyContent
+      summary={summary}
+      lobbyGone={lobbyGone}
+      lobbyStarted={lobbyStarted}
+      isJoining={isJoining}
+      onJoinClick={healthChecked(onJoinClick)}
+    />
+  )
+}
+
+/**
+ * The presentational part of {@link JoinableLobbyView}: renders the loading/gone/started/error/
+ * loaded states without doing any fetching or dispatching itself, so it can be driven directly
+ * (e.g. from a devonly test page) without racing a real lobby or join attempt.
+ */
+export function JoinableLobbyContent({
+  summary,
+  lobbyGone,
+  lobbyStarted,
+  isJoining,
+  onJoinClick,
+}: {
+  summary: LobbySummaryLoadState | undefined
+  lobbyGone: boolean
+  lobbyStarted: boolean
+  isJoining: boolean
+  onJoinClick: () => void
+}) {
+  const { t } = useTranslation()
+
   // NOTE: The button stays enabled even if the summary reports 0 open slots — the summary is a
-  // one-shot snapshot, so fullness may have changed since it loaded. The server arbitrates on
-  // click, and a still-full lobby gets the specific `Full` error below.
+  // snapshot, so fullness may have changed since it loaded. The server arbitrates on click, and a
+  // still-full lobby gets a specific error message from the join attempt.
   const joinButton = (
     <StateMessageActionButton
       label={t('lobbies.joinLobby.action', 'Join lobby')}
       iconStart={<MaterialIcon icon='add' />}
-      onClick={healthChecked(onJoinClick)}
+      onClick={onJoinClick}
       disabled={isJoining}
       testName='join-lobby-button'
     />
@@ -427,11 +473,7 @@ function JoinableLobbyView({ routeLobbyId }: { routeLobbyId: SbLobbyId }) {
       <StateMessageLayout>
         <StateMessageIcon icon='other_houses' />
         <BodyLarge>{t('lobbies.summary.noLongerOpen', 'This lobby is no longer open.')}</BodyLarge>
-        <StateMessageActionButton
-          label={t('lobbies.joinLobby.browseLobbies', 'Browse lobbies')}
-          iconStart={<MaterialIcon icon='list' />}
-          onClick={() => push('/play/lobbies')}
-        />
+        <BrowseLobbiesButton />
       </StateMessageLayout>
     )
   }

--- a/client/lobbies/view.tsx
+++ b/client/lobbies/view.tsx
@@ -405,12 +405,15 @@ function JoinableLobbyView({ routeLobbyId }: { routeLobbyId: SbLobbyId }) {
     )
   }
 
+  // Every slot type counted by `openSlotCount` is joinable via the server's slot search, so a
+  // summary reporting 0 open slots means a join attempt is certain to fail with `Full`.
+  const isFull = summary?.status === 'loaded' && summary.data.summary.openSlotCount === 0
   const joinButton = (
     <StateMessageActionButton
       label={t('lobbies.joinLobby.action', 'Join lobby')}
       iconStart={<MaterialIcon icon='add' />}
       onClick={healthChecked(onJoinClick)}
-      disabled={isJoining}
+      disabled={isJoining || isFull}
       testName='join-lobby-button'
     />
   )

--- a/client/lobbies/view.tsx
+++ b/client/lobbies/view.tsx
@@ -19,6 +19,7 @@ import LoadingIndicator, { LoadingDotsArea } from '../progress/dots'
 import { usePrevious } from '../react/state-hooks'
 import { useAppDispatch, useAppSelector } from '../redux-hooks'
 import { useSnackbarController } from '../snackbars/snackbar-overlay'
+import { healthChecked } from '../starcraft/health-checked'
 import { BodyLarge } from '../styles/typography'
 import {
   activateLobby,
@@ -308,20 +309,26 @@ function LobbyStateContent({
         </StateMessageLayout>
       )
     case 'exists':
-      return <JoinableLobbyView routeLobbyId={routeLobbyId} />
+      return <JoinableLobbyView key={routeLobbyId} routeLobbyId={routeLobbyId} />
     case 'countingDown':
     case 'hasStarted':
-      return (
-        <StateMessageLayout>
-          <StateMessageIcon icon='avg_pace' />
-          <BodyLarge>
-            {t('lobbies.state.started', 'This lobby has already started and cannot be joined.')}
-          </BodyLarge>
-        </StateMessageLayout>
-      )
+      return <LobbyStartedMessage />
     default:
       return assertUnreachable(state)
   }
+}
+
+function LobbyStartedMessage() {
+  const { t } = useTranslation()
+
+  return (
+    <StateMessageLayout>
+      <StateMessageIcon icon='avg_pace' />
+      <BodyLarge>
+        {t('lobbies.state.started', 'This lobby has already started and cannot be joined.')}
+      </BodyLarge>
+    </StateMessageLayout>
+  )
 }
 
 const JoinPreviewLayout = styled.div`
@@ -339,8 +346,8 @@ const JoinPreviewLayout = styled.div`
  * Renders the join interstitial for a lobby that isn't the current user's active lobby: a preview
  * of the lobby (fetched from the unauthenticated summary endpoint, same as the logged-out landing
  * page) plus a button to join it. Falls back to a bare join prompt if the preview fails to load
- * (the lobby may well still be joinable), and to a "no longer open" message if either the preview
- * or the join attempt itself finds the lobby gone.
+ * (the lobby may well still be joinable), and to a "no longer open" or "already started" message
+ * if the preview or the join attempt itself finds the lobby gone or started.
  */
 function JoinableLobbyView({ routeLobbyId }: { routeLobbyId: SbLobbyId }) {
   const dispatch = useAppDispatch()
@@ -349,6 +356,7 @@ function JoinableLobbyView({ routeLobbyId }: { routeLobbyId: SbLobbyId }) {
   const summary = useLobbySummary(routeLobbyId)
   const [isJoining, setIsJoining] = useState(false)
   const [lobbyGone, setLobbyGone] = useState(false)
+  const [lobbyStarted, setLobbyStarted] = useState(false)
 
   const onJoinClick = () => {
     setIsJoining(true)
@@ -373,8 +381,14 @@ function JoinableLobbyView({ routeLobbyId }: { routeLobbyId: SbLobbyId }) {
               )
               break
             case LobbyJoinErrorCode.AlreadyStarted:
+              setLobbyStarted(true)
+              break
+            case LobbyJoinErrorCode.AlreadyInActivity:
               snackbarController.showSnackbar(
-                t('lobbies.state.started', 'This lobby has already started and cannot be joined.'),
+                t(
+                  'lobbies.joinLobby.errorAlreadyInActivity',
+                  'You are already in a game, searching for a match, or in another lobby.',
+                ),
               )
               break
             default:
@@ -395,11 +409,15 @@ function JoinableLobbyView({ routeLobbyId }: { routeLobbyId: SbLobbyId }) {
     <StateMessageActionButton
       label={t('lobbies.joinLobby.action', 'Join lobby')}
       iconStart={<MaterialIcon icon='add' />}
-      onClick={onJoinClick}
+      onClick={healthChecked(onJoinClick)}
       disabled={isJoining}
       testName='join-lobby-button'
     />
   )
+
+  if (lobbyStarted) {
+    return <LobbyStartedMessage />
+  }
 
   if (lobbyGone || summary?.status === 'notFound') {
     return (

--- a/common/lobbies/lobby-network.ts
+++ b/common/lobbies/lobby-network.ts
@@ -24,6 +24,7 @@ export enum LobbyJoinErrorCode {
   Full = 'full',
   Banned = 'banned',
   AlreadyStarted = 'alreadyStarted',
+  AlreadyInActivity = 'alreadyInActivity',
 }
 
 export type LobbyEvent =

--- a/common/lobbies/lobby-network.ts
+++ b/common/lobbies/lobby-network.ts
@@ -15,6 +15,17 @@ export enum LobbyCreateErrorCode {
   NameTaken = 'nameTaken',
 }
 
+/**
+ * Machine-readable codes attached to the error body of failed `/lobbies/join` invokes, so the
+ * client can distinguish failures worth explaining specifically.
+ */
+export enum LobbyJoinErrorCode {
+  NoLongerOpen = 'noLongerOpen',
+  Full = 'full',
+  Banned = 'banned',
+  AlreadyStarted = 'alreadyStarted',
+}
+
 export type LobbyEvent =
   | LobbyInitEvent
   | LobbyDiffEvent

--- a/server/lib/wsapi/lobbies.test.ts
+++ b/server/lib/wsapi/lobbies.test.ts
@@ -4,7 +4,11 @@ import { container } from 'tsyringe'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { GameServerRegion, makeGameServerRegionId } from '../../../common/game-server-regions'
 import { GameType } from '../../../common/games/game-type'
-import { LobbyCreateErrorCode, LobbySummaryJson } from '../../../common/lobbies/lobby-network'
+import {
+  LobbyCreateErrorCode,
+  LobbyJoinErrorCode,
+  LobbySummaryJson,
+} from '../../../common/lobbies/lobby-network'
 import { makeSbLobbyId } from '../../../common/lobbies/sb-lobby-id'
 import { makeSbMapId, MapInfo, MapVisibility, Tileset } from '../../../common/maps'
 import { asMockedFunction } from '../../../common/testing/mocks'
@@ -301,6 +305,32 @@ describe('wsapi/lobbies/visibility', () => {
     await createLobby(host, 'Duplicate name', 'listed')
 
     await expect(createLobby(otherHost, 'Duplicate name', 'unlisted')).resolves.toBeDefined()
+  })
+
+  test('joining an unknown lobby id rejects with a noLongerOpen code', async () => {
+    await expect(
+      lobbyApi.join(apiData(joiner, { id: makeSbLobbyId('nonexistent-lobby') }), NOOP_NEXT),
+    ).rejects.toMatchObject({
+      body: { code: LobbyJoinErrorCode.NoLongerOpen },
+    })
+  })
+
+  test('joining a full lobby rejects with a full code', async () => {
+    const { id } = await lobbyApi.create(
+      apiData(host, {
+        name: 'Full lobby',
+        map: BIG_GAME_HUNTERS.id,
+        gameType: GameType.OneVsOne,
+        visibility: 'listed',
+      }),
+      NOOP_NEXT,
+    )
+    // 1v1 lobbies only have 2 slots, and the host already occupies one.
+    await lobbyApi.join(apiData(joiner, { id }), NOOP_NEXT)
+
+    await expect(lobbyApi.join(apiData(otherHost, { id }), NOOP_NEXT)).rejects.toMatchObject({
+      body: { code: LobbyJoinErrorCode.Full },
+    })
   })
 
   test('a counting-down lobby is reported as gone by the summary getter', async () => {

--- a/server/lib/wsapi/lobbies.test.ts
+++ b/server/lib/wsapi/lobbies.test.ts
@@ -4,6 +4,7 @@ import { container } from 'tsyringe'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { GameServerRegion, makeGameServerRegionId } from '../../../common/game-server-regions'
 import { GameType } from '../../../common/games/game-type'
+import { findSlotByUserId } from '../../../common/lobbies'
 import {
   LobbyCreateErrorCode,
   LobbyJoinErrorCode,
@@ -112,7 +113,7 @@ const LISTER_USER: SbUser = { id: makeSbUserId(4), name: 'ListerUser' } as SbUse
 
 const NOOP_NEXT = async () => {}
 
-describe('wsapi/lobbies/visibility', () => {
+describe('wsapi/lobbies', () => {
   let nydus: NydusServer
   let fakeNydus: FakeNydusServer
   let lobbyApi: LobbyApi
@@ -193,166 +194,204 @@ describe('wsapi/lobbies/visibility', () => {
     vi.useRealTimers()
   })
 
-  test('creating a listed lobby publishes it to the list and counts it', async () => {
-    await createLobby(host, 'Listed lobby', 'listed')
+  describe('visibility', () => {
+    test('creating a listed lobby publishes it to the list and counts it', async () => {
+      await createLobby(host, 'Listed lobby', 'listed')
 
-    expect(listPublishes()).toEqual([
-      { action: 'add', payload: expect.objectContaining({ name: 'Listed lobby' }) },
-    ])
-    expect(latestLobbiesCount()).toBe(1)
-  })
+      expect(listPublishes()).toEqual([
+        { action: 'add', payload: expect.objectContaining({ name: 'Listed lobby' }) },
+      ])
+      expect(latestLobbiesCount()).toBe(1)
+    })
 
-  test('creating an unlisted lobby publishes nothing to the list and is not counted', async () => {
-    await createLobby(host, 'Unlisted lobby', 'unlisted')
+    test('creating an unlisted lobby publishes nothing to the list and is not counted', async () => {
+      await createLobby(host, 'Unlisted lobby', 'unlisted')
 
-    expect(listPublishes()).toEqual([])
-    expect(latestLobbiesCount()).toBe(0)
-  })
+      expect(listPublishes()).toEqual([])
+      expect(latestLobbiesCount()).toBe(0)
+    })
 
-  test("a new subscriber's initial snapshot omits unlisted lobbies", async () => {
-    await createLobby(host, 'Unlisted lobby', 'unlisted')
-    await createLobby(otherHost, 'Listed lobby', 'listed')
+    test("a new subscriber's initial snapshot omits unlisted lobbies", async () => {
+      await createLobby(host, 'Unlisted lobby', 'unlisted')
+      await createLobby(otherHost, 'Listed lobby', 'listed')
 
-    await lobbyApi.subscribe(apiData(lister), NOOP_NEXT)
+      await lobbyApi.subscribe(apiData(lister), NOOP_NEXT)
 
-    const subscribeCall = fakeNydus.subscribeClient.mock.calls.find(
-      ([, path]) => path === '/lobbies',
-    )
-    const initialData = subscribeCall![2] as { action: string; payload: Iterable<LobbySummaryJson> }
-    expect(initialData.action).toBe('full')
-    expect(Array.from(initialData.payload).map(l => l.name)).toEqual(['Listed lobby'])
-  })
+      const subscribeCall = fakeNydus.subscribeClient.mock.calls.find(
+        ([, path]) => path === '/lobbies',
+      )
+      const initialData = subscribeCall![2] as {
+        action: string
+        payload: Iterable<LobbySummaryJson>
+      }
+      expect(initialData.action).toBe('full')
+      expect(Array.from(initialData.payload).map(l => l.name)).toEqual(['Listed lobby'])
+    })
 
-  test('closing an unlisted lobby does not publish its id to the list', async () => {
-    await createLobby(host, 'Unlisted lobby', 'unlisted')
-    fakeNydus.publish.mockClear()
+    test('closing an unlisted lobby does not publish its id to the list', async () => {
+      await createLobby(host, 'Unlisted lobby', 'unlisted')
+      fakeNydus.publish.mockClear()
 
-    // The host is the only occupant, so leaving deletes the lobby.
-    await lobbyApi.leave(apiData(host), NOOP_NEXT)
+      // The host is the only occupant, so leaving deletes the lobby.
+      await lobbyApi.leave(apiData(host), NOOP_NEXT)
 
-    expect(listPublishes()).toEqual([])
-  })
+      expect(listPublishes()).toEqual([])
+    })
 
-  test('closing a listed lobby publishes its id to the list', async () => {
-    const { id } = await createLobby(host, 'Listed lobby', 'listed')
-    fakeNydus.publish.mockClear()
+    test('closing a listed lobby publishes its id to the list', async () => {
+      const { id } = await createLobby(host, 'Listed lobby', 'listed')
+      fakeNydus.publish.mockClear()
 
-    await lobbyApi.leave(apiData(host), NOOP_NEXT)
+      await lobbyApi.leave(apiData(host), NOOP_NEXT)
 
-    expect(listPublishes()).toEqual([{ action: 'delete', payload: id }])
-  })
+      expect(listPublishes()).toEqual([{ action: 'delete', payload: id }])
+    })
 
-  test('starting the countdown in an unlisted lobby does not publish its id to the list', async () => {
-    const { id } = await createLobby(host, 'Unlisted lobby', 'unlisted')
-    await lobbyApi.join(apiData(joiner, { id }), NOOP_NEXT)
-    fakeNydus.publish.mockClear()
+    test('starting the countdown in an unlisted lobby does not publish its id to the list', async () => {
+      const { id } = await createLobby(host, 'Unlisted lobby', 'unlisted')
+      await lobbyApi.join(apiData(joiner, { id }), NOOP_NEXT)
+      fakeNydus.publish.mockClear()
 
-    // Keeps the countdown from ever elapsing, so the test doesn't leave a game load in flight. The
-    // handler publishes everything we care about before it suspends on the timer.
-    vi.useFakeTimers()
-    lobbyApi.startCountdown(apiData(host), NOOP_NEXT).catch(() => {})
+      // Keeps the countdown from ever elapsing, so the test doesn't leave a game load in flight. The
+      // handler publishes everything we care about before it suspends on the timer.
+      vi.useFakeTimers()
+      lobbyApi.startCountdown(apiData(host), NOOP_NEXT).catch(() => {})
 
-    // The occupants still see the countdown; only the public list is kept in the dark.
-    expect(
-      fakeNydus.publish.mock.calls.some(
-        ([path, data]) => path === `/lobbies/${id}` && data?.type === 'startCountdown',
-      ),
-    ).toBe(true)
-    expect(listPublishes()).toEqual([])
-  })
+      // The occupants still see the countdown; only the public list is kept in the dark.
+      expect(
+        fakeNydus.publish.mock.calls.some(
+          ([path, data]) => path === `/lobbies/${id}` && data?.type === 'startCountdown',
+        ),
+      ).toBe(true)
+      expect(listPublishes()).toEqual([])
+    })
 
-  test('joining an unlisted lobby does not publish an update to the list', async () => {
-    const { id } = await createLobby(host, 'Unlisted lobby', 'unlisted')
-    fakeNydus.publish.mockClear()
+    test('joining an unlisted lobby does not publish an update to the list', async () => {
+      const { id } = await createLobby(host, 'Unlisted lobby', 'unlisted')
+      fakeNydus.publish.mockClear()
 
-    await lobbyApi.join(apiData(joiner, { id }), NOOP_NEXT)
+      await lobbyApi.join(apiData(joiner, { id }), NOOP_NEXT)
 
-    // The occupants still see the new player; only the public list is kept in the dark.
-    expect(
-      fakeNydus.publish.mock.calls.some(
-        ([path, data]) => path === `/lobbies/${id}` && data?.type === 'diff',
-      ),
-    ).toBe(true)
-    expect(listPublishes()).toEqual([])
-  })
+      // The occupants still see the new player; only the public list is kept in the dark.
+      expect(
+        fakeNydus.publish.mock.calls.some(
+          ([path, data]) => path === `/lobbies/${id}` && data?.type === 'diff',
+        ),
+      ).toBe(true)
+      expect(listPublishes()).toEqual([])
+    })
 
-  test('joining a listed lobby publishes an update to the list', async () => {
-    const { id } = await createLobby(host, 'Listed lobby', 'listed')
-    fakeNydus.publish.mockClear()
+    test('joining a listed lobby publishes an update to the list', async () => {
+      const { id } = await createLobby(host, 'Listed lobby', 'listed')
+      fakeNydus.publish.mockClear()
 
-    await lobbyApi.join(apiData(joiner, { id }), NOOP_NEXT)
+      await lobbyApi.join(apiData(joiner, { id }), NOOP_NEXT)
 
-    expect(listPublishes()).toEqual([
-      { action: 'update', payload: expect.objectContaining({ name: 'Listed lobby' }) },
-    ])
-  })
+      expect(listPublishes()).toEqual([
+        { action: 'update', payload: expect.objectContaining({ name: 'Listed lobby' }) },
+      ])
+    })
 
-  test('creating a listed lobby with a name matching an existing listed lobby fails', async () => {
-    await createLobby(host, 'Duplicate name', 'listed')
+    test('creating a listed lobby with a name matching an existing listed lobby fails', async () => {
+      await createLobby(host, 'Duplicate name', 'listed')
 
-    await expect(createLobby(otherHost, 'Duplicate name', 'listed')).rejects.toMatchObject({
-      body: { code: LobbyCreateErrorCode.NameTaken },
+      await expect(createLobby(otherHost, 'Duplicate name', 'listed')).rejects.toMatchObject({
+        body: { code: LobbyCreateErrorCode.NameTaken },
+      })
+    })
+
+    test('creating a listed lobby with a name matching an existing unlisted lobby succeeds', async () => {
+      await createLobby(host, 'Duplicate name', 'unlisted')
+
+      await expect(createLobby(otherHost, 'Duplicate name', 'listed')).resolves.toBeDefined()
+    })
+
+    test('creating an unlisted lobby with a name matching an existing listed lobby succeeds', async () => {
+      await createLobby(host, 'Duplicate name', 'listed')
+
+      await expect(createLobby(otherHost, 'Duplicate name', 'unlisted')).resolves.toBeDefined()
     })
   })
 
-  test('creating a listed lobby with a name matching an existing unlisted lobby succeeds', async () => {
-    await createLobby(host, 'Duplicate name', 'unlisted')
+  describe('join', () => {
+    test('joining an unknown lobby id rejects with a noLongerOpen code', async () => {
+      await expect(
+        lobbyApi.join(apiData(joiner, { id: makeSbLobbyId('nonexistent-lobby') }), NOOP_NEXT),
+      ).rejects.toMatchObject({
+        body: { code: LobbyJoinErrorCode.NoLongerOpen },
+      })
+    })
 
-    await expect(createLobby(otherHost, 'Duplicate name', 'listed')).resolves.toBeDefined()
-  })
+    test('joining a full lobby rejects with a full code', async () => {
+      const { id } = await lobbyApi.create(
+        apiData(host, {
+          name: 'Full lobby',
+          map: BIG_GAME_HUNTERS.id,
+          gameType: GameType.OneVsOne,
+          visibility: 'listed',
+        }),
+        NOOP_NEXT,
+      )
+      // 1v1 lobbies only have 2 slots, and the host already occupies one.
+      await lobbyApi.join(apiData(joiner, { id }), NOOP_NEXT)
 
-  test('creating an unlisted lobby with a name matching an existing listed lobby succeeds', async () => {
-    await createLobby(host, 'Duplicate name', 'listed')
+      await expect(lobbyApi.join(apiData(otherHost, { id }), NOOP_NEXT)).rejects.toMatchObject({
+        body: { code: LobbyJoinErrorCode.Full },
+      })
+    })
 
-    await expect(createLobby(otherHost, 'Duplicate name', 'unlisted')).resolves.toBeDefined()
-  })
+    test('joining while already in a gameplay activity rejects with an alreadyInActivity code', async () => {
+      const { id } = await createLobby(otherHost, 'Other lobby', 'listed')
 
-  test('joining an unknown lobby id rejects with a noLongerOpen code', async () => {
-    await expect(
-      lobbyApi.join(apiData(joiner, { id: makeSbLobbyId('nonexistent-lobby') }), NOOP_NEXT),
-    ).rejects.toMatchObject({
-      body: { code: LobbyJoinErrorCode.NoLongerOpen },
+      // Hosting a lobby registers the host as being in a gameplay activity.
+      await createLobby(host, 'Own lobby', 'listed')
+
+      await expect(lobbyApi.join(apiData(host, { id }), NOOP_NEXT)).rejects.toMatchObject({
+        body: { code: LobbyJoinErrorCode.AlreadyInActivity },
+      })
+    })
+
+    test('joining a lobby during its countdown rejects with an alreadyStarted code', async () => {
+      const { id } = await createLobby(host, 'Listed lobby', 'listed')
+      // A countdown requires 2 opposing sides.
+      await lobbyApi.join(apiData(joiner, { id }), NOOP_NEXT)
+
+      // Keeps the countdown from ever elapsing, so the test doesn't leave a game load in flight.
+      vi.useFakeTimers()
+      lobbyApi.startCountdown(apiData(host), NOOP_NEXT).catch(() => {})
+
+      // The client renders a counting-down/loading lobby as a whole separate screen, distinct from
+      // the ordinary join-error codes covered above.
+      await expect(lobbyApi.join(apiData(otherHost, { id }), NOOP_NEXT)).rejects.toMatchObject({
+        body: { code: LobbyJoinErrorCode.AlreadyStarted },
+      })
+    })
+
+    test('joining a lobby the user was banned from rejects with a banned code', async () => {
+      const { id } = await createLobby(host, 'Listed lobby', 'listed')
+      await lobbyApi.join(apiData(joiner, { id }), NOOP_NEXT)
+
+      const lobby = lobbyApi.lobbies.get(makeSbLobbyId(id))!
+      const [, , joinerSlot] = findSlotByUserId(lobby, JOINER_USER.id)
+      await lobbyApi.banPlayer(apiData(host, { slotId: joinerSlot!.id }), NOOP_NEXT)
+
+      await expect(lobbyApi.join(apiData(joiner, { id }), NOOP_NEXT)).rejects.toMatchObject({
+        body: { code: LobbyJoinErrorCode.Banned },
+      })
     })
   })
 
-  test('joining a full lobby rejects with a full code', async () => {
-    const { id } = await lobbyApi.create(
-      apiData(host, {
-        name: 'Full lobby',
-        map: BIG_GAME_HUNTERS.id,
-        gameType: GameType.OneVsOne,
-        visibility: 'listed',
-      }),
-      NOOP_NEXT,
-    )
-    // 1v1 lobbies only have 2 slots, and the host already occupies one.
-    await lobbyApi.join(apiData(joiner, { id }), NOOP_NEXT)
+  describe('summaries', () => {
+    test('a counting-down lobby is reported as gone by the summary getter', async () => {
+      const { id } = await createLobby(host, 'Listed lobby', 'listed')
+      await lobbyApi.join(apiData(joiner, { id }), NOOP_NEXT)
 
-    await expect(lobbyApi.join(apiData(otherHost, { id }), NOOP_NEXT)).rejects.toMatchObject({
-      body: { code: LobbyJoinErrorCode.Full },
+      // It can no longer be joined, so the unauthenticated summary endpoint and page-metadata
+      // resolver must treat it the same as a lobby that doesn't exist at all.
+      vi.useFakeTimers()
+      lobbyApi.startCountdown(apiData(host), NOOP_NEXT).catch(() => {})
+
+      expect(getLobbySummary(makeSbLobbyId(id))).toBeUndefined()
     })
-  })
-
-  test('joining while already in a gameplay activity rejects with an alreadyInActivity code', async () => {
-    const { id } = await createLobby(otherHost, 'Other lobby', 'listed')
-
-    // Hosting a lobby registers the host as being in a gameplay activity.
-    await createLobby(host, 'Own lobby', 'listed')
-
-    await expect(lobbyApi.join(apiData(host, { id }), NOOP_NEXT)).rejects.toMatchObject({
-      body: { code: LobbyJoinErrorCode.AlreadyInActivity },
-    })
-  })
-
-  test('a counting-down lobby is reported as gone by the summary getter', async () => {
-    const { id } = await createLobby(host, 'Listed lobby', 'listed')
-    await lobbyApi.join(apiData(joiner, { id }), NOOP_NEXT)
-
-    // It can no longer be joined, so the unauthenticated summary endpoint and page-metadata
-    // resolver must treat it the same as a lobby that doesn't exist at all.
-    vi.useFakeTimers()
-    lobbyApi.startCountdown(apiData(host), NOOP_NEXT).catch(() => {})
-
-    expect(getLobbySummary(makeSbLobbyId(id))).toBeUndefined()
   })
 })

--- a/server/lib/wsapi/lobbies.test.ts
+++ b/server/lib/wsapi/lobbies.test.ts
@@ -333,6 +333,17 @@ describe('wsapi/lobbies/visibility', () => {
     })
   })
 
+  test('joining while already in a gameplay activity rejects with an alreadyInActivity code', async () => {
+    const { id } = await createLobby(otherHost, 'Other lobby', 'listed')
+
+    // Hosting a lobby registers the host as being in a gameplay activity.
+    await createLobby(host, 'Own lobby', 'listed')
+
+    await expect(lobbyApi.join(apiData(host, { id }), NOOP_NEXT)).rejects.toMatchObject({
+      body: { code: LobbyJoinErrorCode.AlreadyInActivity },
+    })
+  })
+
   test('a counting-down lobby is reported as gone by the summary getter', async () => {
     const { id } = await createLobby(host, 'Listed lobby', 'listed')
     await lobbyApi.join(apiData(joiner, { id }), NOOP_NEXT)

--- a/server/lib/wsapi/lobbies.ts
+++ b/server/lib/wsapi/lobbies.ts
@@ -388,7 +388,9 @@ export class LobbyApi {
     let updated = Lobbies.addPlayer(lobby, teamIndex, slotIndex, player)
 
     if (!this.activityRegistry.registerActiveClient(user.userId, client)) {
-      throw new errors.Conflict('user is already active in a gameplay activity')
+      throw Object.assign(new errors.Conflict('user is already active in a gameplay activity'), {
+        body: { code: LobbyJoinErrorCode.AlreadyInActivity },
+      })
     }
 
     // TODO(tec27): Fix map signing URL refreshing in a more general way, see #593

--- a/server/lib/wsapi/lobbies.ts
+++ b/server/lib/wsapi/lobbies.ts
@@ -23,7 +23,11 @@ import {
   Lobby,
   LobbyVisibility,
 } from '../../../common/lobbies'
-import { LobbyCreateErrorCode, LobbySlotCreateEvent } from '../../../common/lobbies/lobby-network'
+import {
+  LobbyCreateErrorCode,
+  LobbyJoinErrorCode,
+  LobbySlotCreateEvent,
+} from '../../../common/lobbies/lobby-network'
 import { SbLobbyId } from '../../../common/lobbies/sb-lobby-id'
 import * as Slots from '../../../common/lobbies/slot'
 import { Slot, SlotType } from '../../../common/lobbies/slot'
@@ -338,21 +342,31 @@ export class LobbyApi {
     const joinRegion = await this._resolveRegion(region)
 
     if (!this.lobbies.has(id)) {
-      throw new errors.NotFound('no lobby found with that id')
+      throw Object.assign(new errors.NotFound('no lobby found with that id'), {
+        body: { code: LobbyJoinErrorCode.NoLongerOpen },
+      })
     }
     const lobby = this.lobbies.get(id)!
-    this.ensureLobbyNotTransient(lobby)
+    try {
+      this.ensureLobbyNotTransient(lobby)
+    } catch (err) {
+      throw Object.assign(err as Error, { body: { code: LobbyJoinErrorCode.AlreadyStarted } })
+    }
 
     if (
       this.lobbyBannedUsers.has(lobby.id) &&
       this.lobbyBannedUsers.get(lobby.id)!.includes(client.userId)
     ) {
-      throw new errors.Conflict('user has been banned from this lobby')
+      throw Object.assign(new errors.Conflict('user has been banned from this lobby'), {
+        body: { code: LobbyJoinErrorCode.Banned },
+      })
     }
 
     const [teamIndex, slotIndex, availableSlot] = Lobbies.findAvailableSlot(lobby)
     if (teamIndex === undefined || slotIndex === undefined) {
-      throw new errors.Conflict('lobby is full')
+      throw Object.assign(new errors.Conflict('lobby is full'), {
+        body: { code: LobbyJoinErrorCode.Full },
+      })
     }
 
     let player

--- a/server/public/locales/en/global.json
+++ b/server/public/locales/en/global.json
@@ -920,6 +920,7 @@
     "joinLobby": {
       "action": "Join lobby",
       "browseLobbies": "Browse lobbies",
+      "errorAlreadyInActivity": "You are already in a game, searching for a match, or in another lobby.",
       "errorBanned": "You've been banned from this lobby.",
       "errorFull": "This lobby is full.",
       "errorGeneric": "Something went wrong while joining the lobby. Please try again.",

--- a/server/public/locales/en/global.json
+++ b/server/public/locales/en/global.json
@@ -919,6 +919,10 @@
     },
     "joinLobby": {
       "action": "Join lobby",
+      "browseLobbies": "Browse lobbies",
+      "errorBanned": "You've been banned from this lobby.",
+      "errorFull": "This lobby is full.",
+      "errorGeneric": "Something went wrong while joining the lobby. Please try again.",
       "matchmakingActiveDialogText": "You cannot join lobbies while a matchmaking search is active.",
       "matchmakingActiveDialogTitle": "Joining lobbies disabled",
       "noActiveLobbies": "There are no active lobbies",
@@ -929,15 +933,8 @@
     },
     "landing": {
       "download": "Download ShieldBattery",
-      "gameTypeLabel": "Game type",
-      "hostLabel": "Host",
       "loadError": "There was a problem loading this lobby.",
-      "mapLabel": "Map",
-      "notFound": "This lobby is no longer open.",
-      "openInApp": "Already have ShieldBattery? Open this link from inside the app to join the lobby.",
-      "openSlotCount_one": "{{count}} open",
-      "openSlotCount_other": "{{count}} open",
-      "slotsLabel": "Slots"
+      "openInApp": "Already have ShieldBattery? Open this link from inside the app to join the lobby."
     },
     "lobby": {
       "copiedInviteLink": "Copied!",
@@ -984,6 +981,15 @@
       "exists": "You're not currently in this lobby. Would you like to join it?",
       "nonexistent": "Lobby not found. Would you like to create a new one?",
       "started": "This lobby has already started and cannot be joined."
+    },
+    "summary": {
+      "gameTypeLabel": "Game type",
+      "hostLabel": "Host",
+      "mapLabel": "Map",
+      "noLongerOpen": "This lobby is no longer open.",
+      "openSlotCount_one": "{{count}} open",
+      "openSlotCount_other": "{{count}} open",
+      "slotsLabel": "Slots"
     }
   },
   "map": {


### PR DESCRIPTION
Stacked on #1378.

The in-app `/lobbies/:id` interstitial for a lobby you're not in previously showed only "You're not currently in this lobby. Would you like to join it?" — and if the lobby had closed since the link was shared, clicking **Join** did absolutely nothing (the socket invoke rejected and no one listened). Both TODOs on that screen are now resolved:

- The join page fetches the lobby summary (#1378's unauthenticated endpoint) and shows the lobby name, map thumbnail, host, game type, and open slot count alongside the Join button. The summary fetch hook and details presentation move to a shared `lobby-summary` module used by both this page and the logged-out landing page. If the summary fetch fails for a reason other than 404, the page falls back to the old bare join prompt (the lobby may well still be joinable).
- `/lobbies/join` failures now carry machine-readable codes (`LobbyJoinErrorCode`, following the `LobbyCreateErrorCode` pattern). The client maps them: a no-longer-open lobby flips the page to a first-class "This lobby is no longer open" state with a Browse-lobbies CTA (also shown when the summary fetch 404s), while full / banned / already-started show snackbars. Unknown errors get a generic failure snackbar.
- `joinLobby` gains optional `onSuccess`/`onError` callbacks, mirroring `createLobby`, so the join page can observe the invoke result. Reducer-visible actions are unchanged.

The moved/new strings stay English-only for now, matching the landing-page strings they sit alongside.

Tested:
- Live-verified in two Electron clients: invite-link → preview render (name/map/host/type/slots), successful join, and the stale-page case — host closes the lobby while the other client sits on the preview, Join click flips to the "no longer open" state with working Browse-lobbies navigation
- Live-verified the logged-out browser landing page still renders fully after the shared-module refactor (details + slug redirect)
- New wsapi tests: joining an unknown lobby id rejects with `noLongerOpen`, joining a full lobby rejects with `full`