### PR TITLE
Translate the untranslated string backlog (es/ko/ru/zh-Hans)

### DIFF
--- a/server/public/locales/es/global.json
+++ b/server/public/locales/es/global.json
@@ -422,6 +422,10 @@
     "watchReplays": "Mira replays"
   },
   "clientUpdate": {
+    "errorBoundary": {
+      "contents": "Algo salió mal durante la actualización. Visita <2>nuestro sitio web</2> para descargar la última versión.",
+      "title": "Error al actualizar"
+    },
     "overlay": {
       "errorBody": "Hubo un error al descargar la actualización. Reinicia y prueba de nuevo, o visita <2>nuestro sitio web</2> para descargar la última versión.",
       "errorTitle": "Error al descargar la actualización",
@@ -449,6 +453,7 @@
       "create": "Crear",
       "decline": "Rechazar",
       "delete": "Eliminar",
+      "done": "Listo",
       "download": "Descargar",
       "edit": "Editar",
       "hide": "Esconder",
@@ -507,6 +512,17 @@
     "filters": {
       "advanced": "Avanzado",
       "custom": "Personalizado",
+      "date": "Fecha",
+      "dateFrom": "Desde",
+      "datePast3Months": "Últimos 3 meses",
+      "datePastMonth": "Último mes",
+      "datePastWeek": "Última semana",
+      "datePastYear": "Último año",
+      "datePresets": "Rangos rápidos",
+      "dateRangeBetween": "{{start}} – {{end}}",
+      "dateRangeFrom": "Desde {{date}}",
+      "dateRangeUntil": "Hasta {{date}}",
+      "dateTo": "Hasta",
       "duration": {
         "10to20": "10-20 min",
         "20to30": "20-30 min",
@@ -705,6 +721,10 @@
     "reporting": {
       "actionedNotification": "Se tomaron medidas contra un jugador que reportaste. Gracias por ayudar a mantener la comunidad justa.",
       "pointsRefundedNotification": "Se te han devuelto los puntos de clasificación que perdiste en una partida que fue revisada."
+    },
+    "sidePanel": {
+      "empty": "Selecciona una partida para ver sus detalles",
+      "viewFullResults": "Ver resultados completos"
     }
   },
   "gameServerRegions": {
@@ -902,6 +922,11 @@
     },
     "joinLobby": {
       "action": "Unirse al lobby",
+      "browseLobbies": "Explorar lobbies",
+      "errorAlreadyInActivity": "Ya estás en una partida, en búsqueda de emparejamiento o en otro lobby.",
+      "errorBanned": "Te han baneado de este lobby.",
+      "errorFull": "Este lobby está lleno.",
+      "errorGeneric": "Algo salió mal al unirte al lobby. Intenta de nuevo.",
       "matchmakingActiveDialogText": "No puedes unirte a lobbies mientras una búsqueda de emparejamiento está activa.",
       "matchmakingActiveDialogTitle": "Unirse a lobbies deshabilitado",
       "noActiveLobbies": "No hay lobbies activos",
@@ -910,6 +935,11 @@
       "openSlotCount_many": "{{count}} de ranuras abiertas",
       "openSlotCount_other": "{{count}} ranuras abiertas",
       "title": "Unirse al lobby"
+    },
+    "landing": {
+      "download": "Descargar ShieldBattery",
+      "loadError": "Hubo un problema al cargar este lobby.",
+      "openInApp": "¿Ya tienes ShieldBattery? Abre este enlace desde la aplicación para unirte al lobby."
     },
     "lobby": {
       "copiedInviteLink": "¡Copiado!",
@@ -956,6 +986,16 @@
       "exists": "Actualmente no estás en este lobby. ¿Únete?",
       "nonexistent": "No se encontró el lobby. ¿Quieres crear uno nuevo?",
       "started": "Este lobby ya ha comenzado y no se puede unir."
+    },
+    "summary": {
+      "gameTypeLabel": "Tipo de juego",
+      "hostLabel": "Anfitrión",
+      "mapLabel": "Mapa",
+      "noLongerOpen": "Este lobby ya no está abierto.",
+      "openSlotCount_one": "{{count}} abierta",
+      "openSlotCount_many": "{{count}} abiertas",
+      "openSlotCount_other": "{{count}} abiertas",
+      "slotsLabel": "Ranuras"
     }
   },
   "map": {
@@ -1214,6 +1254,9 @@
     }
   },
   "material": {
+    "dateTextField": {
+      "pickerButtonLabel": "Mostrar selector"
+    },
     "datetimeTextField": {
       "pickerButtonLabel": "Mostrar selector"
     },
@@ -1327,6 +1370,8 @@
       "moveDown": "Bajar",
       "moveUp": "Subir",
       "newPlaylistMenu": "Nueva playlist…",
+      "noFolders": "No hay carpetas de replays",
+      "noFoldersBody": "Añade una carpeta en Ajustes > Aplicación > Sistema para empezar a indexar replays.",
       "noMatches": "Ningún replay coincide",
       "playlist": {
         "createError": "Error al crear la playlist: {{errorMessage}}",
@@ -1396,8 +1441,13 @@
         "title": "Sonido"
       },
       "system": {
+        "addReplayFolder": "Añadir carpeta",
+        "addReplayFolderTitle": "Selecciona una carpeta de replays",
         "filesOverline": "Archivos",
         "networkOverline": "Red",
+        "removeReplayFolder": "Quitar carpeta",
+        "replayFoldersDescription": "Carpetas indexadas por tu biblioteca de replays. La carpeta de replays predeterminada de StarCraft se añade automáticamente. Al quitar una carpeta, sus replays se eliminan de la biblioteca, incluidos sus marcadores y entradas en playlists.",
+        "replayFoldersTitle": "Carpetas de replays",
         "replayQuickOpen": "Inicie los replays abiertos con ShieldBattery inmediatamente sin vista previa",
         "runOnStartup": "Ejecute ShieldBattery al iniciar el sistema",
         "serverRegion": {
@@ -1427,6 +1477,45 @@
         "apmValue": "Valor APM",
         "apmValueValidation": "Introduzca un valor entre 1 y 999",
         "colorCycling": "Habilitar ciclo de color",
+        "colorNames": {
+          "azure": "Azur",
+          "black": "Negro",
+          "blue": "Azul",
+          "blueishGrey": "Gris azulado",
+          "brick": "Ladrillo",
+          "brown": "Marrón",
+          "cyan": "Cian",
+          "deepTeal": "Turquesa oscuro",
+          "emerald": "Esmeralda",
+          "gold": "Dorado",
+          "green": "Verde",
+          "grey": "Gris",
+          "lime": "Lima",
+          "magenta": "Magenta",
+          "mint": "Menta",
+          "moss": "Musgo",
+          "navy": "Azul marino",
+          "olive": "Oliva",
+          "orange": "Naranja",
+          "paleGreen": "Verde pálido",
+          "paleYellow": "Amarillo pálido",
+          "peach": "Melocotón",
+          "pink": "Rosa",
+          "purple": "Morado",
+          "red": "Rojo",
+          "rose": "Rosado",
+          "scarlet": "Escarlata",
+          "sky": "Celeste",
+          "tan": "Beige",
+          "teal": "Turquesa",
+          "violet": "Violeta",
+          "white": "Blanco",
+          "yellow": "Amarillo"
+        },
+        "colorPicker": {
+          "builtinColorsLabel": "Colores de StarCraft",
+          "customRgb": "RGB personalizado"
+        },
         "consoleSkins": {
           "20thAnniversary": "20.º aniversario de StarCraft",
           "blizzcon2017": "BlizzCon 2017",
@@ -1438,6 +1527,32 @@
           "warcraft3": "Botín de WarCraft 3"
         },
         "devOnlySettings": "Configuración solo para desarrolladores",
+        "ffaColorPreset": {
+          "arcade": "Arcade",
+          "attributionPrefix": "Paleta: ",
+          "classic": "Clásico",
+          "colorblindSafe": "Apto para daltónicos",
+          "custom": "Personalizado",
+          "jewel": "Joya",
+          "neon": "Neón",
+          "pear": "Pear",
+          "resurrect": "Resurrect",
+          "title": "Preajuste"
+        },
+        "ffaColors": {
+          "attributionBy": "{{palette}} de {{author}}",
+          "attributionInspiredBy": "Inspirado en {{palette}}",
+          "clear": "Limpiar",
+          "pickerTargetPool": "Colores individuales · #{{n}}",
+          "pickerTargetSelf": "Tu color individual",
+          "poolGroup": "Grupo de colores",
+          "poolHint": "Mínimo 8 colores, para que cada jugador siempre tenga un color único.",
+          "quickSwatchesLabel": "De esta paleta",
+          "selfAddLabel": "Color fijo para ti (opcional)",
+          "selfSetHint": "Siempre tendrás este color en partidas sin equipos. Se reserva para que otros jugadores no lo usen.",
+          "selfUnsetHint": "Recibirás un color del grupo, como todos los demás.",
+          "title": "Colores individuales"
+        },
         "gameTimer": "Temporizador de juego",
         "ingameSkins": {
           "carbot": "Carbot",
@@ -1445,7 +1560,13 @@
           "preorder": "Hacer un pedido",
           "title": "Máscara dentro del juego"
         },
+        "interface": {
+          "title": "Interfaz"
+        },
         "latency": "Mostrar latencia",
+        "mapMinimap": {
+          "title": "Mapa y minimapa"
+        },
         "minimapPosition": {
           "bottomLeft": "Esquina izquierda inferior",
           "standard": "Estándar",
@@ -1457,25 +1578,75 @@
           "title": "Terreno del minimapa"
         },
         "showBonusSkins": "Mostrar máscaras de bonificación",
+        "skins": {
+          "description": "Deben comprarse a Blizzard.",
+          "title": "Skins"
+        },
         "startingFog": {
           "legacy": "Legado",
           "showResources": "Mostrar recursos",
           "showTerrainAndResources": "Mostrar terreno y recursos",
           "title": "Comienza la niebla de guerra"
         },
+        "teamColorPreset": {
+          "colorblindSafe": "Apto para daltónicos",
+          "coolVsWarm": "Fríos vs cálidos",
+          "custom": "Personalizado",
+          "legacyDiplomacy": "Diplomacia clásica",
+          "title": "Preajuste",
+          "warmVsCool": "Cálidos vs fríos"
+        },
         "teamColors": {
+          "addColor": "Añadir un color",
+          "clear": "Limpiar",
+          "copyFromPreset": "Copiar del preajuste",
+          "copyFromPresetCaption": "Sobrescribe tus colores personalizados",
+          "description": "Cómo se ven los colores de los jugadores en tus partidas. Cambia de modo dentro del juego con Mayús+Tab.",
+          "editHint": "Haz clic en un color para cambiarlo o arrástralo para reordenar.",
+          "header": "Colores de los jugadores",
           "label": "Modo",
           "mode": {
             "presetEverywhere": "Usar preajuste en todas partes",
+            "presetEverywhereDesc": "Tu esquema de colores en las unidades y el minimapa.",
             "presetOnMinimap": "Usar preajuste en el minimapa",
-            "standard": "Estándar"
+            "presetOnMinimapDesc": "Colores de aliados y enemigos solo en el minimapa.",
+            "standard": "Estándar",
+            "standardDesc": "Los colores normales de StarCraft. Los ajustes de abajo no tienen efecto."
           },
+          "offNote": "Desactivado. Se usan los colores individuales en todas las partidas.",
+          "pickerTargetAlly": "Esquema de equipo · aliados · #{{n}}",
+          "pickerTargetEnemy": "Esquema de equipo · enemigos · #{{n}}",
+          "pickerTargetSelf": "Esquema de equipo · tu color",
+          "poolOrderedHint": "Los colores se usan en orden, desde la izquierda.",
+          "poolShuffledHint": "Estos colores se usan en orden aleatorio en cada partida.",
           "preview": {
             "allies": "Aliados",
             "enemies": "Enemigos",
             "self": "Tú"
           },
-          "title": "Colores de equipo"
+          "previewHeaderFfa": "Vista previa (sin equipos)",
+          "previewHeaderTeam": "Vista previa (4x4)",
+          "quickSwatchesLabel": "De esta paleta",
+          "removeColor": "Quitar color",
+          "selectCustomHint": "Selecciona el preajuste Personalizado para editar los colores.",
+          "selfAddLabel": "Color fijo para ti (opcional)",
+          "selfBadge": "TÚ",
+          "selfFirstAllyHint": "Tendrás el primer color de aliado.",
+          "selfOverrideSetHint": "Siempre serás de este color en partidas de equipos.",
+          "selfShuffleHint": "Recibirás un color aleatorio del grupo de tu equipo en cada partida.",
+          "shuffle": "Mezclar colores en cada partida",
+          "title": "Colores de equipo",
+          "yourTeam": "Tu equipo"
+        },
+        "teamColorUsage": {
+          "always": "En partidas de equipos y 1x1",
+          "alwaysDesc": "Tu oponente de 1x1 siempre recibe el primer color de enemigo.",
+          "alwaysShuffledDesc": "Tu oponente de 1x1 recibe un color aleatorio de tu grupo de enemigos.",
+          "exceptIn1v1": "Solo en partidas de equipos",
+          "exceptIn1v1Desc": "Las partidas de dos jugadores usan colores individuales.",
+          "never": "Nunca",
+          "neverDesc": "Cada uno mantiene su propio color, incluso cuando cambian las alianzas.",
+          "title": "Uso de colores de equipo"
         },
         "title": "Gameplay",
         "unitPortraits": {

--- a/server/public/locales/es/global.json
+++ b/server/public/locales/es/global.json
@@ -1580,7 +1580,7 @@
         "showBonusSkins": "Mostrar máscaras de bonificación",
         "skins": {
           "description": "Deben comprarse a Blizzard.",
-          "title": "Skins"
+          "title": "Máscaras"
         },
         "startingFog": {
           "legacy": "Legado",

--- a/server/public/locales/ko/global.json
+++ b/server/public/locales/ko/global.json
@@ -1241,7 +1241,7 @@
   },
   "material": {
     "dateTextField": {
-      "pickerButtonLabel": "선택기 열기"
+      "pickerButtonLabel": "선택기 표시"
     },
     "datetimeTextField": {
       "pickerButtonLabel": "선택기 표시"

--- a/server/public/locales/ko/global.json
+++ b/server/public/locales/ko/global.json
@@ -420,6 +420,10 @@
     "watchReplays": "다시보기"
   },
   "clientUpdate": {
+    "errorBoundary": {
+      "contents": "업데이트 중 문제가 발생했습니다. <2>웹사이트</2>에서 최신 버전을 다운로드해 주세요.",
+      "title": "업데이트 오류"
+    },
     "overlay": {
       "errorBody": "업데이트를 다운로드하는 동안 오류가 발생했습니다. 다시 시작하고 시도하거나 <2>저희 웹사이트</2>를 방문하여 최신 버전을 다운로드하십시오.",
       "errorTitle": "업데이트 다운로드 중 오류 발생",
@@ -447,6 +451,7 @@
       "create": "만들기",
       "decline": "거절해",
       "delete": "삭제",
+      "done": "완료",
       "download": "다운로드",
       "edit": "편집",
       "hide": "숨기기",
@@ -501,6 +506,17 @@
     "filters": {
       "advanced": "고급",
       "custom": "커스텀",
+      "date": "날짜",
+      "dateFrom": "시작",
+      "datePast3Months": "최근 3개월",
+      "datePastMonth": "최근 1개월",
+      "datePastWeek": "최근 1주",
+      "datePastYear": "최근 1년",
+      "datePresets": "빠른 선택",
+      "dateRangeBetween": "{{start}} – {{end}}",
+      "dateRangeFrom": "{{date}}부터",
+      "dateRangeUntil": "{{date}}까지",
+      "dateTo": "종료",
       "duration": {
         "10to20": "10~20분",
         "20to30": "20~30분",
@@ -699,6 +715,10 @@
     "reporting": {
       "actionedNotification": "회원님이 신고하신 플레이어에게 조치가 취해졌습니다. 공정한 커뮤니티를 유지하는 데 도움을 주셔서 감사합니다.",
       "pointsRefundedNotification": "게임이 검토되어, 회원님이 잃은 랭크 점수가 복구되었습니다."
+    },
+    "sidePanel": {
+      "empty": "게임을 선택하면 상세 정보가 표시됩니다",
+      "viewFullResults": "전체 결과 보기"
     }
   },
   "gameServerRegions": {
@@ -896,12 +916,22 @@
     },
     "joinLobby": {
       "action": "로비 참가",
+      "browseLobbies": "로비 둘러보기",
+      "errorAlreadyInActivity": "이미 게임 중이거나, 매치메이킹 중이거나, 다른 로비에 참여 중입니다.",
+      "errorBanned": "이 로비에서 차단되었습니다.",
+      "errorFull": "로비가 가득 찼습니다.",
+      "errorGeneric": "로비에 참가하는 중 문제가 발생했습니다. 다시 시도해 주세요.",
       "matchmakingActiveDialogText": "매치메이킹이 진행 중일 때는 로비에 참여할 수 없습니다.",
       "matchmakingActiveDialogTitle": "로비 참가 비활성화됨",
       "noActiveLobbies": "활성 로비가 없습니다",
       "noOpenLobbies": "공개된 로비가 없습니다",
       "openSlotCount_other": "{{count}} 슬롯 열림",
       "title": "로비 참가"
+    },
+    "landing": {
+      "download": "ShieldBattery 다운로드",
+      "loadError": "로비를 불러오는 중 문제가 발생했습니다.",
+      "openInApp": "이미 ShieldBattery를 사용 중이신가요? 앱 안에서 이 링크를 열면 로비에 참가할 수 있습니다."
     },
     "lobby": {
       "copiedInviteLink": "복사되었습니다!",
@@ -948,6 +978,14 @@
       "exists": "현재 이 로비에 참여 중이 아닙니다. 참가하시겠어요?",
       "nonexistent": "로비를 찾을 수 없습니다. 새로 만드시겠어요?",
       "started": "이 로비는 이미 게임이 시작되어 참여할 수 없습니다."
+    },
+    "summary": {
+      "gameTypeLabel": "게임 방식",
+      "hostLabel": "호스트",
+      "mapLabel": "맵",
+      "noLongerOpen": "이 로비는 더 이상 열려 있지 않습니다.",
+      "openSlotCount_other": "{{count}}개 열림",
+      "slotsLabel": "슬롯"
     }
   },
   "map": {
@@ -1202,6 +1240,9 @@
     }
   },
   "material": {
+    "dateTextField": {
+      "pickerButtonLabel": "선택기 열기"
+    },
     "datetimeTextField": {
       "pickerButtonLabel": "선택기 표시"
     },
@@ -1315,6 +1356,8 @@
       "moveDown": "아래로 이동",
       "moveUp": "위로 이동",
       "newPlaylistMenu": "새 재생목록…",
+      "noFolders": "리플레이 폴더 없음",
+      "noFoldersBody": "설정 > 앱 > 시스템에서 폴더를 추가하면 리플레이 인덱싱이 시작됩니다.",
       "noMatches": "일치하는 리플레이가 없습니다",
       "playlist": {
         "createError": "재생목록을 만드는 중 오류가 발생했습니다: {{errorMessage}}",
@@ -1384,8 +1427,13 @@
         "title": "소리"
       },
       "system": {
+        "addReplayFolder": "폴더 추가",
+        "addReplayFolderTitle": "리플레이 폴더 선택",
         "filesOverline": "파일",
         "networkOverline": "네트워크",
+        "removeReplayFolder": "폴더 제거",
+        "replayFoldersDescription": "리플레이 라이브러리가 인덱싱하는 폴더입니다. 스타크래프트 기본 리플레이 폴더는 자동으로 추가됩니다. 폴더를 제거하면 해당 폴더의 리플레이가 북마크와 재생목록 항목을 포함해 라이브러리에서 제거됩니다.",
+        "replayFoldersTitle": "리플레이 폴더",
         "replayQuickOpen": "ShieldBattery로 연 리플레이를 미리보기 없이 바로 실행",
         "runOnStartup": "시스템 시작 시 ShieldBattery 실행",
         "serverRegion": {
@@ -1415,6 +1463,45 @@
         "apmValue": "APM 값",
         "apmValueValidation": "1에서 999 사이의 값을 입력하세요",
         "colorCycling": "색상 순환 사용",
+        "colorNames": {
+          "azure": "쪽빛",
+          "black": "검정",
+          "blue": "파랑",
+          "blueishGrey": "청회색",
+          "brick": "벽돌색",
+          "brown": "갈색",
+          "cyan": "시안",
+          "deepTeal": "진청록",
+          "emerald": "에메랄드",
+          "gold": "금색",
+          "green": "초록",
+          "grey": "회색",
+          "lime": "라임",
+          "magenta": "마젠타",
+          "mint": "민트",
+          "moss": "이끼색",
+          "navy": "남색",
+          "olive": "올리브",
+          "orange": "주황",
+          "paleGreen": "연초록",
+          "paleYellow": "연노랑",
+          "peach": "살구색",
+          "pink": "분홍",
+          "purple": "보라",
+          "red": "빨강",
+          "rose": "연분홍",
+          "scarlet": "주홍",
+          "sky": "하늘색",
+          "tan": "황갈색",
+          "teal": "청록",
+          "violet": "바이올렛",
+          "white": "흰색",
+          "yellow": "노랑"
+        },
+        "colorPicker": {
+          "builtinColorsLabel": "스타크래프트 기본 색상",
+          "customRgb": "커스텀 RGB"
+        },
         "consoleSkins": {
           "20thAnniversary": "스타크래프트 20주년",
           "blizzcon2017": "블리즈컨 2017",
@@ -1426,6 +1513,32 @@
           "warcraft3": "워크래프트 3 스포일즈"
         },
         "devOnlySettings": "개발자 전용 설정",
+        "ffaColorPreset": {
+          "arcade": "아케이드",
+          "attributionPrefix": "팔레트: ",
+          "classic": "클래식",
+          "colorblindSafe": "색약 친화",
+          "custom": "커스텀",
+          "jewel": "보석",
+          "neon": "네온",
+          "pear": "Pear",
+          "resurrect": "Resurrect",
+          "title": "프리셋"
+        },
+        "ffaColors": {
+          "attributionBy": "{{author}}의 {{palette}}",
+          "attributionInspiredBy": "{{palette}}에서 영감을 받음",
+          "clear": "비우기",
+          "pickerTargetPool": "개인 색상 · #{{n}}",
+          "pickerTargetSelf": "내 개인 색상",
+          "poolGroup": "색상 풀",
+          "poolHint": "최소 8가지 색상이 있어야 모든 플레이어가 항상 고유한 색상을 갖습니다.",
+          "quickSwatchesLabel": "이 팔레트에서",
+          "selfAddLabel": "내 고정 색상 (선택 사항)",
+          "selfSetHint": "팀이 없는 게임에서 항상 이 색상을 갖게 됩니다. 다른 플레이어가 가져가지 않도록 따로 예약됩니다.",
+          "selfUnsetHint": "다른 플레이어와 마찬가지로 풀에서 색상을 받습니다.",
+          "title": "개인 색상"
+        },
         "gameTimer": "게임 타이머",
         "ingameSkins": {
           "carbot": "카툰드",
@@ -1433,7 +1546,13 @@
           "preorder": "예약판",
           "title": "인게임 스킨"
         },
+        "interface": {
+          "title": "인터페이스"
+        },
         "latency": "지연 시간 표시",
+        "mapMinimap": {
+          "title": "맵 및 미니맵"
+        },
         "minimapPosition": {
           "bottomLeft": "좌측 하단",
           "standard": "기본 위치",
@@ -1445,25 +1564,75 @@
           "title": "미니맵 지형"
         },
         "showBonusSkins": "보너스 스킨 표시",
+        "skins": {
+          "description": "블리자드에서 구매해야 합니다.",
+          "title": "스킨"
+        },
         "startingFog": {
           "legacy": "오리지널",
           "showResources": "자원 표시",
           "showTerrainAndResources": "지형 및 자원 표시",
           "title": "초기 안개 설정"
         },
+        "teamColorPreset": {
+          "colorblindSafe": "색약 친화",
+          "coolVsWarm": "한색 대 난색",
+          "custom": "커스텀",
+          "legacyDiplomacy": "클래식 외교",
+          "title": "프리셋",
+          "warmVsCool": "난색 대 한색"
+        },
         "teamColors": {
+          "addColor": "색상 추가",
+          "clear": "비우기",
+          "copyFromPreset": "프리셋에서 복사",
+          "copyFromPresetCaption": "커스텀 색상을 덮어씁니다",
+          "description": "게임에서 플레이어 색상이 표시되는 방식입니다. 게임 중 Shift+Tab으로 모드를 전환할 수 있습니다.",
+          "editHint": "색상을 클릭해 변경하거나 드래그해 순서를 바꾸세요.",
+          "header": "플레이어 색상",
           "label": "모드",
           "mode": {
             "presetEverywhere": "모든 곳에 프리셋 사용",
+            "presetEverywhereDesc": "유닛과 미니맵에 내 색상 구성을 적용합니다.",
             "presetOnMinimap": "미니맵에 프리셋 사용",
-            "standard": "표준"
+            "presetOnMinimapDesc": "미니맵에서만 아군·적군 색상을 적용합니다.",
+            "standard": "표준",
+            "standardDesc": "스타크래프트 기본 색상입니다. 아래 설정은 적용되지 않습니다."
           },
+          "offNote": "꺼짐. 모든 게임에서 개인 색상이 사용됩니다.",
+          "pickerTargetAlly": "팀 배색 · 아군 · #{{n}}",
+          "pickerTargetEnemy": "팀 배색 · 적군 · #{{n}}",
+          "pickerTargetSelf": "팀 배색 · 내 색상",
+          "poolOrderedHint": "색상은 왼쪽부터 순서대로 사용됩니다.",
+          "poolShuffledHint": "이 색상들은 게임마다 무작위 순서로 사용됩니다.",
           "preview": {
             "allies": "아군",
             "enemies": "적군",
             "self": "나"
           },
-          "title": "팀 색상"
+          "previewHeaderFfa": "미리보기 (팀 없음)",
+          "previewHeaderTeam": "미리보기 (4:4)",
+          "quickSwatchesLabel": "이 팔레트에서",
+          "removeColor": "색상 제거",
+          "selectCustomHint": "색상을 편집하려면 커스텀 프리셋을 선택하세요.",
+          "selfAddLabel": "내 고정 색상 (선택 사항)",
+          "selfBadge": "나",
+          "selfFirstAllyHint": "첫 번째 아군 색상을 받게 됩니다.",
+          "selfOverrideSetHint": "팀 게임에서 항상 이 색상이 됩니다.",
+          "selfShuffleHint": "게임마다 팀 풀에서 무작위 색상을 받습니다.",
+          "shuffle": "게임마다 색상 섞기",
+          "title": "팀 색상",
+          "yourTeam": "내 팀"
+        },
+        "teamColorUsage": {
+          "always": "팀 게임과 1:1에서",
+          "alwaysDesc": "1:1 상대는 항상 첫 번째 적군 색상을 받습니다.",
+          "alwaysShuffledDesc": "1:1 상대는 적군 풀에서 무작위 색상을 받습니다.",
+          "exceptIn1v1": "팀 게임에서만",
+          "exceptIn1v1Desc": "2인 게임에서는 개인 색상을 사용합니다.",
+          "never": "사용 안 함",
+          "neverDesc": "동맹이 바뀌어도 모두 자기 색상을 유지합니다.",
+          "title": "팀 색상 사용"
         },
         "title": "게임플레이",
         "unitPortraits": {

--- a/server/public/locales/ru/global.json
+++ b/server/public/locales/ru/global.json
@@ -1262,7 +1262,7 @@
   },
   "material": {
     "dateTextField": {
-      "pickerButtonLabel": "Открыть календарь"
+      "pickerButtonLabel": "Показать выбор даты"
     },
     "datetimeTextField": {
       "pickerButtonLabel": "Показать выбор даты"
@@ -1548,7 +1548,7 @@
         },
         "ffaColors": {
           "attributionBy": "{{palette}} от {{author}}",
-          "attributionInspiredBy": "Вдохновлено палитрой {{palette}}",
+          "attributionInspiredBy": "Вдохновлено {{palette}}",
           "clear": "Очистить",
           "pickerTargetPool": "Индивидуальные цвета · #{{n}}",
           "pickerTargetSelf": "Ваш индивидуальный цвет",

--- a/server/public/locales/ru/global.json
+++ b/server/public/locales/ru/global.json
@@ -423,6 +423,10 @@
     "watchReplays": "Смотреть повторы"
   },
   "clientUpdate": {
+    "errorBoundary": {
+      "contents": "Что-то пошло не так при обновлении. Пожалуйста, посетите <2>наш сайт</2>, чтобы скачать последнюю версию.",
+      "title": "Ошибка при обновлении"
+    },
     "overlay": {
       "errorBody": "Произошла ошибка при загрузке обновления. Пожалуйста, перезапустите и попробуйте снова, или посетите <2>наш сайт</2>, чтобы скачать последнюю версию.",
       "errorTitle": "Ошибка при загрузке обновления",
@@ -450,6 +454,7 @@
       "create": "Создать",
       "decline": "Отказаться",
       "delete": "Удалить",
+      "done": "Готово",
       "download": "Скачать",
       "edit": "Редактировать",
       "hide": "Спрятать",
@@ -510,6 +515,17 @@
     "filters": {
       "advanced": "Расширенные",
       "custom": "Произвольные",
+      "date": "Дата",
+      "dateFrom": "С",
+      "datePast3Months": "Последние 3 месяца",
+      "datePastMonth": "Последний месяц",
+      "datePastWeek": "Последняя неделя",
+      "datePastYear": "Последний год",
+      "datePresets": "Быстрый выбор",
+      "dateRangeBetween": "{{start}} – {{end}}",
+      "dateRangeFrom": "С {{date}}",
+      "dateRangeUntil": "До {{date}}",
+      "dateTo": "По",
       "duration": {
         "10to20": "10–20 мин",
         "20to30": "20–30 мин",
@@ -708,6 +724,10 @@
     "reporting": {
       "actionedNotification": "К игроку, на которого Вы пожаловались, были приняты меры. Спасибо, что помогаете поддерживать честность сообщества.",
       "pointsRefundedNotification": "Рейтинговые очки, которые Вы потеряли в матче, были возвращены Вам после проверки матча."
+    },
+    "sidePanel": {
+      "empty": "Выберите игру, чтобы увидеть подробности",
+      "viewFullResults": "Показать полные результаты"
     }
   },
   "gameServerRegions": {
@@ -905,6 +925,11 @@
     },
     "joinLobby": {
       "action": "Присоединиться к лобби",
+      "browseLobbies": "К списку лобби",
+      "errorAlreadyInActivity": "Вы уже в игре, в поиске матча или в другом лобби.",
+      "errorBanned": "Вы заблокированы в этом лобби.",
+      "errorFull": "Это лобби заполнено.",
+      "errorGeneric": "Что-то пошло не так при присоединении к лобби. Пожалуйста, попробуйте ещё раз.",
       "matchmakingActiveDialogText": "Вы не можете присоединяться к лобби, пока активен поиск матчей.",
       "matchmakingActiveDialogTitle": "Присоединение к лобби отключено",
       "noActiveLobbies": "Нет активных лобби",
@@ -914,6 +939,11 @@
       "openSlotCount_many": "{{count}} слотов открыто",
       "openSlotCount_other": "{{count}} слота открыто",
       "title": "Присоединиться к лобби"
+    },
+    "landing": {
+      "download": "Скачать ShieldBattery",
+      "loadError": "Не удалось загрузить это лобби.",
+      "openInApp": "Уже есть ShieldBattery? Откройте эту ссылку из приложения, чтобы присоединиться к лобби."
     },
     "lobby": {
       "copiedInviteLink": "Скопировано!",
@@ -960,6 +990,17 @@
       "exists": "Вы не находитесь в этом лобби. Присоединиться?",
       "nonexistent": "Лобби не найдено. Хотите создать новое?",
       "started": "Это лобби уже запущено, и к нему нельзя присоединиться."
+    },
+    "summary": {
+      "gameTypeLabel": "Тип игры",
+      "hostLabel": "Хост",
+      "mapLabel": "Карта",
+      "noLongerOpen": "Это лобби уже недоступно.",
+      "openSlotCount_one": "{{count}} открыт",
+      "openSlotCount_few": "{{count}} открыто",
+      "openSlotCount_many": "{{count}} открыто",
+      "openSlotCount_other": "{{count}} открыто",
+      "slotsLabel": "Слоты"
     }
   },
   "map": {
@@ -1220,6 +1261,9 @@
     }
   },
   "material": {
+    "dateTextField": {
+      "pickerButtonLabel": "Открыть календарь"
+    },
     "datetimeTextField": {
       "pickerButtonLabel": "Показать выбор даты"
     },
@@ -1333,6 +1377,8 @@
       "moveDown": "Переместить вниз",
       "moveUp": "Переместить вверх",
       "newPlaylistMenu": "Новый плейлист…",
+      "noFolders": "Нет папок с реплеями",
+      "noFoldersBody": "Добавьте папку в Настройки > Приложение > Система, чтобы начать индексацию реплеев.",
       "noMatches": "Нет подходящих реплеев",
       "playlist": {
         "createError": "Не удалось создать плейлист: {{errorMessage}}",
@@ -1402,8 +1448,13 @@
         "title": "Звук"
       },
       "system": {
+        "addReplayFolder": "Добавить папку",
+        "addReplayFolderTitle": "Выберите папку с реплеями",
         "filesOverline": "Файлы",
         "networkOverline": "Сеть",
+        "removeReplayFolder": "Удалить папку",
+        "replayFoldersDescription": "Папки, индексируемые вашей библиотекой реплеев. Стандартная папка реплеев StarCraft добавляется автоматически. При удалении папки её реплеи удаляются из библиотеки вместе с закладками и записями в плейлистах.",
+        "replayFoldersTitle": "Папки с реплеями",
         "replayQuickOpen": "Запускать повторы, открытые через ShieldBattery, сразу — без предварительного просмотра",
         "runOnStartup": "Запускать ShieldBattery при запуске системы",
         "serverRegion": {
@@ -1433,6 +1484,45 @@
         "apmValue": "Значение APM",
         "apmValueValidation": "Введите значение от 1 до 999",
         "colorCycling": "Включить циклическое изменение цвета",
+        "colorNames": {
+          "azure": "Лазурный",
+          "black": "Чёрный",
+          "blue": "Синий",
+          "blueishGrey": "Серо-голубой",
+          "brick": "Кирпичный",
+          "brown": "Коричневый",
+          "cyan": "Циан",
+          "deepTeal": "Тёмно-бирюзовый",
+          "emerald": "Изумрудный",
+          "gold": "Золотой",
+          "green": "Зелёный",
+          "grey": "Серый",
+          "lime": "Лаймовый",
+          "magenta": "Пурпурный",
+          "mint": "Мятный",
+          "moss": "Болотный",
+          "navy": "Тёмно-синий",
+          "olive": "Оливковый",
+          "orange": "Оранжевый",
+          "paleGreen": "Бледно-зелёный",
+          "paleYellow": "Бледно-жёлтый",
+          "peach": "Персиковый",
+          "pink": "Розовый",
+          "purple": "Фиолетовый",
+          "red": "Красный",
+          "rose": "Нежно-розовый",
+          "scarlet": "Алый",
+          "sky": "Небесный",
+          "tan": "Песочный",
+          "teal": "Бирюзовый",
+          "violet": "Лиловый",
+          "white": "Белый",
+          "yellow": "Жёлтый"
+        },
+        "colorPicker": {
+          "builtinColorsLabel": "Цвета StarCraft",
+          "customRgb": "Свой RGB"
+        },
         "consoleSkins": {
           "20thAnniversary": "20-летие StarCraft",
           "blizzcon2017": "BlizzCon 2017",
@@ -1444,6 +1534,32 @@
           "warcraft3": "WarCraft 3 Spoils"
         },
         "devOnlySettings": "Настройки только для разработчиков",
+        "ffaColorPreset": {
+          "arcade": "Аркада",
+          "attributionPrefix": "Палитра: ",
+          "classic": "Классика",
+          "colorblindSafe": "Для дальтоников",
+          "custom": "Свой",
+          "jewel": "Самоцветы",
+          "neon": "Неон",
+          "pear": "Pear",
+          "resurrect": "Resurrect",
+          "title": "Пресет"
+        },
+        "ffaColors": {
+          "attributionBy": "{{palette}} от {{author}}",
+          "attributionInspiredBy": "Вдохновлено палитрой {{palette}}",
+          "clear": "Очистить",
+          "pickerTargetPool": "Индивидуальные цвета · #{{n}}",
+          "pickerTargetSelf": "Ваш индивидуальный цвет",
+          "poolGroup": "Пул",
+          "poolHint": "Минимум 8 цветов, чтобы каждому игроку всегда доставался уникальный цвет.",
+          "quickSwatchesLabel": "Из этой палитры",
+          "selfAddLabel": "Закреплённый цвет для вас (необязательно)",
+          "selfSetHint": "В играх без команд у вас всегда будет этот цвет. Он зарезервирован, чтобы другие игроки его не заняли.",
+          "selfUnsetHint": "Вы получите цвет из пула, как и все остальные.",
+          "title": "Индивидуальные цвета"
+        },
         "gameTimer": "Таймер игры",
         "ingameSkins": {
           "carbot": "Carbot",
@@ -1451,7 +1567,13 @@
           "preorder": "Предварительный заказ",
           "title": "Внутриигровой скин"
         },
+        "interface": {
+          "title": "Интерфейс"
+        },
         "latency": "Показать задержку",
+        "mapMinimap": {
+          "title": "Карта и миникарта"
+        },
         "minimapPosition": {
           "bottomLeft": "Нижний левый угол",
           "standard": "Стандарт",
@@ -1463,25 +1585,75 @@
           "title": "Рельеф миникарты"
         },
         "showBonusSkins": "Показать бонусные скины",
+        "skins": {
+          "description": "Приобретаются у Blizzard.",
+          "title": "Скины"
+        },
         "startingFog": {
           "legacy": "Классический",
           "showResources": "Показать ресурсы",
           "showTerrainAndResources": "Показать местность и ресурсы",
           "title": "Начальный туман войны"
         },
+        "teamColorPreset": {
+          "colorblindSafe": "Для дальтоников",
+          "coolVsWarm": "Холодные против тёплых",
+          "custom": "Свой",
+          "legacyDiplomacy": "Классическая дипломатия",
+          "title": "Пресет",
+          "warmVsCool": "Тёплые против холодных"
+        },
         "teamColors": {
+          "addColor": "Добавить цвет",
+          "clear": "Очистить",
+          "copyFromPreset": "Скопировать из пресета",
+          "copyFromPresetCaption": "Перезапишет ваши собственные цвета",
+          "description": "Как цвета игроков выглядят в ваших играх. Переключайте режимы в игре с помощью Shift+Tab.",
+          "editHint": "Нажмите на цвет, чтобы изменить его, или перетащите, чтобы изменить порядок.",
+          "header": "Цвета игроков",
           "label": "Режим",
           "mode": {
             "presetEverywhere": "Использовать пресет везде",
+            "presetEverywhereDesc": "Ваша цветовая схема на юнитах и миникарте.",
             "presetOnMinimap": "Использовать пресет на миникарте",
-            "standard": "Стандартный"
+            "presetOnMinimapDesc": "Цвета союзников и врагов только на миникарте.",
+            "standard": "Стандартный",
+            "standardDesc": "Обычные цвета StarCraft. Настройки ниже не действуют."
           },
+          "offNote": "Выключено. Во всех играх используются индивидуальные цвета.",
+          "pickerTargetAlly": "Командная схема · союзники · #{{n}}",
+          "pickerTargetEnemy": "Командная схема · враги · #{{n}}",
+          "pickerTargetSelf": "Командная схема · ваш цвет",
+          "poolOrderedHint": "Цвета используются по порядку, слева направо.",
+          "poolShuffledHint": "Эти цвета используются в случайном порядке в каждой игре.",
           "preview": {
             "allies": "Союзники",
             "enemies": "Враги",
             "self": "Вы"
           },
-          "title": "Цвета команд"
+          "previewHeaderFfa": "Предпросмотр (без команд)",
+          "previewHeaderTeam": "Предпросмотр (4v4)",
+          "quickSwatchesLabel": "Из этой палитры",
+          "removeColor": "Удалить цвет",
+          "selectCustomHint": "Выберите пресет «Свой», чтобы редактировать цвета.",
+          "selfAddLabel": "Закреплённый цвет для вас (необязательно)",
+          "selfBadge": "ВЫ",
+          "selfFirstAllyHint": "Вы получите первый цвет союзника.",
+          "selfOverrideSetHint": "В командных играх вы всегда будете этого цвета.",
+          "selfShuffleHint": "В каждой игре вы получаете случайный цвет из пула вашей команды.",
+          "shuffle": "Перемешивать цвета в каждой игре",
+          "title": "Цвета команд",
+          "yourTeam": "Ваша команда"
+        },
+        "teamColorUsage": {
+          "always": "В командных играх и 1v1",
+          "alwaysDesc": "Ваш соперник в 1v1 всегда получает первый цвет врага.",
+          "alwaysShuffledDesc": "Ваш соперник в 1v1 получает случайный цвет из вашего пула врагов.",
+          "exceptIn1v1": "Только в командных играх",
+          "exceptIn1v1Desc": "В играх на двоих используются индивидуальные цвета.",
+          "never": "Никогда",
+          "neverDesc": "Каждый сохраняет свой цвет, даже когда меняются альянсы.",
+          "title": "Использование командных цветов"
         },
         "title": "Геймплей",
         "unitPortraits": {

--- a/server/public/locales/zh-Hans/global.json
+++ b/server/public/locales/zh-Hans/global.json
@@ -1241,7 +1241,7 @@
   },
   "material": {
     "dateTextField": {
-      "pickerButtonLabel": "打开日期选择器"
+      "pickerButtonLabel": "打开选择器"
     },
     "datetimeTextField": {
       "pickerButtonLabel": "打开选择器"
@@ -1357,7 +1357,7 @@
       "moveUp": "上移",
       "newPlaylistMenu": "新建播放列表…",
       "noFolders": "没有录像文件夹",
-      "noFoldersBody": "在设置 > 应用 > 系统中添加文件夹，即可开始索引录像。",
+      "noFoldersBody": "在设置 > 应用程序 > 系统中添加文件夹，即可开始索引录像。",
       "noMatches": "没有符合条件的录像",
       "playlist": {
         "createError": "创建播放列表时出错：{{errorMessage}}",
@@ -1432,7 +1432,7 @@
         "filesOverline": "文件",
         "networkOverline": "网络",
         "removeReplayFolder": "移除文件夹",
-        "replayFoldersDescription": "录像库索引的文件夹。StarCraft 默认录像文件夹会自动添加。移除文件夹会将其中的录像从录像库中删除，包括对应的书签和播放列表条目。",
+        "replayFoldersDescription": "录像库索引的文件夹。星际争霸默认录像文件夹会自动添加。移除文件夹会将其中的录像从录像库中删除，包括对应的书签和播放列表条目。",
         "replayFoldersTitle": "录像文件夹",
         "replayQuickOpen": "使用ShieldBattery打开录像时直接开始播放录像，跳过录像预览",
         "runOnStartup": "开机时自动启动ShieldBattery",
@@ -1499,7 +1499,7 @@
           "yellow": "黄色"
         },
         "colorPicker": {
-          "builtinColorsLabel": "StarCraft 原版颜色",
+          "builtinColorsLabel": "星际争霸原版颜色",
           "customRgb": "自定义 RGB"
         },
         "consoleSkins": {
@@ -1597,7 +1597,7 @@
             "presetOnMinimap": "在小地图上使用预设",
             "presetOnMinimapDesc": "盟友和敌人颜色仅应用于小地图。",
             "standard": "标准",
-            "standardDesc": "StarCraft 的普通颜色。下面的设置不会生效。"
+            "standardDesc": "星际争霸的普通颜色。下面的设置不会生效。"
           },
           "offNote": "已关闭。所有游戏均使用个人颜色。",
           "pickerTargetAlly": "队伍配色 · 盟友 · #{{n}}",

--- a/server/public/locales/zh-Hans/global.json
+++ b/server/public/locales/zh-Hans/global.json
@@ -420,6 +420,10 @@
     "watchReplays": "观看录像"
   },
   "clientUpdate": {
+    "errorBoundary": {
+      "contents": "更新时出了点问题。请访问<2>我们的网站</2>下载最新版本。",
+      "title": "更新出错"
+    },
     "overlay": {
       "errorBody": "下载更新时遇到错误。请重启程序并重试，或访问<2>我们的网站</2>下载最新版本。",
       "errorTitle": "下载更新时遇到错误",
@@ -447,6 +451,7 @@
       "create": "创建",
       "decline": "拒绝",
       "delete": "删除",
+      "done": "完成",
       "download": "下载",
       "edit": "编辑",
       "hide": "隐藏",
@@ -501,6 +506,17 @@
     "filters": {
       "advanced": "高级",
       "custom": "自定义",
+      "date": "日期",
+      "dateFrom": "开始",
+      "datePast3Months": "近3个月",
+      "datePastMonth": "近1个月",
+      "datePastWeek": "近1周",
+      "datePastYear": "近1年",
+      "datePresets": "快捷范围",
+      "dateRangeBetween": "{{start}} – {{end}}",
+      "dateRangeFrom": "自{{date}}",
+      "dateRangeUntil": "截至{{date}}",
+      "dateTo": "结束",
       "duration": {
         "10to20": "10-20分钟",
         "20to30": "20-30分钟",
@@ -699,6 +715,10 @@
     "reporting": {
       "actionedNotification": "我们已对您举报的一名玩家采取了处理措施。感谢您帮助维护公平的社区环境。",
       "pointsRefundedNotification": "经过审核，您在一场对局中失去的排位积分已返还给您。"
+    },
+    "sidePanel": {
+      "empty": "选择一场游戏查看详情",
+      "viewFullResults": "查看完整结果"
     }
   },
   "gameServerRegions": {
@@ -896,12 +916,22 @@
     },
     "joinLobby": {
       "action": "加入房间",
+      "browseLobbies": "浏览房间",
+      "errorAlreadyInActivity": "您已在游戏中、正在匹配或已在其他房间。",
+      "errorBanned": "您已被该房间封禁。",
+      "errorFull": "该房间已满。",
+      "errorGeneric": "加入房间时出了点问题。请重试。",
       "matchmakingActiveDialogText": "正在进行匹配时无法加入房间。",
       "matchmakingActiveDialogTitle": "加入房间已禁用",
       "noActiveLobbies": "目前没有活跃的房间",
       "noOpenLobbies": "目前没有开放的房间",
       "openSlotCount_other": "有{{count}}个空位",
       "title": "加入房间"
+    },
+    "landing": {
+      "download": "下载 ShieldBattery",
+      "loadError": "加载该房间时遇到问题。",
+      "openInApp": "已经安装了 ShieldBattery？在应用内打开此链接即可加入房间。"
     },
     "lobby": {
       "copiedInviteLink": "已复制！",
@@ -948,6 +978,14 @@
       "exists": "你现在不在这个房间。想加入吗？",
       "nonexistent": "未找到房间。要新建一个吗？",
       "started": "这个房间已经开始，无法加入。"
+    },
+    "summary": {
+      "gameTypeLabel": "游戏类型",
+      "hostLabel": "主机",
+      "mapLabel": "地图",
+      "noLongerOpen": "该房间已不再开放。",
+      "openSlotCount_other": "剩余{{count}}个",
+      "slotsLabel": "空位"
     }
   },
   "map": {
@@ -1202,6 +1240,9 @@
     }
   },
   "material": {
+    "dateTextField": {
+      "pickerButtonLabel": "打开日期选择器"
+    },
     "datetimeTextField": {
       "pickerButtonLabel": "打开选择器"
     },
@@ -1315,6 +1356,8 @@
       "moveDown": "下移",
       "moveUp": "上移",
       "newPlaylistMenu": "新建播放列表…",
+      "noFolders": "没有录像文件夹",
+      "noFoldersBody": "在设置 > 应用 > 系统中添加文件夹，即可开始索引录像。",
       "noMatches": "没有符合条件的录像",
       "playlist": {
         "createError": "创建播放列表时出错：{{errorMessage}}",
@@ -1384,8 +1427,13 @@
         "title": "声音"
       },
       "system": {
+        "addReplayFolder": "添加文件夹",
+        "addReplayFolderTitle": "选择录像文件夹",
         "filesOverline": "文件",
         "networkOverline": "网络",
+        "removeReplayFolder": "移除文件夹",
+        "replayFoldersDescription": "录像库索引的文件夹。StarCraft 默认录像文件夹会自动添加。移除文件夹会将其中的录像从录像库中删除，包括对应的书签和播放列表条目。",
+        "replayFoldersTitle": "录像文件夹",
         "replayQuickOpen": "使用ShieldBattery打开录像时直接开始播放录像，跳过录像预览",
         "runOnStartup": "开机时自动启动ShieldBattery",
         "serverRegion": {
@@ -1415,6 +1463,45 @@
         "apmValue": "APM值",
         "apmValueValidation": "输入一个1到999之间的数值",
         "colorCycling": "启用颜色循环",
+        "colorNames": {
+          "azure": "蔚蓝",
+          "black": "黑色",
+          "blue": "蓝色",
+          "blueishGrey": "蓝灰",
+          "brick": "砖红",
+          "brown": "棕色",
+          "cyan": "青色",
+          "deepTeal": "深蓝绿",
+          "emerald": "翡翠绿",
+          "gold": "金色",
+          "green": "绿色",
+          "grey": "灰色",
+          "lime": "青柠",
+          "magenta": "洋红",
+          "mint": "薄荷绿",
+          "moss": "苔藓绿",
+          "navy": "藏青",
+          "olive": "橄榄绿",
+          "orange": "橙色",
+          "paleGreen": "浅绿",
+          "paleYellow": "浅黄",
+          "peach": "桃色",
+          "pink": "粉色",
+          "purple": "紫色",
+          "red": "红色",
+          "rose": "玫瑰粉",
+          "scarlet": "猩红",
+          "sky": "天蓝",
+          "tan": "棕褐",
+          "teal": "蓝绿",
+          "violet": "紫罗兰",
+          "white": "白色",
+          "yellow": "黄色"
+        },
+        "colorPicker": {
+          "builtinColorsLabel": "StarCraft 原版颜色",
+          "customRgb": "自定义 RGB"
+        },
         "consoleSkins": {
           "20thAnniversary": "星际争霸20周年",
           "blizzcon2017": "2017暴雪嘉年华",
@@ -1426,6 +1513,32 @@
           "warcraft3": "魔兽争霸3战利品"
         },
         "devOnlySettings": "开发者选项",
+        "ffaColorPreset": {
+          "arcade": "街机",
+          "attributionPrefix": "调色板：",
+          "classic": "经典",
+          "colorblindSafe": "色盲友好",
+          "custom": "自定义",
+          "jewel": "宝石",
+          "neon": "霓虹",
+          "pear": "Pear",
+          "resurrect": "Resurrect",
+          "title": "预设"
+        },
+        "ffaColors": {
+          "attributionBy": "{{palette}}，作者：{{author}}",
+          "attributionInspiredBy": "灵感来自 {{palette}}",
+          "clear": "清空",
+          "pickerTargetPool": "个人颜色 · #{{n}}",
+          "pickerTargetSelf": "您的个人颜色",
+          "poolGroup": "颜色池",
+          "poolHint": "至少需要 8 种颜色，确保每位玩家总能获得不重复的颜色。",
+          "quickSwatchesLabel": "来自此调色板",
+          "selfAddLabel": "为自己固定颜色（可选）",
+          "selfSetHint": "在无队伍的游戏中，您将始终使用此颜色。它会被预留，其他玩家不会占用。",
+          "selfUnsetHint": "您将和其他玩家一样从颜色池中获得颜色。",
+          "title": "个人颜色"
+        },
         "gameTimer": "游戏计时器",
         "ingameSkins": {
           "carbot": "爆笑星际",
@@ -1433,7 +1546,13 @@
           "preorder": "预购",
           "title": "游戏内皮肤"
         },
+        "interface": {
+          "title": "界面"
+        },
         "latency": "显示网络延迟",
+        "mapMinimap": {
+          "title": "地图与小地图"
+        },
         "minimapPosition": {
           "bottomLeft": "左下角",
           "standard": "标准",
@@ -1445,25 +1564,75 @@
           "title": "小地图地形"
         },
         "showBonusSkins": "显示奖励皮肤",
+        "skins": {
+          "description": "需从暴雪购买。",
+          "title": "皮肤"
+        },
         "startingFog": {
           "legacy": "原版",
           "showResources": "显示资源",
           "showTerrainAndResources": "显示地形和资源",
           "title": "初始战争迷雾"
         },
+        "teamColorPreset": {
+          "colorblindSafe": "色盲友好",
+          "coolVsWarm": "冷色对暖色",
+          "custom": "自定义",
+          "legacyDiplomacy": "经典外交",
+          "title": "预设",
+          "warmVsCool": "暖色对冷色"
+        },
         "teamColors": {
+          "addColor": "添加颜色",
+          "clear": "清空",
+          "copyFromPreset": "从预设复制",
+          "copyFromPresetCaption": "会覆盖您的自定义颜色",
+          "description": "玩家颜色在您游戏中的显示方式。游戏内按 Shift+Tab 可切换模式。",
+          "editHint": "点击颜色进行修改，拖动可调整顺序。",
+          "header": "玩家颜色",
           "label": "模式",
           "mode": {
             "presetEverywhere": "全部使用预设",
+            "presetEverywhereDesc": "您的配色方案应用于单位和小地图。",
             "presetOnMinimap": "在小地图上使用预设",
-            "standard": "标准"
+            "presetOnMinimapDesc": "盟友和敌人颜色仅应用于小地图。",
+            "standard": "标准",
+            "standardDesc": "StarCraft 的普通颜色。下面的设置不会生效。"
           },
+          "offNote": "已关闭。所有游戏均使用个人颜色。",
+          "pickerTargetAlly": "队伍配色 · 盟友 · #{{n}}",
+          "pickerTargetEnemy": "队伍配色 · 敌人 · #{{n}}",
+          "pickerTargetSelf": "队伍配色 · 您的颜色",
+          "poolOrderedHint": "颜色从左到右按顺序使用。",
+          "poolShuffledHint": "这些颜色在每场游戏中随机排序使用。",
           "preview": {
             "allies": "盟友",
             "enemies": "敌人",
             "self": "自己"
           },
-          "title": "队伍颜色"
+          "previewHeaderFfa": "预览（无队伍）",
+          "previewHeaderTeam": "预览（4v4）",
+          "quickSwatchesLabel": "来自此调色板",
+          "removeColor": "移除颜色",
+          "selectCustomHint": "选择“自定义”预设即可编辑颜色。",
+          "selfAddLabel": "为自己固定颜色（可选）",
+          "selfBadge": "我",
+          "selfFirstAllyHint": "您将获得第一个盟友颜色。",
+          "selfOverrideSetHint": "在团队游戏中，您将始终使用此颜色。",
+          "selfShuffleHint": "每场游戏您会从您队伍的颜色池中随机获得一个颜色。",
+          "shuffle": "每场游戏随机排列颜色",
+          "title": "队伍颜色",
+          "yourTeam": "您的队伍"
+        },
+        "teamColorUsage": {
+          "always": "团队游戏和 1v1",
+          "alwaysDesc": "您的 1v1 对手总是获得第一个敌人颜色。",
+          "alwaysShuffledDesc": "您的 1v1 对手会从您的敌人颜色池中随机获得颜色。",
+          "exceptIn1v1": "仅团队游戏",
+          "exceptIn1v1Desc": "双人游戏改用个人颜色。",
+          "never": "从不",
+          "neverDesc": "每个人保留自己的颜色，即使结盟关系变化也不变。",
+          "title": "队伍颜色使用"
         },
         "title": "游戏性选项",
         "unitPortraits": {


### PR DESCRIPTION
Clears the full untranslated backlog — 141 keys per language that had accumulated across recently merged features, applied with the i18n tooling (`pnpm run i18n plan/apply/check`):

- **Lobby join preview + web landing** (#1378/#1379): `lobbies.summary.*`, `lobbies.joinLobby.*` error strings, `lobbies.landing.*`
- **Team/player color settings**: `settings.game.gameplay.*` (color names, presets, pool editors, usage options) — 103 keys
- **Games page filters** (#1367): `game.filters.*` date filter strings, `games.sidePanel.*`
- **Replay folders**: `settings.app.system.*`, `replays.library.*`
- Misc: `clientUpdate.errorBoundary.*`, `common.actions.done`, `material.dateTextField.pickerButtonLabel`

Notes on choices:

- Vocabulary matches each file's established renderings (es: lobby/ranura/anfitrión/banear; ko: 로비/호스트/게임 방식/슬롯, 합니다체; ru: formal Вы, Latin type labels like 4v4; zh-Hans: 房间/主机/空位, 您).
- Color names were assigned against the actual hex values in `common/settings/team-colors.ts` (e.g. Azure = medium blue vs Sky = light blue; Rose = light pink; Moss = olive green).
- `Resurrect`/`Pear` preset labels stay in English in all languages — they reference the proper palette names (Resurrect 64, Pear36) shown in the adjacent attribution line.
- Team-size formats follow each language's convention (es `4x4`, ko `4:4`, ru/zh `4v4`).

`pnpm run i18n check` is clean for all four languages (0 to-translate, 0 orphans, 0 token drift), `stale` reports nothing, and `gen-translations` produces no diff.