### PR TITLE
Render lobby links in chat as rich invite cards

### DIFF
--- a/client/lobbies/devonly/lobby-invite-card-test.tsx
+++ b/client/lobbies/devonly/lobby-invite-card-test.tsx
@@ -1,0 +1,41 @@
+import { useState } from 'react'
+import { assertUnreachable } from '../../../common/assert-unreachable'
+import { LobbyInviteCardContent } from '../lobby-invite-card'
+import { LobbySummaryLoadState } from '../lobby-summary'
+import { MOCK_LOBBY_SUMMARY } from './lobby-landing-test'
+import { ScenarioPicker } from './scenario-picker'
+
+type Scenario = 'loading' | 'loaded' | 'notFound' | 'error'
+
+const SCENARIOS: Array<{ id: Scenario; label: string }> = [
+  { id: 'loading', label: 'Loading' },
+  { id: 'loaded', label: 'Loaded' },
+  { id: 'notFound', label: 'Not found' },
+  { id: 'error', label: 'Error' },
+]
+
+function scenarioToState(scenario: Scenario): LobbySummaryLoadState | undefined {
+  switch (scenario) {
+    case 'loading':
+      return undefined
+    case 'loaded':
+      return { status: 'loaded', data: MOCK_LOBBY_SUMMARY }
+    case 'notFound':
+      return { status: 'notFound' }
+    case 'error':
+      return { status: 'error' }
+    default:
+      return assertUnreachable(scenario)
+  }
+}
+
+export function LobbyInviteCardTest() {
+  const [scenario, setScenario] = useState<Scenario>('loaded')
+
+  return (
+    <div>
+      <ScenarioPicker scenarios={SCENARIOS} active={scenario} onChange={setScenario} />
+      <LobbyInviteCardContent state={scenarioToState(scenario)} onJoinClick={() => {}} />
+    </div>
+  )
+}

--- a/client/lobbies/devonly/routes.jsx
+++ b/client/lobbies/devonly/routes.jsx
@@ -1,6 +1,7 @@
 import { Component } from 'react'
 import { Link, Route, Switch } from 'wouter'
 import { JoinPreviewTest } from './join-preview-test'
+import { LobbyInviteCardTest } from './lobby-invite-card-test'
 import { LobbyLandingTest } from './lobby-landing-test'
 import LobbyTest from './lobby-test'
 import RacePickerTest from './race-picker-test'
@@ -23,6 +24,9 @@ class DevLobbiesDashboard extends Component {
         <li>
           <Link href={`${BASE_URL}/join-preview`}>Lobby join preview</Link>
         </li>
+        <li>
+          <Link href={`${BASE_URL}/invite-card`}>Lobby invite card</Link>
+        </li>
       </ul>
     )
   }
@@ -35,6 +39,7 @@ export default () => {
       <Route path={`${BASE_URL}/race-picker`} component={RacePickerTest} />
       <Route path={`${BASE_URL}/lobby-landing`} component={LobbyLandingTest} />
       <Route path={`${BASE_URL}/join-preview`} component={JoinPreviewTest} />
+      <Route path={`${BASE_URL}/invite-card`} component={LobbyInviteCardTest} />
       <Route>
         <DevLobbiesDashboard />
       </Route>

--- a/client/lobbies/join-lobby.tsx
+++ b/client/lobbies/join-lobby.tsx
@@ -5,23 +5,18 @@ import styled from 'styled-components'
 import { getErrorStack } from '../../common/errors'
 import { gameTypeToLabel } from '../../common/games/game-type'
 import { useTrackPageView } from '../analytics/analytics'
-import { openDialog, openSimpleDialog } from '../dialogs/action-creators'
-import { DialogType } from '../dialogs/dialog-type'
 import { MaterialIcon } from '../icons/material/material-icon'
 import logger from '../logging/logger'
 import { ReduxMapThumbnail } from '../maps/map-thumbnail'
 import { isMatchmakingAtom } from '../matchmaking/matchmaking-atoms'
 import { FilledButton } from '../material/button'
 import siteSocket from '../network/site-socket'
-import { useAppDispatch, useAppSelector } from '../redux-hooks'
-import { useSnackbarController } from '../snackbars/snackbar-overlay'
+import { useAppSelector } from '../redux-hooks'
 import { healthChecked } from '../starcraft/health-checked'
 import { FlexSpacer } from '../styles/flex-spacer'
 import { BodyLarge, BodyMedium, TitleLarge, TitleMedium } from '../styles/typography'
-import { joinLobby } from './action-creators'
-import { lobbyJoinErrorMessage } from './lobby-join-errors'
 import { LobbySummary } from './lobby-list-reducer'
-import { navigateToLobby } from './lobby-url'
+import { useJoinLobbyAction } from './use-join-lobby-action'
 
 const ListEntryRoot = styled.div`
   width: 100%;
@@ -173,11 +168,8 @@ function JoinLobby({ onNavigateToCreate }: JoinLobbyProps) {
 
 function LobbyList() {
   const { t } = useTranslation()
-  const dispatch = useAppDispatch()
-  const snackbarController = useSnackbarController()
+  const joinLobbyAction = useJoinLobbyAction()
   const { byId, list } = useAppSelector(s => s.lobbyList)
-
-  const isMatchmaking = useAtomValue(isMatchmakingAtom)
 
   if (!list.size) {
     return (
@@ -197,37 +189,7 @@ function LobbyList() {
           <ListEntry
             key={id}
             lobby={byId.get(id)!}
-            onClick={lobby => {
-              if (IS_ELECTRON) {
-                if (isMatchmaking) {
-                  dispatch(
-                    openSimpleDialog(
-                      t(
-                        'lobbies.joinLobby.matchmakingActiveDialogTitle',
-                        'Joining lobbies disabled',
-                      ),
-                      t(
-                        'lobbies.joinLobby.matchmakingActiveDialogText',
-                        'You cannot join lobbies while a matchmaking search is active.',
-                      ),
-                    ),
-                  )
-                } else {
-                  healthChecked(() => {
-                    dispatch(
-                      joinLobby(lobby.id, {
-                        onError: (err: unknown) => {
-                          snackbarController.showSnackbar(lobbyJoinErrorMessage(err, t))
-                        },
-                      }),
-                    )
-                    navigateToLobby(lobby.id, lobby.name)
-                  })()
-                }
-              } else {
-                dispatch(openDialog({ type: DialogType.Download }))
-              }
-            }}
+            onClick={lobby => joinLobbyAction(lobby.id, lobby.name)}
           />
         ))
       ) : (

--- a/client/lobbies/join-lobby.tsx
+++ b/client/lobbies/join-lobby.tsx
@@ -189,7 +189,7 @@ function LobbyList() {
           <ListEntry
             key={id}
             lobby={byId.get(id)!}
-            onClick={lobby => joinLobbyAction(lobby.id, lobby.name)}
+            onClick={lobby => joinLobbyAction(lobby.id, { name: lobby.name })}
           />
         ))
       ) : (

--- a/client/lobbies/lobby-invite-card.tsx
+++ b/client/lobbies/lobby-invite-card.tsx
@@ -106,6 +106,13 @@ const ThumbnailContainer = styled.div`
   width: ${THUMBNAIL_SIZE}px;
 `
 
+// A long lobby name gives InfoColumn a large flex basis that would otherwise shrink the button
+// past its label (which hard-clips, since the button contains its content); the name is the one
+// that truncates instead.
+const JoinButton = styled(FilledButton)`
+  flex-shrink: 0;
+`
+
 const InfoColumn = styled.div`
   min-width: 0;
   flex-grow: 1;
@@ -175,7 +182,7 @@ export function LobbyInviteCardContent({
           })}
         </SecondaryLine>
       </InfoColumn>
-      <FilledButton
+      <JoinButton
         label={t('lobbies.joinLobby.action', 'Join lobby')}
         onClick={onJoinClick}
         testName='lobby-invite-card-join-button'

--- a/client/lobbies/lobby-invite-card.tsx
+++ b/client/lobbies/lobby-invite-card.tsx
@@ -1,11 +1,15 @@
+import { InvokeError } from 'nydus-client'
+import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled, { css } from 'styled-components'
 import { gameTypeToLabel } from '../../common/games/game-type'
+import { LobbyJoinErrorCode } from '../../common/lobbies/lobby-network'
 import { lobbyIdFromPath } from '../../common/lobbies/lobby-url'
 import { SbLobbyId } from '../../common/lobbies/sb-lobby-id'
 import { MapThumbnail } from '../maps/map-thumbnail'
 import { FilledButton } from '../material/button'
 import { isShieldBatteryUrl } from '../navigation/external-link'
+import { useAppSelector } from '../redux-hooks'
 import { bodySmall, singleLine, titleSmall } from '../styles/typography'
 import { LobbySummaryLoadState, useLobbySummary } from './lobby-summary'
 import { useJoinLobbyAction } from './use-join-lobby-action'
@@ -196,12 +200,34 @@ export function LobbyInviteCardContent({
 export function LobbyInviteCard({ lobbyId }: { lobbyId: SbLobbyId }) {
   const joinLobbyAction = useJoinLobbyAction()
   const [state] = useLobbySummary(lobbyId, { cached: true })
+  // The summary is read once per mount, so a lobby that dies while the card is on screen would
+  // keep showing as joinable; a failed join is the event that corrects it.
+  const [lobbyGone, setLobbyGone] = useState(false)
+  const isInThisLobby = useAppSelector(s => s.lobby.inLobby && s.lobby.info.id === lobbyId)
+
+  if (isInThisLobby) {
+    // Someone seated in this lobby needs no invite to it (the common case being its own invite
+    // link pasted into its own chat): they're already where Join would take them, and the join
+    // itself would only fail.
+    return null
+  }
 
   return (
     <LobbyInviteCardContent
-      state={state}
+      state={lobbyGone ? { status: 'notFound' } : state}
       onJoinClick={() =>
-        joinLobbyAction(lobbyId, state?.status === 'loaded' ? state.data.summary.name : undefined)
+        joinLobbyAction(lobbyId, {
+          name: state?.status === 'loaded' ? state.data.summary.name : undefined,
+          onError: err => {
+            const code = err instanceof InvokeError ? err.body?.code : undefined
+            if (
+              code === LobbyJoinErrorCode.NoLongerOpen ||
+              code === LobbyJoinErrorCode.AlreadyStarted
+            ) {
+              setLobbyGone(true)
+            }
+          },
+        })
       }
     />
   )

--- a/client/lobbies/lobby-invite-card.tsx
+++ b/client/lobbies/lobby-invite-card.tsx
@@ -1,22 +1,16 @@
-import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
-import swallowNonBuiltins from '../../common/async/swallow-non-builtins'
 import { gameTypeToLabel } from '../../common/games/game-type'
-import { LobbySummaryResponse } from '../../common/lobbies/lobby-network'
 import { lobbyIdFromPath } from '../../common/lobbies/lobby-url'
 import { SbLobbyId } from '../../common/lobbies/sb-lobby-id'
-import { apiUrl } from '../../common/urls'
 import { openDialog } from '../dialogs/action-creators'
 import { DialogType } from '../dialogs/dialog-type'
 import { MapThumbnail } from '../maps/map-thumbnail'
 import { FilledButton } from '../material/button'
 import { isShieldBatteryUrl } from '../navigation/external-link'
-import { fetchJson } from '../network/fetch'
-import { isFetchError } from '../network/fetch-errors'
 import { useAppDispatch } from '../redux-hooks'
 import { bodySmall, singleLine, titleSmall } from '../styles/typography'
-import { LobbySummaryLoadState } from './lobby-summary'
+import { LobbySummaryLoadState, useLobbySummary } from './lobby-summary'
 import { navigateToLobby } from './lobby-url'
 
 /**
@@ -35,87 +29,35 @@ export function lobbyIdFromMessageLink(href: string): SbLobbyId | undefined {
   return isShieldBatteryUrl(url) ? lobbyIdFromPath(url.pathname) : undefined
 }
 
-/** How long a fetched summary is shared between all the cards that want it. */
-const SUMMARY_SHARE_MS = 30 * 1000
-
-const summaryCache = new Map<
-  SbLobbyId,
-  { expiresAt: number; promise: Promise<LobbySummaryLoadState> }
->()
-
-/**
- * Fetches a lobby's summary through a short-lived shared cache. The same lobby link often appears
- * in many rendered messages at once (repeated pastes, history pages, the full message list
- * remounting on a channel switch), and each message's card mounts its own fetch -- sharing the
- * result collapses those into one request per lobby per window instead of N identical hits against
- * the summary endpoint's IP throttle. Transient failures aren't kept, so a later mount retries.
- */
-function fetchSummaryShared(lobbyId: SbLobbyId): Promise<LobbySummaryLoadState> {
-  const now = Date.now()
-  const cached = summaryCache.get(lobbyId)
-  if (cached && cached.expiresAt > now) {
-    return cached.promise
-  }
-
-  const promise = fetchJson<LobbySummaryResponse>(apiUrl`lobbies/${lobbyId}/summary`).then(
-    (data): LobbySummaryLoadState => ({ status: 'loaded', data }),
-    (err): LobbySummaryLoadState => {
-      if (isFetchError(err) && err.status === 404) {
-        return { status: 'notFound' }
-      }
-      summaryCache.delete(lobbyId)
-      return { status: 'error' }
-    },
-  )
-  summaryCache.set(lobbyId, { expiresAt: now + SUMMARY_SHARE_MS, promise })
-  return promise
-}
-
-/**
- * The card-oriented counterpart to `useLobbySummary`: same load states, but reads through
- * {@link fetchSummaryShared} so simultaneous cards for the same lobby share one request. The
- * result is tagged with the lobby id it was fetched for, so a stale result from a previous id is
- * never rendered as current.
- */
-function useSharedLobbySummary(lobbyId: SbLobbyId): LobbySummaryLoadState | undefined {
-  const [result, setResult] = useState<{ lobbyId: SbLobbyId; state: LobbySummaryLoadState }>()
-
-  useEffect(() => {
-    let canceled = false
-    fetchSummaryShared(lobbyId)
-      .then(state => {
-        if (!canceled) {
-          setResult({ lobbyId, state })
-        }
-      })
-      .catch(swallowNonBuiltins)
-
-    return () => {
-      canceled = true
-    }
-  }, [lobbyId])
-
-  return result?.lobbyId === lobbyId ? result.state : undefined
-}
-
 // Aligns the card under the message text: `MessageContainer` (message-layout.tsx) uses
 // `padding: 4px 8px 4px 72px`, where the 72px left padding is the timestamp column that message
 // text starts after.
 const CARD_MARGIN = '4px 8px 4px 72px'
 const CARD_MAX_WIDTH = 440
+const CARD_PADDING = 8
+const CARD_BORDER_WIDTH = 1
+
+const THUMBNAIL_SIZE = 64
+
+// The loaded card's height is fully determined by its thumbnail (forced to a square aspect ratio
+// below, regardless of the actual map's dimensions), its padding, and its border -- fixed here so
+// every other state (loading, not-found) can reserve the same height and the card never resizes
+// after it first mounts.
+const CARD_HEIGHT = THUMBNAIL_SIZE + CARD_PADDING * 2 + CARD_BORDER_WIDTH * 2
 
 const CardRoot = styled.div`
   width: fit-content;
   max-width: ${CARD_MAX_WIDTH}px;
+  height: ${CARD_HEIGHT}px;
   margin: ${CARD_MARGIN};
-  padding: 8px;
+  padding: ${CARD_PADDING}px;
 
   display: flex;
   align-items: center;
   gap: 12px;
 
   background-color: var(--theme-container-low);
-  border: 1px solid var(--theme-outline-variant);
+  border: ${CARD_BORDER_WIDTH}px solid var(--theme-outline-variant);
   border-radius: 8px;
 `
 
@@ -124,16 +66,30 @@ const GoneCard = styled.div`
   ${singleLine};
   width: fit-content;
   max-width: ${CARD_MAX_WIDTH}px;
+  height: ${CARD_HEIGHT}px;
   margin: ${CARD_MARGIN};
   padding: 8px 12px;
 
+  display: flex;
+  align-items: center;
+
   color: var(--theme-on-surface-variant);
   background-color: var(--theme-container-low);
-  border: 1px solid var(--theme-outline-variant);
+  border: ${CARD_BORDER_WIDTH}px solid var(--theme-outline-variant);
   border-radius: 8px;
 `
 
-const THUMBNAIL_SIZE = 64
+// A purely visual placeholder shown while the summary is loading, sized to match `CardRoot` (the
+// tallest state) so the card never grows once the real content replaces it.
+const LoadingCard = styled.div`
+  width: ${CARD_MAX_WIDTH}px;
+  height: ${CARD_HEIGHT}px;
+  margin: ${CARD_MARGIN};
+
+  background-color: var(--theme-container-low);
+  border: ${CARD_BORDER_WIDTH}px solid var(--theme-outline-variant);
+  border-radius: 8px;
+`
 
 const ThumbnailContainer = styled.div`
   flex-shrink: 0;
@@ -164,6 +120,11 @@ const SecondaryLine = styled.div`
  * The presentational part of {@link LobbyInviteCard}: renders the loading/notFound/error/loaded
  * states without fetching anything itself, so it can be driven directly (e.g. from a devonly test
  * page) without racing a real lobby.
+ *
+ * The loading state renders a placeholder sized to match the loaded card so the message it's
+ * attached to doesn't grow again once the summary arrives. The error state renders nothing, same
+ * as loading -- the inline link in the message text is still rendered and still works either way,
+ * so there's nothing useful to show and no reserved height to preserve.
  */
 export function LobbyInviteCardContent({
   state,
@@ -174,9 +135,11 @@ export function LobbyInviteCardContent({
 }) {
   const { t } = useTranslation()
 
-  if (!state || state.status === 'error') {
-    // The inline link in the message text is still rendered and still works, so there's nothing
-    // useful to show here while loading or if the preview couldn't be loaded.
+  if (!state) {
+    return <LoadingCard aria-hidden={true} />
+  }
+
+  if (state.status === 'error') {
     return null
   }
 
@@ -189,7 +152,7 @@ export function LobbyInviteCardContent({
   return (
     <CardRoot>
       <ThumbnailContainer>
-        <MapThumbnail map={lobby.map} size={THUMBNAIL_SIZE} />
+        <MapThumbnail map={lobby.map} size={THUMBNAIL_SIZE} forceAspectRatio={1} />
       </ThumbnailContainer>
       <InfoColumn>
         <LobbyName title={lobby.name}>{lobby.name}</LobbyName>
@@ -212,13 +175,12 @@ export function LobbyInviteCardContent({
 
 /**
  * A rich invite preview for a lobby link posted in chat: the lobby's map, name, host, game type,
- * and open slot count, with a button to join it. Renders nothing while the summary is loading or
- * if it fails to load for a reason other than the lobby being gone (the inline link in the message
- * text is unaffected either way).
+ * and open slot count, with a button to join it. Reads through the cached summary lookup (see
+ * `useLobbySummary`) since the same lobby link often appears in several rendered messages at once.
  */
 export function LobbyInviteCard({ lobbyId }: { lobbyId: SbLobbyId }) {
   const dispatch = useAppDispatch()
-  const state = useSharedLobbySummary(lobbyId)
+  const [state] = useLobbySummary(lobbyId, { cached: true })
 
   const onJoinClick = () => {
     if (IS_ELECTRON) {

--- a/client/lobbies/lobby-invite-card.tsx
+++ b/client/lobbies/lobby-invite-card.tsx
@@ -1,0 +1,163 @@
+import { useTranslation } from 'react-i18next'
+import styled from 'styled-components'
+import { gameTypeToLabel } from '../../common/games/game-type'
+import { lobbyIdFromPath } from '../../common/lobbies/lobby-url'
+import { SbLobbyId } from '../../common/lobbies/sb-lobby-id'
+import { openDialog } from '../dialogs/action-creators'
+import { DialogType } from '../dialogs/dialog-type'
+import { MapThumbnail } from '../maps/map-thumbnail'
+import { FilledButton } from '../material/button'
+import { isShieldBatteryUrl } from '../navigation/external-link'
+import { useAppDispatch } from '../redux-hooks'
+import { bodySmall, singleLine, titleSmall } from '../styles/typography'
+import { LobbySummaryLoadState, useLobbySummary } from './lobby-summary'
+import { navigateToLobby } from './lobby-url'
+
+/**
+ * Returns the lobby id embedded in a chat message link, or undefined if the link isn't a
+ * ShieldBattery lobby link (an external URL, or a ShieldBattery URL for something other than a
+ * lobby).
+ */
+export function lobbyIdFromMessageLink(href: string): SbLobbyId | undefined {
+  let url: URL
+  try {
+    url = new URL(href)
+  } catch {
+    return undefined
+  }
+
+  return isShieldBatteryUrl(url) ? lobbyIdFromPath(url.pathname) : undefined
+}
+
+// Aligns the card under the message text: the timestamp column is 72px wide, plus the 8px of
+// horizontal padding `MessageContainer` (message-layout.tsx) uses everywhere else.
+const CARD_MARGIN = '4px 0 4px 80px'
+const CARD_MAX_WIDTH = 440
+
+const CardRoot = styled.div`
+  width: fit-content;
+  max-width: ${CARD_MAX_WIDTH}px;
+  margin: ${CARD_MARGIN};
+  padding: 8px;
+
+  display: flex;
+  align-items: center;
+  gap: 12px;
+
+  background-color: var(--theme-container-low);
+  border: 1px solid var(--theme-outline-variant);
+  border-radius: 8px;
+`
+
+const GoneCard = styled.div`
+  ${bodySmall};
+  ${singleLine};
+  width: fit-content;
+  max-width: ${CARD_MAX_WIDTH}px;
+  margin: ${CARD_MARGIN};
+  padding: 8px 12px;
+
+  color: var(--theme-on-surface-variant);
+  background-color: var(--theme-container-low);
+  border: 1px solid var(--theme-outline-variant);
+  border-radius: 8px;
+`
+
+const THUMBNAIL_SIZE = 64
+
+const ThumbnailContainer = styled.div`
+  flex-shrink: 0;
+  width: ${THUMBNAIL_SIZE}px;
+`
+
+const InfoColumn = styled.div`
+  min-width: 0;
+  flex-grow: 1;
+
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+`
+
+const LobbyName = styled.div`
+  ${titleSmall};
+  ${singleLine};
+`
+
+const SecondaryLine = styled.div`
+  ${bodySmall};
+  ${singleLine};
+  color: var(--theme-on-surface-variant);
+`
+
+/**
+ * The presentational part of {@link LobbyInviteCard}: renders the loading/notFound/error/loaded
+ * states without fetching anything itself, so it can be driven directly (e.g. from a devonly test
+ * page) without racing a real lobby.
+ */
+export function LobbyInviteCardContent({
+  state,
+  onJoinClick,
+}: {
+  state: LobbySummaryLoadState | undefined
+  onJoinClick: () => void
+}) {
+  const { t } = useTranslation()
+
+  if (!state || state.status === 'error') {
+    // The inline link in the message text is still rendered and still works, so there's nothing
+    // useful to show here while loading or if the preview couldn't be loaded.
+    return null
+  }
+
+  if (state.status === 'notFound') {
+    return <GoneCard>{t('lobbies.summary.noLongerOpen', 'This lobby is no longer open.')}</GoneCard>
+  }
+
+  const { summary: lobby, host } = state.data
+
+  return (
+    <CardRoot>
+      <ThumbnailContainer>
+        <MapThumbnail map={lobby.map} size={THUMBNAIL_SIZE} />
+      </ThumbnailContainer>
+      <InfoColumn>
+        <LobbyName title={lobby.name}>{lobby.name}</LobbyName>
+        <SecondaryLine>
+          {host.name} · {gameTypeToLabel(lobby.gameType, t)} ·{' '}
+          {t('lobbies.summary.openSlotCount', {
+            defaultValue: '{{count}} open',
+            count: lobby.openSlotCount,
+          })}
+        </SecondaryLine>
+      </InfoColumn>
+      <FilledButton
+        label={t('lobbies.joinLobby.action', 'Join lobby')}
+        onClick={onJoinClick}
+        testName='lobby-invite-card-join-button'
+      />
+    </CardRoot>
+  )
+}
+
+/**
+ * A rich invite preview for a lobby link posted in chat: the lobby's map, name, host, game type,
+ * and open slot count, with a button to join it. Renders nothing while the summary is loading or
+ * if it fails to load for a reason other than the lobby being gone (the inline link in the message
+ * text is unaffected either way).
+ */
+export function LobbyInviteCard({ lobbyId }: { lobbyId: SbLobbyId }) {
+  const dispatch = useAppDispatch()
+  const [state] = useLobbySummary(lobbyId)
+
+  const onJoinClick = () => {
+    if (IS_ELECTRON) {
+      // The join preview page at this route handles the actual join attempt (and its errors).
+      navigateToLobby(lobbyId, state?.status === 'loaded' ? state.data.summary.name : undefined)
+    } else {
+      dispatch(openDialog({ type: DialogType.Download }))
+    }
+  }
+
+  return <LobbyInviteCardContent state={state} onJoinClick={onJoinClick} />
+}

--- a/client/lobbies/lobby-invite-card.tsx
+++ b/client/lobbies/lobby-invite-card.tsx
@@ -38,12 +38,6 @@ export function lobbyIdFromMessageLink(href: string): SbLobbyId | undefined {
   return isShieldBatteryUrl(url) ? lobbyIdFromPath(url.pathname) : undefined
 }
 
-const CARD_MARGIN_TOP_BOTTOM = 4
-const CARD_MARGIN_RIGHT = 8
-// Aligns the card under the message text: `MessageContainer` (message-layout.tsx) uses
-// `padding: 4px 8px 4px 72px`, where the 72px left padding is the timestamp column that message
-// text starts after.
-const CARD_MARGIN_LEFT = 72
 // All card states share one fixed width (and height, see below) so no state transition ever
 // changes the card's footprint.
 const CARD_WIDTH = 440
@@ -60,12 +54,12 @@ const CARD_HEIGHT = THUMBNAIL_SIZE + CARD_PADDING * 2 + CARD_BORDER_WIDTH * 2
 
 const cardBase = css`
   width: ${CARD_WIDTH}px;
-  /* Margins don't count toward max-width's 100%, so they have to be subtracted explicitly or the
-   * card overflows narrow message lists into a horizontal scrollbar. */
-  max-width: calc(100% - ${CARD_MARGIN_LEFT + CARD_MARGIN_RIGHT}px);
+  max-width: 100%;
   height: ${CARD_HEIGHT}px;
-  margin: ${CARD_MARGIN_TOP_BOTTOM}px ${CARD_MARGIN_RIGHT}px ${CARD_MARGIN_TOP_BOTTOM}px
-    ${CARD_MARGIN_LEFT}px;
+  margin-top: 4px;
+  /* The card renders as a block child of the message container, whose hanging-indent trick
+   * (72px padding pushed back out with a negative text-indent) is meant for message text only. */
+  text-indent: 0;
 
   background-color: var(--theme-container-low);
   border: ${CARD_BORDER_WIDTH}px solid var(--theme-outline-variant);

--- a/client/lobbies/lobby-invite-card.tsx
+++ b/client/lobbies/lobby-invite-card.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from 'react-i18next'
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 import { gameTypeToLabel } from '../../common/games/game-type'
 import { lobbyIdFromPath } from '../../common/lobbies/lobby-url'
 import { SbLobbyId } from '../../common/lobbies/sb-lobby-id'
@@ -38,10 +38,12 @@ export function lobbyIdFromMessageLink(href: string): SbLobbyId | undefined {
   return isShieldBatteryUrl(url) ? lobbyIdFromPath(url.pathname) : undefined
 }
 
+const CARD_MARGIN_TOP_BOTTOM = 4
+const CARD_MARGIN_RIGHT = 8
 // Aligns the card under the message text: `MessageContainer` (message-layout.tsx) uses
 // `padding: 4px 8px 4px 72px`, where the 72px left padding is the timestamp column that message
 // text starts after.
-const CARD_MARGIN = '4px 8px 4px 72px'
+const CARD_MARGIN_LEFT = 72
 // All card states share one fixed width (and height, see below) so no state transition ever
 // changes the card's footprint.
 const CARD_WIDTH = 440
@@ -56,51 +58,53 @@ const THUMBNAIL_SIZE = 64
 // after it first mounts.
 const CARD_HEIGHT = THUMBNAIL_SIZE + CARD_PADDING * 2 + CARD_BORDER_WIDTH * 2
 
-const CardRoot = styled.div`
+const cardBase = css`
   width: ${CARD_WIDTH}px;
-  max-width: 100%;
+  /* Margins don't count toward max-width's 100%, so they have to be subtracted explicitly or the
+   * card overflows narrow message lists into a horizontal scrollbar. */
+  max-width: calc(100% - ${CARD_MARGIN_LEFT + CARD_MARGIN_RIGHT}px);
   height: ${CARD_HEIGHT}px;
-  margin: ${CARD_MARGIN};
+  margin: ${CARD_MARGIN_TOP_BOTTOM}px ${CARD_MARGIN_RIGHT}px ${CARD_MARGIN_TOP_BOTTOM}px
+    ${CARD_MARGIN_LEFT}px;
+
+  background-color: var(--theme-container-low);
+  border: ${CARD_BORDER_WIDTH}px solid var(--theme-outline-variant);
+  border-radius: 8px;
+
+  /* The chat area sets user-select: text on every descendant so message text copies cleanly; the
+   * card is UI rather than message text and must not splice itself into a copied selection. The
+   * doubled class outranks that rule. */
+  &&,
+  && * {
+    user-select: none;
+  }
+`
+
+const CardRoot = styled.div`
+  ${cardBase};
   padding: ${CARD_PADDING}px;
 
   display: flex;
   align-items: center;
   gap: 12px;
-
-  background-color: var(--theme-container-low);
-  border: ${CARD_BORDER_WIDTH}px solid var(--theme-outline-variant);
-  border-radius: 8px;
 `
 
 const GoneCard = styled.div`
+  ${cardBase};
   ${bodySmall};
   ${singleLine};
-  width: ${CARD_WIDTH}px;
-  max-width: 100%;
-  height: ${CARD_HEIGHT}px;
-  margin: ${CARD_MARGIN};
   padding: 8px 12px;
 
   display: flex;
   align-items: center;
 
   color: var(--theme-on-surface-variant);
-  background-color: var(--theme-container-low);
-  border: ${CARD_BORDER_WIDTH}px solid var(--theme-outline-variant);
-  border-radius: 8px;
 `
 
 // A purely visual placeholder shown while the summary is loading, sized to match `CardRoot` (the
 // tallest state) so the card never grows once the real content replaces it.
 const LoadingCard = styled.div`
-  width: ${CARD_WIDTH}px;
-  max-width: 100%;
-  height: ${CARD_HEIGHT}px;
-  margin: ${CARD_MARGIN};
-
-  background-color: var(--theme-container-low);
-  border: ${CARD_BORDER_WIDTH}px solid var(--theme-outline-variant);
-  border-radius: 8px;
+  ${cardBase};
 `
 
 const ThumbnailContainer = styled.div`

--- a/client/lobbies/lobby-invite-card.tsx
+++ b/client/lobbies/lobby-invite-card.tsx
@@ -14,6 +14,15 @@ import { LobbySummaryLoadState, useLobbySummary } from './lobby-summary'
 import { navigateToLobby } from './lobby-url'
 
 /**
+ * How old a message can be while still rendering an invite card for a lobby link in it. Lobbies
+ * are ephemeral, so links past this age are almost certainly dead — not rendering their cards
+ * keeps scrollback from filling with "no longer open" boxes, and caps how many summary fetches a
+ * message list can fan out (the summary endpoint is IP-throttled, and message contents are
+ * sender-controlled).
+ */
+export const LOBBY_INVITE_CARD_MAX_AGE_MS = 60 * 60 * 1000
+
+/**
  * Returns the lobby id embedded in a chat message link, or undefined if the link isn't a
  * ShieldBattery lobby link (an external URL, or a ShieldBattery URL for something other than a
  * lobby).
@@ -122,9 +131,10 @@ const SecondaryLine = styled.div`
  * page) without racing a real lobby.
  *
  * The loading state renders a placeholder sized to match the loaded card so the message it's
- * attached to doesn't grow again once the summary arrives. The error state renders nothing, same
- * as loading -- the inline link in the message text is still rendered and still works either way,
- * so there's nothing useful to show and no reserved height to preserve.
+ * attached to doesn't grow again once the summary arrives. The error state renders nothing at all,
+ * unlike loading's visible skeleton -- the inline link in the message text is still rendered and
+ * still works, so there's nothing useful to show and shrinking away is safe (only growth breaks
+ * the message list's autoscroll).
  */
 export function LobbyInviteCardContent({
   state,

--- a/client/lobbies/lobby-invite-card.tsx
+++ b/client/lobbies/lobby-invite-card.tsx
@@ -1,9 +1,6 @@
-import { InvokeError } from 'nydus-client'
-import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled, { css } from 'styled-components'
 import { gameTypeToLabel } from '../../common/games/game-type'
-import { LobbyJoinErrorCode } from '../../common/lobbies/lobby-network'
 import { lobbyIdFromPath } from '../../common/lobbies/lobby-url'
 import { SbLobbyId } from '../../common/lobbies/sb-lobby-id'
 import { MapThumbnail } from '../maps/map-thumbnail'
@@ -198,35 +195,29 @@ export function LobbyInviteCardContent({
  * `useLobbySummary`) since the same lobby link often appears in several rendered messages at once.
  */
 export function LobbyInviteCard({ lobbyId }: { lobbyId: SbLobbyId }) {
-  const joinLobbyAction = useJoinLobbyAction()
-  const [state] = useLobbySummary(lobbyId, { cached: true })
-  // The summary is read once per mount, so a lobby that dies while the card is on screen would
-  // keep showing as joinable; a failed join is the event that corrects it.
-  const [lobbyGone, setLobbyGone] = useState(false)
   const isInThisLobby = useAppSelector(s => s.lobby.inLobby && s.lobby.info.id === lobbyId)
 
   if (isInThisLobby) {
     // Someone seated in this lobby needs no invite to it (the common case being its own invite
     // link pasted into its own chat): they're already where Join would take them, and the join
-    // itself would only fail.
+    // itself would only fail. Gating outside the inner component also keeps every seated member
+    // from spending a summary fetch on the link.
     return null
   }
 
+  return <JoinableLobbyInviteCard lobbyId={lobbyId} />
+}
+
+function JoinableLobbyInviteCard({ lobbyId }: { lobbyId: SbLobbyId }) {
+  const joinLobbyAction = useJoinLobbyAction()
+  const [state] = useLobbySummary(lobbyId, { cached: true })
+
   return (
     <LobbyInviteCardContent
-      state={lobbyGone ? { status: 'notFound' } : state}
+      state={state}
       onJoinClick={() =>
         joinLobbyAction(lobbyId, {
           name: state?.status === 'loaded' ? state.data.summary.name : undefined,
-          onError: err => {
-            const code = err instanceof InvokeError ? err.body?.code : undefined
-            if (
-              code === LobbyJoinErrorCode.NoLongerOpen ||
-              code === LobbyJoinErrorCode.AlreadyStarted
-            ) {
-              setLobbyGone(true)
-            }
-          },
         })
       }
     />

--- a/client/lobbies/lobby-invite-card.tsx
+++ b/client/lobbies/lobby-invite-card.tsx
@@ -176,8 +176,8 @@ export function LobbyInviteCardContent({
         <LobbyName title={lobby.name}>{lobby.name}</LobbyName>
         <SecondaryLine>
           {host.name} · {gameTypeToLabel(lobby.gameType, t)} ·{' '}
-          {t('lobbies.summary.openSlotCount', {
-            defaultValue: '{{count}} open',
+          {t('lobbies.joinLobby.openSlotCount', {
+            defaultValue: '{{count}} slots open',
             count: lobby.openSlotCount,
           })}
         </SecondaryLine>

--- a/client/lobbies/lobby-invite-card.tsx
+++ b/client/lobbies/lobby-invite-card.tsx
@@ -1,15 +1,21 @@
+import { useAtomValue } from 'jotai'
 import { useTranslation } from 'react-i18next'
 import styled, { css } from 'styled-components'
 import { gameTypeToLabel } from '../../common/games/game-type'
 import { lobbyIdFromPath } from '../../common/lobbies/lobby-url'
 import { SbLobbyId } from '../../common/lobbies/sb-lobby-id'
-import { openDialog } from '../dialogs/action-creators'
+import { openDialog, openSimpleDialog } from '../dialogs/action-creators'
 import { DialogType } from '../dialogs/dialog-type'
 import { MapThumbnail } from '../maps/map-thumbnail'
+import { isMatchmakingAtom } from '../matchmaking/matchmaking-atoms'
 import { FilledButton } from '../material/button'
 import { isShieldBatteryUrl } from '../navigation/external-link'
 import { useAppDispatch } from '../redux-hooks'
+import { useSnackbarController } from '../snackbars/snackbar-overlay'
+import { healthChecked } from '../starcraft/health-checked'
 import { bodySmall, singleLine, titleSmall } from '../styles/typography'
+import { joinLobby } from './action-creators'
+import { lobbyJoinErrorMessage } from './lobby-join-errors'
 import { LobbySummaryLoadState, useLobbySummary } from './lobby-summary'
 import { navigateToLobby } from './lobby-url'
 
@@ -197,16 +203,42 @@ export function LobbyInviteCardContent({
  * `useLobbySummary`) since the same lobby link often appears in several rendered messages at once.
  */
 export function LobbyInviteCard({ lobbyId }: { lobbyId: SbLobbyId }) {
+  const { t } = useTranslation()
   const dispatch = useAppDispatch()
+  const snackbarController = useSnackbarController()
+  const isMatchmaking = useAtomValue(isMatchmakingAtom)
   const [state] = useLobbySummary(lobbyId, { cached: true })
 
   const onJoinClick = () => {
-    if (IS_ELECTRON) {
-      // The join preview page at this route handles the actual join attempt (and its errors).
-      navigateToLobby(lobbyId, state?.status === 'loaded' ? state.data.summary.name : undefined)
-    } else {
+    if (!IS_ELECTRON) {
       dispatch(openDialog({ type: DialogType.Download }))
+      return
     }
+    if (isMatchmaking) {
+      dispatch(
+        openSimpleDialog(
+          t('lobbies.joinLobby.matchmakingActiveDialogTitle', 'Joining lobbies disabled'),
+          t(
+            'lobbies.joinLobby.matchmakingActiveDialogText',
+            'You cannot join lobbies while a matchmaking search is active.',
+          ),
+        ),
+      )
+      return
+    }
+
+    // Joins directly (like clicking a lobby in the list), with the lobby route showing the join's
+    // outcome; failures also surface in a snackbar since navigation isn't blocked on the join.
+    healthChecked(() => {
+      dispatch(
+        joinLobby(lobbyId, {
+          onError: (err: unknown) => {
+            snackbarController.showSnackbar(lobbyJoinErrorMessage(err, t))
+          },
+        }),
+      )
+      navigateToLobby(lobbyId, state?.status === 'loaded' ? state.data.summary.name : undefined)
+    })()
   }
 
   return <LobbyInviteCardContent state={state} onJoinClick={onJoinClick} />

--- a/client/lobbies/lobby-invite-card.tsx
+++ b/client/lobbies/lobby-invite-card.tsx
@@ -102,6 +102,11 @@ const LoadingCard = styled.div`
 const ThumbnailContainer = styled.div`
   flex-shrink: 0;
   width: ${THUMBNAIL_SIZE}px;
+  /* The thumbnail's no-image fallback sizes itself to its (larger) placeholder icon rather than
+   * the requested size, so both axes are pinned and the excess clipped to keep the card's fixed
+   * height holding for maps without a generated image. */
+  height: ${THUMBNAIL_SIZE}px;
+  overflow: hidden;
 `
 
 // A long lobby name gives InfoColumn a large flex basis that would otherwise shrink the button

--- a/client/lobbies/lobby-invite-card.tsx
+++ b/client/lobbies/lobby-invite-card.tsx
@@ -1,16 +1,22 @@
+import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
+import swallowNonBuiltins from '../../common/async/swallow-non-builtins'
 import { gameTypeToLabel } from '../../common/games/game-type'
+import { LobbySummaryResponse } from '../../common/lobbies/lobby-network'
 import { lobbyIdFromPath } from '../../common/lobbies/lobby-url'
 import { SbLobbyId } from '../../common/lobbies/sb-lobby-id'
+import { apiUrl } from '../../common/urls'
 import { openDialog } from '../dialogs/action-creators'
 import { DialogType } from '../dialogs/dialog-type'
 import { MapThumbnail } from '../maps/map-thumbnail'
 import { FilledButton } from '../material/button'
 import { isShieldBatteryUrl } from '../navigation/external-link'
+import { fetchJson } from '../network/fetch'
+import { isFetchError } from '../network/fetch-errors'
 import { useAppDispatch } from '../redux-hooks'
 import { bodySmall, singleLine, titleSmall } from '../styles/typography'
-import { LobbySummaryLoadState, useLobbySummary } from './lobby-summary'
+import { LobbySummaryLoadState } from './lobby-summary'
 import { navigateToLobby } from './lobby-url'
 
 /**
@@ -29,9 +35,73 @@ export function lobbyIdFromMessageLink(href: string): SbLobbyId | undefined {
   return isShieldBatteryUrl(url) ? lobbyIdFromPath(url.pathname) : undefined
 }
 
-// Aligns the card under the message text: the timestamp column is 72px wide, plus the 8px of
-// horizontal padding `MessageContainer` (message-layout.tsx) uses everywhere else.
-const CARD_MARGIN = '4px 0 4px 80px'
+/** How long a fetched summary is shared between all the cards that want it. */
+const SUMMARY_SHARE_MS = 30 * 1000
+
+const summaryCache = new Map<
+  SbLobbyId,
+  { expiresAt: number; promise: Promise<LobbySummaryLoadState> }
+>()
+
+/**
+ * Fetches a lobby's summary through a short-lived shared cache. The same lobby link often appears
+ * in many rendered messages at once (repeated pastes, history pages, the full message list
+ * remounting on a channel switch), and each message's card mounts its own fetch -- sharing the
+ * result collapses those into one request per lobby per window instead of N identical hits against
+ * the summary endpoint's IP throttle. Transient failures aren't kept, so a later mount retries.
+ */
+function fetchSummaryShared(lobbyId: SbLobbyId): Promise<LobbySummaryLoadState> {
+  const now = Date.now()
+  const cached = summaryCache.get(lobbyId)
+  if (cached && cached.expiresAt > now) {
+    return cached.promise
+  }
+
+  const promise = fetchJson<LobbySummaryResponse>(apiUrl`lobbies/${lobbyId}/summary`).then(
+    (data): LobbySummaryLoadState => ({ status: 'loaded', data }),
+    (err): LobbySummaryLoadState => {
+      if (isFetchError(err) && err.status === 404) {
+        return { status: 'notFound' }
+      }
+      summaryCache.delete(lobbyId)
+      return { status: 'error' }
+    },
+  )
+  summaryCache.set(lobbyId, { expiresAt: now + SUMMARY_SHARE_MS, promise })
+  return promise
+}
+
+/**
+ * The card-oriented counterpart to `useLobbySummary`: same load states, but reads through
+ * {@link fetchSummaryShared} so simultaneous cards for the same lobby share one request. The
+ * result is tagged with the lobby id it was fetched for, so a stale result from a previous id is
+ * never rendered as current.
+ */
+function useSharedLobbySummary(lobbyId: SbLobbyId): LobbySummaryLoadState | undefined {
+  const [result, setResult] = useState<{ lobbyId: SbLobbyId; state: LobbySummaryLoadState }>()
+
+  useEffect(() => {
+    let canceled = false
+    fetchSummaryShared(lobbyId)
+      .then(state => {
+        if (!canceled) {
+          setResult({ lobbyId, state })
+        }
+      })
+      .catch(swallowNonBuiltins)
+
+    return () => {
+      canceled = true
+    }
+  }, [lobbyId])
+
+  return result?.lobbyId === lobbyId ? result.state : undefined
+}
+
+// Aligns the card under the message text: `MessageContainer` (message-layout.tsx) uses
+// `padding: 4px 8px 4px 72px`, where the 72px left padding is the timestamp column that message
+// text starts after.
+const CARD_MARGIN = '4px 8px 4px 72px'
 const CARD_MAX_WIDTH = 440
 
 const CardRoot = styled.div`
@@ -148,7 +218,7 @@ export function LobbyInviteCardContent({
  */
 export function LobbyInviteCard({ lobbyId }: { lobbyId: SbLobbyId }) {
   const dispatch = useAppDispatch()
-  const [state] = useLobbySummary(lobbyId)
+  const state = useSharedLobbySummary(lobbyId)
 
   const onJoinClick = () => {
     if (IS_ELECTRON) {

--- a/client/lobbies/lobby-invite-card.tsx
+++ b/client/lobbies/lobby-invite-card.tsx
@@ -1,23 +1,14 @@
-import { useAtomValue } from 'jotai'
 import { useTranslation } from 'react-i18next'
 import styled, { css } from 'styled-components'
 import { gameTypeToLabel } from '../../common/games/game-type'
 import { lobbyIdFromPath } from '../../common/lobbies/lobby-url'
 import { SbLobbyId } from '../../common/lobbies/sb-lobby-id'
-import { openDialog, openSimpleDialog } from '../dialogs/action-creators'
-import { DialogType } from '../dialogs/dialog-type'
 import { MapThumbnail } from '../maps/map-thumbnail'
-import { isMatchmakingAtom } from '../matchmaking/matchmaking-atoms'
 import { FilledButton } from '../material/button'
 import { isShieldBatteryUrl } from '../navigation/external-link'
-import { useAppDispatch } from '../redux-hooks'
-import { useSnackbarController } from '../snackbars/snackbar-overlay'
-import { healthChecked } from '../starcraft/health-checked'
 import { bodySmall, singleLine, titleSmall } from '../styles/typography'
-import { joinLobby } from './action-creators'
-import { lobbyJoinErrorMessage } from './lobby-join-errors'
 import { LobbySummaryLoadState, useLobbySummary } from './lobby-summary'
-import { navigateToLobby } from './lobby-url'
+import { useJoinLobbyAction } from './use-join-lobby-action'
 
 /**
  * How old a message can be while still rendering an invite card for a lobby link in it. Lobbies
@@ -203,43 +194,15 @@ export function LobbyInviteCardContent({
  * `useLobbySummary`) since the same lobby link often appears in several rendered messages at once.
  */
 export function LobbyInviteCard({ lobbyId }: { lobbyId: SbLobbyId }) {
-  const { t } = useTranslation()
-  const dispatch = useAppDispatch()
-  const snackbarController = useSnackbarController()
-  const isMatchmaking = useAtomValue(isMatchmakingAtom)
+  const joinLobbyAction = useJoinLobbyAction()
   const [state] = useLobbySummary(lobbyId, { cached: true })
 
-  const onJoinClick = () => {
-    if (!IS_ELECTRON) {
-      dispatch(openDialog({ type: DialogType.Download }))
-      return
-    }
-    if (isMatchmaking) {
-      dispatch(
-        openSimpleDialog(
-          t('lobbies.joinLobby.matchmakingActiveDialogTitle', 'Joining lobbies disabled'),
-          t(
-            'lobbies.joinLobby.matchmakingActiveDialogText',
-            'You cannot join lobbies while a matchmaking search is active.',
-          ),
-        ),
-      )
-      return
-    }
-
-    // Joins directly (like clicking a lobby in the list), with the lobby route showing the join's
-    // outcome; failures also surface in a snackbar since navigation isn't blocked on the join.
-    healthChecked(() => {
-      dispatch(
-        joinLobby(lobbyId, {
-          onError: (err: unknown) => {
-            snackbarController.showSnackbar(lobbyJoinErrorMessage(err, t))
-          },
-        }),
-      )
-      navigateToLobby(lobbyId, state?.status === 'loaded' ? state.data.summary.name : undefined)
-    })()
-  }
-
-  return <LobbyInviteCardContent state={state} onJoinClick={onJoinClick} />
+  return (
+    <LobbyInviteCardContent
+      state={state}
+      onJoinClick={() =>
+        joinLobbyAction(lobbyId, state?.status === 'loaded' ? state.data.summary.name : undefined)
+      }
+    />
+  )
 }

--- a/client/lobbies/lobby-invite-card.tsx
+++ b/client/lobbies/lobby-invite-card.tsx
@@ -16,9 +16,9 @@ import { navigateToLobby } from './lobby-url'
 /**
  * How old a message can be while still rendering an invite card for a lobby link in it. Lobbies
  * are ephemeral, so links past this age are almost certainly dead — not rendering their cards
- * keeps scrollback from filling with "no longer open" boxes, and caps how many summary fetches a
- * message list can fan out (the summary endpoint is IP-throttled, and message contents are
- * sender-controlled).
+ * keeps scrollback from filling with "no longer open" boxes and reduces how many cards load a
+ * summary at all. (This bounds cards by age, not count; the hard bound on summary-fetch fan-out
+ * from sender-controlled message content is the fetch budget in `lobby-summary.tsx`.)
  */
 export const LOBBY_INVITE_CARD_MAX_AGE_MS = 60 * 60 * 1000
 
@@ -42,7 +42,9 @@ export function lobbyIdFromMessageLink(href: string): SbLobbyId | undefined {
 // `padding: 4px 8px 4px 72px`, where the 72px left padding is the timestamp column that message
 // text starts after.
 const CARD_MARGIN = '4px 8px 4px 72px'
-const CARD_MAX_WIDTH = 440
+// All card states share one fixed width (and height, see below) so no state transition ever
+// changes the card's footprint.
+const CARD_WIDTH = 440
 const CARD_PADDING = 8
 const CARD_BORDER_WIDTH = 1
 
@@ -55,8 +57,8 @@ const THUMBNAIL_SIZE = 64
 const CARD_HEIGHT = THUMBNAIL_SIZE + CARD_PADDING * 2 + CARD_BORDER_WIDTH * 2
 
 const CardRoot = styled.div`
-  width: fit-content;
-  max-width: ${CARD_MAX_WIDTH}px;
+  width: ${CARD_WIDTH}px;
+  max-width: 100%;
   height: ${CARD_HEIGHT}px;
   margin: ${CARD_MARGIN};
   padding: ${CARD_PADDING}px;
@@ -73,8 +75,8 @@ const CardRoot = styled.div`
 const GoneCard = styled.div`
   ${bodySmall};
   ${singleLine};
-  width: fit-content;
-  max-width: ${CARD_MAX_WIDTH}px;
+  width: ${CARD_WIDTH}px;
+  max-width: 100%;
   height: ${CARD_HEIGHT}px;
   margin: ${CARD_MARGIN};
   padding: 8px 12px;
@@ -91,7 +93,8 @@ const GoneCard = styled.div`
 // A purely visual placeholder shown while the summary is loading, sized to match `CardRoot` (the
 // tallest state) so the card never grows once the real content replaces it.
 const LoadingCard = styled.div`
-  width: ${CARD_MAX_WIDTH}px;
+  width: ${CARD_WIDTH}px;
+  max-width: 100%;
   height: ${CARD_HEIGHT}px;
   margin: ${CARD_MARGIN};
 

--- a/client/lobbies/lobby-summary.test.ts
+++ b/client/lobbies/lobby-summary.test.ts
@@ -1,10 +1,12 @@
+import { renderHook } from '@testing-library/react'
+import { act } from 'react'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { LobbySummaryResponse } from '../../common/lobbies/lobby-network'
 import { makeSbLobbyId } from '../../common/lobbies/sb-lobby-id'
 import { asMockedFunction } from '../../common/testing/mocks'
 import { fetchJson } from '../network/fetch'
 import { FetchError } from '../network/fetch-errors'
-import { fetchLobbySummary, resetSummaryCacheForTesting } from './lobby-summary'
+import { fetchLobbySummary, resetSummaryCacheForTesting, useLobbySummary } from './lobby-summary'
 
 vi.mock('../network/fetch', () => ({
   fetchJson: vi.fn(),
@@ -91,7 +93,7 @@ describe('client/lobbies/lobby-summary/fetchLobbySummary', () => {
     expect(fetchJsonMock).toHaveBeenCalledTimes(15)
 
     const denied = await fetchLobbySummary(makeSbLobbyId('lobby-15'), { cached: true })
-    expect(denied).toEqual({ status: 'error' })
+    expect(denied).toEqual({ status: 'denied', retryAfterMs: 30 * 1000 })
     expect(fetchJsonMock).toHaveBeenCalledTimes(15)
 
     // The budget refills in the next window, and the denial wasn't cached as this lobby's result
@@ -99,6 +101,48 @@ describe('client/lobbies/lobby-summary/fetchLobbySummary', () => {
     const retried = await fetchLobbySummary(makeSbLobbyId('lobby-15'), { cached: true })
     expect(retried).toEqual({ status: 'loaded', data: RESPONSE })
     expect(fetchJsonMock).toHaveBeenCalledTimes(16)
+  })
+
+  test('a denied cached hook read retries once the window refills', async () => {
+    fetchJsonMock.mockResolvedValue(RESPONSE)
+    for (let i = 0; i < 15; i++) {
+      await fetchLobbySummary(makeSbLobbyId(`lobby-${i}`), { cached: true })
+    }
+
+    const { result } = renderHook(() =>
+      useLobbySummary(makeSbLobbyId('lobby-15'), { cached: true }),
+    )
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0)
+    })
+    expect(result.current[0]).toBeUndefined()
+    expect(fetchJsonMock).toHaveBeenCalledTimes(15)
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(31 * 1000)
+    })
+    expect(result.current[0]).toEqual({ status: 'loaded', data: RESPONSE })
+    expect(fetchJsonMock).toHaveBeenCalledTimes(16)
+  })
+
+  test('unmounting a denied cached hook read cancels its retry', async () => {
+    fetchJsonMock.mockResolvedValue(RESPONSE)
+    for (let i = 0; i < 15; i++) {
+      await fetchLobbySummary(makeSbLobbyId(`lobby-${i}`), { cached: true })
+    }
+
+    const { unmount } = renderHook(() =>
+      useLobbySummary(makeSbLobbyId('lobby-15'), { cached: true }),
+    )
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0)
+    })
+    unmount()
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(61 * 1000)
+    })
+    expect(fetchJsonMock).toHaveBeenCalledTimes(15)
   })
 
   test('a stale failing request does not evict a fresher cache entry', async () => {

--- a/client/lobbies/lobby-summary.test.ts
+++ b/client/lobbies/lobby-summary.test.ts
@@ -82,42 +82,23 @@ describe('client/lobbies/lobby-summary/fetchLobbySummary', () => {
     expect(second).toEqual({ status: 'loaded', data: RESPONSE })
   })
 
-  test('queues reads past the fetch budget until the window refills', async () => {
+  test('denies reads past the fetch budget without caching the denial', async () => {
     fetchJsonMock.mockResolvedValue(RESPONSE)
 
-    for (let i = 0; i < 10; i++) {
+    for (let i = 0; i < 15; i++) {
       await fetchLobbySummary(makeSbLobbyId(`lobby-${i}`), { cached: true })
     }
-    expect(fetchJsonMock).toHaveBeenCalledTimes(10)
+    expect(fetchJsonMock).toHaveBeenCalledTimes(15)
 
-    const queued = fetchLobbySummary(makeSbLobbyId('lobby-10'), { cached: true })
-    // Repeated reads of the same lobby share the queued read instead of queueing another
-    const alsoQueued = fetchLobbySummary(makeSbLobbyId('lobby-10'), { cached: true })
-    expect(fetchJsonMock).toHaveBeenCalledTimes(10)
+    const denied = await fetchLobbySummary(makeSbLobbyId('lobby-15'), { cached: true })
+    expect(denied).toEqual({ status: 'error' })
+    expect(fetchJsonMock).toHaveBeenCalledTimes(15)
 
-    await vi.advanceTimersByTimeAsync(31 * 1000)
-
-    expect(await queued).toEqual({ status: 'loaded', data: RESPONSE })
-    expect(await alsoQueued).toEqual({ status: 'loaded', data: RESPONSE })
-    expect(fetchJsonMock).toHaveBeenCalledTimes(11)
-  })
-
-  test('a queued read that fails transiently is not cached', async () => {
-    fetchJsonMock.mockResolvedValue(RESPONSE)
-
-    for (let i = 0; i < 10; i++) {
-      await fetchLobbySummary(makeSbLobbyId(`lobby-${i}`), { cached: true })
-    }
-    fetchJsonMock.mockRejectedValueOnce(new Error('network down'))
-
-    const queued = fetchLobbySummary(makeSbLobbyId('lobby-10'), { cached: true })
-    await vi.advanceTimersByTimeAsync(31 * 1000)
-    expect(await queued).toEqual({ status: 'error' })
-    expect(fetchJsonMock).toHaveBeenCalledTimes(11)
-
-    const retried = await fetchLobbySummary(makeSbLobbyId('lobby-10'), { cached: true })
+    // The budget refills in the next window, and the denial wasn't cached as this lobby's result
+    vi.advanceTimersByTime(31 * 1000)
+    const retried = await fetchLobbySummary(makeSbLobbyId('lobby-15'), { cached: true })
     expect(retried).toEqual({ status: 'loaded', data: RESPONSE })
-    expect(fetchJsonMock).toHaveBeenCalledTimes(12)
+    expect(fetchJsonMock).toHaveBeenCalledTimes(16)
   })
 
   test('a stale failing request does not evict a fresher cache entry', async () => {

--- a/client/lobbies/lobby-summary.test.ts
+++ b/client/lobbies/lobby-summary.test.ts
@@ -1,12 +1,10 @@
-import { renderHook } from '@testing-library/react'
-import { act } from 'react'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { LobbySummaryResponse } from '../../common/lobbies/lobby-network'
 import { makeSbLobbyId } from '../../common/lobbies/sb-lobby-id'
 import { asMockedFunction } from '../../common/testing/mocks'
 import { fetchJson } from '../network/fetch'
 import { FetchError } from '../network/fetch-errors'
-import { fetchLobbySummary, resetSummaryCacheForTesting, useLobbySummary } from './lobby-summary'
+import { fetchLobbySummary, resetSummaryCacheForTesting } from './lobby-summary'
 
 vi.mock('../network/fetch', () => ({
   fetchJson: vi.fn(),
@@ -93,7 +91,7 @@ describe('client/lobbies/lobby-summary/fetchLobbySummary', () => {
     expect(fetchJsonMock).toHaveBeenCalledTimes(15)
 
     const denied = await fetchLobbySummary(makeSbLobbyId('lobby-15'), { cached: true })
-    expect(denied).toEqual({ status: 'denied', retryAfterMs: 30 * 1000 })
+    expect(denied).toEqual({ status: 'error' })
     expect(fetchJsonMock).toHaveBeenCalledTimes(15)
 
     // The budget refills in the next window, and the denial wasn't cached as this lobby's result
@@ -101,48 +99,6 @@ describe('client/lobbies/lobby-summary/fetchLobbySummary', () => {
     const retried = await fetchLobbySummary(makeSbLobbyId('lobby-15'), { cached: true })
     expect(retried).toEqual({ status: 'loaded', data: RESPONSE })
     expect(fetchJsonMock).toHaveBeenCalledTimes(16)
-  })
-
-  test('a denied cached hook read retries once the window refills', async () => {
-    fetchJsonMock.mockResolvedValue(RESPONSE)
-    for (let i = 0; i < 15; i++) {
-      await fetchLobbySummary(makeSbLobbyId(`lobby-${i}`), { cached: true })
-    }
-
-    const { result } = renderHook(() =>
-      useLobbySummary(makeSbLobbyId('lobby-15'), { cached: true }),
-    )
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(0)
-    })
-    expect(result.current[0]).toBeUndefined()
-    expect(fetchJsonMock).toHaveBeenCalledTimes(15)
-
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(31 * 1000)
-    })
-    expect(result.current[0]).toEqual({ status: 'loaded', data: RESPONSE })
-    expect(fetchJsonMock).toHaveBeenCalledTimes(16)
-  })
-
-  test('unmounting a denied cached hook read cancels its retry', async () => {
-    fetchJsonMock.mockResolvedValue(RESPONSE)
-    for (let i = 0; i < 15; i++) {
-      await fetchLobbySummary(makeSbLobbyId(`lobby-${i}`), { cached: true })
-    }
-
-    const { unmount } = renderHook(() =>
-      useLobbySummary(makeSbLobbyId('lobby-15'), { cached: true }),
-    )
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(0)
-    })
-    unmount()
-
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(61 * 1000)
-    })
-    expect(fetchJsonMock).toHaveBeenCalledTimes(15)
   })
 
   test('a stale failing request does not evict a fresher cache entry', async () => {

--- a/client/lobbies/lobby-summary.test.ts
+++ b/client/lobbies/lobby-summary.test.ts
@@ -82,7 +82,7 @@ describe('client/lobbies/lobby-summary/fetchLobbySummary', () => {
     expect(second).toEqual({ status: 'loaded', data: RESPONSE })
   })
 
-  test('denies reads past the fetch budget without caching the denial', async () => {
+  test('queues reads past the fetch budget until the window refills', async () => {
     fetchJsonMock.mockResolvedValue(RESPONSE)
 
     for (let i = 0; i < 10; i++) {
@@ -90,15 +90,34 @@ describe('client/lobbies/lobby-summary/fetchLobbySummary', () => {
     }
     expect(fetchJsonMock).toHaveBeenCalledTimes(10)
 
-    const denied = await fetchLobbySummary(makeSbLobbyId('lobby-10'), { cached: true })
-    expect(denied).toEqual({ status: 'error' })
+    const queued = fetchLobbySummary(makeSbLobbyId('lobby-10'), { cached: true })
+    // Repeated reads of the same lobby share the queued read instead of queueing another
+    const alsoQueued = fetchLobbySummary(makeSbLobbyId('lobby-10'), { cached: true })
     expect(fetchJsonMock).toHaveBeenCalledTimes(10)
 
-    // The budget refills in the next window, and the denial wasn't cached as this lobby's result
-    vi.advanceTimersByTime(31 * 1000)
+    await vi.advanceTimersByTimeAsync(31 * 1000)
+
+    expect(await queued).toEqual({ status: 'loaded', data: RESPONSE })
+    expect(await alsoQueued).toEqual({ status: 'loaded', data: RESPONSE })
+    expect(fetchJsonMock).toHaveBeenCalledTimes(11)
+  })
+
+  test('a queued read that fails transiently is not cached', async () => {
+    fetchJsonMock.mockResolvedValue(RESPONSE)
+
+    for (let i = 0; i < 10; i++) {
+      await fetchLobbySummary(makeSbLobbyId(`lobby-${i}`), { cached: true })
+    }
+    fetchJsonMock.mockRejectedValueOnce(new Error('network down'))
+
+    const queued = fetchLobbySummary(makeSbLobbyId('lobby-10'), { cached: true })
+    await vi.advanceTimersByTimeAsync(31 * 1000)
+    expect(await queued).toEqual({ status: 'error' })
+    expect(fetchJsonMock).toHaveBeenCalledTimes(11)
+
     const retried = await fetchLobbySummary(makeSbLobbyId('lobby-10'), { cached: true })
     expect(retried).toEqual({ status: 'loaded', data: RESPONSE })
-    expect(fetchJsonMock).toHaveBeenCalledTimes(11)
+    expect(fetchJsonMock).toHaveBeenCalledTimes(12)
   })
 
   test('a stale failing request does not evict a fresher cache entry', async () => {

--- a/client/lobbies/lobby-summary.test.ts
+++ b/client/lobbies/lobby-summary.test.ts
@@ -1,0 +1,142 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { LobbySummaryResponse } from '../../common/lobbies/lobby-network'
+import { makeSbLobbyId } from '../../common/lobbies/sb-lobby-id'
+import { asMockedFunction } from '../../common/testing/mocks'
+import { fetchJson } from '../network/fetch'
+import { FetchError } from '../network/fetch-errors'
+import { fetchLobbySummary, resetSummaryCacheForTesting } from './lobby-summary'
+
+vi.mock('../network/fetch', () => ({
+  fetchJson: vi.fn(),
+}))
+
+const fetchJsonMock = asMockedFunction(fetchJson)
+
+const RESPONSE = { summary: { name: 'Test lobby' }, host: { name: 'host' } } as LobbySummaryResponse
+
+function notFoundError(): FetchError {
+  return new FetchError(new Response('', { status: 404, statusText: 'Not Found' }), '')
+}
+
+describe('client/lobbies/lobby-summary/fetchLobbySummary', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(1_000_000)
+    resetSummaryCacheForTesting()
+    fetchJsonMock.mockReset()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  test('shares one request across concurrent cached reads', async () => {
+    fetchJsonMock.mockResolvedValue(RESPONSE)
+    const id = makeSbLobbyId('lobby-a')
+
+    const [first, second] = await Promise.all([
+      fetchLobbySummary(id, { cached: true }),
+      fetchLobbySummary(id, { cached: true }),
+    ])
+
+    expect(fetchJsonMock).toHaveBeenCalledTimes(1)
+    expect(first).toEqual({ status: 'loaded', data: RESPONSE })
+    expect(second).toEqual({ status: 'loaded', data: RESPONSE })
+  })
+
+  test('serves a cached result within the window and refetches after it expires', async () => {
+    fetchJsonMock.mockResolvedValue(RESPONSE)
+    const id = makeSbLobbyId('lobby-a')
+
+    await fetchLobbySummary(id, { cached: true })
+    vi.advanceTimersByTime(10 * 1000)
+    await fetchLobbySummary(id, { cached: true })
+    expect(fetchJsonMock).toHaveBeenCalledTimes(1)
+
+    vi.advanceTimersByTime(31 * 1000)
+    await fetchLobbySummary(id, { cached: true })
+    expect(fetchJsonMock).toHaveBeenCalledTimes(2)
+  })
+
+  test('caches a 404 like any other result', async () => {
+    fetchJsonMock.mockRejectedValue(notFoundError())
+    const id = makeSbLobbyId('lobby-a')
+
+    const first = await fetchLobbySummary(id, { cached: true })
+    const second = await fetchLobbySummary(id, { cached: true })
+
+    expect(fetchJsonMock).toHaveBeenCalledTimes(1)
+    expect(first).toEqual({ status: 'notFound' })
+    expect(second).toEqual({ status: 'notFound' })
+  })
+
+  test('does not cache a transient failure, so the next reader retries', async () => {
+    fetchJsonMock.mockRejectedValueOnce(new Error('network down')).mockResolvedValue(RESPONSE)
+    const id = makeSbLobbyId('lobby-a')
+
+    const first = await fetchLobbySummary(id, { cached: true })
+    const second = await fetchLobbySummary(id, { cached: true })
+
+    expect(fetchJsonMock).toHaveBeenCalledTimes(2)
+    expect(first).toEqual({ status: 'error' })
+    expect(second).toEqual({ status: 'loaded', data: RESPONSE })
+  })
+
+  test('denies reads past the fetch budget without caching the denial', async () => {
+    fetchJsonMock.mockResolvedValue(RESPONSE)
+
+    for (let i = 0; i < 10; i++) {
+      await fetchLobbySummary(makeSbLobbyId(`lobby-${i}`), { cached: true })
+    }
+    expect(fetchJsonMock).toHaveBeenCalledTimes(10)
+
+    const denied = await fetchLobbySummary(makeSbLobbyId('lobby-10'), { cached: true })
+    expect(denied).toEqual({ status: 'error' })
+    expect(fetchJsonMock).toHaveBeenCalledTimes(10)
+
+    // The budget refills in the next window, and the denial wasn't cached as this lobby's result
+    vi.advanceTimersByTime(31 * 1000)
+    const retried = await fetchLobbySummary(makeSbLobbyId('lobby-10'), { cached: true })
+    expect(retried).toEqual({ status: 'loaded', data: RESPONSE })
+    expect(fetchJsonMock).toHaveBeenCalledTimes(11)
+  })
+
+  test('a stale failing request does not evict a fresher cache entry', async () => {
+    const id = makeSbLobbyId('lobby-a')
+    let rejectFirst: (err: Error) => void = () => {}
+    fetchJsonMock
+      .mockImplementationOnce(
+        () =>
+          new Promise<LobbySummaryResponse>((_resolve, reject) => {
+            rejectFirst = reject
+          }),
+      )
+      .mockResolvedValue(RESPONSE)
+
+    const first = fetchLobbySummary(id, { cached: true })
+
+    // The first request outlives its whole cache window, and a second read starts a fresh one
+    vi.advanceTimersByTime(31 * 1000)
+    const second = await fetchLobbySummary(id, { cached: true })
+    expect(second).toEqual({ status: 'loaded', data: RESPONSE })
+    expect(fetchJsonMock).toHaveBeenCalledTimes(2)
+
+    rejectFirst(new Error('timed out'))
+    expect(await first).toEqual({ status: 'error' })
+
+    // The late failure must not have evicted the fresh entry
+    const third = await fetchLobbySummary(id, { cached: true })
+    expect(third).toEqual({ status: 'loaded', data: RESPONSE })
+    expect(fetchJsonMock).toHaveBeenCalledTimes(2)
+  })
+
+  test('uncached reads always hit the network', async () => {
+    fetchJsonMock.mockResolvedValue(RESPONSE)
+    const id = makeSbLobbyId('lobby-a')
+
+    await fetchLobbySummary(id)
+    await fetchLobbySummary(id)
+
+    expect(fetchJsonMock).toHaveBeenCalledTimes(2)
+  })
+})

--- a/client/lobbies/lobby-summary.tsx
+++ b/client/lobbies/lobby-summary.tsx
@@ -66,15 +66,6 @@ const DetailValue = styled.div`
 export type LobbySummaryLoadState =
   { status: 'loaded'; data: LobbySummaryResponse } | { status: 'notFound' } | { status: 'error' }
 
-/**
- * The result of a cached summary read that the fetch budget denied: no network request was made,
- * and a read issued `retryAfterMs` from now lands in a refilled budget window.
- */
-export interface LobbySummaryDenial {
-  status: 'denied'
-  retryAfterMs: number
-}
-
 /** How long a cached summary fetch is shared between callers that opt into caching. */
 const SUMMARY_CACHE_MS = 30 * 1000
 
@@ -89,19 +80,12 @@ const summaryCache = new Map<
  * a history page full of distinct lobby-shaped ids must not be able to fan out one request each,
  * both because of the summary endpoint's per-IP throttle (whose budget also serves the join
  * preview and web landing page) and because none of those requests are the user's own doing. The
- * budget is sized to cover a realistically lobby-link-heavy channel in one window while staying
- * below the endpoint's sustained rate, so direct, user-initiated summary views keep working even
- * while it's being spent.
+ * budget is sized to cover a realistically lobby-link-heavy channel in one window, while leaving
+ * the rest of the endpoint's sustained per-IP rate (plus its burst allowance) as headroom for
+ * direct, user-initiated summary views.
  */
 const SUMMARY_FETCH_BUDGET = 15
 const SUMMARY_FETCH_BUDGET_WINDOW_MS = 30 * 1000
-
-/**
- * How many times a mounted cached reader waits out the budget window and reads again after being
- * denied, before settling for the error state. This bounds how long a card can sit in its loading
- * state when a large backlog of distinct lobbies keeps exhausting consecutive windows.
- */
-const MAX_DENIAL_RETRIES = 3
 
 let budgetWindowStart = 0
 let budgetUsed = 0
@@ -140,16 +124,8 @@ export function resetSummaryCacheForTesting() {
  */
 export function fetchLobbySummary(
   lobbyId: SbLobbyId,
-  options?: { cached?: false; signal?: AbortSignal },
-): Promise<LobbySummaryLoadState>
-export function fetchLobbySummary(
-  lobbyId: SbLobbyId,
-  options: { cached: true },
-): Promise<LobbySummaryLoadState | LobbySummaryDenial>
-export function fetchLobbySummary(
-  lobbyId: SbLobbyId,
   options: { cached?: false; signal?: AbortSignal } | { cached: true } = {},
-): Promise<LobbySummaryLoadState | LobbySummaryDenial> {
+): Promise<LobbySummaryLoadState> {
   if (!options.cached) {
     return fetchJson<LobbySummaryResponse>(apiUrl`lobbies/${lobbyId}/summary`, {
       signal: options.signal,
@@ -175,12 +151,11 @@ export function fetchLobbySummary(
   }
 
   if (!takeSummaryFetchBudget(now)) {
-    // Denials never touch the network and are never cached; they carry when the window refills so
-    // the caller can choose to read again then.
-    return Promise.resolve({
-      status: 'denied',
-      retryAfterMs: budgetWindowStart + SUMMARY_FETCH_BUDGET_WINDOW_MS - now,
-    })
+    // Over-budget reads fail as transient errors without touching the network. The denial isn't
+    // cached, so a denied card that remounts (e.g. its channel is reopened) reads again against
+    // whatever budget exists at that point; until then it renders nothing, while its message's
+    // inline link keeps working.
+    return Promise.resolve({ status: 'error' })
   }
 
   const promise: Promise<LobbySummaryLoadState> = fetchJson<LobbySummaryResponse>(
@@ -225,12 +200,11 @@ export function fetchLobbySummary(
  *
  * Pass `cached: true` to read through the shared cache described in {@link fetchLobbySummary}
  * instead of always hitting the network -- appropriate for call sites where the same lobby can be
- * requested many times at once and an eventually-consistent summary is fine. A fetch-budget denial
- * is retried a bounded number of times as windows refill (the state stays undefined meanwhile),
- * and only reported as an error once those run out. Note that caching makes `refresh` effectively
- * a no-op for the rest of the cache window: it re-runs the read, but the read is handed the same
- * cached result back. Leave `cached` unset for a single authoritative view (e.g. the join preview)
- * that should always see the current state and control its own refreshes.
+ * requested many times at once and an eventually-consistent summary is fine. Note that caching
+ * makes `refresh` effectively a no-op for the rest of the cache window: it re-runs the read, but
+ * the read is handed the same cached result back. Leave `cached` unset for a single authoritative
+ * view (e.g. the join preview) that should always see the current state and control its own
+ * refreshes.
  */
 export function useLobbySummary(
   lobbyId: SbLobbyId,
@@ -244,38 +218,18 @@ export function useLobbySummary(
     if (cached) {
       // The fetch itself is shared across every mount currently requesting this lobby, so it can't
       // be aborted just because this particular mount goes away -- only ignore a result that
-      // arrives after that happens. A budget denial is waited out and re-read a bounded number of
-      // times; the retry timer is scoped to this mount, so an unmounted card stops competing for
-      // the refilled budget.
+      // arrives after that happens.
       let canceled = false
-      let retryTimer: ReturnType<typeof setTimeout> | undefined
-      let denials = 0
-      const read = () => {
-        fetchLobbySummary(lobbyId, { cached: true })
-          .then(state => {
-            if (canceled) {
-              return
-            }
-            if (state.status === 'denied') {
-              denials += 1
-              if (denials <= MAX_DENIAL_RETRIES) {
-                retryTimer = setTimeout(read, state.retryAfterMs)
-              } else {
-                setResult({ lobbyId, state: { status: 'error' } })
-              }
-              return
-            }
+      fetchLobbySummary(lobbyId, { cached: true })
+        .then(state => {
+          if (!canceled) {
             setResult({ lobbyId, state })
-          })
-          .catch(swallowNonBuiltins)
-      }
-      read()
+          }
+        })
+        .catch(swallowNonBuiltins)
 
       return () => {
         canceled = true
-        if (retryTimer !== undefined) {
-          clearTimeout(retryTimer)
-        }
       }
     }
 

--- a/client/lobbies/lobby-summary.tsx
+++ b/client/lobbies/lobby-summary.tsx
@@ -66,6 +66,15 @@ const DetailValue = styled.div`
 export type LobbySummaryLoadState =
   { status: 'loaded'; data: LobbySummaryResponse } | { status: 'notFound' } | { status: 'error' }
 
+/**
+ * The result of a cached summary read that the fetch budget denied: no network request was made,
+ * and a read issued `retryAfterMs` from now lands in a refilled budget window.
+ */
+export interface LobbySummaryDenial {
+  status: 'denied'
+  retryAfterMs: number
+}
+
 /** How long a cached summary fetch is shared between callers that opt into caching. */
 const SUMMARY_CACHE_MS = 30 * 1000
 
@@ -86,6 +95,13 @@ const summaryCache = new Map<
  */
 const SUMMARY_FETCH_BUDGET = 15
 const SUMMARY_FETCH_BUDGET_WINDOW_MS = 30 * 1000
+
+/**
+ * How many times a mounted cached reader waits out the budget window and reads again after being
+ * denied, before settling for the error state. This bounds how long a card can sit in its loading
+ * state when a large backlog of distinct lobbies keeps exhausting consecutive windows.
+ */
+const MAX_DENIAL_RETRIES = 3
 
 let budgetWindowStart = 0
 let budgetUsed = 0
@@ -124,8 +140,16 @@ export function resetSummaryCacheForTesting() {
  */
 export function fetchLobbySummary(
   lobbyId: SbLobbyId,
+  options?: { cached?: false; signal?: AbortSignal },
+): Promise<LobbySummaryLoadState>
+export function fetchLobbySummary(
+  lobbyId: SbLobbyId,
+  options: { cached: true },
+): Promise<LobbySummaryLoadState | LobbySummaryDenial>
+export function fetchLobbySummary(
+  lobbyId: SbLobbyId,
   options: { cached?: false; signal?: AbortSignal } | { cached: true } = {},
-): Promise<LobbySummaryLoadState> {
+): Promise<LobbySummaryLoadState | LobbySummaryDenial> {
   if (!options.cached) {
     return fetchJson<LobbySummaryResponse>(apiUrl`lobbies/${lobbyId}/summary`, {
       signal: options.signal,
@@ -151,11 +175,12 @@ export function fetchLobbySummary(
   }
 
   if (!takeSummaryFetchBudget(now)) {
-    // Over-budget reads fail as transient errors without touching the network. The denial isn't
-    // cached, so a denied card that remounts (e.g. its channel is reopened) reads again against
-    // whatever budget is left at that point; until then it renders nothing, while its message's
-    // inline link keeps working.
-    return Promise.resolve({ status: 'error' })
+    // Denials never touch the network and are never cached; they carry when the window refills so
+    // the caller can choose to read again then.
+    return Promise.resolve({
+      status: 'denied',
+      retryAfterMs: budgetWindowStart + SUMMARY_FETCH_BUDGET_WINDOW_MS - now,
+    })
   }
 
   const promise: Promise<LobbySummaryLoadState> = fetchJson<LobbySummaryResponse>(
@@ -200,10 +225,12 @@ export function fetchLobbySummary(
  *
  * Pass `cached: true` to read through the shared cache described in {@link fetchLobbySummary}
  * instead of always hitting the network -- appropriate for call sites where the same lobby can be
- * requested many times at once and an eventually-consistent summary is fine. Note that this makes
- * `refresh` effectively a no-op for the rest of the cache window: it re-runs the read, but the
- * read is handed the same cached result back. Leave `cached` unset for a single authoritative view
- * (e.g. the join preview) that should always see the current state and control its own refreshes.
+ * requested many times at once and an eventually-consistent summary is fine. A fetch-budget denial
+ * is retried a bounded number of times as windows refill (the state stays undefined meanwhile),
+ * and only reported as an error once those run out. Note that caching makes `refresh` effectively
+ * a no-op for the rest of the cache window: it re-runs the read, but the read is handed the same
+ * cached result back. Leave `cached` unset for a single authoritative view (e.g. the join preview)
+ * that should always see the current state and control its own refreshes.
  */
 export function useLobbySummary(
   lobbyId: SbLobbyId,
@@ -217,18 +244,38 @@ export function useLobbySummary(
     if (cached) {
       // The fetch itself is shared across every mount currently requesting this lobby, so it can't
       // be aborted just because this particular mount goes away -- only ignore a result that
-      // arrives after that happens.
+      // arrives after that happens. A budget denial is waited out and re-read a bounded number of
+      // times; the retry timer is scoped to this mount, so an unmounted card stops competing for
+      // the refilled budget.
       let canceled = false
-      fetchLobbySummary(lobbyId, { cached: true })
-        .then(state => {
-          if (!canceled) {
+      let retryTimer: ReturnType<typeof setTimeout> | undefined
+      let denials = 0
+      const read = () => {
+        fetchLobbySummary(lobbyId, { cached: true })
+          .then(state => {
+            if (canceled) {
+              return
+            }
+            if (state.status === 'denied') {
+              denials += 1
+              if (denials <= MAX_DENIAL_RETRIES) {
+                retryTimer = setTimeout(read, state.retryAfterMs)
+              } else {
+                setResult({ lobbyId, state: { status: 'error' } })
+              }
+              return
+            }
             setResult({ lobbyId, state })
-          }
-        })
-        .catch(swallowNonBuiltins)
+          })
+          .catch(swallowNonBuiltins)
+      }
+      read()
 
       return () => {
         canceled = true
+        if (retryTimer !== undefined) {
+          clearTimeout(retryTimer)
+        }
       }
     }
 

--- a/client/lobbies/lobby-summary.tsx
+++ b/client/lobbies/lobby-summary.tsx
@@ -123,7 +123,7 @@ export function resetSummaryCacheForTesting() {
  */
 export function fetchLobbySummary(
   lobbyId: SbLobbyId,
-  options: { cached?: boolean; signal?: AbortSignal } = {},
+  options: { cached?: false; signal?: AbortSignal } | { cached: true } = {},
 ): Promise<LobbySummaryLoadState> {
   if (!options.cached) {
     return fetchJson<LobbySummaryResponse>(apiUrl`lobbies/${lobbyId}/summary`, {

--- a/client/lobbies/lobby-summary.tsx
+++ b/client/lobbies/lobby-summary.tsx
@@ -75,6 +75,34 @@ const summaryCache = new Map<
 >()
 
 /**
+ * How many cache-missing cached reads may actually hit the network per window. Cached reads are
+ * driven by rendered content (chat-message lobby links), and message text is sender-controlled:
+ * a history page full of distinct lobby-shaped ids must not be able to fan out one request each,
+ * both because of the summary endpoint's per-IP throttle (whose budget also serves the join
+ * preview and web landing page) and because none of those requests are the user's own doing. The
+ * budget is deliberately below the endpoint's sustained rate so direct, user-initiated summary
+ * views keep working even while at it.
+ */
+const SUMMARY_FETCH_BUDGET = 10
+const SUMMARY_FETCH_BUDGET_WINDOW_MS = 30 * 1000
+
+let budgetWindowStart = 0
+let budgetUsed = 0
+
+/** Consumes one unit of the cached-read fetch budget, returning whether any budget remained. */
+function takeSummaryFetchBudget(now: number): boolean {
+  if (now - budgetWindowStart >= SUMMARY_FETCH_BUDGET_WINDOW_MS) {
+    budgetWindowStart = now
+    budgetUsed = 0
+  }
+  if (budgetUsed >= SUMMARY_FETCH_BUDGET) {
+    return false
+  }
+  budgetUsed += 1
+  return true
+}
+
+/**
  * Fetches the unauthenticated lobby summary (`GET /api/1/lobbies/:lobbyId/summary`) for `lobbyId`,
  * either directly (`signal` aborts the request the same way a plain `fetchJson` call would) or,
  * with `cached: true`, through a short-lived cache shared by every caller that opts in.
@@ -114,10 +142,24 @@ function fetchLobbySummary(
     }
   }
 
+  if (!takeSummaryFetchBudget(now)) {
+    // Over-budget reads report as transient errors without touching the network, and aren't
+    // cached, so a later read (with budget) simply retries.
+    return Promise.resolve({ status: 'error' })
+  }
+
   const promise: Promise<LobbySummaryLoadState> = fetchJson<LobbySummaryResponse>(
     apiUrl`lobbies/${lobbyId}/summary`,
   ).then(
-    (data): LobbySummaryLoadState => ({ status: 'loaded', data }),
+    (data): LobbySummaryLoadState => {
+      // The shared window starts when the response arrives, not when the request started, so a
+      // slow fetch doesn't eat into it.
+      const entry = summaryCache.get(lobbyId)
+      if (entry?.promise === promise) {
+        entry.expiresAt = Date.now() + SUMMARY_CACHE_MS
+      }
+      return { status: 'loaded', data }
+    },
     (err): LobbySummaryLoadState => {
       if (isFetchError(err) && err.status === 404) {
         return { status: 'notFound' }

--- a/client/lobbies/lobby-summary.tsx
+++ b/client/lobbies/lobby-summary.tsx
@@ -81,7 +81,9 @@ const summaryCache = new Map<
  * both because of the summary endpoint's per-IP throttle (whose budget also serves the join
  * preview and web landing page) and because none of those requests are the user's own doing. The
  * budget is deliberately below the endpoint's sustained rate so direct, user-initiated summary
- * views keep working even while at it.
+ * views keep working even while at it. Reads past the budget aren't dropped -- they wait for the
+ * next window (see the denial branch below) -- so the budget shapes traffic rather than deciding
+ * which cards ever load.
  */
 const SUMMARY_FETCH_BUDGET = 10
 const SUMMARY_FETCH_BUDGET_WINDOW_MS = 30 * 1000
@@ -150,11 +152,25 @@ export function fetchLobbySummary(
   }
 
   if (!takeSummaryFetchBudget(now)) {
-    // Over-budget reads report as transient errors without touching the network and aren't
-    // cached. Nothing retries a denied read on its own: a card denied here stays empty until it
-    // remounts (e.g. its channel is reopened), which is acceptable because the message's inline
-    // link keeps working regardless.
-    return Promise.resolve({ status: 'error' })
+    // Over-budget reads wait for the window to refill and then go through the whole read again:
+    // that retry can end in a cache hit (someone else fetched this lobby meanwhile), a real fetch,
+    // or another wait if the refilled window is exhausted first -- each window drains part of the
+    // backlog, so every waiter gets through eventually. The waiter is cached like an in-flight
+    // fetch so repeated reads of the same lobby share it, and it evicts itself just before
+    // retrying: the retry must see a cache miss (its own entry would otherwise be returned right
+    // back to it), and whatever the retry caches -- or deliberately doesn't, for a transient
+    // failure -- then stands on its own.
+    const waitMs = budgetWindowStart + SUMMARY_FETCH_BUDGET_WINDOW_MS - now
+    const promise: Promise<LobbySummaryLoadState> = new Promise<void>(resolve => {
+      setTimeout(resolve, waitMs)
+    }).then(() => {
+      if (summaryCache.get(lobbyId)?.promise === promise) {
+        summaryCache.delete(lobbyId)
+      }
+      return fetchLobbySummary(lobbyId, { cached: true })
+    })
+    summaryCache.set(lobbyId, { expiresAt: now + waitMs + SUMMARY_CACHE_MS, promise })
+    return promise
   }
 
   const promise: Promise<LobbySummaryLoadState> = fetchJson<LobbySummaryResponse>(

--- a/client/lobbies/lobby-summary.tsx
+++ b/client/lobbies/lobby-summary.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
+import swallowNonBuiltins from '../../common/async/swallow-non-builtins'
 import { gameTypeToLabel } from '../../common/games/game-type'
 import { LobbySummaryResponse } from '../../common/lobbies/lobby-network'
 import { SbLobbyId } from '../../common/lobbies/sb-lobby-id'
@@ -65,42 +66,120 @@ const DetailValue = styled.div`
 export type LobbySummaryLoadState =
   { status: 'loaded'; data: LobbySummaryResponse } | { status: 'notFound' } | { status: 'error' }
 
+/** How long a cached summary fetch is shared between callers that opt into caching. */
+const SUMMARY_CACHE_MS = 30 * 1000
+
+const summaryCache = new Map<
+  SbLobbyId,
+  { expiresAt: number; promise: Promise<LobbySummaryLoadState> }
+>()
+
 /**
- * Fetches the unauthenticated lobby summary (`GET /api/1/lobbies/:lobbyId/summary`) for `lobbyId`.
- * Returns a tuple of the load state (undefined while the fetch for the current `lobbyId` is in
- * flight) and a `refresh` function that re-runs the fetch for the current `lobbyId`.
+ * Fetches the unauthenticated lobby summary (`GET /api/1/lobbies/:lobbyId/summary`) for `lobbyId`,
+ * either directly (`signal` aborts the request the same way a plain `fetchJson` call would) or,
+ * with `cached: true`, through a short-lived cache shared by every caller that opts in.
+ *
+ * Caching exists for call sites where the same lobby can be requested many times at once (e.g. the
+ * same lobby link appearing in several rendered chat messages, or a full message list remounting on
+ * a channel switch) -- collapsing those into one request per lobby per window avoids fanning out
+ * to the summary endpoint's IP throttle. A transient failure (anything other than a 404) isn't
+ * cached, so a later caller retries instead of being stuck with the error for the whole window; a
+ * 404 is cached like any other result, since a lobby that's gone stays gone.
+ */
+function fetchLobbySummary(
+  lobbyId: SbLobbyId,
+  options: { cached?: boolean; signal?: AbortSignal } = {},
+): Promise<LobbySummaryLoadState> {
+  if (!options.cached) {
+    return fetchJson<LobbySummaryResponse>(apiUrl`lobbies/${lobbyId}/summary`, {
+      signal: options.signal,
+    }).then(
+      (data): LobbySummaryLoadState => ({ status: 'loaded', data }),
+      (err): LobbySummaryLoadState =>
+        isFetchError(err) && err.status === 404 ? { status: 'notFound' } : { status: 'error' },
+    )
+  }
+
+  const now = Date.now()
+  const cached = summaryCache.get(lobbyId)
+  if (cached && cached.expiresAt > now) {
+    return cached.promise
+  }
+
+  // Sweep other expired entries out while we're here -- they're otherwise only replaced when the
+  // same lobby is requested again, so the cache would grow unbounded over a long session.
+  for (const [id, entry] of summaryCache) {
+    if (entry.expiresAt <= now) {
+      summaryCache.delete(id)
+    }
+  }
+
+  const promise = fetchJson<LobbySummaryResponse>(apiUrl`lobbies/${lobbyId}/summary`).then(
+    (data): LobbySummaryLoadState => ({ status: 'loaded', data }),
+    (err): LobbySummaryLoadState => {
+      if (isFetchError(err) && err.status === 404) {
+        return { status: 'notFound' }
+      }
+      summaryCache.delete(lobbyId)
+      return { status: 'error' }
+    },
+  )
+  summaryCache.set(lobbyId, { expiresAt: now + SUMMARY_CACHE_MS, promise })
+  return promise
+}
+
+/**
+ * Loads a lobby's unauthenticated summary. Returns a tuple of the load state (undefined while the
+ * fetch for the current `lobbyId` is in flight) and a `refresh` function that re-runs the fetch for
+ * the current `lobbyId`.
  *
  * The result is tagged with the lobby id it was fetched for, so a stale result from a previous id
  * (e.g. if `lobbyId` changes without the caller unmounting) is never rendered as current -- the
  * state stays undefined until a result tagged with the current id arrives. A `refresh` doesn't
  * clear the existing result, so the previous state remains rendered until the new one lands. If a
- * refresh fails for a reason other than a 404, the last successfully loaded summary is kept
- * instead of being downgraded to the error state.
+ * refresh fails for a reason other than a 404, the last successfully loaded summary is kept instead
+ * of being downgraded to the error state.
+ *
+ * Pass `cached: true` to read through the shared cache described in {@link fetchLobbySummary}
+ * instead of always hitting the network -- appropriate for call sites where the same lobby can be
+ * requested many times at once and an eventually-consistent summary is fine. Leave it unset for a
+ * single authoritative view (e.g. the join preview) that should always see the current state and
+ * control its own refreshes.
  */
 export function useLobbySummary(
   lobbyId: SbLobbyId,
+  options?: { cached?: boolean },
 ): [state: LobbySummaryLoadState | undefined, refresh: () => void] {
-  const [result, setResult] = useState<{ lobbyId: string; state: LobbySummaryLoadState }>()
+  const cached = options?.cached ?? false
+  const [result, setResult] = useState<{ lobbyId: SbLobbyId; state: LobbySummaryLoadState }>()
   const [refreshToken, setRefreshToken] = useState(0)
 
   useEffect(() => {
+    if (cached) {
+      // The fetch itself is shared across every mount currently requesting this lobby, so it can't
+      // be aborted just because this particular mount goes away -- only ignore a result that
+      // arrives after that happens.
+      let canceled = false
+      fetchLobbySummary(lobbyId, { cached: true })
+        .then(state => {
+          if (!canceled) {
+            setResult({ lobbyId, state })
+          }
+        })
+        .catch(swallowNonBuiltins)
+
+      return () => {
+        canceled = true
+      }
+    }
+
     const controller = new AbortController()
 
-    fetchJson<LobbySummaryResponse>(apiUrl`lobbies/${lobbyId}/summary`, {
-      signal: controller.signal,
-    }).then(
-      data => {
+    fetchLobbySummary(lobbyId, { signal: controller.signal })
+      .then(state => {
         if (controller.signal.aborted) {
           return
         }
-        setResult({ lobbyId, state: { status: 'loaded', data } })
-      },
-      err => {
-        if (controller.signal.aborted) {
-          return
-        }
-        const state: LobbySummaryLoadState =
-          isFetchError(err) && err.status === 404 ? { status: 'notFound' } : { status: 'error' }
         setResult(prev =>
           // A lobby that's still loadable shouldn't lose its rendered details to a transient
           // failure; only a 404 (definitively gone) replaces a loaded summary.
@@ -108,11 +187,11 @@ export function useLobbySummary(
             ? prev
             : { lobbyId, state },
         )
-      },
-    )
+      })
+      .catch(swallowNonBuiltins)
 
     return () => controller.abort()
-  }, [lobbyId, refreshToken])
+  }, [lobbyId, refreshToken, cached])
 
   const refresh = () => setRefreshToken(t => t + 1)
 

--- a/client/lobbies/lobby-summary.tsx
+++ b/client/lobbies/lobby-summary.tsx
@@ -80,12 +80,11 @@ const summaryCache = new Map<
  * a history page full of distinct lobby-shaped ids must not be able to fan out one request each,
  * both because of the summary endpoint's per-IP throttle (whose budget also serves the join
  * preview and web landing page) and because none of those requests are the user's own doing. The
- * budget is deliberately below the endpoint's sustained rate so direct, user-initiated summary
- * views keep working even while at it. Reads past the budget aren't dropped -- they wait for the
- * next window (see the denial branch below) -- so the budget shapes traffic rather than deciding
- * which cards ever load.
+ * budget is sized to cover a realistically lobby-link-heavy channel in one window while staying
+ * below the endpoint's sustained rate, so direct, user-initiated summary views keep working even
+ * while it's being spent.
  */
-const SUMMARY_FETCH_BUDGET = 10
+const SUMMARY_FETCH_BUDGET = 15
 const SUMMARY_FETCH_BUDGET_WINDOW_MS = 30 * 1000
 
 let budgetWindowStart = 0
@@ -152,25 +151,11 @@ export function fetchLobbySummary(
   }
 
   if (!takeSummaryFetchBudget(now)) {
-    // Over-budget reads wait for the window to refill and then go through the whole read again:
-    // that retry can end in a cache hit (someone else fetched this lobby meanwhile), a real fetch,
-    // or another wait if the refilled window is exhausted first -- each window drains part of the
-    // backlog, so every waiter gets through eventually. The waiter is cached like an in-flight
-    // fetch so repeated reads of the same lobby share it, and it evicts itself just before
-    // retrying: the retry must see a cache miss (its own entry would otherwise be returned right
-    // back to it), and whatever the retry caches -- or deliberately doesn't, for a transient
-    // failure -- then stands on its own.
-    const waitMs = budgetWindowStart + SUMMARY_FETCH_BUDGET_WINDOW_MS - now
-    const promise: Promise<LobbySummaryLoadState> = new Promise<void>(resolve => {
-      setTimeout(resolve, waitMs)
-    }).then(() => {
-      if (summaryCache.get(lobbyId)?.promise === promise) {
-        summaryCache.delete(lobbyId)
-      }
-      return fetchLobbySummary(lobbyId, { cached: true })
-    })
-    summaryCache.set(lobbyId, { expiresAt: now + waitMs + SUMMARY_CACHE_MS, promise })
-    return promise
+    // Over-budget reads fail as transient errors without touching the network. The denial isn't
+    // cached, so a denied card that remounts (e.g. its channel is reopened) reads again against
+    // whatever budget is left at that point; until then it renders nothing, while its message's
+    // inline link keeps working.
+    return Promise.resolve({ status: 'error' })
   }
 
   const promise: Promise<LobbySummaryLoadState> = fetchJson<LobbySummaryResponse>(

--- a/client/lobbies/lobby-summary.tsx
+++ b/client/lobbies/lobby-summary.tsx
@@ -114,13 +114,19 @@ function fetchLobbySummary(
     }
   }
 
-  const promise = fetchJson<LobbySummaryResponse>(apiUrl`lobbies/${lobbyId}/summary`).then(
+  const promise: Promise<LobbySummaryLoadState> = fetchJson<LobbySummaryResponse>(
+    apiUrl`lobbies/${lobbyId}/summary`,
+  ).then(
     (data): LobbySummaryLoadState => ({ status: 'loaded', data }),
     (err): LobbySummaryLoadState => {
       if (isFetchError(err) && err.status === 404) {
         return { status: 'notFound' }
       }
-      summaryCache.delete(lobbyId)
+      // Evict only our own entry: a request that outlives its window may fail after a later
+      // caller has already repopulated the cache with a fresh in-flight fetch.
+      if (summaryCache.get(lobbyId)?.promise === promise) {
+        summaryCache.delete(lobbyId)
+      }
       return { status: 'error' }
     },
   )
@@ -142,9 +148,10 @@ function fetchLobbySummary(
  *
  * Pass `cached: true` to read through the shared cache described in {@link fetchLobbySummary}
  * instead of always hitting the network -- appropriate for call sites where the same lobby can be
- * requested many times at once and an eventually-consistent summary is fine. Leave it unset for a
- * single authoritative view (e.g. the join preview) that should always see the current state and
- * control its own refreshes.
+ * requested many times at once and an eventually-consistent summary is fine. Note that this makes
+ * `refresh` effectively a no-op for the rest of the cache window: it re-runs the read, but the
+ * read is handed the same cached result back. Leave `cached` unset for a single authoritative view
+ * (e.g. the join preview) that should always see the current state and control its own refreshes.
  */
 export function useLobbySummary(
   lobbyId: SbLobbyId,

--- a/client/lobbies/lobby-summary.tsx
+++ b/client/lobbies/lobby-summary.tsx
@@ -102,6 +102,13 @@ function takeSummaryFetchBudget(now: number): boolean {
   return true
 }
 
+/** Clears the shared summary cache and fetch budget, so tests don't depend on each other. */
+export function resetSummaryCacheForTesting() {
+  summaryCache.clear()
+  budgetWindowStart = 0
+  budgetUsed = 0
+}
+
 /**
  * Fetches the unauthenticated lobby summary (`GET /api/1/lobbies/:lobbyId/summary`) for `lobbyId`,
  * either directly (`signal` aborts the request the same way a plain `fetchJson` call would) or,
@@ -114,7 +121,7 @@ function takeSummaryFetchBudget(now: number): boolean {
  * cached, so a later caller retries instead of being stuck with the error for the whole window; a
  * 404 is cached like any other result, since a lobby that's gone stays gone.
  */
-function fetchLobbySummary(
+export function fetchLobbySummary(
   lobbyId: SbLobbyId,
   options: { cached?: boolean; signal?: AbortSignal } = {},
 ): Promise<LobbySummaryLoadState> {
@@ -143,8 +150,10 @@ function fetchLobbySummary(
   }
 
   if (!takeSummaryFetchBudget(now)) {
-    // Over-budget reads report as transient errors without touching the network, and aren't
-    // cached, so a later read (with budget) simply retries.
+    // Over-budget reads report as transient errors without touching the network and aren't
+    // cached. Nothing retries a denied read on its own: a card denied here stays empty until it
+    // remounts (e.g. its channel is reopened), which is acceptable because the message's inline
+    // link keeps working regardless.
     return Promise.resolve({ status: 'error' })
   }
 

--- a/client/lobbies/use-join-lobby-action.ts
+++ b/client/lobbies/use-join-lobby-action.ts
@@ -15,13 +15,9 @@ import { navigateToLobby } from './lobby-url'
  * Returns a function that joins a lobby the way clicking one in the lobby list does. On web it
  * shows the download dialog; in the app it refuses while a matchmaking search is active, and
  * otherwise health-checks the game install, dispatches the join (reporting failures in a
- * snackbar, and to `onError` if given), and navigates to the lobby route, which shows the join's
- * outcome.
+ * snackbar), and navigates to the lobby route, which shows the join's outcome.
  */
-export function useJoinLobbyAction(): (
-  lobbyId: SbLobbyId,
-  options?: { name?: string; onError?: (err: unknown) => void },
-) => void {
+export function useJoinLobbyAction(): (lobbyId: SbLobbyId, options?: { name?: string }) => void {
   const { t } = useTranslation()
   const dispatch = useAppDispatch()
   const snackbarController = useSnackbarController()
@@ -50,7 +46,6 @@ export function useJoinLobbyAction(): (
         joinLobby(lobbyId, {
           onError: (err: unknown) => {
             snackbarController.showSnackbar(lobbyJoinErrorMessage(err, t))
-            options?.onError?.(err)
           },
         }),
       )

--- a/client/lobbies/use-join-lobby-action.ts
+++ b/client/lobbies/use-join-lobby-action.ts
@@ -1,0 +1,55 @@
+import { useAtomValue } from 'jotai'
+import { useTranslation } from 'react-i18next'
+import { SbLobbyId } from '../../common/lobbies/sb-lobby-id'
+import { openDialog, openSimpleDialog } from '../dialogs/action-creators'
+import { DialogType } from '../dialogs/dialog-type'
+import { isMatchmakingAtom } from '../matchmaking/matchmaking-atoms'
+import { useAppDispatch } from '../redux-hooks'
+import { useSnackbarController } from '../snackbars/snackbar-overlay'
+import { healthChecked } from '../starcraft/health-checked'
+import { joinLobby } from './action-creators'
+import { lobbyJoinErrorMessage } from './lobby-join-errors'
+import { navigateToLobby } from './lobby-url'
+
+/**
+ * Returns a function that joins a lobby the way clicking one in the lobby list does. On web it
+ * shows the download dialog; in the app it refuses while a matchmaking search is active, and
+ * otherwise health-checks the game install, dispatches the join (reporting failures in a
+ * snackbar), and navigates to the lobby route, which shows the join's outcome.
+ */
+export function useJoinLobbyAction(): (lobbyId: SbLobbyId, name?: string) => void {
+  const { t } = useTranslation()
+  const dispatch = useAppDispatch()
+  const snackbarController = useSnackbarController()
+  const isMatchmaking = useAtomValue(isMatchmakingAtom)
+
+  return (lobbyId, name) => {
+    if (!IS_ELECTRON) {
+      dispatch(openDialog({ type: DialogType.Download }))
+      return
+    }
+    if (isMatchmaking) {
+      dispatch(
+        openSimpleDialog(
+          t('lobbies.joinLobby.matchmakingActiveDialogTitle', 'Joining lobbies disabled'),
+          t(
+            'lobbies.joinLobby.matchmakingActiveDialogText',
+            'You cannot join lobbies while a matchmaking search is active.',
+          ),
+        ),
+      )
+      return
+    }
+
+    healthChecked(() => {
+      dispatch(
+        joinLobby(lobbyId, {
+          onError: (err: unknown) => {
+            snackbarController.showSnackbar(lobbyJoinErrorMessage(err, t))
+          },
+        }),
+      )
+      navigateToLobby(lobbyId, name)
+    })()
+  }
+}

--- a/client/lobbies/use-join-lobby-action.ts
+++ b/client/lobbies/use-join-lobby-action.ts
@@ -15,15 +15,19 @@ import { navigateToLobby } from './lobby-url'
  * Returns a function that joins a lobby the way clicking one in the lobby list does. On web it
  * shows the download dialog; in the app it refuses while a matchmaking search is active, and
  * otherwise health-checks the game install, dispatches the join (reporting failures in a
- * snackbar), and navigates to the lobby route, which shows the join's outcome.
+ * snackbar, and to `onError` if given), and navigates to the lobby route, which shows the join's
+ * outcome.
  */
-export function useJoinLobbyAction(): (lobbyId: SbLobbyId, name?: string) => void {
+export function useJoinLobbyAction(): (
+  lobbyId: SbLobbyId,
+  options?: { name?: string; onError?: (err: unknown) => void },
+) => void {
   const { t } = useTranslation()
   const dispatch = useAppDispatch()
   const snackbarController = useSnackbarController()
   const isMatchmaking = useAtomValue(isMatchmakingAtom)
 
-  return (lobbyId, name) => {
+  return (lobbyId, options) => {
     if (!IS_ELECTRON) {
       dispatch(openDialog({ type: DialogType.Download }))
       return
@@ -46,10 +50,11 @@ export function useJoinLobbyAction(): (lobbyId: SbLobbyId, name?: string) => voi
         joinLobby(lobbyId, {
           onError: (err: unknown) => {
             snackbarController.showSnackbar(lobbyJoinErrorMessage(err, t))
+            options?.onError?.(err)
           },
         }),
       )
-      navigateToLobby(lobbyId, name)
+      navigateToLobby(lobbyId, options?.name)
     })()
   }
 }

--- a/client/messaging/__snapshots__/common-message-layout.test.tsx.snap
+++ b/client/messaging/__snapshots__/common-message-layout.test.tsx.snap
@@ -5,50 +5,50 @@ exports[`client/messaging/common-message-layout/TextMessage > message as a norma
   data-testid="message-container"
 >
   <div
-    class="sc-jhbick gJVEas"
+    class="sc-tYtIg hVCEwm"
     role="document"
   >
     <div
-      class="sc-dkljCc DKtQu sc-gHmoSK tWBDv"
+      class="sc-csnpUd kEFzEs sc-jKLfHm fqXavo"
       tabindex="0"
     >
       <span
-        class="sc-djMJHV hqkuKg"
+        class="sc-bUkNyH eimBLo"
       >
         <i
           aria-hidden="true"
-          class="sc-JXQyv iHSScO"
+          class="sc-iWyXrV gJQEpB"
         >
           [
         </i>
         12:00 AM
         <i
           aria-hidden="true"
-          class="sc-JXQyv iHSScO"
+          class="sc-iWyXrV gJQEpB"
         >
           ] 
         </i>
       </span>
     </div>
     <span
-      class="sc-hZxFvJ hWYCGm sc-ewKWQi jIIrqK"
+      class="sc-gJVJmv czgVew sc-bRBteW cUWkSM"
       tabindex="0"
     >
       <span
         aria-label="Username loading…"
-        class="sc-cHqurc cczfoP"
+        class="sc-fxDGbE iEnalz"
       >
                    
       </span>
     </span>
     <i
       aria-hidden="true"
-      class="sc-JXQyv iHSScO"
+      class="sc-iWyXrV gJQEpB"
     >
       : 
     </i>
     <span
-      class="sc-eillgj iTYiLF"
+      class="sc-jvDgNt bGSTzd"
     >
       This is test message
     </span>
@@ -61,50 +61,50 @@ exports[`client/messaging/common-message-layout/TextMessage > message with a lin
   data-testid="message-container"
 >
   <div
-    class="sc-jhbick gJVEas"
+    class="sc-tYtIg hVCEwm"
     role="document"
   >
     <div
-      class="sc-dkljCc DKtQu sc-gHmoSK tWBDv"
+      class="sc-csnpUd kEFzEs sc-jKLfHm fqXavo"
       tabindex="0"
     >
       <span
-        class="sc-djMJHV hqkuKg"
+        class="sc-bUkNyH eimBLo"
       >
         <i
           aria-hidden="true"
-          class="sc-JXQyv iHSScO"
+          class="sc-iWyXrV gJQEpB"
         >
           [
         </i>
         12:00 AM
         <i
           aria-hidden="true"
-          class="sc-JXQyv iHSScO"
+          class="sc-iWyXrV gJQEpB"
         >
           ] 
         </i>
       </span>
     </div>
     <span
-      class="sc-hZxFvJ hWYCGm sc-ewKWQi jIIrqK"
+      class="sc-gJVJmv czgVew sc-bRBteW cUWkSM"
       tabindex="0"
     >
       <span
         aria-label="Username loading…"
-        class="sc-cHqurc cczfoP"
+        class="sc-fxDGbE iEnalz"
       >
                    
       </span>
     </span>
     <i
       aria-hidden="true"
-      class="sc-JXQyv iHSScO"
+      class="sc-iWyXrV gJQEpB"
     >
       : 
     </i>
     <span
-      class="sc-eillgj iTYiLF"
+      class="sc-jvDgNt bGSTzd"
     >
       here is a link 
       <a
@@ -124,50 +124,50 @@ exports[`client/messaging/common-message-layout/TextMessage > message with a lin
   data-testid="message-container"
 >
   <div
-    class="sc-jhbick gJVEas"
+    class="sc-tYtIg hVCEwm"
     role="document"
   >
     <div
-      class="sc-dkljCc DKtQu sc-gHmoSK tWBDv"
+      class="sc-csnpUd kEFzEs sc-jKLfHm fqXavo"
       tabindex="0"
     >
       <span
-        class="sc-djMJHV hqkuKg"
+        class="sc-bUkNyH eimBLo"
       >
         <i
           aria-hidden="true"
-          class="sc-JXQyv iHSScO"
+          class="sc-iWyXrV gJQEpB"
         >
           [
         </i>
         12:00 AM
         <i
           aria-hidden="true"
-          class="sc-JXQyv iHSScO"
+          class="sc-iWyXrV gJQEpB"
         >
           ] 
         </i>
       </span>
     </div>
     <span
-      class="sc-hZxFvJ hWYCGm sc-ewKWQi jIIrqK"
+      class="sc-gJVJmv czgVew sc-bRBteW cUWkSM"
       tabindex="0"
     >
       <span
         aria-label="Username loading…"
-        class="sc-cHqurc cczfoP"
+        class="sc-fxDGbE iEnalz"
       >
                    
       </span>
     </span>
     <i
       aria-hidden="true"
-      class="sc-JXQyv iHSScO"
+      class="sc-iWyXrV gJQEpB"
     >
       : 
     </i>
     <span
-      class="sc-eillgj iTYiLF"
+      class="sc-jvDgNt bGSTzd"
     >
       <a
         href="http://www.example.com"
@@ -179,13 +179,13 @@ exports[`client/messaging/common-message-layout/TextMessage > message with a lin
        go here
        
       <span
-        class="sc-hZxFvJ hWYCGm sc-djDiuc ceOyJL"
+        class="sc-gJVJmv czgVew sc-edvVIM jPpNsz"
         tabindex="0"
       >
         @
         <span
           aria-label="Username loading…"
-          class="sc-cHqurc cczfoP"
+          class="sc-fxDGbE iEnalz"
         >
                      
         </span>
@@ -200,61 +200,61 @@ exports[`client/messaging/common-message-layout/TextMessage > message with a lin
   data-testid="message-container"
 >
   <div
-    class="sc-jhbick gJVEas"
+    class="sc-tYtIg hVCEwm"
     role="document"
   >
     <div
-      class="sc-dkljCc DKtQu sc-gHmoSK tWBDv"
+      class="sc-csnpUd kEFzEs sc-jKLfHm fqXavo"
       tabindex="0"
     >
       <span
-        class="sc-djMJHV hqkuKg"
+        class="sc-bUkNyH eimBLo"
       >
         <i
           aria-hidden="true"
-          class="sc-JXQyv iHSScO"
+          class="sc-iWyXrV gJQEpB"
         >
           [
         </i>
         12:00 AM
         <i
           aria-hidden="true"
-          class="sc-JXQyv iHSScO"
+          class="sc-iWyXrV gJQEpB"
         >
           ] 
         </i>
       </span>
     </div>
     <span
-      class="sc-hZxFvJ hWYCGm sc-ewKWQi jIIrqK"
+      class="sc-gJVJmv czgVew sc-bRBteW cUWkSM"
       tabindex="0"
     >
       <span
         aria-label="Username loading…"
-        class="sc-cHqurc cczfoP"
+        class="sc-fxDGbE iEnalz"
       >
                    
       </span>
     </span>
     <i
       aria-hidden="true"
-      class="sc-JXQyv iHSScO"
+      class="sc-iWyXrV gJQEpB"
     >
       : 
     </i>
     <span
-      class="sc-eillgj iTYiLF"
+      class="sc-jvDgNt bGSTzd"
     >
       hey
        
       <span
-        class="sc-hZxFvJ hWYCGm sc-djDiuc ceOyJL"
+        class="sc-gJVJmv czgVew sc-edvVIM jPpNsz"
         tabindex="0"
       >
         @
         <span
           aria-label="Username loading…"
-          class="sc-cHqurc cczfoP"
+          class="sc-fxDGbE iEnalz"
         >
                      
         </span>
@@ -270,13 +270,13 @@ exports[`client/messaging/common-message-layout/TextMessage > message with a lin
        go here
        
       <span
-        class="sc-hZxFvJ hWYCGm sc-djDiuc ceOyJL"
+        class="sc-gJVJmv czgVew sc-edvVIM jPpNsz"
         tabindex="0"
       >
         @
         <span
           aria-label="Username loading…"
-          class="sc-cHqurc cczfoP"
+          class="sc-fxDGbE iEnalz"
         >
                      
         </span>
@@ -291,61 +291,61 @@ exports[`client/messaging/common-message-layout/TextMessage > message with a men
   data-testid="message-container"
 >
   <div
-    class="sc-jhbick gJVEas"
+    class="sc-tYtIg hVCEwm"
     role="document"
   >
     <div
-      class="sc-dkljCc DKtQu sc-gHmoSK tWBDv"
+      class="sc-csnpUd kEFzEs sc-jKLfHm fqXavo"
       tabindex="0"
     >
       <span
-        class="sc-djMJHV hqkuKg"
+        class="sc-bUkNyH eimBLo"
       >
         <i
           aria-hidden="true"
-          class="sc-JXQyv iHSScO"
+          class="sc-iWyXrV gJQEpB"
         >
           [
         </i>
         12:00 AM
         <i
           aria-hidden="true"
-          class="sc-JXQyv iHSScO"
+          class="sc-iWyXrV gJQEpB"
         >
           ] 
         </i>
       </span>
     </div>
     <span
-      class="sc-hZxFvJ hWYCGm sc-ewKWQi jIIrqK"
+      class="sc-gJVJmv czgVew sc-bRBteW cUWkSM"
       tabindex="0"
     >
       <span
         aria-label="Username loading…"
-        class="sc-cHqurc cczfoP"
+        class="sc-fxDGbE iEnalz"
       >
                    
       </span>
     </span>
     <i
       aria-hidden="true"
-      class="sc-JXQyv iHSScO"
+      class="sc-iWyXrV gJQEpB"
     >
       : 
     </i>
     <span
-      class="sc-eillgj iTYiLF"
+      class="sc-jvDgNt bGSTzd"
     >
       hey
        
       <span
-        class="sc-hZxFvJ hWYCGm sc-djDiuc ceOyJL"
+        class="sc-gJVJmv czgVew sc-edvVIM jPpNsz"
         tabindex="0"
       >
         @
         <span
           aria-label="Username loading…"
-          class="sc-cHqurc cczfoP"
+          class="sc-fxDGbE iEnalz"
         >
                      
         </span>
@@ -360,59 +360,59 @@ exports[`client/messaging/common-message-layout/TextMessage > message with a men
   data-testid="message-container"
 >
   <div
-    class="sc-jhbick gJVEas"
+    class="sc-tYtIg hVCEwm"
     role="document"
   >
     <div
-      class="sc-dkljCc DKtQu sc-gHmoSK tWBDv"
+      class="sc-csnpUd kEFzEs sc-jKLfHm fqXavo"
       tabindex="0"
     >
       <span
-        class="sc-djMJHV hqkuKg"
+        class="sc-bUkNyH eimBLo"
       >
         <i
           aria-hidden="true"
-          class="sc-JXQyv iHSScO"
+          class="sc-iWyXrV gJQEpB"
         >
           [
         </i>
         12:00 AM
         <i
           aria-hidden="true"
-          class="sc-JXQyv iHSScO"
+          class="sc-iWyXrV gJQEpB"
         >
           ] 
         </i>
       </span>
     </div>
     <span
-      class="sc-hZxFvJ hWYCGm sc-ewKWQi jIIrqK"
+      class="sc-gJVJmv czgVew sc-bRBteW cUWkSM"
       tabindex="0"
     >
       <span
         aria-label="Username loading…"
-        class="sc-cHqurc cczfoP"
+        class="sc-fxDGbE iEnalz"
       >
                    
       </span>
     </span>
     <i
       aria-hidden="true"
-      class="sc-JXQyv iHSScO"
+      class="sc-iWyXrV gJQEpB"
     >
       : 
     </i>
     <span
-      class="sc-eillgj iTYiLF"
+      class="sc-jvDgNt bGSTzd"
     >
       <span
-        class="sc-hZxFvJ hWYCGm sc-djDiuc ceOyJL"
+        class="sc-gJVJmv czgVew sc-edvVIM jPpNsz"
         tabindex="0"
       >
         @
         <span
           aria-label="Username loading…"
-          class="sc-cHqurc cczfoP"
+          class="sc-fxDGbE iEnalz"
         >
                      
         </span>
@@ -435,50 +435,50 @@ exports[`client/messaging/common-message-layout/TextMessage > message with a men
   data-testid="message-container"
 >
   <div
-    class="sc-jhbick gJVEas"
+    class="sc-tYtIg hVCEwm"
     role="document"
   >
     <div
-      class="sc-dkljCc DKtQu sc-gHmoSK tWBDv"
+      class="sc-csnpUd kEFzEs sc-jKLfHm fqXavo"
       tabindex="0"
     >
       <span
-        class="sc-djMJHV hqkuKg"
+        class="sc-bUkNyH eimBLo"
       >
         <i
           aria-hidden="true"
-          class="sc-JXQyv iHSScO"
+          class="sc-iWyXrV gJQEpB"
         >
           [
         </i>
         12:00 AM
         <i
           aria-hidden="true"
-          class="sc-JXQyv iHSScO"
+          class="sc-iWyXrV gJQEpB"
         >
           ] 
         </i>
       </span>
     </div>
     <span
-      class="sc-hZxFvJ hWYCGm sc-ewKWQi jIIrqK"
+      class="sc-gJVJmv czgVew sc-bRBteW cUWkSM"
       tabindex="0"
     >
       <span
         aria-label="Username loading…"
-        class="sc-cHqurc cczfoP"
+        class="sc-fxDGbE iEnalz"
       >
                    
       </span>
     </span>
     <i
       aria-hidden="true"
-      class="sc-JXQyv iHSScO"
+      class="sc-iWyXrV gJQEpB"
     >
       : 
     </i>
     <span
-      class="sc-eillgj iTYiLF"
+      class="sc-jvDgNt bGSTzd"
     >
       <a
         href="http://www.example.com"
@@ -490,13 +490,13 @@ exports[`client/messaging/common-message-layout/TextMessage > message with a men
        go here
        
       <span
-        class="sc-hZxFvJ hWYCGm sc-djDiuc ceOyJL"
+        class="sc-gJVJmv czgVew sc-edvVIM jPpNsz"
         tabindex="0"
       >
         @
         <span
           aria-label="Username loading…"
-          class="sc-cHqurc cczfoP"
+          class="sc-fxDGbE iEnalz"
         >
                      
         </span>
@@ -519,61 +519,61 @@ exports[`client/messaging/common-message-layout/TextMessage > message with a men
   data-testid="message-container"
 >
   <div
-    class="sc-jhbick fWJZTT"
+    class="sc-tYtIg kwFpMV"
     role="document"
   >
     <div
-      class="sc-dkljCc DKtQu sc-gHmoSK tWBDv"
+      class="sc-csnpUd kEFzEs sc-jKLfHm fqXavo"
       tabindex="0"
     >
       <span
-        class="sc-djMJHV hqkuKg"
+        class="sc-bUkNyH eimBLo"
       >
         <i
           aria-hidden="true"
-          class="sc-JXQyv iHSScO"
+          class="sc-iWyXrV gJQEpB"
         >
           [
         </i>
         12:00 AM
         <i
           aria-hidden="true"
-          class="sc-JXQyv iHSScO"
+          class="sc-iWyXrV gJQEpB"
         >
           ] 
         </i>
       </span>
     </div>
     <span
-      class="sc-hZxFvJ hWYCGm sc-ewKWQi jIIrqK"
+      class="sc-gJVJmv czgVew sc-bRBteW cUWkSM"
       tabindex="0"
     >
       <span
         aria-label="Username loading…"
-        class="sc-cHqurc cczfoP"
+        class="sc-fxDGbE iEnalz"
       >
                    
       </span>
     </span>
     <i
       aria-hidden="true"
-      class="sc-JXQyv iHSScO"
+      class="sc-iWyXrV gJQEpB"
     >
       : 
     </i>
     <span
-      class="sc-eillgj iTYiLF"
+      class="sc-jvDgNt bGSTzd"
     >
       Hey
        
       <span
-        class="sc-hZxFvJ hWYCGm sc-djDiuc ceOyJL"
+        class="sc-gJVJmv czgVew sc-edvVIM jPpNsz"
         tabindex="0"
       >
         @
         <span
           aria-label="Username loading…"
-          class="sc-cHqurc cczfoP"
+          class="sc-fxDGbE iEnalz"
         >
                      
         </span>

--- a/client/messaging/__snapshots__/common-message-layout.test.tsx.snap
+++ b/client/messaging/__snapshots__/common-message-layout.test.tsx.snap
@@ -5,50 +5,50 @@ exports[`client/messaging/common-message-layout/TextMessage > message as a norma
   data-testid="message-container"
 >
   <div
-    class="sc-tYtIg hVCEwm"
+    class="sc-hjIEjD fGCOqt"
     role="document"
   >
     <div
-      class="sc-csnpUd kEFzEs sc-jKLfHm fqXavo"
+      class="sc-Wunit kaMHNy sc-djMJHV hihmdV"
       tabindex="0"
     >
       <span
-        class="sc-bUkNyH eimBLo"
+        class="sc-jhbick hNFseq"
       >
         <i
           aria-hidden="true"
-          class="sc-iWyXrV gJQEpB"
+          class="sc-gHmoSK cBteqP"
         >
           [
         </i>
         12:00 AM
         <i
           aria-hidden="true"
-          class="sc-iWyXrV gJQEpB"
+          class="sc-gHmoSK cBteqP"
         >
           ] 
         </i>
       </span>
     </div>
     <span
-      class="sc-gJVJmv czgVew sc-bRBteW cUWkSM"
+      class="sc-cHqurc dnJec sc-eillgj gosFKJ"
       tabindex="0"
     >
       <span
         aria-label="Username loading…"
-        class="sc-fxDGbE iEnalz"
+        class="sc-JXQyv lceOth"
       >
                    
       </span>
     </span>
     <i
       aria-hidden="true"
-      class="sc-iWyXrV gJQEpB"
+      class="sc-gHmoSK cBteqP"
     >
       : 
     </i>
     <span
-      class="sc-jvDgNt bGSTzd"
+      class="sc-djDiuc crCdON"
     >
       This is test message
     </span>
@@ -61,50 +61,50 @@ exports[`client/messaging/common-message-layout/TextMessage > message with a lin
   data-testid="message-container"
 >
   <div
-    class="sc-tYtIg hVCEwm"
+    class="sc-hjIEjD fGCOqt"
     role="document"
   >
     <div
-      class="sc-csnpUd kEFzEs sc-jKLfHm fqXavo"
+      class="sc-Wunit kaMHNy sc-djMJHV hihmdV"
       tabindex="0"
     >
       <span
-        class="sc-bUkNyH eimBLo"
+        class="sc-jhbick hNFseq"
       >
         <i
           aria-hidden="true"
-          class="sc-iWyXrV gJQEpB"
+          class="sc-gHmoSK cBteqP"
         >
           [
         </i>
         12:00 AM
         <i
           aria-hidden="true"
-          class="sc-iWyXrV gJQEpB"
+          class="sc-gHmoSK cBteqP"
         >
           ] 
         </i>
       </span>
     </div>
     <span
-      class="sc-gJVJmv czgVew sc-bRBteW cUWkSM"
+      class="sc-cHqurc dnJec sc-eillgj gosFKJ"
       tabindex="0"
     >
       <span
         aria-label="Username loading…"
-        class="sc-fxDGbE iEnalz"
+        class="sc-JXQyv lceOth"
       >
                    
       </span>
     </span>
     <i
       aria-hidden="true"
-      class="sc-iWyXrV gJQEpB"
+      class="sc-gHmoSK cBteqP"
     >
       : 
     </i>
     <span
-      class="sc-jvDgNt bGSTzd"
+      class="sc-djDiuc crCdON"
     >
       here is a link 
       <a
@@ -124,50 +124,50 @@ exports[`client/messaging/common-message-layout/TextMessage > message with a lin
   data-testid="message-container"
 >
   <div
-    class="sc-tYtIg hVCEwm"
+    class="sc-hjIEjD fGCOqt"
     role="document"
   >
     <div
-      class="sc-csnpUd kEFzEs sc-jKLfHm fqXavo"
+      class="sc-Wunit kaMHNy sc-djMJHV hihmdV"
       tabindex="0"
     >
       <span
-        class="sc-bUkNyH eimBLo"
+        class="sc-jhbick hNFseq"
       >
         <i
           aria-hidden="true"
-          class="sc-iWyXrV gJQEpB"
+          class="sc-gHmoSK cBteqP"
         >
           [
         </i>
         12:00 AM
         <i
           aria-hidden="true"
-          class="sc-iWyXrV gJQEpB"
+          class="sc-gHmoSK cBteqP"
         >
           ] 
         </i>
       </span>
     </div>
     <span
-      class="sc-gJVJmv czgVew sc-bRBteW cUWkSM"
+      class="sc-cHqurc dnJec sc-eillgj gosFKJ"
       tabindex="0"
     >
       <span
         aria-label="Username loading…"
-        class="sc-fxDGbE iEnalz"
+        class="sc-JXQyv lceOth"
       >
                    
       </span>
     </span>
     <i
       aria-hidden="true"
-      class="sc-iWyXrV gJQEpB"
+      class="sc-gHmoSK cBteqP"
     >
       : 
     </i>
     <span
-      class="sc-jvDgNt bGSTzd"
+      class="sc-djDiuc crCdON"
     >
       <a
         href="http://www.example.com"
@@ -179,13 +179,13 @@ exports[`client/messaging/common-message-layout/TextMessage > message with a lin
        go here
        
       <span
-        class="sc-gJVJmv czgVew sc-edvVIM jPpNsz"
+        class="sc-cHqurc dnJec sc-cVdwKd hQJeCT"
         tabindex="0"
       >
         @
         <span
           aria-label="Username loading…"
-          class="sc-fxDGbE iEnalz"
+          class="sc-JXQyv lceOth"
         >
                      
         </span>
@@ -200,61 +200,61 @@ exports[`client/messaging/common-message-layout/TextMessage > message with a lin
   data-testid="message-container"
 >
   <div
-    class="sc-tYtIg hVCEwm"
+    class="sc-hjIEjD fGCOqt"
     role="document"
   >
     <div
-      class="sc-csnpUd kEFzEs sc-jKLfHm fqXavo"
+      class="sc-Wunit kaMHNy sc-djMJHV hihmdV"
       tabindex="0"
     >
       <span
-        class="sc-bUkNyH eimBLo"
+        class="sc-jhbick hNFseq"
       >
         <i
           aria-hidden="true"
-          class="sc-iWyXrV gJQEpB"
+          class="sc-gHmoSK cBteqP"
         >
           [
         </i>
         12:00 AM
         <i
           aria-hidden="true"
-          class="sc-iWyXrV gJQEpB"
+          class="sc-gHmoSK cBteqP"
         >
           ] 
         </i>
       </span>
     </div>
     <span
-      class="sc-gJVJmv czgVew sc-bRBteW cUWkSM"
+      class="sc-cHqurc dnJec sc-eillgj gosFKJ"
       tabindex="0"
     >
       <span
         aria-label="Username loading…"
-        class="sc-fxDGbE iEnalz"
+        class="sc-JXQyv lceOth"
       >
                    
       </span>
     </span>
     <i
       aria-hidden="true"
-      class="sc-iWyXrV gJQEpB"
+      class="sc-gHmoSK cBteqP"
     >
       : 
     </i>
     <span
-      class="sc-jvDgNt bGSTzd"
+      class="sc-djDiuc crCdON"
     >
       hey
        
       <span
-        class="sc-gJVJmv czgVew sc-edvVIM jPpNsz"
+        class="sc-cHqurc dnJec sc-cVdwKd hQJeCT"
         tabindex="0"
       >
         @
         <span
           aria-label="Username loading…"
-          class="sc-fxDGbE iEnalz"
+          class="sc-JXQyv lceOth"
         >
                      
         </span>
@@ -270,13 +270,13 @@ exports[`client/messaging/common-message-layout/TextMessage > message with a lin
        go here
        
       <span
-        class="sc-gJVJmv czgVew sc-edvVIM jPpNsz"
+        class="sc-cHqurc dnJec sc-cVdwKd hQJeCT"
         tabindex="0"
       >
         @
         <span
           aria-label="Username loading…"
-          class="sc-fxDGbE iEnalz"
+          class="sc-JXQyv lceOth"
         >
                      
         </span>
@@ -291,61 +291,61 @@ exports[`client/messaging/common-message-layout/TextMessage > message with a men
   data-testid="message-container"
 >
   <div
-    class="sc-tYtIg hVCEwm"
+    class="sc-hjIEjD fGCOqt"
     role="document"
   >
     <div
-      class="sc-csnpUd kEFzEs sc-jKLfHm fqXavo"
+      class="sc-Wunit kaMHNy sc-djMJHV hihmdV"
       tabindex="0"
     >
       <span
-        class="sc-bUkNyH eimBLo"
+        class="sc-jhbick hNFseq"
       >
         <i
           aria-hidden="true"
-          class="sc-iWyXrV gJQEpB"
+          class="sc-gHmoSK cBteqP"
         >
           [
         </i>
         12:00 AM
         <i
           aria-hidden="true"
-          class="sc-iWyXrV gJQEpB"
+          class="sc-gHmoSK cBteqP"
         >
           ] 
         </i>
       </span>
     </div>
     <span
-      class="sc-gJVJmv czgVew sc-bRBteW cUWkSM"
+      class="sc-cHqurc dnJec sc-eillgj gosFKJ"
       tabindex="0"
     >
       <span
         aria-label="Username loading…"
-        class="sc-fxDGbE iEnalz"
+        class="sc-JXQyv lceOth"
       >
                    
       </span>
     </span>
     <i
       aria-hidden="true"
-      class="sc-iWyXrV gJQEpB"
+      class="sc-gHmoSK cBteqP"
     >
       : 
     </i>
     <span
-      class="sc-jvDgNt bGSTzd"
+      class="sc-djDiuc crCdON"
     >
       hey
        
       <span
-        class="sc-gJVJmv czgVew sc-edvVIM jPpNsz"
+        class="sc-cHqurc dnJec sc-cVdwKd hQJeCT"
         tabindex="0"
       >
         @
         <span
           aria-label="Username loading…"
-          class="sc-fxDGbE iEnalz"
+          class="sc-JXQyv lceOth"
         >
                      
         </span>
@@ -360,59 +360,59 @@ exports[`client/messaging/common-message-layout/TextMessage > message with a men
   data-testid="message-container"
 >
   <div
-    class="sc-tYtIg hVCEwm"
+    class="sc-hjIEjD fGCOqt"
     role="document"
   >
     <div
-      class="sc-csnpUd kEFzEs sc-jKLfHm fqXavo"
+      class="sc-Wunit kaMHNy sc-djMJHV hihmdV"
       tabindex="0"
     >
       <span
-        class="sc-bUkNyH eimBLo"
+        class="sc-jhbick hNFseq"
       >
         <i
           aria-hidden="true"
-          class="sc-iWyXrV gJQEpB"
+          class="sc-gHmoSK cBteqP"
         >
           [
         </i>
         12:00 AM
         <i
           aria-hidden="true"
-          class="sc-iWyXrV gJQEpB"
+          class="sc-gHmoSK cBteqP"
         >
           ] 
         </i>
       </span>
     </div>
     <span
-      class="sc-gJVJmv czgVew sc-bRBteW cUWkSM"
+      class="sc-cHqurc dnJec sc-eillgj gosFKJ"
       tabindex="0"
     >
       <span
         aria-label="Username loading…"
-        class="sc-fxDGbE iEnalz"
+        class="sc-JXQyv lceOth"
       >
                    
       </span>
     </span>
     <i
       aria-hidden="true"
-      class="sc-iWyXrV gJQEpB"
+      class="sc-gHmoSK cBteqP"
     >
       : 
     </i>
     <span
-      class="sc-jvDgNt bGSTzd"
+      class="sc-djDiuc crCdON"
     >
       <span
-        class="sc-gJVJmv czgVew sc-edvVIM jPpNsz"
+        class="sc-cHqurc dnJec sc-cVdwKd hQJeCT"
         tabindex="0"
       >
         @
         <span
           aria-label="Username loading…"
-          class="sc-fxDGbE iEnalz"
+          class="sc-JXQyv lceOth"
         >
                      
         </span>
@@ -435,50 +435,50 @@ exports[`client/messaging/common-message-layout/TextMessage > message with a men
   data-testid="message-container"
 >
   <div
-    class="sc-tYtIg hVCEwm"
+    class="sc-hjIEjD fGCOqt"
     role="document"
   >
     <div
-      class="sc-csnpUd kEFzEs sc-jKLfHm fqXavo"
+      class="sc-Wunit kaMHNy sc-djMJHV hihmdV"
       tabindex="0"
     >
       <span
-        class="sc-bUkNyH eimBLo"
+        class="sc-jhbick hNFseq"
       >
         <i
           aria-hidden="true"
-          class="sc-iWyXrV gJQEpB"
+          class="sc-gHmoSK cBteqP"
         >
           [
         </i>
         12:00 AM
         <i
           aria-hidden="true"
-          class="sc-iWyXrV gJQEpB"
+          class="sc-gHmoSK cBteqP"
         >
           ] 
         </i>
       </span>
     </div>
     <span
-      class="sc-gJVJmv czgVew sc-bRBteW cUWkSM"
+      class="sc-cHqurc dnJec sc-eillgj gosFKJ"
       tabindex="0"
     >
       <span
         aria-label="Username loading…"
-        class="sc-fxDGbE iEnalz"
+        class="sc-JXQyv lceOth"
       >
                    
       </span>
     </span>
     <i
       aria-hidden="true"
-      class="sc-iWyXrV gJQEpB"
+      class="sc-gHmoSK cBteqP"
     >
       : 
     </i>
     <span
-      class="sc-jvDgNt bGSTzd"
+      class="sc-djDiuc crCdON"
     >
       <a
         href="http://www.example.com"
@@ -490,13 +490,13 @@ exports[`client/messaging/common-message-layout/TextMessage > message with a men
        go here
        
       <span
-        class="sc-gJVJmv czgVew sc-edvVIM jPpNsz"
+        class="sc-cHqurc dnJec sc-cVdwKd hQJeCT"
         tabindex="0"
       >
         @
         <span
           aria-label="Username loading…"
-          class="sc-fxDGbE iEnalz"
+          class="sc-JXQyv lceOth"
         >
                      
         </span>
@@ -519,61 +519,61 @@ exports[`client/messaging/common-message-layout/TextMessage > message with a men
   data-testid="message-container"
 >
   <div
-    class="sc-tYtIg kwFpMV"
+    class="sc-hjIEjD bGBnGq"
     role="document"
   >
     <div
-      class="sc-csnpUd kEFzEs sc-jKLfHm fqXavo"
+      class="sc-Wunit kaMHNy sc-djMJHV hihmdV"
       tabindex="0"
     >
       <span
-        class="sc-bUkNyH eimBLo"
+        class="sc-jhbick hNFseq"
       >
         <i
           aria-hidden="true"
-          class="sc-iWyXrV gJQEpB"
+          class="sc-gHmoSK cBteqP"
         >
           [
         </i>
         12:00 AM
         <i
           aria-hidden="true"
-          class="sc-iWyXrV gJQEpB"
+          class="sc-gHmoSK cBteqP"
         >
           ] 
         </i>
       </span>
     </div>
     <span
-      class="sc-gJVJmv czgVew sc-bRBteW cUWkSM"
+      class="sc-cHqurc dnJec sc-eillgj gosFKJ"
       tabindex="0"
     >
       <span
         aria-label="Username loading…"
-        class="sc-fxDGbE iEnalz"
+        class="sc-JXQyv lceOth"
       >
                    
       </span>
     </span>
     <i
       aria-hidden="true"
-      class="sc-iWyXrV gJQEpB"
+      class="sc-gHmoSK cBteqP"
     >
       : 
     </i>
     <span
-      class="sc-jvDgNt bGSTzd"
+      class="sc-djDiuc crCdON"
     >
       Hey
        
       <span
-        class="sc-gJVJmv czgVew sc-edvVIM jPpNsz"
+        class="sc-cHqurc dnJec sc-cVdwKd hQJeCT"
         tabindex="0"
       >
         @
         <span
           aria-label="Username loading…"
-          class="sc-fxDGbE iEnalz"
+          class="sc-JXQyv lceOth"
         >
                      
         </span>

--- a/client/messaging/__snapshots__/common-message-layout.test.tsx.snap
+++ b/client/messaging/__snapshots__/common-message-layout.test.tsx.snap
@@ -5,50 +5,50 @@ exports[`client/messaging/common-message-layout/TextMessage > message as a norma
   data-testid="message-container"
 >
   <div
-    class="sc-hjIEjD fGCOqt"
+    class="sc-bRBteW vgGRl"
     role="document"
   >
     <div
-      class="sc-Wunit kaMHNy sc-djMJHV hihmdV"
+      class="sc-ikrMhg iRLQJB sc-jhbick htKfXz"
       tabindex="0"
     >
       <span
-        class="sc-jhbick hNFseq"
+        class="sc-hjIEjD hqqYur"
       >
         <i
           aria-hidden="true"
-          class="sc-gHmoSK cBteqP"
+          class="sc-djMJHV hIWVlF"
         >
           [
         </i>
         12:00 AM
         <i
           aria-hidden="true"
-          class="sc-gHmoSK cBteqP"
+          class="sc-djMJHV hIWVlF"
         >
           ] 
         </i>
       </span>
     </div>
     <span
-      class="sc-cHqurc dnJec sc-eillgj gosFKJ"
+      class="sc-JXQyv iLcsyW sc-djDiuc bnbDrZ"
       tabindex="0"
     >
       <span
         aria-label="Username loading…"
-        class="sc-JXQyv lceOth"
+        class="sc-gHmoSK hMLjng"
       >
                    
       </span>
     </span>
     <i
       aria-hidden="true"
-      class="sc-gHmoSK cBteqP"
+      class="sc-djMJHV hIWVlF"
     >
       : 
     </i>
     <span
-      class="sc-djDiuc crCdON"
+      class="sc-cVdwKd gshNdF"
     >
       This is test message
     </span>
@@ -61,50 +61,50 @@ exports[`client/messaging/common-message-layout/TextMessage > message with a lin
   data-testid="message-container"
 >
   <div
-    class="sc-hjIEjD fGCOqt"
+    class="sc-bRBteW vgGRl"
     role="document"
   >
     <div
-      class="sc-Wunit kaMHNy sc-djMJHV hihmdV"
+      class="sc-ikrMhg iRLQJB sc-jhbick htKfXz"
       tabindex="0"
     >
       <span
-        class="sc-jhbick hNFseq"
+        class="sc-hjIEjD hqqYur"
       >
         <i
           aria-hidden="true"
-          class="sc-gHmoSK cBteqP"
+          class="sc-djMJHV hIWVlF"
         >
           [
         </i>
         12:00 AM
         <i
           aria-hidden="true"
-          class="sc-gHmoSK cBteqP"
+          class="sc-djMJHV hIWVlF"
         >
           ] 
         </i>
       </span>
     </div>
     <span
-      class="sc-cHqurc dnJec sc-eillgj gosFKJ"
+      class="sc-JXQyv iLcsyW sc-djDiuc bnbDrZ"
       tabindex="0"
     >
       <span
         aria-label="Username loading…"
-        class="sc-JXQyv lceOth"
+        class="sc-gHmoSK hMLjng"
       >
                    
       </span>
     </span>
     <i
       aria-hidden="true"
-      class="sc-gHmoSK cBteqP"
+      class="sc-djMJHV hIWVlF"
     >
       : 
     </i>
     <span
-      class="sc-djDiuc crCdON"
+      class="sc-cVdwKd gshNdF"
     >
       here is a link 
       <a
@@ -124,50 +124,50 @@ exports[`client/messaging/common-message-layout/TextMessage > message with a lin
   data-testid="message-container"
 >
   <div
-    class="sc-hjIEjD fGCOqt"
+    class="sc-bRBteW vgGRl"
     role="document"
   >
     <div
-      class="sc-Wunit kaMHNy sc-djMJHV hihmdV"
+      class="sc-ikrMhg iRLQJB sc-jhbick htKfXz"
       tabindex="0"
     >
       <span
-        class="sc-jhbick hNFseq"
+        class="sc-hjIEjD hqqYur"
       >
         <i
           aria-hidden="true"
-          class="sc-gHmoSK cBteqP"
+          class="sc-djMJHV hIWVlF"
         >
           [
         </i>
         12:00 AM
         <i
           aria-hidden="true"
-          class="sc-gHmoSK cBteqP"
+          class="sc-djMJHV hIWVlF"
         >
           ] 
         </i>
       </span>
     </div>
     <span
-      class="sc-cHqurc dnJec sc-eillgj gosFKJ"
+      class="sc-JXQyv iLcsyW sc-djDiuc bnbDrZ"
       tabindex="0"
     >
       <span
         aria-label="Username loading…"
-        class="sc-JXQyv lceOth"
+        class="sc-gHmoSK hMLjng"
       >
                    
       </span>
     </span>
     <i
       aria-hidden="true"
-      class="sc-gHmoSK cBteqP"
+      class="sc-djMJHV hIWVlF"
     >
       : 
     </i>
     <span
-      class="sc-djDiuc crCdON"
+      class="sc-cVdwKd gshNdF"
     >
       <a
         href="http://www.example.com"
@@ -179,13 +179,13 @@ exports[`client/messaging/common-message-layout/TextMessage > message with a lin
        go here
        
       <span
-        class="sc-cHqurc dnJec sc-cVdwKd hQJeCT"
+        class="sc-JXQyv iLcsyW sc-kIBtVG hxjDVv"
         tabindex="0"
       >
         @
         <span
           aria-label="Username loading…"
-          class="sc-JXQyv lceOth"
+          class="sc-gHmoSK hMLjng"
         >
                      
         </span>
@@ -200,61 +200,61 @@ exports[`client/messaging/common-message-layout/TextMessage > message with a lin
   data-testid="message-container"
 >
   <div
-    class="sc-hjIEjD fGCOqt"
+    class="sc-bRBteW vgGRl"
     role="document"
   >
     <div
-      class="sc-Wunit kaMHNy sc-djMJHV hihmdV"
+      class="sc-ikrMhg iRLQJB sc-jhbick htKfXz"
       tabindex="0"
     >
       <span
-        class="sc-jhbick hNFseq"
+        class="sc-hjIEjD hqqYur"
       >
         <i
           aria-hidden="true"
-          class="sc-gHmoSK cBteqP"
+          class="sc-djMJHV hIWVlF"
         >
           [
         </i>
         12:00 AM
         <i
           aria-hidden="true"
-          class="sc-gHmoSK cBteqP"
+          class="sc-djMJHV hIWVlF"
         >
           ] 
         </i>
       </span>
     </div>
     <span
-      class="sc-cHqurc dnJec sc-eillgj gosFKJ"
+      class="sc-JXQyv iLcsyW sc-djDiuc bnbDrZ"
       tabindex="0"
     >
       <span
         aria-label="Username loading…"
-        class="sc-JXQyv lceOth"
+        class="sc-gHmoSK hMLjng"
       >
                    
       </span>
     </span>
     <i
       aria-hidden="true"
-      class="sc-gHmoSK cBteqP"
+      class="sc-djMJHV hIWVlF"
     >
       : 
     </i>
     <span
-      class="sc-djDiuc crCdON"
+      class="sc-cVdwKd gshNdF"
     >
       hey
        
       <span
-        class="sc-cHqurc dnJec sc-cVdwKd hQJeCT"
+        class="sc-JXQyv iLcsyW sc-kIBtVG hxjDVv"
         tabindex="0"
       >
         @
         <span
           aria-label="Username loading…"
-          class="sc-JXQyv lceOth"
+          class="sc-gHmoSK hMLjng"
         >
                      
         </span>
@@ -270,13 +270,13 @@ exports[`client/messaging/common-message-layout/TextMessage > message with a lin
        go here
        
       <span
-        class="sc-cHqurc dnJec sc-cVdwKd hQJeCT"
+        class="sc-JXQyv iLcsyW sc-kIBtVG hxjDVv"
         tabindex="0"
       >
         @
         <span
           aria-label="Username loading…"
-          class="sc-JXQyv lceOth"
+          class="sc-gHmoSK hMLjng"
         >
                      
         </span>
@@ -291,61 +291,61 @@ exports[`client/messaging/common-message-layout/TextMessage > message with a men
   data-testid="message-container"
 >
   <div
-    class="sc-hjIEjD fGCOqt"
+    class="sc-bRBteW vgGRl"
     role="document"
   >
     <div
-      class="sc-Wunit kaMHNy sc-djMJHV hihmdV"
+      class="sc-ikrMhg iRLQJB sc-jhbick htKfXz"
       tabindex="0"
     >
       <span
-        class="sc-jhbick hNFseq"
+        class="sc-hjIEjD hqqYur"
       >
         <i
           aria-hidden="true"
-          class="sc-gHmoSK cBteqP"
+          class="sc-djMJHV hIWVlF"
         >
           [
         </i>
         12:00 AM
         <i
           aria-hidden="true"
-          class="sc-gHmoSK cBteqP"
+          class="sc-djMJHV hIWVlF"
         >
           ] 
         </i>
       </span>
     </div>
     <span
-      class="sc-cHqurc dnJec sc-eillgj gosFKJ"
+      class="sc-JXQyv iLcsyW sc-djDiuc bnbDrZ"
       tabindex="0"
     >
       <span
         aria-label="Username loading…"
-        class="sc-JXQyv lceOth"
+        class="sc-gHmoSK hMLjng"
       >
                    
       </span>
     </span>
     <i
       aria-hidden="true"
-      class="sc-gHmoSK cBteqP"
+      class="sc-djMJHV hIWVlF"
     >
       : 
     </i>
     <span
-      class="sc-djDiuc crCdON"
+      class="sc-cVdwKd gshNdF"
     >
       hey
        
       <span
-        class="sc-cHqurc dnJec sc-cVdwKd hQJeCT"
+        class="sc-JXQyv iLcsyW sc-kIBtVG hxjDVv"
         tabindex="0"
       >
         @
         <span
           aria-label="Username loading…"
-          class="sc-JXQyv lceOth"
+          class="sc-gHmoSK hMLjng"
         >
                      
         </span>
@@ -360,59 +360,59 @@ exports[`client/messaging/common-message-layout/TextMessage > message with a men
   data-testid="message-container"
 >
   <div
-    class="sc-hjIEjD fGCOqt"
+    class="sc-bRBteW vgGRl"
     role="document"
   >
     <div
-      class="sc-Wunit kaMHNy sc-djMJHV hihmdV"
+      class="sc-ikrMhg iRLQJB sc-jhbick htKfXz"
       tabindex="0"
     >
       <span
-        class="sc-jhbick hNFseq"
+        class="sc-hjIEjD hqqYur"
       >
         <i
           aria-hidden="true"
-          class="sc-gHmoSK cBteqP"
+          class="sc-djMJHV hIWVlF"
         >
           [
         </i>
         12:00 AM
         <i
           aria-hidden="true"
-          class="sc-gHmoSK cBteqP"
+          class="sc-djMJHV hIWVlF"
         >
           ] 
         </i>
       </span>
     </div>
     <span
-      class="sc-cHqurc dnJec sc-eillgj gosFKJ"
+      class="sc-JXQyv iLcsyW sc-djDiuc bnbDrZ"
       tabindex="0"
     >
       <span
         aria-label="Username loading…"
-        class="sc-JXQyv lceOth"
+        class="sc-gHmoSK hMLjng"
       >
                    
       </span>
     </span>
     <i
       aria-hidden="true"
-      class="sc-gHmoSK cBteqP"
+      class="sc-djMJHV hIWVlF"
     >
       : 
     </i>
     <span
-      class="sc-djDiuc crCdON"
+      class="sc-cVdwKd gshNdF"
     >
       <span
-        class="sc-cHqurc dnJec sc-cVdwKd hQJeCT"
+        class="sc-JXQyv iLcsyW sc-kIBtVG hxjDVv"
         tabindex="0"
       >
         @
         <span
           aria-label="Username loading…"
-          class="sc-JXQyv lceOth"
+          class="sc-gHmoSK hMLjng"
         >
                      
         </span>
@@ -435,50 +435,50 @@ exports[`client/messaging/common-message-layout/TextMessage > message with a men
   data-testid="message-container"
 >
   <div
-    class="sc-hjIEjD fGCOqt"
+    class="sc-bRBteW vgGRl"
     role="document"
   >
     <div
-      class="sc-Wunit kaMHNy sc-djMJHV hihmdV"
+      class="sc-ikrMhg iRLQJB sc-jhbick htKfXz"
       tabindex="0"
     >
       <span
-        class="sc-jhbick hNFseq"
+        class="sc-hjIEjD hqqYur"
       >
         <i
           aria-hidden="true"
-          class="sc-gHmoSK cBteqP"
+          class="sc-djMJHV hIWVlF"
         >
           [
         </i>
         12:00 AM
         <i
           aria-hidden="true"
-          class="sc-gHmoSK cBteqP"
+          class="sc-djMJHV hIWVlF"
         >
           ] 
         </i>
       </span>
     </div>
     <span
-      class="sc-cHqurc dnJec sc-eillgj gosFKJ"
+      class="sc-JXQyv iLcsyW sc-djDiuc bnbDrZ"
       tabindex="0"
     >
       <span
         aria-label="Username loading…"
-        class="sc-JXQyv lceOth"
+        class="sc-gHmoSK hMLjng"
       >
                    
       </span>
     </span>
     <i
       aria-hidden="true"
-      class="sc-gHmoSK cBteqP"
+      class="sc-djMJHV hIWVlF"
     >
       : 
     </i>
     <span
-      class="sc-djDiuc crCdON"
+      class="sc-cVdwKd gshNdF"
     >
       <a
         href="http://www.example.com"
@@ -490,13 +490,13 @@ exports[`client/messaging/common-message-layout/TextMessage > message with a men
        go here
        
       <span
-        class="sc-cHqurc dnJec sc-cVdwKd hQJeCT"
+        class="sc-JXQyv iLcsyW sc-kIBtVG hxjDVv"
         tabindex="0"
       >
         @
         <span
           aria-label="Username loading…"
-          class="sc-JXQyv lceOth"
+          class="sc-gHmoSK hMLjng"
         >
                      
         </span>
@@ -519,61 +519,61 @@ exports[`client/messaging/common-message-layout/TextMessage > message with a men
   data-testid="message-container"
 >
   <div
-    class="sc-hjIEjD bGBnGq"
+    class="sc-bRBteW fwrlCu"
     role="document"
   >
     <div
-      class="sc-Wunit kaMHNy sc-djMJHV hihmdV"
+      class="sc-ikrMhg iRLQJB sc-jhbick htKfXz"
       tabindex="0"
     >
       <span
-        class="sc-jhbick hNFseq"
+        class="sc-hjIEjD hqqYur"
       >
         <i
           aria-hidden="true"
-          class="sc-gHmoSK cBteqP"
+          class="sc-djMJHV hIWVlF"
         >
           [
         </i>
         12:00 AM
         <i
           aria-hidden="true"
-          class="sc-gHmoSK cBteqP"
+          class="sc-djMJHV hIWVlF"
         >
           ] 
         </i>
       </span>
     </div>
     <span
-      class="sc-cHqurc dnJec sc-eillgj gosFKJ"
+      class="sc-JXQyv iLcsyW sc-djDiuc bnbDrZ"
       tabindex="0"
     >
       <span
         aria-label="Username loading…"
-        class="sc-JXQyv lceOth"
+        class="sc-gHmoSK hMLjng"
       >
                    
       </span>
     </span>
     <i
       aria-hidden="true"
-      class="sc-gHmoSK cBteqP"
+      class="sc-djMJHV hIWVlF"
     >
       : 
     </i>
     <span
-      class="sc-djDiuc crCdON"
+      class="sc-cVdwKd gshNdF"
     >
       Hey
        
       <span
-        class="sc-cHqurc dnJec sc-cVdwKd hQJeCT"
+        class="sc-JXQyv iLcsyW sc-kIBtVG hxjDVv"
         tabindex="0"
       >
         @
         <span
           aria-label="Username loading…"
-          class="sc-JXQyv lceOth"
+          class="sc-gHmoSK hMLjng"
         >
                      
         </span>

--- a/client/messaging/__snapshots__/common-message-layout.test.tsx.snap
+++ b/client/messaging/__snapshots__/common-message-layout.test.tsx.snap
@@ -5,50 +5,50 @@ exports[`client/messaging/common-message-layout/TextMessage > message as a norma
   data-testid="message-container"
 >
   <div
-    class="sc-iFEEnu llqPcV"
+    class="sc-jhbick gJVEas"
     role="document"
   >
     <div
-      class="sc-lbpHHC jRmSVS sc-fmzYco jjjVfe"
+      class="sc-dkljCc DKtQu sc-gHmoSK tWBDv"
       tabindex="0"
     >
       <span
-        class="sc-eYamsp lgXetw"
+        class="sc-djMJHV hqkuKg"
       >
         <i
           aria-hidden="true"
-          class="sc-gliaOv epmnrc"
+          class="sc-JXQyv iHSScO"
         >
           [
         </i>
         12:00 AM
         <i
           aria-hidden="true"
-          class="sc-gliaOv epmnrc"
+          class="sc-JXQyv iHSScO"
         >
           ] 
         </i>
       </span>
     </div>
     <span
-      class="sc-fHRCPF cvkTmv sc-iILUYU hBIpDd"
+      class="sc-hZxFvJ hWYCGm sc-ewKWQi jIIrqK"
       tabindex="0"
     >
       <span
         aria-label="Username loading…"
-        class="sc-gzHMyu kUTliR"
+        class="sc-cHqurc cczfoP"
       >
                    
       </span>
     </span>
     <i
       aria-hidden="true"
-      class="sc-gliaOv epmnrc"
+      class="sc-JXQyv iHSScO"
     >
       : 
     </i>
     <span
-      class="sc-grNHTL dlSwMX"
+      class="sc-eillgj iTYiLF"
     >
       This is test message
     </span>
@@ -61,50 +61,50 @@ exports[`client/messaging/common-message-layout/TextMessage > message with a lin
   data-testid="message-container"
 >
   <div
-    class="sc-iFEEnu llqPcV"
+    class="sc-jhbick gJVEas"
     role="document"
   >
     <div
-      class="sc-lbpHHC jRmSVS sc-fmzYco jjjVfe"
+      class="sc-dkljCc DKtQu sc-gHmoSK tWBDv"
       tabindex="0"
     >
       <span
-        class="sc-eYamsp lgXetw"
+        class="sc-djMJHV hqkuKg"
       >
         <i
           aria-hidden="true"
-          class="sc-gliaOv epmnrc"
+          class="sc-JXQyv iHSScO"
         >
           [
         </i>
         12:00 AM
         <i
           aria-hidden="true"
-          class="sc-gliaOv epmnrc"
+          class="sc-JXQyv iHSScO"
         >
           ] 
         </i>
       </span>
     </div>
     <span
-      class="sc-fHRCPF cvkTmv sc-iILUYU hBIpDd"
+      class="sc-hZxFvJ hWYCGm sc-ewKWQi jIIrqK"
       tabindex="0"
     >
       <span
         aria-label="Username loading…"
-        class="sc-gzHMyu kUTliR"
+        class="sc-cHqurc cczfoP"
       >
                    
       </span>
     </span>
     <i
       aria-hidden="true"
-      class="sc-gliaOv epmnrc"
+      class="sc-JXQyv iHSScO"
     >
       : 
     </i>
     <span
-      class="sc-grNHTL dlSwMX"
+      class="sc-eillgj iTYiLF"
     >
       here is a link 
       <a
@@ -124,50 +124,50 @@ exports[`client/messaging/common-message-layout/TextMessage > message with a lin
   data-testid="message-container"
 >
   <div
-    class="sc-iFEEnu llqPcV"
+    class="sc-jhbick gJVEas"
     role="document"
   >
     <div
-      class="sc-lbpHHC jRmSVS sc-fmzYco jjjVfe"
+      class="sc-dkljCc DKtQu sc-gHmoSK tWBDv"
       tabindex="0"
     >
       <span
-        class="sc-eYamsp lgXetw"
+        class="sc-djMJHV hqkuKg"
       >
         <i
           aria-hidden="true"
-          class="sc-gliaOv epmnrc"
+          class="sc-JXQyv iHSScO"
         >
           [
         </i>
         12:00 AM
         <i
           aria-hidden="true"
-          class="sc-gliaOv epmnrc"
+          class="sc-JXQyv iHSScO"
         >
           ] 
         </i>
       </span>
     </div>
     <span
-      class="sc-fHRCPF cvkTmv sc-iILUYU hBIpDd"
+      class="sc-hZxFvJ hWYCGm sc-ewKWQi jIIrqK"
       tabindex="0"
     >
       <span
         aria-label="Username loading…"
-        class="sc-gzHMyu kUTliR"
+        class="sc-cHqurc cczfoP"
       >
                    
       </span>
     </span>
     <i
       aria-hidden="true"
-      class="sc-gliaOv epmnrc"
+      class="sc-JXQyv iHSScO"
     >
       : 
     </i>
     <span
-      class="sc-grNHTL dlSwMX"
+      class="sc-eillgj iTYiLF"
     >
       <a
         href="http://www.example.com"
@@ -179,13 +179,13 @@ exports[`client/messaging/common-message-layout/TextMessage > message with a lin
        go here
        
       <span
-        class="sc-fHRCPF cvkTmv sc-ZGwPe dHHPwJ"
+        class="sc-hZxFvJ hWYCGm sc-djDiuc ceOyJL"
         tabindex="0"
       >
         @
         <span
           aria-label="Username loading…"
-          class="sc-gzHMyu kUTliR"
+          class="sc-cHqurc cczfoP"
         >
                      
         </span>
@@ -200,61 +200,61 @@ exports[`client/messaging/common-message-layout/TextMessage > message with a lin
   data-testid="message-container"
 >
   <div
-    class="sc-iFEEnu llqPcV"
+    class="sc-jhbick gJVEas"
     role="document"
   >
     <div
-      class="sc-lbpHHC jRmSVS sc-fmzYco jjjVfe"
+      class="sc-dkljCc DKtQu sc-gHmoSK tWBDv"
       tabindex="0"
     >
       <span
-        class="sc-eYamsp lgXetw"
+        class="sc-djMJHV hqkuKg"
       >
         <i
           aria-hidden="true"
-          class="sc-gliaOv epmnrc"
+          class="sc-JXQyv iHSScO"
         >
           [
         </i>
         12:00 AM
         <i
           aria-hidden="true"
-          class="sc-gliaOv epmnrc"
+          class="sc-JXQyv iHSScO"
         >
           ] 
         </i>
       </span>
     </div>
     <span
-      class="sc-fHRCPF cvkTmv sc-iILUYU hBIpDd"
+      class="sc-hZxFvJ hWYCGm sc-ewKWQi jIIrqK"
       tabindex="0"
     >
       <span
         aria-label="Username loading…"
-        class="sc-gzHMyu kUTliR"
+        class="sc-cHqurc cczfoP"
       >
                    
       </span>
     </span>
     <i
       aria-hidden="true"
-      class="sc-gliaOv epmnrc"
+      class="sc-JXQyv iHSScO"
     >
       : 
     </i>
     <span
-      class="sc-grNHTL dlSwMX"
+      class="sc-eillgj iTYiLF"
     >
       hey
        
       <span
-        class="sc-fHRCPF cvkTmv sc-ZGwPe dHHPwJ"
+        class="sc-hZxFvJ hWYCGm sc-djDiuc ceOyJL"
         tabindex="0"
       >
         @
         <span
           aria-label="Username loading…"
-          class="sc-gzHMyu kUTliR"
+          class="sc-cHqurc cczfoP"
         >
                      
         </span>
@@ -270,13 +270,13 @@ exports[`client/messaging/common-message-layout/TextMessage > message with a lin
        go here
        
       <span
-        class="sc-fHRCPF cvkTmv sc-ZGwPe dHHPwJ"
+        class="sc-hZxFvJ hWYCGm sc-djDiuc ceOyJL"
         tabindex="0"
       >
         @
         <span
           aria-label="Username loading…"
-          class="sc-gzHMyu kUTliR"
+          class="sc-cHqurc cczfoP"
         >
                      
         </span>
@@ -291,61 +291,61 @@ exports[`client/messaging/common-message-layout/TextMessage > message with a men
   data-testid="message-container"
 >
   <div
-    class="sc-iFEEnu llqPcV"
+    class="sc-jhbick gJVEas"
     role="document"
   >
     <div
-      class="sc-lbpHHC jRmSVS sc-fmzYco jjjVfe"
+      class="sc-dkljCc DKtQu sc-gHmoSK tWBDv"
       tabindex="0"
     >
       <span
-        class="sc-eYamsp lgXetw"
+        class="sc-djMJHV hqkuKg"
       >
         <i
           aria-hidden="true"
-          class="sc-gliaOv epmnrc"
+          class="sc-JXQyv iHSScO"
         >
           [
         </i>
         12:00 AM
         <i
           aria-hidden="true"
-          class="sc-gliaOv epmnrc"
+          class="sc-JXQyv iHSScO"
         >
           ] 
         </i>
       </span>
     </div>
     <span
-      class="sc-fHRCPF cvkTmv sc-iILUYU hBIpDd"
+      class="sc-hZxFvJ hWYCGm sc-ewKWQi jIIrqK"
       tabindex="0"
     >
       <span
         aria-label="Username loading…"
-        class="sc-gzHMyu kUTliR"
+        class="sc-cHqurc cczfoP"
       >
                    
       </span>
     </span>
     <i
       aria-hidden="true"
-      class="sc-gliaOv epmnrc"
+      class="sc-JXQyv iHSScO"
     >
       : 
     </i>
     <span
-      class="sc-grNHTL dlSwMX"
+      class="sc-eillgj iTYiLF"
     >
       hey
        
       <span
-        class="sc-fHRCPF cvkTmv sc-ZGwPe dHHPwJ"
+        class="sc-hZxFvJ hWYCGm sc-djDiuc ceOyJL"
         tabindex="0"
       >
         @
         <span
           aria-label="Username loading…"
-          class="sc-gzHMyu kUTliR"
+          class="sc-cHqurc cczfoP"
         >
                      
         </span>
@@ -360,59 +360,59 @@ exports[`client/messaging/common-message-layout/TextMessage > message with a men
   data-testid="message-container"
 >
   <div
-    class="sc-iFEEnu llqPcV"
+    class="sc-jhbick gJVEas"
     role="document"
   >
     <div
-      class="sc-lbpHHC jRmSVS sc-fmzYco jjjVfe"
+      class="sc-dkljCc DKtQu sc-gHmoSK tWBDv"
       tabindex="0"
     >
       <span
-        class="sc-eYamsp lgXetw"
+        class="sc-djMJHV hqkuKg"
       >
         <i
           aria-hidden="true"
-          class="sc-gliaOv epmnrc"
+          class="sc-JXQyv iHSScO"
         >
           [
         </i>
         12:00 AM
         <i
           aria-hidden="true"
-          class="sc-gliaOv epmnrc"
+          class="sc-JXQyv iHSScO"
         >
           ] 
         </i>
       </span>
     </div>
     <span
-      class="sc-fHRCPF cvkTmv sc-iILUYU hBIpDd"
+      class="sc-hZxFvJ hWYCGm sc-ewKWQi jIIrqK"
       tabindex="0"
     >
       <span
         aria-label="Username loading…"
-        class="sc-gzHMyu kUTliR"
+        class="sc-cHqurc cczfoP"
       >
                    
       </span>
     </span>
     <i
       aria-hidden="true"
-      class="sc-gliaOv epmnrc"
+      class="sc-JXQyv iHSScO"
     >
       : 
     </i>
     <span
-      class="sc-grNHTL dlSwMX"
+      class="sc-eillgj iTYiLF"
     >
       <span
-        class="sc-fHRCPF cvkTmv sc-ZGwPe dHHPwJ"
+        class="sc-hZxFvJ hWYCGm sc-djDiuc ceOyJL"
         tabindex="0"
       >
         @
         <span
           aria-label="Username loading…"
-          class="sc-gzHMyu kUTliR"
+          class="sc-cHqurc cczfoP"
         >
                      
         </span>
@@ -435,50 +435,50 @@ exports[`client/messaging/common-message-layout/TextMessage > message with a men
   data-testid="message-container"
 >
   <div
-    class="sc-iFEEnu llqPcV"
+    class="sc-jhbick gJVEas"
     role="document"
   >
     <div
-      class="sc-lbpHHC jRmSVS sc-fmzYco jjjVfe"
+      class="sc-dkljCc DKtQu sc-gHmoSK tWBDv"
       tabindex="0"
     >
       <span
-        class="sc-eYamsp lgXetw"
+        class="sc-djMJHV hqkuKg"
       >
         <i
           aria-hidden="true"
-          class="sc-gliaOv epmnrc"
+          class="sc-JXQyv iHSScO"
         >
           [
         </i>
         12:00 AM
         <i
           aria-hidden="true"
-          class="sc-gliaOv epmnrc"
+          class="sc-JXQyv iHSScO"
         >
           ] 
         </i>
       </span>
     </div>
     <span
-      class="sc-fHRCPF cvkTmv sc-iILUYU hBIpDd"
+      class="sc-hZxFvJ hWYCGm sc-ewKWQi jIIrqK"
       tabindex="0"
     >
       <span
         aria-label="Username loading…"
-        class="sc-gzHMyu kUTliR"
+        class="sc-cHqurc cczfoP"
       >
                    
       </span>
     </span>
     <i
       aria-hidden="true"
-      class="sc-gliaOv epmnrc"
+      class="sc-JXQyv iHSScO"
     >
       : 
     </i>
     <span
-      class="sc-grNHTL dlSwMX"
+      class="sc-eillgj iTYiLF"
     >
       <a
         href="http://www.example.com"
@@ -490,13 +490,13 @@ exports[`client/messaging/common-message-layout/TextMessage > message with a men
        go here
        
       <span
-        class="sc-fHRCPF cvkTmv sc-ZGwPe dHHPwJ"
+        class="sc-hZxFvJ hWYCGm sc-djDiuc ceOyJL"
         tabindex="0"
       >
         @
         <span
           aria-label="Username loading…"
-          class="sc-gzHMyu kUTliR"
+          class="sc-cHqurc cczfoP"
         >
                      
         </span>
@@ -519,61 +519,61 @@ exports[`client/messaging/common-message-layout/TextMessage > message with a men
   data-testid="message-container"
 >
   <div
-    class="sc-iFEEnu tiMuK"
+    class="sc-jhbick fWJZTT"
     role="document"
   >
     <div
-      class="sc-lbpHHC jRmSVS sc-fmzYco jjjVfe"
+      class="sc-dkljCc DKtQu sc-gHmoSK tWBDv"
       tabindex="0"
     >
       <span
-        class="sc-eYamsp lgXetw"
+        class="sc-djMJHV hqkuKg"
       >
         <i
           aria-hidden="true"
-          class="sc-gliaOv epmnrc"
+          class="sc-JXQyv iHSScO"
         >
           [
         </i>
         12:00 AM
         <i
           aria-hidden="true"
-          class="sc-gliaOv epmnrc"
+          class="sc-JXQyv iHSScO"
         >
           ] 
         </i>
       </span>
     </div>
     <span
-      class="sc-fHRCPF cvkTmv sc-iILUYU hBIpDd"
+      class="sc-hZxFvJ hWYCGm sc-ewKWQi jIIrqK"
       tabindex="0"
     >
       <span
         aria-label="Username loading…"
-        class="sc-gzHMyu kUTliR"
+        class="sc-cHqurc cczfoP"
       >
                    
       </span>
     </span>
     <i
       aria-hidden="true"
-      class="sc-gliaOv epmnrc"
+      class="sc-JXQyv iHSScO"
     >
       : 
     </i>
     <span
-      class="sc-grNHTL dlSwMX"
+      class="sc-eillgj iTYiLF"
     >
       Hey
        
       <span
-        class="sc-fHRCPF cvkTmv sc-ZGwPe dHHPwJ"
+        class="sc-hZxFvJ hWYCGm sc-djDiuc ceOyJL"
         tabindex="0"
       >
         @
         <span
           aria-label="Username loading…"
-          class="sc-gzHMyu kUTliR"
+          class="sc-cHqurc cczfoP"
         >
                      
         </span>

--- a/client/messaging/common-message-layout.test.tsx
+++ b/client/messaging/common-message-layout.test.tsx
@@ -1,9 +1,10 @@
 import { render, screen } from '@testing-library/react'
 import { Provider as ReduxProvider } from 'react-redux'
-import { describe, expect, test, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { encodePrettyId } from '../../common/pretty-id'
 import { makeSbUserId } from '../../common/users/sb-user-id'
 import createStore from '../create-store'
+import { LOBBY_INVITE_CARD_MAX_AGE_MS } from '../lobbies/lobby-invite-card'
 import { TextMessage } from './common-message-layout'
 
 vi.mock('../lobbies/lobby-invite-card', async importOriginal => {
@@ -21,8 +22,18 @@ const userId = makeSbUserId(2)
 const LOBBY_ID = encodePrettyId('5eed0000-0000-0000-0000-000000000042')
 
 describe('client/messaging/common-message-layout/TextMessage', () => {
+  beforeEach(() => {
+    // The invite-card age gate compares the message time against the current time; pinning the
+    // clock to 0 makes the fixed `time={0}` used across these tests read as "just sent"
+    vi.spyOn(Date, 'now').mockReturnValue(0)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
   const store = createStore()
-  const doRender = (text: string): HTMLElement => {
+  const doRender = (text: string, { time = 0 }: { time?: number } = {}): HTMLElement => {
     render(
       <ReduxProvider store={store}>
         <div data-testid='message-container'>
@@ -30,7 +41,7 @@ describe('client/messaging/common-message-layout/TextMessage', () => {
             msgId='MESSAGE_ID'
             userId={userId}
             selfUserId={selfUserId}
-            time={0}
+            time={time}
             text={text}
           />
         </div>
@@ -94,5 +105,12 @@ describe('client/messaging/common-message-layout/TextMessage', () => {
         `https://shieldbattery.net/lobbies/${LOBBY_ID}/other-slug`,
     )
     expect(screen.getAllByTestId('lobby-invite-card')).toHaveLength(1)
+  })
+
+  test('message older than the invite-card age limit renders no invite card', () => {
+    doRender(`join me: https://shieldbattery.net/lobbies/${LOBBY_ID}/my-cool-lobby`, {
+      time: -(LOBBY_INVITE_CARD_MAX_AGE_MS + 1),
+    })
+    expect(screen.queryByTestId('lobby-invite-card')).toBeNull()
   })
 })

--- a/client/messaging/common-message-layout.test.tsx
+++ b/client/messaging/common-message-layout.test.tsx
@@ -1,12 +1,24 @@
 import { render, screen } from '@testing-library/react'
 import { Provider as ReduxProvider } from 'react-redux'
-import { describe, expect, test } from 'vitest'
+import { describe, expect, test, vi } from 'vitest'
+import { encodePrettyId } from '../../common/pretty-id'
 import { makeSbUserId } from '../../common/users/sb-user-id'
 import createStore from '../create-store'
 import { TextMessage } from './common-message-layout'
 
+vi.mock('../lobbies/lobby-invite-card', async importOriginal => {
+  const actual = await importOriginal<typeof import('../lobbies/lobby-invite-card')>()
+  return {
+    ...actual,
+    LobbyInviteCard: ({ lobbyId }: { lobbyId: string }) => (
+      <div data-testid='lobby-invite-card'>{lobbyId}</div>
+    ),
+  }
+})
+
 const selfUserId = makeSbUserId(1)
 const userId = makeSbUserId(2)
+const LOBBY_ID = encodePrettyId('5eed0000-0000-0000-0000-000000000042')
 
 describe('client/messaging/common-message-layout/TextMessage', () => {
   const store = createStore()
@@ -59,5 +71,23 @@ describe('client/messaging/common-message-layout/TextMessage', () => {
 
   test('message with a mention of self user', () => {
     expect(doRender('Hey <@1>')).toMatchSnapshot()
+  })
+
+  test('message with a lobby link renders exactly one invite card', () => {
+    doRender(`join me: https://shieldbattery.net/lobbies/${LOBBY_ID}/my-cool-lobby`)
+    expect(screen.getAllByTestId('lobby-invite-card')).toHaveLength(1)
+  })
+
+  test('message with a non-lobby link renders no invite card', () => {
+    doRender('here is a link http://www.example.com')
+    expect(screen.queryByTestId('lobby-invite-card')).toBeNull()
+  })
+
+  test('message with multiple lobby links renders only one invite card', () => {
+    doRender(
+      `https://shieldbattery.net/lobbies/${LOBBY_ID} or ` +
+        `https://shieldbattery.net/lobbies/${LOBBY_ID}/other-slug`,
+    )
+    expect(screen.getAllByTestId('lobby-invite-card')).toHaveLength(1)
   })
 })

--- a/client/messaging/common-message-layout.test.tsx
+++ b/client/messaging/common-message-layout.test.tsx
@@ -83,6 +83,11 @@ describe('client/messaging/common-message-layout/TextMessage', () => {
     expect(screen.queryByTestId('lobby-invite-card')).toBeNull()
   })
 
+  test('lobby-shaped path on a foreign origin renders no invite card', () => {
+    doRender(`https://example.com/lobbies/${LOBBY_ID}/my-cool-lobby`)
+    expect(screen.queryByTestId('lobby-invite-card')).toBeNull()
+  })
+
   test('message with multiple lobby links renders only one invite card', () => {
     doRender(
       `https://shieldbattery.net/lobbies/${LOBBY_ID} or ` +

--- a/client/messaging/common-message-layout.tsx
+++ b/client/messaging/common-message-layout.tsx
@@ -172,7 +172,9 @@ export function TextMessage({ msgId, userId, selfUserId, time, text, testId }: T
         />
         <Separator>{': '}</Separator>
         <Text>{parsedText}</Text>
-        {inviteLobbyId !== undefined && mountTime - time < LOBBY_INVITE_CARD_MAX_AGE_MS ? (
+        {inviteLobbyId !== undefined &&
+        !disallowMentionInteraction &&
+        mountTime - time < LOBBY_INVITE_CARD_MAX_AGE_MS ? (
           <LobbyInviteCard lobbyId={inviteLobbyId} />
         ) : undefined}
       </TimestampMessageLayout>

--- a/client/messaging/common-message-layout.tsx
+++ b/client/messaging/common-message-layout.tsx
@@ -10,7 +10,11 @@ import { makeSbUserId, SbUserId } from '../../common/users/sb-user-id'
 import { ConnectedChannelName } from '../chat/connected-channel-name'
 import { useContextMenu } from '../dom/use-context-menu'
 import { TransInterpolation } from '../i18n/i18next'
-import { lobbyIdFromMessageLink, LobbyInviteCard } from '../lobbies/lobby-invite-card'
+import {
+  LOBBY_INVITE_CARD_MAX_AGE_MS,
+  lobbyIdFromMessageLink,
+  LobbyInviteCard,
+} from '../lobbies/lobby-invite-card'
 import { ExternalLink } from '../navigation/external-link'
 import { titleSmall } from '../styles/typography'
 import { ConnectedUsername } from '../users/connected-username'
@@ -74,6 +78,10 @@ export interface TextMessageProps {
 export function TextMessage({ msgId, userId, selfUserId, time, text, testId }: TextMessageProps) {
   const filterClick = useMentionFilterClick()
   const { UserMenu, MessageMenu, disallowMentionInteraction } = useContext(ChatContext)
+  // The invite-card age gate needs the current time, which a pure render can't read directly;
+  // capture it once on mount. A message mounts when it first becomes visible (on arrival, or when
+  // scrollback loads), which is the moment the age check is about.
+  const [mountTime] = useState(() => Date.now())
 
   const { onContextMenu, contextMenuPopoverProps, selectedText } = useContextMenu()
 
@@ -165,7 +173,9 @@ export function TextMessage({ msgId, userId, selfUserId, time, text, testId }: T
         <Separator>{': '}</Separator>
         <Text>{parsedText}</Text>
       </TimestampMessageLayout>
-      {inviteLobbyId !== undefined ? <LobbyInviteCard lobbyId={inviteLobbyId} /> : undefined}
+      {inviteLobbyId !== undefined && mountTime - time < LOBBY_INVITE_CARD_MAX_AGE_MS ? (
+        <LobbyInviteCard lobbyId={inviteLobbyId} />
+      ) : undefined}
 
       <MessageContextMenu
         messageId={msgId}

--- a/client/messaging/common-message-layout.tsx
+++ b/client/messaging/common-message-layout.tsx
@@ -2,6 +2,7 @@ import React, { useContext, useState } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 import { makeSbChannelId } from '../../common/chat'
+import { SbLobbyId } from '../../common/lobbies/sb-lobby-id'
 import { matchChannelMentionsMarkup } from '../../common/text/channel-mentions'
 import { matchLinks } from '../../common/text/links'
 import { matchUserMentionsMarkup } from '../../common/text/user-mentions'
@@ -9,6 +10,7 @@ import { makeSbUserId, SbUserId } from '../../common/users/sb-user-id'
 import { ConnectedChannelName } from '../chat/connected-channel-name'
 import { useContextMenu } from '../dom/use-context-menu'
 import { TransInterpolation } from '../i18n/i18next'
+import { lobbyIdFromMessageLink, LobbyInviteCard } from '../lobbies/lobby-invite-card'
 import { ExternalLink } from '../navigation/external-link'
 import { titleSmall } from '../styles/typography'
 import { ConnectedUsername } from '../users/connected-username'
@@ -77,6 +79,7 @@ export function TextMessage({ msgId, userId, selfUserId, time, text, testId }: T
 
   const parsedText: React.ReactNode[] = []
   let isHighlighted = false
+  let inviteLobbyId: SbLobbyId | undefined
   const matches = getAllMatches(text)
   const sortedMatches = Array.from(matches).sort((a, b) => a.index - b.index)
   let lastIndex = 0
@@ -123,6 +126,11 @@ export function TextMessage({ msgId, userId, selfUserId, time, text, testId }: T
         />,
       )
     } else if (match.type === 'link') {
+      if (inviteLobbyId === undefined) {
+        // Only the first lobby link in a message gets an invite card.
+        inviteLobbyId = lobbyIdFromMessageLink(match.text)
+      }
+
       parsedText.push(
         <ExternalLink key={match.index} href={match.text}>
           {match.text}
@@ -157,6 +165,7 @@ export function TextMessage({ msgId, userId, selfUserId, time, text, testId }: T
         <Separator>{': '}</Separator>
         <Text>{parsedText}</Text>
       </TimestampMessageLayout>
+      {inviteLobbyId !== undefined ? <LobbyInviteCard lobbyId={inviteLobbyId} /> : undefined}
 
       <MessageContextMenu
         messageId={msgId}

--- a/client/messaging/common-message-layout.tsx
+++ b/client/messaging/common-message-layout.tsx
@@ -172,10 +172,10 @@ export function TextMessage({ msgId, userId, selfUserId, time, text, testId }: T
         />
         <Separator>{': '}</Separator>
         <Text>{parsedText}</Text>
+        {inviteLobbyId !== undefined && mountTime - time < LOBBY_INVITE_CARD_MAX_AGE_MS ? (
+          <LobbyInviteCard lobbyId={inviteLobbyId} />
+        ) : undefined}
       </TimestampMessageLayout>
-      {inviteLobbyId !== undefined && mountTime - time < LOBBY_INVITE_CARD_MAX_AGE_MS ? (
-        <LobbyInviteCard lobbyId={inviteLobbyId} />
-      ) : undefined}
 
       <MessageContextMenu
         messageId={msgId}

--- a/client/navigation/external-link.tsx
+++ b/client/navigation/external-link.tsx
@@ -17,7 +17,7 @@ const ELECTRON_PROTO = 'shieldbattery:'
 const ELECTRON_HOST = 'app'
 const ELECTRON_ORIGIN = `${ELECTRON_PROTO}//${ELECTRON_HOST}`
 
-function isShieldBatteryUrl(url: URL): boolean {
+export function isShieldBatteryUrl(url: URL): boolean {
   const urlOrigin = url.origin.toLowerCase()
   return urlOrigin === ELECTRON_ORIGIN || urlOrigin === getServerOrigin().toLowerCase()
 }

--- a/common/lobbies/lobby-url.test.ts
+++ b/common/lobbies/lobby-url.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test, vi } from 'vitest'
-import { lobbySlug, urlForLobby } from './lobby-url'
+import { lobbyIdFromPath, lobbySlug, urlForLobby } from './lobby-url'
 import { SbLobbyId } from './sb-lobby-id'
 
 const LOBBY_ID = 'AbCdEfGhIjKlMnOpQrStUv' as SbLobbyId
@@ -48,6 +48,40 @@ describe('lobbies/lobby-url', () => {
 
     test('uses the "_" placeholder when no name is provided', () => {
       expect(urlForLobby(LOBBY_ID)).toBe(`/lobbies/${LOBBY_ID}/_`)
+    })
+  })
+
+  describe('lobbyIdFromPath', () => {
+    test('returns the id for a bare id path', () => {
+      expect(lobbyIdFromPath(`/lobbies/${LOBBY_ID}`)).toBe(LOBBY_ID)
+    })
+
+    test('returns the id for a slugged path', () => {
+      expect(lobbyIdFromPath(`/lobbies/${LOBBY_ID}/my-cool-lobby`)).toBe(LOBBY_ID)
+    })
+
+    test('returns the id when the path has a trailing slash', () => {
+      expect(lobbyIdFromPath(`/lobbies/${LOBBY_ID}/`)).toBe(LOBBY_ID)
+    })
+
+    test('returns the id when there are extra segments after the slug', () => {
+      expect(lobbyIdFromPath(`/lobbies/${LOBBY_ID}/my-cool-lobby/extra`)).toBe(LOBBY_ID)
+    })
+
+    test('returns undefined for the bare lobbies list path', () => {
+      expect(lobbyIdFromPath('/lobbies')).toBeUndefined()
+    })
+
+    test('returns undefined for an invalid id segment', () => {
+      expect(lobbyIdFromPath('/lobbies/not-a-valid-id')).toBeUndefined()
+    })
+
+    test('returns undefined for a non-lobby path', () => {
+      expect(lobbyIdFromPath(`/games/${LOBBY_ID}`)).toBeUndefined()
+    })
+
+    test('returns undefined for an empty string', () => {
+      expect(lobbyIdFromPath('')).toBeUndefined()
     })
   })
 })

--- a/common/lobbies/lobby-url.ts
+++ b/common/lobbies/lobby-url.ts
@@ -1,6 +1,7 @@
 import slug from 'slug'
+import { isPrettyId } from '../pretty-id'
 import { urlPath } from '../urls'
-import { SbLobbyId } from './sb-lobby-id'
+import { makeSbLobbyId, SbLobbyId } from './sb-lobby-id'
 
 /**
  * Returns the URL slug for a lobby name, falling back to a `_` placeholder when the name is
@@ -18,4 +19,18 @@ export function lobbySlug(name: string | undefined): string {
  */
 export function urlForLobby(id: SbLobbyId, name?: string): string {
   return urlPath`/lobbies/${id}/${lobbySlug(name)}`
+}
+
+/**
+ * Returns the lobby id from a lobby URL path (`/lobbies/<id>` or `/lobbies/<id>/<slug>`), or
+ * undefined if the path isn't a lobby path or the id segment isn't a valid pretty id.
+ */
+export function lobbyIdFromPath(pathname: string): SbLobbyId | undefined {
+  const segments = pathname.split('/').filter(segment => segment.length > 0)
+  if (segments.length < 2 || segments[0] !== 'lobbies') {
+    return undefined
+  }
+
+  const id = segments[1]
+  return isPrettyId(id) ? makeSbLobbyId(id) : undefined
 }


### PR DESCRIPTION
Lobby redesign Phase 2 chunk (iii), D18: a lobby link posted in any SB chat (channel, whisper, etc.) renders as a rich invite card below the message — map thumbnail, lobby name, host · game type · open slot count, and a Join button. A link to a lobby that no longer exists renders a muted "This lobby is no longer open." note. Links that aren't lobby links (or aren't ShieldBattery-origin) are untouched, and only the first lobby link in a message gets a card.

Implementation notes:

- Detection is `lobbyIdFromPath` (new, in `common/lobbies/lobby-url.ts` beside `urlForLobby`) behind the existing `isShieldBatteryUrl` origin check (now exported from `external-link.tsx`). The inline `<ExternalLink>` rendering in `TextMessage` is unchanged — the card adds the preview + one-click Join on top. Cards render only for messages younger than an hour (lobbies are ephemeral; old links are near-certainly dead) and never where chat interaction is disallowed (the draft screen).
- Data comes from #1378's unauthenticated summary endpoint through `useLobbySummary`, which now owns a cached read mode: 30s TTL + in-flight dedupe shared across every rendered card, plus a client-side fetch budget (15 network reads per 30s) so a burst of distinct sender-controlled lobby-shaped ids can't spend the endpoint's per-IP throttle out from under the join preview / landing page. A read past the budget simply fails uncached (no card; the inline link still works) — the budget is sized so organic channels never hit it. The join-preview page's uncached semantics are unchanged.
- Every card state has the same fixed 82×440 footprint (the loading placeholder reserves it, the map thumbnail is forced square), so an async load can never grow a message after the list has autoscrolled. The card renders inside `TimestampMessageLayout` — covered by the message's hover/highlight background and context menu — and opts out of text selection so copied chat stays clean.
- Join joins directly, exactly like clicking the lobby in the lobby list: the shared `useJoinLobbyAction()` hook (extracted from `join-lobby.tsx`; both call sites use it) guards on an active matchmaking search, health-checks, dispatches `joinLobby` with snackbar error reporting, and navigates to the lobby route. On web it opens the download dialog.
- `LobbyInviteCardContent` is a presentational split (same pattern as `JoinableLobbyContent`), driven by a new `/dev/lobbies/invite-card` scenario page.
- Zero new i18n keys — the card reuses `lobbies.joinLobby.action`, `lobbies.joinLobby.openSlotCount`, and `lobbies.summary.noLongerOpen`.
- Message-layout snapshot changes are styled-components hash shifts only (new components in the module graph).

The review's recurring design question — how much denial machinery the fan-out protection deserves — settled on the simple point: cache + age gate + a drop-on-deny budget generous enough that organic channels never trigger it. A denial-retry layer existed briefly and was removed as net-negative complexity (it was also the source of the empty-skeleton-during-denial artifact the review kept flagging). Known v1 limitation, deliberate: a mounted card never re-reads its summary, so a long-open chat window can show a stale slot count / live Join for an ended lobby — the join itself is server-arbitrated either way, and this surface gets reworked in the redesign's later UI phase.

Verification: typecheck/lint clean, full unit suite green (including `lobby-summary.test.ts` covering the cache/budget logic: shared in-flight reads, TTL expiry, 404-cached vs transient-uncached, denial + window refill). Live-verified 2-client against the dev stack: card renders on both sender and receiver (including loading a card from channel history on join), fixed 82×440 geometry with `user-select: none` and neutralized hanging indent confirmed via computed styles, Join seats the clicker directly in the lobby and lands them on the lobby route, and re-posting the link after the lobby died renders the gone card.
