### PR TITLE
Convert the lobby domain model off Immutable.js

### DIFF
--- a/client/lobbies/devonly/lobby-test.jsx
+++ b/client/lobbies/devonly/lobby-test.jsx
@@ -1,35 +1,33 @@
 import { List, Range } from 'immutable'
 import { Component } from 'react'
-import { Lobby, Team } from '../../../common/lobbies'
-import { Slot } from '../../../common/lobbies/slot'
 import { FightingSpirit } from '../../maps/devonly/maps-for-testing'
 import LobbyComponent from '../lobby'
 import { LobbyLoadingState } from '../lobby-reducer'
 
-const SLOTS = new List([
-  new Slot({ type: 'human', name: 'tec27', id: 'a', race: 'p' }),
-  new Slot({ type: 'human', name: '2Pacalypse-', id: 'b', race: 't' }),
-  new Slot({ type: 'human', name: 'dronebabo', id: 'c', race: 'z' }),
-  new Slot({ type: 'human', name: 'pachi', id: 'd', race: 'r' }),
-  new Slot({ type: 'human', name: 'Heyoka', id: 'e', race: 'r' }),
-  new Slot({ type: 'human', name: 'Legionnaire', id: 'f', race: 'p' }),
-  new Slot({ type: 'human', name: 'boesthius', id: 'g', race: 't' }),
-  new Slot({ type: 'human', name: 'harem', id: 'h', race: 'z' }),
-])
+const SLOTS = [
+  { type: 'human', name: 'tec27', id: 'a', race: 'p' },
+  { type: 'human', name: '2Pacalypse-', id: 'b', race: 't' },
+  { type: 'human', name: 'dronebabo', id: 'c', race: 'z' },
+  { type: 'human', name: 'pachi', id: 'd', race: 'r' },
+  { type: 'human', name: 'Heyoka', id: 'e', race: 'r' },
+  { type: 'human', name: 'Legionnaire', id: 'f', race: 'p' },
+  { type: 'human', name: 'boesthius', id: 'g', race: 't' },
+  { type: 'human', name: 'harem', id: 'h', race: 'z' },
+]
 
 const LOBBIES = Range(2, 9).map(numSlots => {
-  return new Lobby({
+  return {
     name: `My ${numSlots}-slot Lobby`,
     map: FightingSpirit,
     gameType: 'melee',
     gameSubType: 0,
-    teams: new List([
-      new Team({
-        slots: SLOTS.take(numSlots),
-      }),
-    ]),
-    host: SLOTS.get(0),
-  })
+    teams: [
+      {
+        slots: SLOTS.slice(0, numSlots),
+      },
+    ],
+    host: SLOTS[0],
+  }
 })
 
 const USER = { id: 27, name: 'tec27' }

--- a/client/lobbies/lobby-reducer.js
+++ b/client/lobbies/lobby-reducer.js
@@ -1,7 +1,6 @@
+import { produce } from 'immer'
 import { List, Record } from 'immutable'
 import { nanoid } from 'nanoid'
-import { Lobby, Team } from '../../common/lobbies/index'
-import { Slot } from '../../common/lobbies/slot'
 import {
   LOBBY_ACTIVATE,
   LOBBY_DEACTIVATE,
@@ -45,12 +44,34 @@ export class LobbyLoadingState extends Record({
   isLoading: false,
 }) {}
 
+/** @type {import('../../common/lobbies/slot').Slot} */
+const EMPTY_SLOT = Object.freeze({
+  type: 'open',
+  race: 'r',
+  id: '',
+  joinedAt: 0,
+  hasForcedRace: false,
+  playerId: 0,
+  typeId: 0,
+})
+/** @type {import('../../common/lobbies').Lobby} */
+const EMPTY_LOBBY = Object.freeze({
+  id: '',
+  name: '',
+  map: undefined,
+  gameType: 'melee',
+  gameSubType: 0,
+  teams: [],
+  host: EMPTY_SLOT,
+  useLegacyLimits: false,
+  visibility: 'listed',
+})
+
 export class LobbyRecord extends Record({
-  // TODO(tec27): This isn't totally correct as some parts of this are actually the JSON versions
-  // (i.e. the map). This makes the normal Lobby functions usable on this though and dealing with
-  // the types in Immutable is a real pain. We should clean this up when we move this off
-  // Immutable though (and probably just move the Map data out of this struct generally).
-  info: new Lobby(),
+  // TODO(tec27): `info` holds the server's JSON-serialized lobby directly, so e.g. `map` is a
+  // `MapInfoJson` rather than a full `MapInfo`. We should probably move the map data out of this
+  // struct generally.
+  info: EMPTY_LOBBY,
   loadingState: new LobbyLoadingState(),
   chat: List(),
 
@@ -62,60 +83,54 @@ export class LobbyRecord extends Record({
   }
 }
 
-const infoReducer = keyedReducer(new Lobby(), {
+const infoReducer = keyedReducer(EMPTY_LOBBY, {
   [LOBBY_INIT_DATA](state, action) {
-    const { lobby } = action.payload
-    const teams = lobby.teams.map(team => {
-      const slots = team.slots.map(slot => new Slot(slot))
-      const hiddenSlots = team.hiddenSlots.map(slot => new Slot(slot))
-      return new Team({ ...team, slots: List(slots), hiddenSlots })
-    })
-    const lobbyInfo = new Lobby({
-      ...lobby,
-      teams: List(teams),
-      host: new Slot(lobby.host),
-    })
-
-    return lobbyInfo
+    return action.payload.lobby
   },
 
   [LOBBY_UPDATE_SLOT_CREATE](state, action) {
     const { teamIndex, slotIndex, slot } = action.payload
-    return state.setIn(['teams', teamIndex, 'slots', slotIndex], new Slot(slot))
+    return produce(state, draft => {
+      draft.teams[teamIndex].slots[slotIndex] = slot
+    })
   },
 
   [LOBBY_UPDATE_RACE_CHANGE](state, action) {
     const { teamIndex, slotIndex, newRace } = action.payload
-    return state.setIn(['teams', teamIndex, 'slots', slotIndex, 'race'], newRace)
+    return produce(state, draft => {
+      draft.teams[teamIndex].slots[slotIndex].race = newRace
+    })
   },
 
   [LOBBY_UPDATE_SLOT_CHANGE](state, action) {
     const { teamIndex, slotIndex, player } = action.payload
-    return state.setIn(['teams', teamIndex, 'slots', slotIndex], new Slot(player))
+    return produce(state, draft => {
+      draft.teams[teamIndex].slots[slotIndex] = player
+    })
   },
 
   [LOBBY_UPDATE_LEAVE_SELF](state, action) {
-    return new Lobby()
+    return EMPTY_LOBBY
   },
 
   [LOBBY_UPDATE_KICK_SELF](state, action) {
-    return new Lobby()
+    return EMPTY_LOBBY
   },
 
   [LOBBY_UPDATE_BAN_SELF](state, action) {
-    return new Lobby()
+    return EMPTY_LOBBY
   },
 
   [LOBBY_UPDATE_HOST_CHANGE](state, action) {
-    return state.set('host', new Slot(action.payload))
+    return { ...state, host: action.payload }
   },
 
   [LOBBY_UPDATE_GAME_STARTED](state, action) {
-    return new Lobby()
+    return EMPTY_LOBBY
   },
 
   ['@network/connect'](state, action) {
-    return new Lobby()
+    return EMPTY_LOBBY
   },
 })
 

--- a/client/lobbies/lobby-reducer.js
+++ b/client/lobbies/lobby-reducer.js
@@ -89,6 +89,10 @@ const infoReducer = keyedReducer(EMPTY_LOBBY, {
   },
 
   [LOBBY_UPDATE_SLOT_CREATE](state, action) {
+    if (!state.name) {
+      // Not in a lobby (e.g. this event trailed our own removal in a diff) - nothing to update
+      return state
+    }
     const { teamIndex, slotIndex, slot } = action.payload
     return produce(state, draft => {
       draft.teams[teamIndex].slots[slotIndex] = slot
@@ -96,6 +100,10 @@ const infoReducer = keyedReducer(EMPTY_LOBBY, {
   },
 
   [LOBBY_UPDATE_RACE_CHANGE](state, action) {
+    if (!state.name) {
+      // Not in a lobby (e.g. this event trailed our own removal in a diff) - nothing to update
+      return state
+    }
     const { teamIndex, slotIndex, newRace } = action.payload
     return produce(state, draft => {
       draft.teams[teamIndex].slots[slotIndex].race = newRace
@@ -103,6 +111,10 @@ const infoReducer = keyedReducer(EMPTY_LOBBY, {
   },
 
   [LOBBY_UPDATE_SLOT_CHANGE](state, action) {
+    if (!state.name) {
+      // Not in a lobby (e.g. this event trailed our own removal in a diff) - nothing to update
+      return state
+    }
     const { teamIndex, slotIndex, player } = action.payload
     return produce(state, draft => {
       draft.teams[teamIndex].slots[slotIndex] = player
@@ -122,6 +134,10 @@ const infoReducer = keyedReducer(EMPTY_LOBBY, {
   },
 
   [LOBBY_UPDATE_HOST_CHANGE](state, action) {
+    if (!state.name) {
+      // Not in a lobby (e.g. this event trailed our own removal in a diff) - nothing to update
+      return state
+    }
     return { ...state, host: action.payload }
   },
 

--- a/client/lobbies/lobby-reducer.test.ts
+++ b/client/lobbies/lobby-reducer.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, test } from 'vitest'
+import { GameType } from '../../common/games/game-type'
+import { Lobby } from '../../common/lobbies'
+import { Slot, SlotType } from '../../common/lobbies/slot'
+import {
+  LOBBY_INIT_DATA,
+  LOBBY_UPDATE_BAN_SELF,
+  LOBBY_UPDATE_HOST_CHANGE,
+  LOBBY_UPDATE_KICK_SELF,
+  LOBBY_UPDATE_LEAVE_SELF,
+  LOBBY_UPDATE_RACE_CHANGE,
+  LOBBY_UPDATE_SLOT_CREATE,
+} from '../actions'
+import lobbyReducerImport, { LobbyRecord } from './lobby-reducer'
+
+// `lobby-reducer.js` is untyped JS; give the default export a minimal, honest signature for use
+// in these tests rather than fighting inference on every call site.
+const lobbyReducer = lobbyReducerImport as (
+  state: LobbyRecord | undefined,
+  action: { type: string; payload?: any },
+) => LobbyRecord
+
+const HOST_SLOT: Slot = {
+  type: SlotType.Human,
+  userId: 1 as any,
+  race: 'r',
+  id: 'host-slot',
+  joinedAt: 0,
+  hasForcedRace: false,
+  playerId: 0,
+  typeId: 0,
+}
+
+const SLOT_A: Slot = {
+  type: SlotType.Human,
+  userId: 2 as any,
+  race: 'z',
+  id: 'slot-a',
+  joinedAt: 0,
+  hasForcedRace: false,
+  playerId: 1,
+  typeId: 0,
+}
+
+const SLOT_B: Slot = {
+  type: SlotType.Open,
+  race: 'r',
+  id: 'slot-b',
+  joinedAt: 0,
+  hasForcedRace: false,
+  playerId: 2,
+  typeId: 0,
+}
+
+const LOBBY: Lobby = {
+  id: 'lobby-1' as any,
+  name: 'Test Lobby',
+  map: undefined,
+  gameType: GameType.Melee,
+  gameSubType: 0,
+  teams: [
+    {
+      name: 'Team 1',
+      teamId: 0,
+      isObserver: false,
+      slots: [HOST_SLOT, SLOT_A, SLOT_B],
+      hiddenSlots: [],
+    },
+  ],
+  host: HOST_SLOT,
+  useLegacyLimits: false,
+  visibility: 'listed',
+}
+
+function initAction() {
+  return { type: LOBBY_INIT_DATA, payload: { lobby: LOBBY, userInfos: [] } }
+}
+
+describe('client/lobbies/lobby-reducer', () => {
+  test('LOBBY_INIT_DATA stores the payload lobby as state.info directly', () => {
+    const state = lobbyReducer(undefined, initAction())
+
+    expect(state.info).toBe(LOBBY)
+  })
+
+  test('LOBBY_UPDATE_SLOT_CREATE replaces the targeted slot and leaves the others untouched', () => {
+    let state = lobbyReducer(undefined, initAction())
+
+    const newSlot: Slot = {
+      type: SlotType.Human,
+      userId: 3 as any,
+      race: 'p',
+      id: 'slot-c',
+      joinedAt: 0,
+      hasForcedRace: false,
+      playerId: 2,
+      typeId: 0,
+    }
+    state = lobbyReducer(state, {
+      type: LOBBY_UPDATE_SLOT_CREATE,
+      payload: { teamIndex: 0, slotIndex: 2, slot: newSlot },
+    })
+
+    expect(state.info.teams[0].slots[2]).toEqual(newSlot)
+    expect(state.info.teams[0].slots[0]).toEqual(HOST_SLOT)
+    expect(state.info.teams[0].slots[1]).toEqual(SLOT_A)
+  })
+
+  test('LOBBY_UPDATE_RACE_CHANGE updates just the race of the targeted slot', () => {
+    let state = lobbyReducer(undefined, initAction())
+
+    state = lobbyReducer(state, {
+      type: LOBBY_UPDATE_RACE_CHANGE,
+      payload: { teamIndex: 0, slotIndex: 1, newRace: 'p' },
+    })
+
+    expect(state.info.teams[0].slots[1]).toEqual({ ...SLOT_A, race: 'p' })
+    expect(state.info.teams[0].slots[0]).toEqual(HOST_SLOT)
+    expect(state.info.teams[0].slots[2]).toEqual(SLOT_B)
+  })
+
+  test('a slotCreate trailing our own kick does not throw and leaves us out of the lobby', () => {
+    let state = lobbyReducer(undefined, initAction())
+    state = lobbyReducer(state, { type: LOBBY_UPDATE_KICK_SELF })
+
+    expect(() => {
+      state = lobbyReducer(state, {
+        type: LOBBY_UPDATE_SLOT_CREATE,
+        payload: { teamIndex: 0, slotIndex: 1, slot: SLOT_A },
+      })
+    }).not.toThrow()
+
+    expect(state.info.name).toBe('')
+    expect(state.inLobby).toBe(false)
+  })
+
+  test('a raceChange trailing our own leave does not throw and leaves us out of the lobby', () => {
+    let state = lobbyReducer(undefined, initAction())
+    state = lobbyReducer(state, { type: LOBBY_UPDATE_LEAVE_SELF })
+
+    expect(() => {
+      state = lobbyReducer(state, {
+        type: LOBBY_UPDATE_RACE_CHANGE,
+        payload: { teamIndex: 0, slotIndex: 1, newRace: 'p' },
+      })
+    }).not.toThrow()
+
+    expect(state.info.name).toBe('')
+    expect(state.inLobby).toBe(false)
+  })
+
+  test('a hostChange trailing our own ban does not throw and leaves us out of the lobby', () => {
+    let state = lobbyReducer(undefined, initAction())
+    state = lobbyReducer(state, { type: LOBBY_UPDATE_BAN_SELF })
+
+    expect(() => {
+      state = lobbyReducer(state, {
+        type: LOBBY_UPDATE_HOST_CHANGE,
+        payload: SLOT_A,
+      })
+    }).not.toThrow()
+
+    expect(state.info.name).toBe('')
+    expect(state.inLobby).toBe(false)
+  })
+})

--- a/client/lobbies/lobby.tsx
+++ b/client/lobbies/lobby.tsx
@@ -234,112 +234,110 @@ class LobbyComponent extends React.Component<LobbyProps & WithTranslation> {
     const canAddObsSlots = canAddObservers(lobby)
     const canRemoveObsSlots = canRemoveObservers(lobby)
 
-    return team.slots
-      .map((slot: Slot) => {
-        const { type, userId, race, id, controlledBy } = slot
-        switch (type) {
-          case SlotType.Open:
-            return (
-              <OpenSlot
-                key={id}
-                race={race}
-                isHost={isHost}
-                isObserver={isObserver}
-                onAddComputer={!isLobbyUms ? () => onAddComputer(id) : undefined}
-                onSwitchClick={() => onSwitchSlot(id)}
-                onCloseSlot={() => onCloseSlot(id)}
-              />
-            )
-          case SlotType.Closed:
-            return (
-              <ClosedSlot
-                key={id}
-                race={race}
-                isHost={isHost}
-                isObserver={isObserver}
-                onAddComputer={!isLobbyUms ? () => onAddComputer(id) : undefined}
-                onOpenSlot={() => onOpenSlot(id)}
-              />
-            )
-          case SlotType.Human:
-            return (
-              <PlayerSlot
-                key={id}
-                userId={userId}
-                race={race}
-                isHost={isHost}
-                canSetRace={slot === mySlot && !slot.hasForcedRace}
-                canMakeObserver={canAddObsSlots}
-                isSelf={slot === mySlot}
-                onSetRace={(race: RaceChar) => onSetRace(id, race)}
-                onCloseSlot={() => onCloseSlot(id)}
-                onKickPlayer={() => onKickPlayer(id)}
-                onBanPlayer={() => onBanPlayer(id)}
-                onMakeObserver={() => onMakeObserver(id)}
-              />
-            )
-          case SlotType.Observer:
-            return (
-              <PlayerSlot
-                key={id}
-                userId={userId}
-                isHost={isHost}
-                isObserver={true}
-                canRemoveObserver={canRemoveObsSlots}
-                isSelf={slot === mySlot}
-                onCloseSlot={() => onCloseSlot(id)}
-                onKickPlayer={() => onKickPlayer(id)}
-                onBanPlayer={() => onBanPlayer(id)}
-                onRemoveObserver={() => onRemoveObserver(id)}
-              />
-            )
-          case SlotType.Computer:
-            return (
-              <PlayerSlot
-                key={id}
-                userId={userId}
-                race={race}
-                isComputer={true}
-                canSetRace={isHost}
-                isHost={isHost}
-                isSelf={false}
-                onSetRace={(race: RaceChar) => onSetRace(id, race)}
-                onCloseSlot={() => onCloseSlot(id)}
-                onKickPlayer={() => onKickPlayer(id)}
-              />
-            )
-          case SlotType.UmsComputer:
-            return <PlayerSlot key={id} userId={userId} race={race} isComputer={true} />
-          case SlotType.ControlledOpen:
-            return (
-              <OpenSlot
-                key={id}
-                race={race}
-                controlledOpen={true}
-                canSetRace={mySlot && controlledBy === mySlot.id}
-                isHost={isHost}
-                onSetRace={(race: RaceChar) => onSetRace(id, race)}
-                onSwitchClick={() => onSwitchSlot(id)}
-                onCloseSlot={() => onCloseSlot(id)}
-              />
-            )
-          case SlotType.ControlledClosed:
-            return (
-              <ClosedSlot
-                key={id}
-                race={race}
-                controlledClosed={true}
-                canSetRace={mySlot && controlledBy === mySlot.id}
-                isHost={isHost}
-                onOpenSlot={() => onOpenSlot(id)}
-                onSetRace={(race: RaceChar) => onSetRace(id, race)}
-              />
-            )
-          default:
-            return assertUnreachable(type)
-        }
-      })
-      .toArray()
+    return team.slots.map((slot: Slot) => {
+      const { type, userId, race, id, controlledBy } = slot
+      switch (type) {
+        case SlotType.Open:
+          return (
+            <OpenSlot
+              key={id}
+              race={race}
+              isHost={isHost}
+              isObserver={isObserver}
+              onAddComputer={!isLobbyUms ? () => onAddComputer(id) : undefined}
+              onSwitchClick={() => onSwitchSlot(id)}
+              onCloseSlot={() => onCloseSlot(id)}
+            />
+          )
+        case SlotType.Closed:
+          return (
+            <ClosedSlot
+              key={id}
+              race={race}
+              isHost={isHost}
+              isObserver={isObserver}
+              onAddComputer={!isLobbyUms ? () => onAddComputer(id) : undefined}
+              onOpenSlot={() => onOpenSlot(id)}
+            />
+          )
+        case SlotType.Human:
+          return (
+            <PlayerSlot
+              key={id}
+              userId={userId}
+              race={race}
+              isHost={isHost}
+              canSetRace={slot === mySlot && !slot.hasForcedRace}
+              canMakeObserver={canAddObsSlots}
+              isSelf={slot === mySlot}
+              onSetRace={(race: RaceChar) => onSetRace(id, race)}
+              onCloseSlot={() => onCloseSlot(id)}
+              onKickPlayer={() => onKickPlayer(id)}
+              onBanPlayer={() => onBanPlayer(id)}
+              onMakeObserver={() => onMakeObserver(id)}
+            />
+          )
+        case SlotType.Observer:
+          return (
+            <PlayerSlot
+              key={id}
+              userId={userId}
+              isHost={isHost}
+              isObserver={true}
+              canRemoveObserver={canRemoveObsSlots}
+              isSelf={slot === mySlot}
+              onCloseSlot={() => onCloseSlot(id)}
+              onKickPlayer={() => onKickPlayer(id)}
+              onBanPlayer={() => onBanPlayer(id)}
+              onRemoveObserver={() => onRemoveObserver(id)}
+            />
+          )
+        case SlotType.Computer:
+          return (
+            <PlayerSlot
+              key={id}
+              userId={userId}
+              race={race}
+              isComputer={true}
+              canSetRace={isHost}
+              isHost={isHost}
+              isSelf={false}
+              onSetRace={(race: RaceChar) => onSetRace(id, race)}
+              onCloseSlot={() => onCloseSlot(id)}
+              onKickPlayer={() => onKickPlayer(id)}
+            />
+          )
+        case SlotType.UmsComputer:
+          return <PlayerSlot key={id} userId={userId} race={race} isComputer={true} />
+        case SlotType.ControlledOpen:
+          return (
+            <OpenSlot
+              key={id}
+              race={race}
+              controlledOpen={true}
+              canSetRace={mySlot && controlledBy === mySlot.id}
+              isHost={isHost}
+              onSetRace={(race: RaceChar) => onSetRace(id, race)}
+              onSwitchClick={() => onSwitchSlot(id)}
+              onCloseSlot={() => onCloseSlot(id)}
+            />
+          )
+        case SlotType.ControlledClosed:
+          return (
+            <ClosedSlot
+              key={id}
+              race={race}
+              controlledClosed={true}
+              canSetRace={mySlot && controlledBy === mySlot.id}
+              isHost={isHost}
+              onOpenSlot={() => onOpenSlot(id)}
+              onSetRace={(race: RaceChar) => onSetRace(id, race)}
+            />
+          )
+        default:
+          return assertUnreachable(type)
+      }
+    })
   }
 
   override render() {
@@ -348,11 +346,11 @@ class LobbyComponent extends React.Component<LobbyProps & WithTranslation> {
     const isLobbyUms = isUms(lobby.gameType)
     const slots = []
     const obsSlots = []
-    for (let teamIndex = 0; teamIndex < lobby.teams.size; teamIndex++) {
-      const currentTeam = lobby.teams.get(teamIndex)!
+    for (let teamIndex = 0; teamIndex < lobby.teams.length; teamIndex++) {
+      const currentTeam = lobby.teams[teamIndex]
       const isObserver = currentTeam.isObserver
       const displayTeamName =
-        (isTeamType(lobby.gameType) || isLobbyUms || isObserver) && currentTeam.slots.size !== 0
+        (isTeamType(lobby.gameType) || isLobbyUms || isObserver) && currentTeam.slots.length !== 0
       if (displayTeamName) {
         slots.push(<TeamName key={'team' + teamIndex}>{currentTeam.name}</TeamName>)
       }

--- a/common/lobbies/index.ts
+++ b/common/lobbies/index.ts
@@ -1,4 +1,3 @@
-import { List, Record } from 'immutable'
 import { PlayerInfo } from '../games/game-launch-config'
 import { GameType, isTeamType } from '../games/game-type'
 import { MapInfo } from '../maps'
@@ -18,42 +17,42 @@ export type LobbyState = 'nonexistent' | 'exists' | 'countingDown' | 'hasStarted
 
 export * from './lobby-visibility'
 
-export class Team extends Record({
-  name: '',
-  teamId: 0,
-  isObserver: false,
+export interface Team {
+  readonly name: string
+  readonly teamId: number
+  readonly isObserver: boolean
   /** Slots that belong to a particular team. */
-  slots: List<Slot>(),
+  readonly slots: ReadonlyArray<Slot>
   /** UMS maps can have slots which are not shown in lobby but get initialized in game. */
-  hiddenSlots: List<Slot>(),
-}) {}
+  readonly hiddenSlots: ReadonlyArray<Slot>
+}
 
-export class Lobby extends Record({
-  id: '' as SbLobbyId,
-  name: '',
-  map: undefined as MapInfo | undefined,
-  gameType: GameType.Melee,
-  gameSubType: 0,
+export interface Lobby {
+  readonly id: SbLobbyId
+  readonly name: string
+  readonly map?: MapInfo
+  readonly gameType: GameType
+  readonly gameSubType: number
   /** All lobbies have at least one team (even Melee and FFA). */
-  teams: List<Team>(),
-  host: new Slot(),
-  useLegacyLimits: false,
-  visibility: 'listed' as LobbyVisibility,
-}) {}
+  readonly teams: ReadonlyArray<Team>
+  readonly host: Slot
+  readonly useLegacyLimits: boolean
+  readonly visibility: LobbyVisibility
+}
 
 export function isUms(gameType: GameType): gameType is GameType.UseMapSettings {
   return gameType === GameType.UseMapSettings
 }
 
 /**
- * Returns a List of all the slots in a lobby.
+ * Returns an array of all the slots in a lobby.
  *
  * Since we don't keep a separate list just for the slots, this function iterates over all of the
- * teams in a lobby and accumulates the slots into a new list. Keep in mind that you lose the team
+ * teams in a lobby and accumulates the slots into a new array. Keep in mind that you lose the team
  * index and slot index, so use this function only when you care about the slots themselves, not
  * their indexes; otherwise, use the `getLobbySlotsWithIndexes`.
  */
-export function getLobbySlots(lobby: Lobby): List<Slot> {
+export function getLobbySlots(lobby: Lobby): Slot[] {
   return lobby.teams.flatMap(team => team.slots)
 }
 
@@ -61,7 +60,7 @@ export function getLobbySlots(lobby: Lobby): List<Slot> {
  * Gets all the player slots for a lobby, which for now are: `human`, `computer` and `umsComputer`
  * type slots.
  */
-export function getPlayerSlots(lobby: Lobby): List<Slot> {
+export function getPlayerSlots(lobby: Lobby): Slot[] {
   return getLobbySlots(lobby).filter(
     slot =>
       slot.type === SlotType.Human ||
@@ -71,7 +70,7 @@ export function getPlayerSlots(lobby: Lobby): List<Slot> {
 }
 
 /** Gets all the human slots in a lobby. This includes both the players and the observers. */
-export function getHumanSlots(lobby: Lobby): List<Slot> {
+export function getHumanSlots(lobby: Lobby): Slot[] {
   return getLobbySlots(lobby).filter(
     slot => slot.type === SlotType.Human || slot.type === SlotType.Observer,
   )
@@ -80,25 +79,27 @@ export function getHumanSlots(lobby: Lobby): List<Slot> {
 export type SlotWithIndexes = [teamIndex: number, slotIndex: number, slot: Slot]
 
 /**
- * Returns a List of tuples with info for each slot in the lobby.
+ * Returns an array of tuples with info for each slot in the lobby.
  *
  * This function is similar to the `getLobbySlots`, only it preserves the team index and slot index
- * after flat mapping the team, and as a result returns an immutable list where each element is in
- * the following form: [teamIndex, slotIndex, slot]
+ * after flat mapping the team, and as a result returns an array where each element is in the
+ * following form: [teamIndex, slotIndex, slot]
  */
-export function getLobbySlotsWithIndexes(lobby: Lobby): List<SlotWithIndexes> {
+export function getLobbySlotsWithIndexes(lobby: Lobby): SlotWithIndexes[] {
   return lobby.teams.flatMap((team, teamIndex) =>
-    team.slots.map((slot, slotIndex) => [teamIndex, slotIndex, slot]),
+    team.slots.map((slot, slotIndex): SlotWithIndexes => [teamIndex, slotIndex, slot]),
   )
 }
 
 /**
- * Returns a List of tuples with info for each slot in the lobby, including possible UMS hidden
+ * Returns an array of tuples with info for each slot in the lobby, including possible UMS hidden
  * slots that are necessary for game initialization.
  */
-export function getIngameLobbySlotsWithIndexes(lobby: Lobby): List<SlotWithIndexes> {
+export function getIngameLobbySlotsWithIndexes(lobby: Lobby): SlotWithIndexes[] {
   return lobby.teams.flatMap((team, teamIndex) =>
-    team.slots.concat(team.hiddenSlots).map((slot, slotIndex) => [teamIndex, slotIndex, slot]),
+    team.slots
+      .concat(team.hiddenSlots)
+      .map((slot, slotIndex): SlotWithIndexes => [teamIndex, slotIndex, slot]),
   )
 }
 
@@ -112,7 +113,7 @@ export function getPlayerInfos(lobby: Lobby): PlayerInfo[] {
         // An observer slot with nobody in it has no in-game counterpart — the game reserves its
         // observer slots unconditionally — and emitting one would claim a game slot meant for a
         // player.
-        !lobby.teams.get(teamIndex)!.isObserver || slot.type === SlotType.Observer,
+        !lobby.teams[teamIndex].isObserver || slot.type === SlotType.Observer,
     )
     .map(([teamIndex, _slotIndex, slot]) => ({
       id: slot.id,
@@ -121,9 +122,8 @@ export function getPlayerInfos(lobby: Lobby): PlayerInfo[] {
       playerId: slot.playerId,
       type: slot.type,
       typeId: slot.typeId,
-      teamId: lobby.teams.get(teamIndex)?.teamId ?? 0,
+      teamId: lobby.teams[teamIndex]?.teamId ?? 0,
     }))
-    .toArray()
 }
 
 /**
@@ -137,7 +137,7 @@ export function findSlotByUserId(lobby: Lobby, userId: SbUserId): SlotWithIndexe
 }
 
 /**
- * Finds the slot with the specified id in the lobby. Returns the [teamIndex, slotIndex, slot] list
+ * Finds the slot with the specified id in the lobby. Returns the [teamIndex, slotIndex, slot] tuple
  * if the slot is found; otherwise returns an empty array.
  */
 export function findSlotById(lobby: Lobby, id: string): SlotWithIndexes | [] {
@@ -151,8 +151,8 @@ export function findSlotById(lobby: Lobby, id: string): SlotWithIndexes | [] {
  */
 export function slotCount(lobby: Lobby): number {
   return lobby.teams
-    .filterNot(team => team.isObserver)
-    .reduce((slots, team) => slots + team.slots.size, 0)
+    .filter(team => !team.isObserver)
+    .reduce((slots, team) => slots + team.slots.length, 0)
 }
 
 /**
@@ -163,7 +163,8 @@ export function humanSlotCount(lobby: Lobby): number {
   return lobby.teams.reduce(
     (humanSlots, team) =>
       humanSlots +
-      team.slots.count(slot => slot.type === SlotType.Human || slot.type === SlotType.Observer),
+      team.slots.filter(slot => slot.type === SlotType.Human || slot.type === SlotType.Observer)
+        .length,
     0,
   )
 }
@@ -175,12 +176,12 @@ export function humanSlotCount(lobby: Lobby): number {
  * Player slot types for now are: `human`, `computer`, `umsComputer`
  */
 export function teamPlayerSlotCount(team: Team): number {
-  return team.slots.count(
+  return team.slots.filter(
     slot =>
       slot.type === SlotType.Human ||
       slot.type === SlotType.Computer ||
       slot.type === SlotType.UmsComputer,
-  )
+  ).length
 }
 
 /**
@@ -189,7 +190,7 @@ export function teamPlayerSlotCount(team: Team): number {
  */
 export function takenSlotCount(lobby: Lobby): number {
   return lobby.teams
-    .filterNot(team => team.isObserver)
+    .filter(team => !team.isObserver)
     .reduce((takenSlots, team) => takenSlots + teamTakenSlotCount(team), 0)
 }
 
@@ -198,9 +199,9 @@ export function takenSlotCount(lobby: Lobby): number {
  * or `controlledOpen`.
  */
 export function teamTakenSlotCount(team: Team): number {
-  return team.slots.count(
+  return team.slots.filter(
     slot => slot.type !== SlotType.Open && slot.type !== SlotType.ControlledOpen,
-  )
+  ).length
 }
 
 /**
@@ -212,9 +213,9 @@ export function openSlotCount(lobby: Lobby): number {
   return lobby.teams.reduce(
     (openSlots, team) =>
       openSlots +
-      team.slots.count(
+      team.slots.filter(
         slot => slot.type === SlotType.Open || slot.type === SlotType.ControlledOpen,
-      ),
+      ).length,
     0,
   )
 }
@@ -225,8 +226,8 @@ export function openSlotCount(lobby: Lobby): number {
  */
 export function hasOpposingSides(lobby: Lobby): boolean {
   return !isTeamType(lobby.gameType)
-    ? getPlayerSlots(lobby).size > 1
-    : lobby.teams.filter(team => !team.isObserver && teamPlayerSlotCount(team) > 0).size > 1
+    ? getPlayerSlots(lobby).length > 1
+    : lobby.teams.filter(team => !team.isObserver && teamPlayerSlotCount(team) > 0).length > 1
 }
 
 /** Returns true if the lobby has an observer team; false otherwise. */

--- a/common/lobbies/slot.ts
+++ b/common/lobbies/slot.ts
@@ -1,4 +1,3 @@
-import { Record } from 'immutable'
 import { nanoid } from 'nanoid'
 import { GameServerRegionId } from '../game-server-regions'
 import { RaceChar } from '../races'
@@ -15,49 +14,52 @@ export enum SlotType {
   Closed = 'closed',
 }
 
-export class Slot extends Record({
-  type: SlotType.Open,
-  userId: undefined as SbUserId | undefined,
-  race: 'r' as RaceChar,
-  id: '',
-  joinedAt: 0,
-  controlledBy: undefined as string | undefined,
-  hasForcedRace: false,
-  playerId: 0,
-  typeId: 0,
+export interface Slot {
+  readonly type: SlotType
+  readonly userId?: SbUserId
+  readonly race: RaceChar
+  readonly id: string
+  readonly joinedAt: number
+  readonly controlledBy?: string
+  readonly hasForcedRace: boolean
+  readonly playerId: number
+  readonly typeId: number
   /**
    * The home game-server region this occupant selected when they joined, if any. Set only on slots
    * a human occupies (`human`/`observer`); used to home their netcode v2 relay at session create.
    * Absent when the occupant reported no region (e.g. no coordinator-configured regions) or for
    * non-occupant slot types (open, computer, etc.).
    */
-  region: undefined as GameServerRegionId | undefined,
-}) {}
+  readonly region?: GameServerRegionId
+}
 
-export type SlotJson = ReturnType<Slot['toJSON']>
+/** Every field of a `Slot` is JSON-safe, so the interface is also its own JSON form. */
+export type SlotJson = Slot
 
 export function createOpen(race: RaceChar = 'r', hasForcedRace = false, playerId = 0): Slot {
-  return new Slot({
+  return {
     type: SlotType.Open,
     race,
     id: nanoid(),
+    joinedAt: 0,
     // These last three fields are used in UMS
     hasForcedRace,
     playerId,
     typeId: 6,
-  })
+  }
 }
 
 export function createClosed(race: RaceChar = 'r', hasForcedRace = false, playerId = 0): Slot {
-  return new Slot({
+  return {
     type: SlotType.Closed,
     race,
     id: nanoid(),
+    joinedAt: 0,
     // These last three fields are used in UMS
     hasForcedRace,
     playerId,
     typeId: 6,
-  })
+  }
 }
 
 export function createHuman(
@@ -66,7 +68,7 @@ export function createHuman(
   hasForcedRace = false,
   playerId = 0,
 ): Slot {
-  return new Slot({
+  return {
     type: SlotType.Human,
     userId,
     race,
@@ -76,62 +78,79 @@ export function createHuman(
     hasForcedRace,
     playerId,
     typeId: 6,
-  })
+  }
 }
 
 export function createComputer(race: RaceChar = 'r'): Slot {
-  return new Slot({
+  return {
     type: SlotType.Computer,
     race,
     id: nanoid(),
-  })
+    joinedAt: 0,
+    hasForcedRace: false,
+    playerId: 0,
+    typeId: 0,
+  }
 }
 
 // Creates a slot that is open (can still be used for joining players), but is controlled by a
 // particular player for as long as it is unoccupied. These are used for Team games (e.g.
 // Team Melee), where open slots still affect the composition of starting units.
 export function createControlledOpen(race: RaceChar, controllerId: string): Slot {
-  return new Slot({
+  return {
     type: SlotType.ControlledOpen,
     race,
     id: nanoid(),
     controlledBy: controllerId,
-  })
+    joinedAt: 0,
+    hasForcedRace: false,
+    playerId: 0,
+    typeId: 0,
+  }
 }
 
 // Creates a slot that is closed (can't be used for joining players), but is controlled by a certain
 // player for as long as it is closed and unoccupied. These are used for Team games (e.g. Team
 // Melee), where closed slots can still have a race which affects the composition of starting units.
 export function createControlledClosed(race: RaceChar, controllerId: string): Slot {
-  return new Slot({
+  return {
     type: SlotType.ControlledClosed,
     race,
     id: nanoid(),
     controlledBy: controllerId,
-  })
+    joinedAt: 0,
+    hasForcedRace: false,
+    playerId: 0,
+    typeId: 0,
+  }
 }
 
 // Creates a computer slot that is used in UMS lobbies. Computers in UMS lobbies can't be removed
 // from the lobby and their race can't be changed. TypeId is the exact type (regular computer,
 // rescueable, neutral, etc) which needs to be passed to bw but can otherwise be ignored.
 export function createUmsComputer(race: RaceChar, playerId: number, typeId: number): Slot {
-  return new Slot({
+  return {
     type: SlotType.UmsComputer,
     race,
     id: nanoid(),
+    joinedAt: 0,
     hasForcedRace: true,
     playerId,
     typeId,
-  })
+  }
 }
 
 // Creates an observer slot, which is a human in a lobby who is not playing, but rather watching
 // other people play.
-export function createObserver(userId: SbUserId) {
-  return new Slot({
+export function createObserver(userId: SbUserId): Slot {
+  return {
     type: SlotType.Observer,
     userId,
+    race: 'r',
     id: nanoid(),
     joinedAt: Date.now(),
-  })
+    hasForcedRace: false,
+    playerId: 0,
+    typeId: 0,
+  }
 }

--- a/server/lib/lobbies/lobby.test.ts
+++ b/server/lib/lobbies/lobby.test.ts
@@ -82,18 +82,18 @@ const BOXER_LOBBY_WITH_OBSERVERS = createLobby({
 })
 
 const evaluateMeleeLobby = (lobby: Lobby, teamSize: number, slotCount = 4) => {
-  expect(lobby.teams).toHaveProperty('size', teamSize)
-  const team = lobby.teams.get(0)!
-  expect(team.slots).toHaveProperty('size', slotCount)
+  expect(lobby.teams).toHaveLength(teamSize)
+  const team = lobby.teams[0]
+  expect(team.slots).toHaveLength(slotCount)
   expect(humanSlotCount(lobby)).toBe(1)
   expect(hasOpposingSides(lobby)).toBe(false)
-  const player = team.slots.get(0)!
+  const player = team.slots[0]
   expect(player.type).toBe('human')
   expect(player.race).toBe('r')
   expect(player).toEqual(lobby.host)
-  expect(team.slots.get(1)!.type).toBe('open')
-  expect(team.slots.get(2)!.type).toBe('open')
-  expect(team.slots.get(3)!.type).toBe('open')
+  expect(team.slots[1].type).toBe('open')
+  expect(team.slots[2].type).toBe('open')
+  expect(team.slots[3].type).toBe('open')
 }
 
 const evaluateSummarizedJson = (lobby: Lobby, openSlotCount: number) => {
@@ -120,14 +120,14 @@ describe('Lobbies - melee', () => {
 
     let l = BOXER_LOBBY_WITH_OBSERVERS
     evaluateMeleeLobby(l, 2, 6)
-    let observers = l.teams.get(1)!
-    expect(observers.slots).toHaveProperty('size', MAX_OBSERVERS)
+    let observers = l.teams[1]
+    expect(observers.slots).toHaveLength(MAX_OBSERVERS)
     expect(observers.slots.every(s => s.type === 'closed')).toBe(true)
 
     l = openSlot(l, 1, 0)
-    observers = l.teams.get(1)!
-    expect(observers.slots.get(0)!.type).toBe('open')
-    expect(observers.slots.get(1)!.type).toBe('closed')
+    observers = l.teams[1]
+    expect(observers.slots[0].type).toBe('open')
+    expect(observers.slots[1].type).toBe('closed')
   })
 
   test('should support summarized JSON serialization', () => {
@@ -270,7 +270,7 @@ describe('Lobbies - melee', () => {
 
     expect(lobby).not.toEqual(beforeRemoval)
     expect(humanSlotCount(lobby)).toBe(1)
-    expect(lobby.teams.get(t2!)!.slots.get(s2!)!.type).toBe('open')
+    expect(lobby.teams[t2!].slots[s2!].type).toBe('open')
 
     const [t3, s3, host] = findSlotByUserId(lobby, lobby.host.userId!)
     lobby = removePlayer(lobby, t3!, s3!, host!)!
@@ -284,7 +284,7 @@ describe('Lobbies - melee', () => {
 
     lobby = setRace(lobby, t1!, s1!, 'z')
 
-    expect(lobby.teams.get(t1!)!.slots.get(s1!)!.race).toBe('z')
+    expect(lobby.teams[t1!].slots[s1!].race).toBe('z')
   })
 
   test('should support finding players by user id', () => {
@@ -351,22 +351,22 @@ describe('Lobbies - melee', () => {
     lobby = movePlayerToSlot(lobby, t1!, s1!, 0, 3)
 
     expect(humanSlotCount(lobby)).toBe(2)
-    expect(lobby.teams.get(0)!.slots.get(3)).toBe(babo)
-    expect(lobby.teams.get(t1!)!.slots.get(s1!)!.type).toBe('open')
+    expect(lobby.teams[0].slots[3]).toBe(babo)
+    expect(lobby.teams[t1!].slots[s1!].type).toBe('open')
   })
 
   test('should support closing an open slot', () => {
     let lobby = BOXER_LOBBY
-    expect(lobby.teams.get(0)!.slots.get(0)).toEqual(lobby.host)
-    expect(lobby.teams.get(0)!.slots.get(1)!.type).toBe('open')
-    expect(lobby.teams.get(0)!.slots.get(2)!.type).toBe('open')
-    expect(lobby.teams.get(0)!.slots.get(3)!.type).toBe('open')
+    expect(lobby.teams[0].slots[0]).toEqual(lobby.host)
+    expect(lobby.teams[0].slots[1].type).toBe('open')
+    expect(lobby.teams[0].slots[2].type).toBe('open')
+    expect(lobby.teams[0].slots[3].type).toBe('open')
 
     lobby = closeSlot(lobby, 0, 1)
-    expect(lobby.teams.get(0)!.slots.get(0)).toEqual(lobby.host)
-    expect(lobby.teams.get(0)!.slots.get(1)!.type).toBe('closed')
-    expect(lobby.teams.get(0)!.slots.get(2)!.type).toBe('open')
-    expect(lobby.teams.get(0)!.slots.get(3)!.type).toBe('open')
+    expect(lobby.teams[0].slots[0]).toEqual(lobby.host)
+    expect(lobby.teams[0].slots[1].type).toBe('closed')
+    expect(lobby.teams[0].slots[2].type).toBe('open')
+    expect(lobby.teams[0].slots[3].type).toBe('open')
 
     expect(() => closeSlot(lobby, 0, 0)).toThrow()
     expect(() => closeSlot(lobby, 0, 1)).toThrow()
@@ -374,22 +374,22 @@ describe('Lobbies - melee', () => {
 
   test('should support opening a closed slot', () => {
     let lobby = BOXER_LOBBY
-    expect(lobby.teams.get(0)!.slots.get(0)).toEqual(lobby.host)
-    expect(lobby.teams.get(0)!.slots.get(1)!.type).toBe('open')
-    expect(lobby.teams.get(0)!.slots.get(2)!.type).toBe('open')
-    expect(lobby.teams.get(0)!.slots.get(3)!.type).toBe('open')
+    expect(lobby.teams[0].slots[0]).toEqual(lobby.host)
+    expect(lobby.teams[0].slots[1].type).toBe('open')
+    expect(lobby.teams[0].slots[2].type).toBe('open')
+    expect(lobby.teams[0].slots[3].type).toBe('open')
 
     lobby = closeSlot(lobby, 0, 1)
-    expect(lobby.teams.get(0)!.slots.get(0)).toEqual(lobby.host)
-    expect(lobby.teams.get(0)!.slots.get(1)!.type).toBe('closed')
-    expect(lobby.teams.get(0)!.slots.get(2)!.type).toBe('open')
-    expect(lobby.teams.get(0)!.slots.get(3)!.type).toBe('open')
+    expect(lobby.teams[0].slots[0]).toEqual(lobby.host)
+    expect(lobby.teams[0].slots[1].type).toBe('closed')
+    expect(lobby.teams[0].slots[2].type).toBe('open')
+    expect(lobby.teams[0].slots[3].type).toBe('open')
 
     lobby = openSlot(lobby, 0, 1)
-    expect(lobby.teams.get(0)!.slots.get(0)).toEqual(lobby.host)
-    expect(lobby.teams.get(0)!.slots.get(1)!.type).toBe('open')
-    expect(lobby.teams.get(0)!.slots.get(2)!.type).toBe('open')
-    expect(lobby.teams.get(0)!.slots.get(3)!.type).toBe('open')
+    expect(lobby.teams[0].slots[0]).toEqual(lobby.host)
+    expect(lobby.teams[0].slots[1].type).toBe('open')
+    expect(lobby.teams[0].slots[2].type).toBe('open')
+    expect(lobby.teams[0].slots[3].type).toBe('open')
 
     expect(() => openSlot(lobby, 0, 0)).toThrow()
     expect(() => openSlot(lobby, 0, 1)).toThrow()
@@ -409,21 +409,21 @@ describe('Lobbies - melee', () => {
 
     lobby = makeObserver(lobby, 0, 0)
 
-    let players = lobby.teams.get(0)!
-    let observers = lobby.teams.get(1)!
-    expect(players.slots).toHaveProperty('size', 6)
-    expect(observers.slots).toHaveProperty('size', MAX_OBSERVERS)
-    expect(players.slots.get(0)!.type).toBe('open')
-    expect(observers.slots.get(0)!.type).toBe('observer')
-    expect(observers.slots.get(0)!.userId).toBe(HOST_USER_ID)
-    expect(lobby.host.id).toBe(observers.slots.get(0)!.id)
+    let players = lobby.teams[0]
+    let observers = lobby.teams[1]
+    expect(players.slots).toHaveLength(6)
+    expect(observers.slots).toHaveLength(MAX_OBSERVERS)
+    expect(players.slots[0].type).toBe('open')
+    expect(observers.slots[0].type).toBe('observer')
+    expect(observers.slots[0].userId).toBe(HOST_USER_ID)
+    expect(lobby.host.id).toBe(observers.slots[0].id)
     expect(humanSlotCount(lobby)).toBe(2)
 
     lobby = makeObserver(lobby, 0, 1)
-    players = lobby.teams.get(0)!
-    observers = lobby.teams.get(1)!
-    expect(players.slots.get(1)!.type).toBe('open')
-    expect(observers.slots.get(1)!.userId).toBe(makeSbUserId(1))
+    players = lobby.teams[0]
+    observers = lobby.teams[1]
+    expect(players.slots[1].type).toBe('open')
+    expect(observers.slots[1].userId).toBe(makeSbUserId(1))
     expect(canAddObservers(lobby)).toBe(true)
   })
 
@@ -435,7 +435,7 @@ describe('Lobbies - melee', () => {
     }
 
     expect(canAddObservers(lobby)).toBe(false)
-    expect(lobby.teams.get(1)!.slots.every(s => s.type === 'observer')).toBe(true)
+    expect(lobby.teams[1].slots.every(s => s.type === 'observer')).toBe(true)
     expect(() => makeObserver(lobby, 0, 0)).toThrow()
   })
 
@@ -448,16 +448,16 @@ describe('Lobbies - melee', () => {
     expect(canRemoveObservers(lobby)).toBe(true)
     lobby = removeObserver(lobby, 0)
 
-    const players = lobby.teams.get(0)!
-    const observers = lobby.teams.get(1)!
-    expect(players.slots).toHaveProperty('size', 6)
-    expect(observers.slots).toHaveProperty('size', MAX_OBSERVERS)
+    const players = lobby.teams[0]
+    const observers = lobby.teams[1]
+    expect(players.slots).toHaveLength(6)
+    expect(observers.slots).toHaveLength(MAX_OBSERVERS)
     // The observer slot they came from is left open for the next joiner
-    expect(observers.slots.get(0)!.type).toBe('open')
-    expect(observers.slots.skip(1).every(s => s.type === 'closed')).toBe(true)
-    expect(players.slots.get(0)!.type).toBe('human')
-    expect(players.slots.get(0)!.userId).toBe(HOST_USER_ID)
-    expect(lobby.host.id).toBe(players.slots.get(0)!.id)
+    expect(observers.slots[0].type).toBe('open')
+    expect(observers.slots.slice(1).every(s => s.type === 'closed')).toBe(true)
+    expect(players.slots[0].type).toBe('human')
+    expect(players.slots[0].userId).toBe(HOST_USER_ID)
+    expect(lobby.host.id).toBe(players.slots[0].id)
     expect(humanSlotCount(lobby)).toBe(1)
     expect(canRemoveObservers(lobby)).toBe(false)
   })
@@ -496,25 +496,25 @@ const TEAM_LOBBY = createLobby({
 describe('Lobbies - Top vs bottom', () => {
   test('should create the lobby correctly', () => {
     const l = TEAM_LOBBY
-    expect(l.teams).toHaveProperty('size', 2)
-    const team1 = l.teams.get(0)!
-    expect(team1.slots).toHaveProperty('size', 2)
-    const team2 = l.teams.get(1)!
-    expect(team2.slots).toHaveProperty('size', 6)
+    expect(l.teams).toHaveLength(2)
+    const team1 = l.teams[0]
+    expect(team1.slots).toHaveLength(2)
+    const team2 = l.teams[1]
+    expect(team2.slots).toHaveLength(6)
     expect(humanSlotCount(l)).toBe(1)
     expect(hasOpposingSides(l)).toBe(false)
-    const player = team1.slots.get(0)!
+    const player = team1.slots[0]
     expect(player.type).toBe('human')
     expect(player.userId).toBe(HOST_USER_ID)
     expect(player.race).toBe('r')
     expect(player).toEqual(l.host)
-    expect(team1.slots.get(1)!.type).toBe('open')
-    expect(team2.slots.get(0)!.type).toBe('open')
-    expect(team2.slots.get(1)!.type).toBe('open')
-    expect(team2.slots.get(2)!.type).toBe('open')
-    expect(team2.slots.get(3)!.type).toBe('open')
-    expect(team2.slots.get(4)!.type).toBe('open')
-    expect(team2.slots.get(5)!.type).toBe('open')
+    expect(team1.slots[1].type).toBe('open')
+    expect(team2.slots[0].type).toBe('open')
+    expect(team2.slots[1].type).toBe('open')
+    expect(team2.slots[2].type).toBe('open')
+    expect(team2.slots[3].type).toBe('open')
+    expect(team2.slots[4].type).toBe('open')
+    expect(team2.slots[5].type).toBe('open')
   })
 
   test('should balance teams when adding new players', () => {
@@ -574,8 +574,8 @@ describe('Lobbies - Top vs bottom', () => {
     lobby = movePlayerToSlot(lobby, t1!, s1!, 1, 3)
 
     expect(humanSlotCount(lobby)).toBe(2)
-    expect(lobby.teams.get(1)!.slots.get(3)).toBe(babo)
-    expect(lobby.teams.get(t1!)!.slots.get(s1!)!.type).toBe('open')
+    expect(lobby.teams[1].slots[3]).toBe(babo)
+    expect(lobby.teams[t1!].slots[s1!].type).toBe('open')
   })
 })
 
@@ -619,73 +619,73 @@ const evaluateControlledSlot = (slot: Slot, type: string, race: RaceChar, contro
 describe('Lobbies - Team melee', () => {
   test('should create the lobby correctly', () => {
     const l2 = TEAM_MELEE_2
-    expect(l2.teams).toHaveProperty('size', 2)
-    let team1 = l2.teams.get(0)!
-    expect(team1.slots).toHaveProperty('size', 4)
-    let team2 = l2.teams.get(1)!
-    expect(team2.slots).toHaveProperty('size', 4)
+    expect(l2.teams).toHaveLength(2)
+    let team1 = l2.teams[0]
+    expect(team1.slots).toHaveLength(4)
+    let team2 = l2.teams[1]
+    expect(team2.slots).toHaveLength(4)
     expect(humanSlotCount(l2)).toBe(1)
     expect(hasOpposingSides(l2)).toBe(false)
-    let player = team1.slots.get(0)!
+    let player = team1.slots[0]
     expect(player.type).toBe('human')
     expect(player.userId).toBe(HOST_USER_ID)
     expect(player.race).toBe('r')
     expect(player).toEqual(l2.host)
-    evaluateControlledSlot(team1.slots.get(1)!, 'controlledOpen', player.race, player.id)
-    evaluateControlledSlot(team1.slots.get(2)!, 'controlledOpen', player.race, player.id)
-    evaluateControlledSlot(team1.slots.get(3)!, 'controlledOpen', player.race, player.id)
-    expect(team2.slots.get(0)!.type).toBe('open')
-    expect(team2.slots.get(1)!.type).toBe('open')
-    expect(team2.slots.get(2)!.type).toBe('open')
-    expect(team2.slots.get(3)!.type).toBe('open')
+    evaluateControlledSlot(team1.slots[1], 'controlledOpen', player.race, player.id)
+    evaluateControlledSlot(team1.slots[2], 'controlledOpen', player.race, player.id)
+    evaluateControlledSlot(team1.slots[3], 'controlledOpen', player.race, player.id)
+    expect(team2.slots[0].type).toBe('open')
+    expect(team2.slots[1].type).toBe('open')
+    expect(team2.slots[2].type).toBe('open')
+    expect(team2.slots[3].type).toBe('open')
 
     const l3 = TEAM_MELEE_3
-    expect(l3.teams).toHaveProperty('size', 3)
-    team1 = l3.teams.get(0)!
-    expect(team1.slots).toHaveProperty('size', 3)
-    team2 = l3.teams.get(1)!
-    expect(team2.slots).toHaveProperty('size', 3)
-    let team3 = l3.teams.get(2)!
-    expect(team3.slots).toHaveProperty('size', 2)
+    expect(l3.teams).toHaveLength(3)
+    team1 = l3.teams[0]
+    expect(team1.slots).toHaveLength(3)
+    team2 = l3.teams[1]
+    expect(team2.slots).toHaveLength(3)
+    let team3 = l3.teams[2]
+    expect(team3.slots).toHaveLength(2)
     expect(humanSlotCount(l3)).toBe(1)
     expect(hasOpposingSides(l3)).toBe(false)
-    player = team1.slots.get(0)!
+    player = team1.slots[0]
     expect(player.type).toBe('human')
     expect(player.userId).toBe(HOST_USER_ID)
     expect(player.race).toBe('r')
     expect(player).toEqual(l3.host)
-    evaluateControlledSlot(team1.slots.get(1)!, 'controlledOpen', player.race, player.id)
-    evaluateControlledSlot(team1.slots.get(2)!, 'controlledOpen', player.race, player.id)
-    expect(team2.slots.get(0)!.type).toBe('open')
-    expect(team2.slots.get(1)!.type).toBe('open')
-    expect(team2.slots.get(2)!.type).toBe('open')
-    expect(team3.slots.get(0)!.type).toBe('open')
-    expect(team3.slots.get(1)!.type).toBe('open')
+    evaluateControlledSlot(team1.slots[1], 'controlledOpen', player.race, player.id)
+    evaluateControlledSlot(team1.slots[2], 'controlledOpen', player.race, player.id)
+    expect(team2.slots[0].type).toBe('open')
+    expect(team2.slots[1].type).toBe('open')
+    expect(team2.slots[2].type).toBe('open')
+    expect(team3.slots[0].type).toBe('open')
+    expect(team3.slots[1].type).toBe('open')
 
     const l4 = TEAM_MELEE_4
-    expect(l4.teams).toHaveProperty('size', 4)
-    team1 = l4.teams.get(0)!
-    expect(team1.slots).toHaveProperty('size', 2)
-    team2 = l4.teams.get(1)!
-    expect(team2.slots).toHaveProperty('size', 2)
-    team3 = l4.teams.get(2)!
-    expect(team3.slots).toHaveProperty('size', 2)
-    const team4 = l4.teams.get(3)!
-    expect(team4.slots).toHaveProperty('size', 2)
+    expect(l4.teams).toHaveLength(4)
+    team1 = l4.teams[0]
+    expect(team1.slots).toHaveLength(2)
+    team2 = l4.teams[1]
+    expect(team2.slots).toHaveLength(2)
+    team3 = l4.teams[2]
+    expect(team3.slots).toHaveLength(2)
+    const team4 = l4.teams[3]
+    expect(team4.slots).toHaveLength(2)
     expect(humanSlotCount(l4)).toBe(1)
     expect(hasOpposingSides(l4)).toBe(false)
-    player = team1.slots.get(0)!
+    player = team1.slots[0]
     expect(player.type).toBe('human')
     expect(player.userId).toBe(HOST_USER_ID)
     expect(player.race).toBe('r')
     expect(player).toEqual(l4.host)
-    evaluateControlledSlot(team1.slots.get(1)!, 'controlledOpen', player.race, player.id)
-    expect(team2.slots.get(0)!.type).toBe('open')
-    expect(team2.slots.get(1)!.type).toBe('open')
-    expect(team3.slots.get(0)!.type).toBe('open')
-    expect(team3.slots.get(1)!.type).toBe('open')
-    expect(team4.slots.get(0)!.type).toBe('open')
-    expect(team4.slots.get(1)!.type).toBe('open')
+    evaluateControlledSlot(team1.slots[1], 'controlledOpen', player.race, player.id)
+    expect(team2.slots[0].type).toBe('open')
+    expect(team2.slots[1].type).toBe('open')
+    expect(team3.slots[0].type).toBe('open')
+    expect(team3.slots[1].type).toBe('open')
+    expect(team4.slots[0].type).toBe('open')
+    expect(team4.slots[1].type).toBe('open')
   })
 
   test('should fill team slots when a player is added to an empty team', () => {
@@ -693,17 +693,17 @@ describe('Lobbies - Team melee', () => {
     const l = addPlayer(TEAM_MELEE_2, 1, 0, babo)
     expect(humanSlotCount(l)).toBe(2)
     expect(hasOpposingSides(l)).toBe(true)
-    expect(l.teams.get(1)!.slots.get(0)).toEqual(babo)
-    evaluateControlledSlot(l.teams.get(1)!.slots.get(1)!, 'controlledOpen', babo.race, babo.id)
+    expect(l.teams[1].slots[0]).toEqual(babo)
+    evaluateControlledSlot(l.teams[1].slots[1], 'controlledOpen', babo.race, babo.id)
   })
 
   test('should allow players to join slots that were previously controlled opens', () => {
-    expect(TEAM_MELEE_4.teams.get(0)!.slots.get(1)!.type).toBe('controlledOpen')
+    expect(TEAM_MELEE_4.teams[0].slots[1].type).toBe('controlledOpen')
     const babo = createHuman(makeSbUserId(1), 'z')
     const l = addPlayer(TEAM_MELEE_4, 0, 1, babo)
     expect(humanSlotCount(l)).toBe(2)
     expect(hasOpposingSides(l)).toBe(false)
-    expect(l.teams.get(0)!.slots.get(1)).toEqual(babo)
+    expect(l.teams[0].slots[1]).toEqual(babo)
   })
 
   test('should fill team slots with computers when a computer is added to an empty team', () => {
@@ -711,8 +711,8 @@ describe('Lobbies - Team melee', () => {
     const l = addPlayer(TEAM_MELEE_4, 1, 0, comp)
     expect(humanSlotCount(l)).toBe(1)
     expect(hasOpposingSides(l)).toBe(true)
-    expect(l.teams.get(1)!.slots.get(0)).toEqual(comp)
-    expect(l.teams.get(1)!.slots.get(1)!.type).toBe('computer')
+    expect(l.teams[1].slots[0]).toEqual(comp)
+    expect(l.teams[1].slots[1].type).toBe('computer')
   })
 
   test('should balance teams when adding new players', () => {
@@ -762,13 +762,13 @@ describe('Lobbies - Team melee', () => {
   test('should remove the controlled open slots when the last player on a team leaves', () => {
     const babo = createHuman(makeSbUserId(1), 'z')
     let l = addPlayer(TEAM_MELEE_4, 1, 0, babo)
-    evaluateControlledSlot(l.teams.get(1)!.slots.get(1)!, 'controlledOpen', babo.race, babo.id)
+    evaluateControlledSlot(l.teams[1].slots[1], 'controlledOpen', babo.race, babo.id)
     l = removePlayer(l, 1, 0, babo)!
 
     expect(humanSlotCount(l)).toBe(1)
     expect(hasOpposingSides(l)).toBe(false)
-    expect(l.teams.get(1)!.slots.get(0)!.type).toBe('open')
-    expect(l.teams.get(1)!.slots.get(1)!.type).toBe('open')
+    expect(l.teams[1].slots[0].type).toBe('open')
+    expect(l.teams[1].slots[1].type).toBe('open')
 
     expect(removePlayer(l, 0, 0, l.host)).toBeUndefined()
   })
@@ -776,15 +776,15 @@ describe('Lobbies - Team melee', () => {
   test('should remove all the computers in a team whenever one of the computers is removed', () => {
     const comp1 = createComputer('z')
     let l = addPlayer(TEAM_MELEE_4, 1, 0, comp1)
-    const comp2 = l.teams.get(1)!.slots.get(1)!
+    const comp2 = l.teams[1].slots[1]
     expect(comp2.type).toBe('computer')
     expect(comp2.race).toBe(comp1.race)
     l = removePlayer(l, 1, 0, comp1)!
 
     expect(humanSlotCount(l)).toBe(1)
     expect(hasOpposingSides(l)).toBe(false)
-    expect(l.teams.get(1)!.slots.get(0)!.type).toBe('open')
-    expect(l.teams.get(1)!.slots.get(1)!.type).toBe('open')
+    expect(l.teams[1].slots[0].type).toBe('open')
+    expect(l.teams[1].slots[1].type).toBe('open')
 
     expect(l.host.userId).toBe(HOST_USER_ID)
   })
@@ -797,13 +797,13 @@ describe('Lobbies - Team melee', () => {
     expect(humanSlotCount(l)).toBe(1)
     expect(hasOpposingSides(l)).toBe(false)
     expect(l.host).toEqual(babo)
-    expect(l.teams.get(0)!.slots.get(1)).toEqual(babo)
-    const controlledOpen = l.teams.get(0)!.slots.get(0)!
+    expect(l.teams[0].slots[1]).toEqual(babo)
+    const controlledOpen = l.teams[0].slots[0]
     evaluateControlledSlot(controlledOpen, 'controlledOpen', 'r', babo.id)
     // Ensure the player in the leaving player's slot got a new ID
     expect(controlledOpen.id).not.toEqual(TEAM_MELEE_2.host.id)
-    evaluateControlledSlot(l.teams.get(0)!.slots.get(2)!, 'controlledOpen', 'r', babo.id)
-    evaluateControlledSlot(l.teams.get(0)!.slots.get(3)!, 'controlledOpen', 'r', babo.id)
+    evaluateControlledSlot(l.teams[0].slots[2], 'controlledOpen', 'r', babo.id)
+    evaluateControlledSlot(l.teams[0].slots[3], 'controlledOpen', 'r', babo.id)
   })
 
   test('should support moving players between slots in the same team', () => {
@@ -814,34 +814,34 @@ describe('Lobbies - Team melee', () => {
     expect(humanSlotCount(l)).toBe(2)
     expect(hasOpposingSides(l)).toBe(false)
 
-    evaluateControlledSlot(l.teams.get(0)!.slots.get(1)!, 'controlledOpen', 'r', l.host.id)
-    evaluateControlledSlot(l.teams.get(0)!.slots.get(3)!, 'controlledOpen', l.host.race, l.host.id)
+    evaluateControlledSlot(l.teams[0].slots[1], 'controlledOpen', 'r', l.host.id)
+    evaluateControlledSlot(l.teams[0].slots[3], 'controlledOpen', l.host.race, l.host.id)
   })
 
   test('should support closing an open slot', () => {
     let lobby = TEAM_MELEE_2
-    expect(lobby.teams.get(0)!.slots.get(0)).toEqual(lobby.host)
-    const openSlot = lobby.teams.get(0)!.slots.get(1)!
+    expect(lobby.teams[0].slots[0]).toEqual(lobby.host)
+    const openSlot = lobby.teams[0].slots[1]
     expect(openSlot.type).toBe('controlledOpen')
-    expect(lobby.teams.get(0)!.slots.get(2)!.type).toBe('controlledOpen')
-    expect(lobby.teams.get(0)!.slots.get(3)!.type).toBe('controlledOpen')
-    expect(lobby.teams.get(1)!.slots.get(0)!.type).toBe('open')
-    expect(lobby.teams.get(1)!.slots.get(1)!.type).toBe('open')
-    expect(lobby.teams.get(1)!.slots.get(2)!.type).toBe('open')
-    expect(lobby.teams.get(1)!.slots.get(3)!.type).toBe('open')
+    expect(lobby.teams[0].slots[2].type).toBe('controlledOpen')
+    expect(lobby.teams[0].slots[3].type).toBe('controlledOpen')
+    expect(lobby.teams[1].slots[0].type).toBe('open')
+    expect(lobby.teams[1].slots[1].type).toBe('open')
+    expect(lobby.teams[1].slots[2].type).toBe('open')
+    expect(lobby.teams[1].slots[3].type).toBe('open')
 
     lobby = closeSlot(lobby, 0, 1)
-    expect(lobby.teams.get(0)!.slots.get(0)).toEqual(lobby.host)
-    const closedSlot = lobby.teams.get(0)!.slots.get(1)!
+    expect(lobby.teams[0].slots[0]).toEqual(lobby.host)
+    const closedSlot = lobby.teams[0].slots[1]
     expect(closedSlot.type).toBe('controlledClosed')
     expect(closedSlot.race).toBe(openSlot.race)
     expect(closedSlot.controlledBy).toBe(openSlot.controlledBy)
-    expect(lobby.teams.get(0)!.slots.get(2)!.type).toBe('controlledOpen')
-    expect(lobby.teams.get(0)!.slots.get(3)!.type).toBe('controlledOpen')
-    expect(lobby.teams.get(1)!.slots.get(0)!.type).toBe('open')
-    expect(lobby.teams.get(1)!.slots.get(1)!.type).toBe('open')
-    expect(lobby.teams.get(1)!.slots.get(2)!.type).toBe('open')
-    expect(lobby.teams.get(1)!.slots.get(3)!.type).toBe('open')
+    expect(lobby.teams[0].slots[2].type).toBe('controlledOpen')
+    expect(lobby.teams[0].slots[3].type).toBe('controlledOpen')
+    expect(lobby.teams[1].slots[0].type).toBe('open')
+    expect(lobby.teams[1].slots[1].type).toBe('open')
+    expect(lobby.teams[1].slots[2].type).toBe('open')
+    expect(lobby.teams[1].slots[3].type).toBe('open')
 
     expect(() => closeSlot(lobby, 0, 0)).toThrow()
     expect(() => closeSlot(lobby, 0, 1)).toThrow()
@@ -849,43 +849,43 @@ describe('Lobbies - Team melee', () => {
 
   test('should support opening a closed slot', () => {
     let lobby = TEAM_MELEE_2
-    expect(lobby.teams.get(0)!.slots.get(0)).toEqual(lobby.host)
-    const openSlot1 = lobby.teams.get(0)!.slots.get(1)!
+    expect(lobby.teams[0].slots[0]).toEqual(lobby.host)
+    const openSlot1 = lobby.teams[0].slots[1]
     expect(openSlot1.type).toBe('controlledOpen')
     expect(openSlot1.race).toBe(lobby.host.race)
     expect(openSlot1.controlledBy).toBe(lobby.host.id)
-    expect(lobby.teams.get(0)!.slots.get(2)!.type).toBe('controlledOpen')
-    expect(lobby.teams.get(0)!.slots.get(3)!.type).toBe('controlledOpen')
-    expect(lobby.teams.get(1)!.slots.get(0)!.type).toBe('open')
-    expect(lobby.teams.get(1)!.slots.get(1)!.type).toBe('open')
-    expect(lobby.teams.get(1)!.slots.get(2)!.type).toBe('open')
-    expect(lobby.teams.get(1)!.slots.get(3)!.type).toBe('open')
+    expect(lobby.teams[0].slots[2].type).toBe('controlledOpen')
+    expect(lobby.teams[0].slots[3].type).toBe('controlledOpen')
+    expect(lobby.teams[1].slots[0].type).toBe('open')
+    expect(lobby.teams[1].slots[1].type).toBe('open')
+    expect(lobby.teams[1].slots[2].type).toBe('open')
+    expect(lobby.teams[1].slots[3].type).toBe('open')
 
     lobby = closeSlot(lobby, 0, 1)
-    expect(lobby.teams.get(0)!.slots.get(0)).toEqual(lobby.host)
-    const closedSlot = lobby.teams.get(0)!.slots.get(1)!
+    expect(lobby.teams[0].slots[0]).toEqual(lobby.host)
+    const closedSlot = lobby.teams[0].slots[1]
     expect(closedSlot.type).toBe('controlledClosed')
     expect(closedSlot.race).toBe(openSlot1.race)
     expect(closedSlot.controlledBy).toBe(openSlot1.controlledBy)
-    expect(lobby.teams.get(0)!.slots.get(2)!.type).toBe('controlledOpen')
-    expect(lobby.teams.get(0)!.slots.get(3)!.type).toBe('controlledOpen')
-    expect(lobby.teams.get(1)!.slots.get(0)!.type).toBe('open')
-    expect(lobby.teams.get(1)!.slots.get(1)!.type).toBe('open')
-    expect(lobby.teams.get(1)!.slots.get(2)!.type).toBe('open')
-    expect(lobby.teams.get(1)!.slots.get(3)!.type).toBe('open')
+    expect(lobby.teams[0].slots[2].type).toBe('controlledOpen')
+    expect(lobby.teams[0].slots[3].type).toBe('controlledOpen')
+    expect(lobby.teams[1].slots[0].type).toBe('open')
+    expect(lobby.teams[1].slots[1].type).toBe('open')
+    expect(lobby.teams[1].slots[2].type).toBe('open')
+    expect(lobby.teams[1].slots[3].type).toBe('open')
 
     lobby = openSlot(lobby, 0, 1)
-    expect(lobby.teams.get(0)!.slots.get(0)).toEqual(lobby.host)
-    const openSlot2 = lobby.teams.get(0)!.slots.get(1)!
+    expect(lobby.teams[0].slots[0]).toEqual(lobby.host)
+    const openSlot2 = lobby.teams[0].slots[1]
     expect(openSlot2.type).toBe('controlledOpen')
     expect(openSlot2.race).toBe(closedSlot.race)
     expect(openSlot2.controlledBy).toBe(closedSlot.controlledBy)
-    expect(lobby.teams.get(0)!.slots.get(2)!.type).toBe('controlledOpen')
-    expect(lobby.teams.get(0)!.slots.get(3)!.type).toBe('controlledOpen')
-    expect(lobby.teams.get(1)!.slots.get(0)!.type).toBe('open')
-    expect(lobby.teams.get(1)!.slots.get(1)!.type).toBe('open')
-    expect(lobby.teams.get(1)!.slots.get(2)!.type).toBe('open')
-    expect(lobby.teams.get(1)!.slots.get(3)!.type).toBe('open')
+    expect(lobby.teams[0].slots[2].type).toBe('controlledOpen')
+    expect(lobby.teams[0].slots[3].type).toBe('controlledOpen')
+    expect(lobby.teams[1].slots[0].type).toBe('open')
+    expect(lobby.teams[1].slots[1].type).toBe('open')
+    expect(lobby.teams[1].slots[2].type).toBe('open')
+    expect(lobby.teams[1].slots[3].type).toBe('open')
 
     expect(() => openSlot(lobby, 0, 0)).toThrow()
     expect(() => openSlot(lobby, 0, 1)).toThrow()
@@ -894,14 +894,14 @@ describe('Lobbies - Team melee', () => {
   test('should only allow a single race for computer teams', () => {
     const comp = createComputer('t')
     let lobby = addPlayer(TEAM_MELEE_3, 1, 0, comp)
-    expect(lobby.teams.get(1)!.slots.get(0)).toEqual(comp)
-    expect(lobby.teams.get(1)!.slots.get(1)!.race).toBe('t')
-    expect(lobby.teams.get(1)!.slots.get(2)!.race).toBe('t')
+    expect(lobby.teams[1].slots[0]).toEqual(comp)
+    expect(lobby.teams[1].slots[1].race).toBe('t')
+    expect(lobby.teams[1].slots[2].race).toBe('t')
 
     lobby = setRace(lobby, 1, 1, 'r')
-    expect(lobby.teams.get(1)!.slots.get(0)!.race).toBe('r')
-    expect(lobby.teams.get(1)!.slots.get(1)!.race).toBe('r')
-    expect(lobby.teams.get(1)!.slots.get(2)!.race).toBe('r')
+    expect(lobby.teams[1].slots[0].race).toBe('r')
+    expect(lobby.teams[1].slots[1].race).toBe('r')
+    expect(lobby.teams[1].slots[2].race).toBe('r')
   })
 })
 
@@ -1137,7 +1137,7 @@ const evaluateUmsLobby = (
   opposingSides: boolean,
   host: Slot,
 ) => {
-  expect(lobby.teams).toHaveProperty('size', teamCount)
+  expect(lobby.teams).toHaveLength(teamCount)
   expect(humanSlotCount(lobby)).toBe(humanSlotsCount)
   expect(hasOpposingSides(lobby)).toBe(opposingSides)
   expect(host).toEqual(lobby.host)
@@ -1150,8 +1150,8 @@ const evaluateUmsTeam = (
   hiddenSlotsCount: number,
 ) => {
   expect(team.teamId).toBe(teamId)
-  expect(team.slots).toHaveProperty('size', slotsCount)
-  expect(team.hiddenSlots).toHaveProperty('size', hiddenSlotsCount)
+  expect(team.slots).toHaveLength(slotsCount)
+  expect(team.hiddenSlots).toHaveLength(hiddenSlotsCount)
 }
 
 const evaluateUmsSlot = (
@@ -1172,229 +1172,229 @@ const evaluateUmsSlot = (
 describe('Lobbies - Use map settings', () => {
   test('should create the lobby correctly', () => {
     const l1 = UMS_LOBBY_1
-    let team1 = l1.teams.get(0)!
-    let team2 = l1.teams.get(1)!
-    let team3 = l1.teams.get(2)!
-    evaluateUmsLobby(l1, 3, 1, true, team1.slots.get(0)!)
+    let team1 = l1.teams[0]
+    let team2 = l1.teams[1]
+    let team3 = l1.teams[2]
+    evaluateUmsLobby(l1, 3, 1, true, team1.slots[0])
     evaluateUmsTeam(team1, 1, 6, 0)
     evaluateUmsTeam(team2, 2, 1, 0)
     evaluateUmsTeam(team3, 3, 1, 0)
-    evaluateUmsSlot(team1.slots.get(0)!, 'human', HOST_USER_ID, 'z', true, 0)
-    evaluateUmsSlot(team1.slots.get(1)!, 'open', undefined, 'z', true, 1)
-    evaluateUmsSlot(team1.slots.get(2)!, 'open', undefined, 'z', true, 2)
-    evaluateUmsSlot(team1.slots.get(3)!, 'open', undefined, 'z', true, 3)
-    evaluateUmsSlot(team1.slots.get(4)!, 'open', undefined, 'z', true, 4)
-    evaluateUmsSlot(team1.slots.get(5)!, 'open', undefined, 'z', true, 5)
-    evaluateUmsSlot(team2.slots.get(0)!, 'umsComputer', undefined, 'z', true, 7)
-    evaluateUmsSlot(team3.slots.get(0)!, 'umsComputer', undefined, 'z', true, 6)
+    evaluateUmsSlot(team1.slots[0], 'human', HOST_USER_ID, 'z', true, 0)
+    evaluateUmsSlot(team1.slots[1], 'open', undefined, 'z', true, 1)
+    evaluateUmsSlot(team1.slots[2], 'open', undefined, 'z', true, 2)
+    evaluateUmsSlot(team1.slots[3], 'open', undefined, 'z', true, 3)
+    evaluateUmsSlot(team1.slots[4], 'open', undefined, 'z', true, 4)
+    evaluateUmsSlot(team1.slots[5], 'open', undefined, 'z', true, 5)
+    evaluateUmsSlot(team2.slots[0], 'umsComputer', undefined, 'z', true, 7)
+    evaluateUmsSlot(team3.slots[0], 'umsComputer', undefined, 'z', true, 6)
 
     const l2 = UMS_LOBBY_2
-    team1 = l2.teams.get(0)!
-    team2 = l2.teams.get(1)!
-    team3 = l2.teams.get(2)!
-    evaluateUmsLobby(l2, 3, 1, true, team1.slots.get(0)!)
+    team1 = l2.teams[0]
+    team2 = l2.teams[1]
+    team3 = l2.teams[2]
+    evaluateUmsLobby(l2, 3, 1, true, team1.slots[0])
     evaluateUmsTeam(team1, 1, 1, 0)
     evaluateUmsTeam(team2, 2, 6, 0)
     evaluateUmsTeam(team3, 4, 1, 0)
-    evaluateUmsSlot(team1.slots.get(0)!, 'human', HOST_USER_ID, 't', true, 1)
-    evaluateUmsSlot(team2.slots.get(0)!, 'umsComputer', undefined, 't', true, 0)
-    evaluateUmsSlot(team2.slots.get(1)!, 'umsComputer', undefined, 'z', true, 3)
-    evaluateUmsSlot(team2.slots.get(2)!, 'umsComputer', undefined, 'z', true, 4)
-    evaluateUmsSlot(team2.slots.get(3)!, 'umsComputer', undefined, 'z', true, 5)
-    evaluateUmsSlot(team2.slots.get(4)!, 'umsComputer', undefined, 't', true, 6)
-    evaluateUmsSlot(team2.slots.get(5)!, 'umsComputer', undefined, 'z', true, 7)
-    evaluateUmsSlot(team3.slots.get(0)!, 'umsComputer', undefined, 'p', true, 2)
+    evaluateUmsSlot(team1.slots[0], 'human', HOST_USER_ID, 't', true, 1)
+    evaluateUmsSlot(team2.slots[0], 'umsComputer', undefined, 't', true, 0)
+    evaluateUmsSlot(team2.slots[1], 'umsComputer', undefined, 'z', true, 3)
+    evaluateUmsSlot(team2.slots[2], 'umsComputer', undefined, 'z', true, 4)
+    evaluateUmsSlot(team2.slots[3], 'umsComputer', undefined, 'z', true, 5)
+    evaluateUmsSlot(team2.slots[4], 'umsComputer', undefined, 't', true, 6)
+    evaluateUmsSlot(team2.slots[5], 'umsComputer', undefined, 'z', true, 7)
+    evaluateUmsSlot(team3.slots[0], 'umsComputer', undefined, 'p', true, 2)
 
     const l3 = UMS_LOBBY_3
-    team1 = l3.teams.get(0)!
-    team2 = l3.teams.get(1)!
-    evaluateUmsLobby(l3, 2, 1, false, team1.slots.get(0)!)
+    team1 = l3.teams[0]
+    team2 = l3.teams[1]
+    evaluateUmsLobby(l3, 2, 1, false, team1.slots[0])
     evaluateUmsTeam(team1, 1, 2, 0)
     evaluateUmsTeam(team2, 2, 2, 0)
-    evaluateUmsSlot(team1.slots.get(0)!, 'human', HOST_USER_ID, 'r', false, 0)
-    evaluateUmsSlot(team1.slots.get(1)!, 'open', undefined, 'r', false, 1)
-    evaluateUmsSlot(team2.slots.get(0)!, 'open', undefined, 'p', true, 2)
-    evaluateUmsSlot(team2.slots.get(1)!, 'open', undefined, 't', true, 3)
+    evaluateUmsSlot(team1.slots[0], 'human', HOST_USER_ID, 'r', false, 0)
+    evaluateUmsSlot(team1.slots[1], 'open', undefined, 'r', false, 1)
+    evaluateUmsSlot(team2.slots[0], 'open', undefined, 'p', true, 2)
+    evaluateUmsSlot(team2.slots[1], 'open', undefined, 't', true, 3)
 
     const l4 = UMS_LOBBY_4
-    team1 = l4.teams.get(0)!
-    team2 = l4.teams.get(1)!
-    team3 = l4.teams.get(2)!
-    const team4 = l4.teams.get(3)!
-    evaluateUmsLobby(l4, 4, 1, false, team1.slots.get(0)!)
+    team1 = l4.teams[0]
+    team2 = l4.teams[1]
+    team3 = l4.teams[2]
+    const team4 = l4.teams[3]
+    evaluateUmsLobby(l4, 4, 1, false, team1.slots[0])
     evaluateUmsTeam(team1, 1, 3, 0)
     evaluateUmsTeam(team2, 2, 3, 0)
     evaluateUmsTeam(team3, 3, 0, 1)
     evaluateUmsTeam(team4, 4, 0, 1)
-    evaluateUmsSlot(team1.slots.get(0)!, 'human', HOST_USER_ID, 't', true, 0)
-    evaluateUmsSlot(team1.slots.get(1)!, 'open', undefined, 't', true, 1)
-    evaluateUmsSlot(team1.slots.get(2)!, 'open', undefined, 't', true, 2)
-    evaluateUmsSlot(team2.slots.get(0)!, 'open', undefined, 't', true, 3)
-    evaluateUmsSlot(team2.slots.get(1)!, 'open', undefined, 't', true, 4)
-    evaluateUmsSlot(team2.slots.get(2)!, 'open', undefined, 't', true, 5)
-    evaluateUmsSlot(team3.hiddenSlots.get(0)!, 'umsComputer', undefined, 't', true, 6)
-    evaluateUmsSlot(team4.hiddenSlots.get(0)!, 'umsComputer', undefined, 't', true, 7)
+    evaluateUmsSlot(team1.slots[0], 'human', HOST_USER_ID, 't', true, 0)
+    evaluateUmsSlot(team1.slots[1], 'open', undefined, 't', true, 1)
+    evaluateUmsSlot(team1.slots[2], 'open', undefined, 't', true, 2)
+    evaluateUmsSlot(team2.slots[0], 'open', undefined, 't', true, 3)
+    evaluateUmsSlot(team2.slots[1], 'open', undefined, 't', true, 4)
+    evaluateUmsSlot(team2.slots[2], 'open', undefined, 't', true, 5)
+    evaluateUmsSlot(team3.hiddenSlots[0], 'umsComputer', undefined, 't', true, 6)
+    evaluateUmsSlot(team4.hiddenSlots[0], 'umsComputer', undefined, 't', true, 7)
   })
 
   test('should support removing players', () => {
     const babo = createHuman(makeSbUserId(1), 'z', true, 1)
     let lobby = addPlayer(UMS_LOBBY_1, 0, 1, babo)
 
-    let team1 = lobby.teams.get(0)!
-    evaluateUmsLobby(lobby, 3, 2, true, team1.slots.get(0)!)
-    evaluateUmsSlot(team1.slots.get(1)!, 'human', makeSbUserId(1), 'z', true, 1)
+    let team1 = lobby.teams[0]
+    evaluateUmsLobby(lobby, 3, 2, true, team1.slots[0])
+    evaluateUmsSlot(team1.slots[1], 'human', makeSbUserId(1), 'z', true, 1)
 
-    lobby = removePlayer(lobby, 0, 1, team1.slots.get(1)!)!
-    team1 = lobby.teams.get(0)!
-    evaluateUmsLobby(lobby, 3, 1, true, team1.slots.get(0)!)
-    evaluateUmsSlot(team1.slots.get(1)!, 'open', undefined, 'z', true, 1)
+    lobby = removePlayer(lobby, 0, 1, team1.slots[1])!
+    team1 = lobby.teams[0]
+    evaluateUmsLobby(lobby, 3, 1, true, team1.slots[0])
+    evaluateUmsSlot(team1.slots[1], 'open', undefined, 'z', true, 1)
   })
 
   test('should support moving players between slots', () => {
     let l1 = UMS_LOBBY_1
-    let team1 = l1.teams.get(0)!
-    let team2 = l1.teams.get(1)!
-    let team3 = l1.teams.get(2)!
-    evaluateUmsLobby(l1, 3, 1, true, team1.slots.get(0)!)
+    let team1 = l1.teams[0]
+    let team2 = l1.teams[1]
+    let team3 = l1.teams[2]
+    evaluateUmsLobby(l1, 3, 1, true, team1.slots[0])
     evaluateUmsTeam(team1, 1, 6, 0)
     evaluateUmsTeam(team2, 2, 1, 0)
     evaluateUmsTeam(team3, 3, 1, 0)
-    evaluateUmsSlot(team1.slots.get(0)!, 'human', HOST_USER_ID, 'z', true, 0)
-    evaluateUmsSlot(team1.slots.get(1)!, 'open', undefined, 'z', true, 1)
-    evaluateUmsSlot(team1.slots.get(2)!, 'open', undefined, 'z', true, 2)
-    evaluateUmsSlot(team1.slots.get(3)!, 'open', undefined, 'z', true, 3)
-    evaluateUmsSlot(team1.slots.get(4)!, 'open', undefined, 'z', true, 4)
-    evaluateUmsSlot(team1.slots.get(5)!, 'open', undefined, 'z', true, 5)
-    evaluateUmsSlot(team2.slots.get(0)!, 'umsComputer', undefined, 'z', true, 7)
-    evaluateUmsSlot(team3.slots.get(0)!, 'umsComputer', undefined, 'z', true, 6)
+    evaluateUmsSlot(team1.slots[0], 'human', HOST_USER_ID, 'z', true, 0)
+    evaluateUmsSlot(team1.slots[1], 'open', undefined, 'z', true, 1)
+    evaluateUmsSlot(team1.slots[2], 'open', undefined, 'z', true, 2)
+    evaluateUmsSlot(team1.slots[3], 'open', undefined, 'z', true, 3)
+    evaluateUmsSlot(team1.slots[4], 'open', undefined, 'z', true, 4)
+    evaluateUmsSlot(team1.slots[5], 'open', undefined, 'z', true, 5)
+    evaluateUmsSlot(team2.slots[0], 'umsComputer', undefined, 'z', true, 7)
+    evaluateUmsSlot(team3.slots[0], 'umsComputer', undefined, 'z', true, 6)
 
     l1 = movePlayerToSlot(l1, 0, 0, 0, 1)
-    team1 = l1.teams.get(0)!
-    team2 = l1.teams.get(1)!
-    team3 = l1.teams.get(2)!
-    evaluateUmsLobby(l1, 3, 1, true, team1.slots.get(1)!)
+    team1 = l1.teams[0]
+    team2 = l1.teams[1]
+    team3 = l1.teams[2]
+    evaluateUmsLobby(l1, 3, 1, true, team1.slots[1])
     evaluateUmsTeam(team1, 1, 6, 0)
     evaluateUmsTeam(team2, 2, 1, 0)
     evaluateUmsTeam(team3, 3, 1, 0)
-    evaluateUmsSlot(team1.slots.get(0)!, 'open', undefined, 'z', true, 0)
-    evaluateUmsSlot(team1.slots.get(1)!, 'human', HOST_USER_ID, 'z', true, 1)
-    evaluateUmsSlot(team1.slots.get(2)!, 'open', undefined, 'z', true, 2)
-    evaluateUmsSlot(team1.slots.get(3)!, 'open', undefined, 'z', true, 3)
-    evaluateUmsSlot(team1.slots.get(4)!, 'open', undefined, 'z', true, 4)
-    evaluateUmsSlot(team1.slots.get(5)!, 'open', undefined, 'z', true, 5)
-    evaluateUmsSlot(team2.slots.get(0)!, 'umsComputer', undefined, 'z', true, 7)
-    evaluateUmsSlot(team3.slots.get(0)!, 'umsComputer', undefined, 'z', true, 6)
+    evaluateUmsSlot(team1.slots[0], 'open', undefined, 'z', true, 0)
+    evaluateUmsSlot(team1.slots[1], 'human', HOST_USER_ID, 'z', true, 1)
+    evaluateUmsSlot(team1.slots[2], 'open', undefined, 'z', true, 2)
+    evaluateUmsSlot(team1.slots[3], 'open', undefined, 'z', true, 3)
+    evaluateUmsSlot(team1.slots[4], 'open', undefined, 'z', true, 4)
+    evaluateUmsSlot(team1.slots[5], 'open', undefined, 'z', true, 5)
+    evaluateUmsSlot(team2.slots[0], 'umsComputer', undefined, 'z', true, 7)
+    evaluateUmsSlot(team3.slots[0], 'umsComputer', undefined, 'z', true, 6)
 
     let l3 = UMS_LOBBY_3
-    team1 = l3.teams.get(0)!
-    team2 = l3.teams.get(1)!
-    evaluateUmsLobby(l3, 2, 1, false, team1.slots.get(0)!)
+    team1 = l3.teams[0]
+    team2 = l3.teams[1]
+    evaluateUmsLobby(l3, 2, 1, false, team1.slots[0])
     evaluateUmsTeam(team1, 1, 2, 0)
     evaluateUmsTeam(team2, 2, 2, 0)
-    evaluateUmsSlot(team1.slots.get(0)!, 'human', HOST_USER_ID, 'r', false, 0)
-    evaluateUmsSlot(team1.slots.get(1)!, 'open', undefined, 'r', false, 1)
-    evaluateUmsSlot(team2.slots.get(0)!, 'open', undefined, 'p', true, 2)
-    evaluateUmsSlot(team2.slots.get(1)!, 'open', undefined, 't', true, 3)
+    evaluateUmsSlot(team1.slots[0], 'human', HOST_USER_ID, 'r', false, 0)
+    evaluateUmsSlot(team1.slots[1], 'open', undefined, 'r', false, 1)
+    evaluateUmsSlot(team2.slots[0], 'open', undefined, 'p', true, 2)
+    evaluateUmsSlot(team2.slots[1], 'open', undefined, 't', true, 3)
 
     l3 = movePlayerToSlot(l3, 0, 0, 0, 1)
-    team1 = l3.teams.get(0)!
-    team2 = l3.teams.get(1)!
-    evaluateUmsLobby(l3, 2, 1, false, team1.slots.get(1)!)
+    team1 = l3.teams[0]
+    team2 = l3.teams[1]
+    evaluateUmsLobby(l3, 2, 1, false, team1.slots[1])
     evaluateUmsTeam(team1, 1, 2, 0)
     evaluateUmsTeam(team2, 2, 2, 0)
-    evaluateUmsSlot(team1.slots.get(0)!, 'open', undefined, 'r', false, 0)
-    evaluateUmsSlot(team1.slots.get(1)!, 'human', HOST_USER_ID, 'r', false, 1)
-    evaluateUmsSlot(team2.slots.get(0)!, 'open', undefined, 'p', true, 2)
-    evaluateUmsSlot(team2.slots.get(1)!, 'open', undefined, 't', true, 3)
+    evaluateUmsSlot(team1.slots[0], 'open', undefined, 'r', false, 0)
+    evaluateUmsSlot(team1.slots[1], 'human', HOST_USER_ID, 'r', false, 1)
+    evaluateUmsSlot(team2.slots[0], 'open', undefined, 'p', true, 2)
+    evaluateUmsSlot(team2.slots[1], 'open', undefined, 't', true, 3)
   })
 
   test('should support closing an open slot', () => {
     let l1 = UMS_LOBBY_1
-    let team1 = l1.teams.get(0)!
-    let team2 = l1.teams.get(1)!
-    let team3 = l1.teams.get(2)!
-    evaluateUmsLobby(l1, 3, 1, true, team1.slots.get(0)!)
+    let team1 = l1.teams[0]
+    let team2 = l1.teams[1]
+    let team3 = l1.teams[2]
+    evaluateUmsLobby(l1, 3, 1, true, team1.slots[0])
     evaluateUmsTeam(team1, 1, 6, 0)
     evaluateUmsTeam(team2, 2, 1, 0)
     evaluateUmsTeam(team3, 3, 1, 0)
-    evaluateUmsSlot(team1.slots.get(0)!, 'human', HOST_USER_ID, 'z', true, 0)
-    evaluateUmsSlot(team1.slots.get(1)!, 'open', undefined, 'z', true, 1)
-    evaluateUmsSlot(team1.slots.get(2)!, 'open', undefined, 'z', true, 2)
-    evaluateUmsSlot(team1.slots.get(3)!, 'open', undefined, 'z', true, 3)
-    evaluateUmsSlot(team1.slots.get(4)!, 'open', undefined, 'z', true, 4)
-    evaluateUmsSlot(team1.slots.get(5)!, 'open', undefined, 'z', true, 5)
-    evaluateUmsSlot(team2.slots.get(0)!, 'umsComputer', undefined, 'z', true, 7)
-    evaluateUmsSlot(team3.slots.get(0)!, 'umsComputer', undefined, 'z', true, 6)
+    evaluateUmsSlot(team1.slots[0], 'human', HOST_USER_ID, 'z', true, 0)
+    evaluateUmsSlot(team1.slots[1], 'open', undefined, 'z', true, 1)
+    evaluateUmsSlot(team1.slots[2], 'open', undefined, 'z', true, 2)
+    evaluateUmsSlot(team1.slots[3], 'open', undefined, 'z', true, 3)
+    evaluateUmsSlot(team1.slots[4], 'open', undefined, 'z', true, 4)
+    evaluateUmsSlot(team1.slots[5], 'open', undefined, 'z', true, 5)
+    evaluateUmsSlot(team2.slots[0], 'umsComputer', undefined, 'z', true, 7)
+    evaluateUmsSlot(team3.slots[0], 'umsComputer', undefined, 'z', true, 6)
 
     l1 = closeSlot(l1, 0, 1)
-    team1 = l1.teams.get(0)!
-    team2 = l1.teams.get(1)!
-    team3 = l1.teams.get(2)!
-    evaluateUmsLobby(l1, 3, 1, true, team1.slots.get(0)!)
+    team1 = l1.teams[0]
+    team2 = l1.teams[1]
+    team3 = l1.teams[2]
+    evaluateUmsLobby(l1, 3, 1, true, team1.slots[0])
     evaluateUmsTeam(team1, 1, 6, 0)
     evaluateUmsTeam(team2, 2, 1, 0)
     evaluateUmsTeam(team3, 3, 1, 0)
-    evaluateUmsSlot(team1.slots.get(0)!, 'human', HOST_USER_ID, 'z', true, 0)
-    evaluateUmsSlot(team1.slots.get(1)!, 'closed', undefined, 'z', true, 1)
-    evaluateUmsSlot(team1.slots.get(2)!, 'open', undefined, 'z', true, 2)
-    evaluateUmsSlot(team1.slots.get(3)!, 'open', undefined, 'z', true, 3)
-    evaluateUmsSlot(team1.slots.get(4)!, 'open', undefined, 'z', true, 4)
-    evaluateUmsSlot(team1.slots.get(5)!, 'open', undefined, 'z', true, 5)
-    evaluateUmsSlot(team2.slots.get(0)!, 'umsComputer', undefined, 'z', true, 7)
-    evaluateUmsSlot(team3.slots.get(0)!, 'umsComputer', undefined, 'z', true, 6)
+    evaluateUmsSlot(team1.slots[0], 'human', HOST_USER_ID, 'z', true, 0)
+    evaluateUmsSlot(team1.slots[1], 'closed', undefined, 'z', true, 1)
+    evaluateUmsSlot(team1.slots[2], 'open', undefined, 'z', true, 2)
+    evaluateUmsSlot(team1.slots[3], 'open', undefined, 'z', true, 3)
+    evaluateUmsSlot(team1.slots[4], 'open', undefined, 'z', true, 4)
+    evaluateUmsSlot(team1.slots[5], 'open', undefined, 'z', true, 5)
+    evaluateUmsSlot(team2.slots[0], 'umsComputer', undefined, 'z', true, 7)
+    evaluateUmsSlot(team3.slots[0], 'umsComputer', undefined, 'z', true, 6)
   })
 
   test('should support opening a closed slot', () => {
     let l1 = UMS_LOBBY_1
-    let team1 = l1.teams.get(0)!
-    let team2 = l1.teams.get(1)!
-    let team3 = l1.teams.get(2)!
-    evaluateUmsLobby(l1, 3, 1, true, team1.slots.get(0)!)
+    let team1 = l1.teams[0]
+    let team2 = l1.teams[1]
+    let team3 = l1.teams[2]
+    evaluateUmsLobby(l1, 3, 1, true, team1.slots[0])
     evaluateUmsTeam(team1, 1, 6, 0)
     evaluateUmsTeam(team2, 2, 1, 0)
     evaluateUmsTeam(team3, 3, 1, 0)
-    evaluateUmsSlot(team1.slots.get(0)!, 'human', HOST_USER_ID, 'z', true, 0)
-    evaluateUmsSlot(team1.slots.get(1)!, 'open', undefined, 'z', true, 1)
-    evaluateUmsSlot(team1.slots.get(2)!, 'open', undefined, 'z', true, 2)
-    evaluateUmsSlot(team1.slots.get(3)!, 'open', undefined, 'z', true, 3)
-    evaluateUmsSlot(team1.slots.get(4)!, 'open', undefined, 'z', true, 4)
-    evaluateUmsSlot(team1.slots.get(5)!, 'open', undefined, 'z', true, 5)
-    evaluateUmsSlot(team2.slots.get(0)!, 'umsComputer', undefined, 'z', true, 7)
-    evaluateUmsSlot(team3.slots.get(0)!, 'umsComputer', undefined, 'z', true, 6)
+    evaluateUmsSlot(team1.slots[0], 'human', HOST_USER_ID, 'z', true, 0)
+    evaluateUmsSlot(team1.slots[1], 'open', undefined, 'z', true, 1)
+    evaluateUmsSlot(team1.slots[2], 'open', undefined, 'z', true, 2)
+    evaluateUmsSlot(team1.slots[3], 'open', undefined, 'z', true, 3)
+    evaluateUmsSlot(team1.slots[4], 'open', undefined, 'z', true, 4)
+    evaluateUmsSlot(team1.slots[5], 'open', undefined, 'z', true, 5)
+    evaluateUmsSlot(team2.slots[0], 'umsComputer', undefined, 'z', true, 7)
+    evaluateUmsSlot(team3.slots[0], 'umsComputer', undefined, 'z', true, 6)
 
     l1 = closeSlot(l1, 0, 1)
-    team1 = l1.teams.get(0)!
-    team2 = l1.teams.get(1)!
-    team3 = l1.teams.get(2)!
-    evaluateUmsLobby(l1, 3, 1, true, team1.slots.get(0)!)
+    team1 = l1.teams[0]
+    team2 = l1.teams[1]
+    team3 = l1.teams[2]
+    evaluateUmsLobby(l1, 3, 1, true, team1.slots[0])
     evaluateUmsTeam(team1, 1, 6, 0)
     evaluateUmsTeam(team2, 2, 1, 0)
     evaluateUmsTeam(team3, 3, 1, 0)
-    evaluateUmsSlot(team1.slots.get(0)!, 'human', HOST_USER_ID, 'z', true, 0)
-    evaluateUmsSlot(team1.slots.get(1)!, 'closed', undefined, 'z', true, 1)
-    evaluateUmsSlot(team1.slots.get(2)!, 'open', undefined, 'z', true, 2)
-    evaluateUmsSlot(team1.slots.get(3)!, 'open', undefined, 'z', true, 3)
-    evaluateUmsSlot(team1.slots.get(4)!, 'open', undefined, 'z', true, 4)
-    evaluateUmsSlot(team1.slots.get(5)!, 'open', undefined, 'z', true, 5)
-    evaluateUmsSlot(team2.slots.get(0)!, 'umsComputer', undefined, 'z', true, 7)
-    evaluateUmsSlot(team3.slots.get(0)!, 'umsComputer', undefined, 'z', true, 6)
+    evaluateUmsSlot(team1.slots[0], 'human', HOST_USER_ID, 'z', true, 0)
+    evaluateUmsSlot(team1.slots[1], 'closed', undefined, 'z', true, 1)
+    evaluateUmsSlot(team1.slots[2], 'open', undefined, 'z', true, 2)
+    evaluateUmsSlot(team1.slots[3], 'open', undefined, 'z', true, 3)
+    evaluateUmsSlot(team1.slots[4], 'open', undefined, 'z', true, 4)
+    evaluateUmsSlot(team1.slots[5], 'open', undefined, 'z', true, 5)
+    evaluateUmsSlot(team2.slots[0], 'umsComputer', undefined, 'z', true, 7)
+    evaluateUmsSlot(team3.slots[0], 'umsComputer', undefined, 'z', true, 6)
 
     l1 = openSlot(l1, 0, 1)
-    team1 = l1.teams.get(0)!
-    team2 = l1.teams.get(1)!
-    team3 = l1.teams.get(2)!
-    evaluateUmsLobby(l1, 3, 1, true, team1.slots.get(0)!)
+    team1 = l1.teams[0]
+    team2 = l1.teams[1]
+    team3 = l1.teams[2]
+    evaluateUmsLobby(l1, 3, 1, true, team1.slots[0])
     evaluateUmsTeam(team1, 1, 6, 0)
     evaluateUmsTeam(team2, 2, 1, 0)
     evaluateUmsTeam(team3, 3, 1, 0)
-    evaluateUmsSlot(team1.slots.get(0)!, 'human', HOST_USER_ID, 'z', true, 0)
-    evaluateUmsSlot(team1.slots.get(1)!, 'open', undefined, 'z', true, 1)
-    evaluateUmsSlot(team1.slots.get(2)!, 'open', undefined, 'z', true, 2)
-    evaluateUmsSlot(team1.slots.get(3)!, 'open', undefined, 'z', true, 3)
-    evaluateUmsSlot(team1.slots.get(4)!, 'open', undefined, 'z', true, 4)
-    evaluateUmsSlot(team1.slots.get(5)!, 'open', undefined, 'z', true, 5)
-    evaluateUmsSlot(team2.slots.get(0)!, 'umsComputer', undefined, 'z', true, 7)
-    evaluateUmsSlot(team3.slots.get(0)!, 'umsComputer', undefined, 'z', true, 6)
+    evaluateUmsSlot(team1.slots[0], 'human', HOST_USER_ID, 'z', true, 0)
+    evaluateUmsSlot(team1.slots[1], 'open', undefined, 'z', true, 1)
+    evaluateUmsSlot(team1.slots[2], 'open', undefined, 'z', true, 2)
+    evaluateUmsSlot(team1.slots[3], 'open', undefined, 'z', true, 3)
+    evaluateUmsSlot(team1.slots[4], 'open', undefined, 'z', true, 4)
+    evaluateUmsSlot(team1.slots[5], 'open', undefined, 'z', true, 5)
+    evaluateUmsSlot(team2.slots[0], 'umsComputer', undefined, 'z', true, 7)
+    evaluateUmsSlot(team3.slots[0], 'umsComputer', undefined, 'z', true, 6)
   })
 })
 
@@ -1446,10 +1446,10 @@ describe('Lobbies - observers', () => {
         allowObservers: true,
       })
 
-      expect(lobby.teams).toHaveProperty('size', playerTeams + 1)
+      expect(lobby.teams).toHaveLength(playerTeams + 1)
       const [obsTeamIndex, obsTeam] = getObserverTeam(lobby)
       expect(obsTeamIndex).toBe(playerTeams)
-      expect(obsTeam!.slots).toHaveProperty('size', MAX_OBSERVERS)
+      expect(obsTeam!.slots).toHaveLength(MAX_OBSERVERS)
       expect(obsTeam!.slots.every(s => s.type === 'closed')).toBe(true)
       // Observer slots are in addition to the map's player slots, not carved out of them
       expect(slotCount(lobby)).toBe(numSlots)
@@ -1469,7 +1469,7 @@ describe('Lobbies - observers', () => {
       allowObservers: false,
     })
 
-    expect(lobby.teams).toHaveProperty('size', 2)
+    expect(lobby.teams).toHaveLength(2)
     expect(getObserverTeam(lobby)[0]).toBeUndefined()
     expect(canAddObservers(lobby)).toBe(false)
     expect(canRemoveObservers(lobby)).toBe(false)
@@ -1506,35 +1506,30 @@ describe('Lobbies - observers', () => {
 
   test('should keep the observer team out of team melee controlled slot handling', () => {
     let lobby = TEAM_MELEE_WITH_OBSERVERS
-    expect(lobby.teams).toHaveProperty('size', 3)
-    expect(lobby.teams.get(0)!.slots.get(1)!.type).toBe('controlledOpen')
+    expect(lobby.teams).toHaveLength(3)
+    expect(lobby.teams[0].slots[1].type).toBe('controlledOpen')
 
     lobby = makeObserver(lobby, 0, 0)
 
     // The team the host left has no one controlling it anymore, so it becomes plain open slots
-    const vacatedTeam = lobby.teams.get(0)!
-    expect(vacatedTeam.slots).toHaveProperty('size', 4)
+    const vacatedTeam = lobby.teams[0]
+    expect(vacatedTeam.slots).toHaveLength(4)
     expect(vacatedTeam.slots.every(s => s.type === 'open')).toBe(true)
-    const observers = lobby.teams.get(2)!
-    expect(observers.slots).toHaveProperty('size', MAX_OBSERVERS)
-    expect(observers.slots.get(0)!.type).toBe('observer')
-    expect(observers.slots.get(0)!.userId).toBe(HOST_USER_ID)
-    expect(observers.slots.get(1)!.type).toBe('closed')
+    const observers = lobby.teams[2]
+    expect(observers.slots).toHaveLength(MAX_OBSERVERS)
+    expect(observers.slots[0].type).toBe('observer')
+    expect(observers.slots[0].userId).toBe(HOST_USER_ID)
+    expect(observers.slots[1].type).toBe('closed')
 
     lobby = removeObserver(lobby, 0)
 
-    expect(lobby.teams.get(2)!.slots.get(0)!.type).toBe('open')
-    expect(
-      lobby.teams
-        .get(2)!
-        .slots.skip(1)
-        .every(s => s.type === 'closed'),
-    ).toBe(true)
+    expect(lobby.teams[2].slots[0].type).toBe('open')
+    expect(lobby.teams[2].slots.slice(1).every(s => s.type === 'closed')).toBe(true)
     const [teamIndex, , hostSlot] = findSlotByUserId(lobby, HOST_USER_ID)
     expect(hostSlot!.type).toBe('human')
     // Arriving in an empty controlled team fills the rest of it with slots the host controls
-    const destTeam = lobby.teams.get(teamIndex!)!
-    expect(destTeam.slots.count(s => s.type === 'controlledOpen')).toBe(3)
+    const destTeam = lobby.teams[teamIndex!]
+    expect(destTeam.slots.filter(s => s.type === 'controlledOpen').length).toBe(3)
     expect(destTeam.slots.every(s => s.type === 'human' || s.controlledBy === hostSlot!.id)).toBe(
       true,
     )
@@ -1542,17 +1537,17 @@ describe('Lobbies - observers', () => {
 
   test('should preserve UMS slot data across moves into and out of the observer team', () => {
     let lobby = UMS_LOBBY_WITH_OBSERVERS
-    expect(lobby.teams).toHaveProperty('size', 3)
+    expect(lobby.teams).toHaveLength(3)
     lobby = addPlayer(lobby, 1, 0, createHuman(makeSbUserId(1), 'p', true, 2))
 
     lobby = makeObserver(lobby, 0, 0)
 
-    const obsSlot = lobby.teams.get(2)!.slots.get(0)!
+    const obsSlot = lobby.teams[2].slots[0]
     expect(obsSlot.type).toBe('observer')
     expect(obsSlot.userId).toBe(HOST_USER_ID)
     expect(lobby.host.id).toBe(obsSlot.id)
     // The slot they left keeps the map-defined player id and race
-    evaluateUmsSlot(lobby.teams.get(0)!.slots.get(0)!, 'open', undefined, 'r', false, 0)
+    evaluateUmsSlot(lobby.teams[0].slots[0], 'open', undefined, 'r', false, 0)
 
     const observerInfos = getPlayerInfos(lobby).filter(p => p.type === 'observer')
     expect(observerInfos).toHaveLength(1)
@@ -1560,10 +1555,10 @@ describe('Lobbies - observers', () => {
 
     lobby = removeObserver(lobby, 0)
 
-    expect(lobby.teams.get(2)!.slots.get(0)!.type).toBe('open')
+    expect(lobby.teams[2].slots[0].type).toBe('open')
     // A vacated observer slot carries no UMS map data
-    expect(lobby.teams.get(2)!.slots.get(0)!.hasForcedRace).toBe(false)
-    evaluateUmsSlot(lobby.teams.get(0)!.slots.get(0)!, 'human', HOST_USER_ID, 'r', false, 0)
+    expect(lobby.teams[2].slots[0].hasForcedRace).toBe(false)
+    evaluateUmsSlot(lobby.teams[0].slots[0], 'human', HOST_USER_ID, 'r', false, 0)
   })
 
   test('should leave unoccupied observer slots out of the player infos', () => {
@@ -1584,8 +1579,8 @@ describe('Lobbies - observers', () => {
     let lobby = TEAM_MELEE_WITH_OBSERVERS
     lobby = addPlayer(lobby, 1, 0, createHuman(makeSbUserId(1), 'z'))
     lobby = makeObserver(lobby, 1, 0)
-    const observers = lobby.teams.get(2)!
-    const leaver = observers.slots.get(0)!
+    const observers = lobby.teams[2]
+    const leaver = observers.slots[0]
     expect(leaver.type).toBe('observer')
 
     const updated = removePlayer(lobby, 2, 0, leaver)!
@@ -1593,15 +1588,10 @@ describe('Lobbies - observers', () => {
     expect(updated).toBeDefined()
     // The vacated observer slot is left open for the next joiner, and the player teams are
     // untouched by the leave (no controlled-team cleanup for the observer team)
-    expect(updated.teams.get(2)!.slots.get(0)!.type).toBe('open')
-    expect(
-      updated.teams
-        .get(2)!
-        .slots.skip(1)
-        .every(s => s.type === 'closed'),
-    ).toBe(true)
-    expect(updated.teams.get(0)!.slots.get(0)!.type).toBe('human')
-    expect(updated.teams.get(1)!.slots.every(s => s.type === 'open')).toBe(true)
+    expect(updated.teams[2].slots[0].type).toBe('open')
+    expect(updated.teams[2].slots.slice(1).every(s => s.type === 'closed')).toBe(true)
+    expect(updated.teams[0].slots[0].type).toBe('human')
+    expect(updated.teams[1].slots.every(s => s.type === 'open')).toBe(true)
   })
 
   test('should not create controlled slots when someone joins an observer slot in team melee', () => {
@@ -1610,30 +1600,25 @@ describe('Lobbies - observers', () => {
 
     lobby = addPlayer(lobby, 2, 0, createObserver(makeSbUserId(1)))
 
-    const observers = lobby.teams.get(2)!
-    expect(observers.slots.get(0)!.type).toBe('observer')
-    expect(observers.slots.get(0)!.userId).toBe(makeSbUserId(1))
-    expect(
-      observers.slots.filterNot(s => s.type === 'observer').every(s => s.type === 'closed'),
-    ).toBe(true)
+    const observers = lobby.teams[2]
+    expect(observers.slots[0].type).toBe('observer')
+    expect(observers.slots[0].userId).toBe(makeSbUserId(1))
+    expect(observers.slots.filter(s => s.type !== 'observer').every(s => s.type === 'closed')).toBe(
+      true,
+    )
   })
 
   test('should leave an observer slot open when its occupant changes slots', () => {
     let lobby = BOXER_LOBBY_WITH_OBSERVERS
     lobby = addPlayer(lobby, 0, 1, createHuman(makeSbUserId(1), 'z'))
     lobby = makeObserver(lobby, 0, 1)
-    expect(lobby.teams.get(1)!.slots.get(0)!.type).toBe('observer')
+    expect(lobby.teams[1].slots[0].type).toBe('observer')
 
     lobby = movePlayerToSlot(lobby, 1, 0, 0, 1)
 
-    expect(lobby.teams.get(0)!.slots.get(1)!.type).toBe('human')
-    expect(lobby.teams.get(1)!.slots.get(0)!.type).toBe('open')
-    expect(
-      lobby.teams
-        .get(1)!
-        .slots.skip(1)
-        .every(s => s.type === 'closed'),
-    ).toBe(true)
+    expect(lobby.teams[0].slots[1].type).toBe('human')
+    expect(lobby.teams[1].slots[0].type).toBe('open')
+    expect(lobby.teams[1].slots.slice(1).every(s => s.type === 'closed')).toBe(true)
   })
 
   test('should prefer a closed observer slot when making an observer', () => {
@@ -1644,9 +1629,9 @@ describe('Lobbies - observers', () => {
     lobby = makeObserver(lobby, 0, 1)
 
     // The host-opened slot stays available for joiners; the converted player took a closed one
-    expect(lobby.teams.get(1)!.slots.get(0)!.type).toBe('open')
-    expect(lobby.teams.get(1)!.slots.get(1)!.type).toBe('observer')
-    expect(lobby.teams.get(1)!.slots.get(1)!.userId).toBe(makeSbUserId(1))
+    expect(lobby.teams[1].slots[0].type).toBe('open')
+    expect(lobby.teams[1].slots[1].type).toBe('observer')
+    expect(lobby.teams[1].slots[1].userId).toBe(makeSbUserId(1))
   })
 
   test('should prefer a team with an open slot when unseating an observer', () => {
@@ -1676,7 +1661,7 @@ describe('Lobbies - observers', () => {
     expect(teamIndex).toBe(0)
     expect(slotIndex).toBe(1)
     expect(slot!.type).toBe('human')
-    expect(lobby.teams.get(1)!.slots.every(s => s.type === 'closed')).toBe(true)
+    expect(lobby.teams[1].slots.every(s => s.type === 'closed')).toBe(true)
   })
 
   test('should re-open a closed slot for an unseated observer only when no open slot exists', () => {
@@ -1718,11 +1703,11 @@ describe('Lobbies - observers', () => {
       allowObservers: true,
     })
 
-    expect(lobby.teams).toHaveProperty('size', 5)
-    evaluateUmsTeam(lobby.teams.get(2)!, 3, 0, 1)
-    evaluateUmsTeam(lobby.teams.get(3)!, 4, 0, 1)
-    const observers = lobby.teams.get(4)!
-    expect(observers.slots).toHaveProperty('size', MAX_OBSERVERS)
-    expect(observers.hiddenSlots).toHaveProperty('size', 0)
+    expect(lobby.teams).toHaveLength(5)
+    evaluateUmsTeam(lobby.teams[2], 3, 0, 1)
+    evaluateUmsTeam(lobby.teams[3], 4, 0, 1)
+    const observers = lobby.teams[4]
+    expect(observers.slots).toHaveLength(MAX_OBSERVERS)
+    expect(observers.hiddenSlots).toHaveLength(0)
   })
 })

--- a/server/lib/lobbies/lobby.ts
+++ b/server/lib/lobbies/lobby.ts
@@ -1,4 +1,4 @@
-import { List, Range } from 'immutable'
+import { produce } from 'immer'
 import { randomUUID } from 'node:crypto'
 import { GameServerRegionId } from '../../../common/game-server-regions'
 import { GameType, isTeamType } from '../../../common/games/game-type'
@@ -6,9 +6,9 @@ import {
   Lobby,
   LobbyVisibility,
   MAX_OBSERVERS,
+  SlotWithIndexes,
   Team,
   getLobbySlots,
-  getLobbySlotsWithIndexes,
   getObserverTeam,
   hasObservers,
   humanSlotCount,
@@ -119,7 +119,7 @@ export function findAvailableSlot(
       // Find the first available slot in the observer team
       const slotIndex = observerTeam!.slots.findIndex(slot => slot.type === SlotType.Open)
       return slotIndex !== -1
-        ? [teamIndex!, slotIndex, observerTeam!.slots.get(slotIndex)!]
+        ? [teamIndex!, slotIndex, observerTeam!.slots[slotIndex]]
         : [undefined, undefined, undefined]
     } else {
       // There is no available slot in the lobby
@@ -132,17 +132,16 @@ export function findAvailableSlot(
   // players (ie. the highest number of available slots). Note that we're excluding the observer
   // team from this algorithm, because we've handled the observer team above.
   const availableTeam = lobby.teams
-    .filterNot(team => team.isObserver)
+    .filter(team => !team.isObserver)
     .map<[index: number, team: Team]>((team, teamIndex) => [teamIndex, team])
-    .filter(([, team]) => teamTakenSlotCount(team) < team.slots.size)
+    .filter(([, team]) => teamTakenSlotCount(team) < team.slots.length)
     .sort(([, a], [, b]) => {
-      const availableCountA = a.slots.size - teamTakenSlotCount(a)
-      const availableCountB = b.slots.size - teamTakenSlotCount(b)
+      const availableCountA = a.slots.length - teamTakenSlotCount(a)
+      const availableCountB = b.slots.length - teamTakenSlotCount(b)
       if (availableCountA > availableCountB) return -1
       else if (availableCountA < availableCountB) return 1
       else return 0
-    })
-    .first()!
+    })[0]
 
   const [teamIndex, team] = availableTeam
   // After finding the available team, find the first available slot in that team and return its
@@ -150,7 +149,7 @@ export function findAvailableSlot(
   const slotIndex = team.slots.findIndex(
     slot => slot.type === SlotType.Open || slot.type === SlotType.ControlledOpen,
   )
-  return [teamIndex, slotIndex, team.slots.get(slotIndex)!]
+  return [teamIndex, slotIndex, team.slots[slotIndex]]
 }
 
 function createInitialTeams(
@@ -158,60 +157,60 @@ function createInitialTeams(
   gameType: GameType,
   gameSubType: number,
   numSlots: number,
-) {
+): Team[] {
   // When creating a lobby, we first create all the individual slots for the lobby, and then we
   // distribute each of the slots into their respective teams. The number of slots in each team is
   // fixed for the lifetime of the lobby; only the contents of the slots ever change.
   const slotsPerTeam = getSlotsPerTeam(gameType, gameSubType, numSlots, map.mapData.umsForces)
-  let slots: List<Slot>
+  let slots: Slot[]
   if (!isUms(gameType)) {
-    slots = Range(0, numSlots)
-      .map(() => createOpen())
-      .toList()
+    slots = Array.from({ length: numSlots }, () => createOpen())
   } else {
-    slots = List(
-      map.mapData.umsForces.flatMap(force =>
-        force.players.map(player => {
-          const playerId = player.id
-          const playerRace = player.race
-          const race = playerRace !== 'any' ? playerRace : 'r'
-          const hasForcedRace = playerRace !== 'any'
-          return player.computer
-            ? createUmsComputer(race, playerId, player.typeId)
-            : createOpen(race, hasForcedRace, playerId)
-        }),
-      ),
+    slots = map.mapData.umsForces.flatMap(force =>
+      force.players.map(player => {
+        const playerId = player.id
+        const playerRace = player.race
+        const race = playerRace !== 'any' ? playerRace : 'r'
+        const hasForcedRace = playerRace !== 'any'
+        return player.computer
+          ? createUmsComputer(race, playerId, player.typeId)
+          : createOpen(race, hasForcedRace, playerId)
+      }),
     )
   }
 
   const teamNames = getTeamNames({ gameType, gameSubType, umsForces: map.mapData.umsForces })
+  const teamCount = numTeams(gameType, gameSubType, map.mapData.umsForces)
+  const teams: Team[] = []
   let slotIndex = 0
-  return Range(0, numTeams(gameType, gameSubType, map.mapData.umsForces))
-    .map(teamIndex => {
-      let teamSlots = slots.slice(slotIndex, slotIndex + slotsPerTeam[teamIndex])
-      let hiddenSlots
-      slotIndex += slotsPerTeam[teamIndex]
-      const teamName = teamNames[teamIndex]
-      let teamId
-      if (isUms(gameType)) {
-        // Player type 5 means regular computer and 6 means human
-        const isHiddenSlot = (player: Slot) => player.typeId !== 5 && player.typeId !== 6
-        teamId = map.mapData.umsForces[teamIndex].teamId
-        hiddenSlots = teamSlots.filter(isHiddenSlot)
-        teamSlots = teamSlots.filterNot(isHiddenSlot)
-      } else {
-        hiddenSlots = List<Slot>()
-        teamId = isTeamType(gameType) ? teamIndex + 1 : teamIndex
-      }
+  for (let teamIndex = 0; teamIndex < teamCount; teamIndex++) {
+    let teamSlots = slots.slice(slotIndex, slotIndex + slotsPerTeam[teamIndex])
+    let hiddenSlots: Slot[]
+    slotIndex += slotsPerTeam[teamIndex]
+    // Game types whose teams aren't named (melee, FFA, 1v1) have no entry for this team
+    const teamName = teamNames[teamIndex] ?? ''
+    let teamId: number
+    if (isUms(gameType)) {
+      // Player type 5 means regular computer and 6 means human
+      const isHiddenSlot = (player: Slot) => player.typeId !== 5 && player.typeId !== 6
+      teamId = map.mapData.umsForces[teamIndex].teamId
+      hiddenSlots = teamSlots.filter(isHiddenSlot)
+      teamSlots = teamSlots.filter(slot => !isHiddenSlot(slot))
+    } else {
+      hiddenSlots = []
+      teamId = isTeamType(gameType) ? teamIndex + 1 : teamIndex
+    }
 
-      return new Team({
-        name: teamName,
-        teamId,
-        slots: teamSlots,
-        hiddenSlots,
-      })
+    teams.push({
+      name: teamName,
+      teamId,
+      isObserver: false,
+      slots: teamSlots,
+      hiddenSlots,
     })
-    .toList()
+  }
+
+  return teams
 }
 
 /** Creates a new lobby, and an initial host player in the first slot. */
@@ -241,44 +240,46 @@ export function createLobby({
   useLegacyLimits?: boolean
   visibility?: LobbyVisibility
 }) {
-  let teams = createInitialTeams(map, gameType, gameSubType, numSlots)
+  const teams = createInitialTeams(map, gameType, gameSubType, numSlots)
   if (allowObservers) {
     // Observer slots sit alongside the map's player slots rather than being taken from them, so
     // every game type gets the same fixed-size observer team. They start closed, so a lobby only
     // takes on observers once someone deliberately opens a slot or is moved into one.
-    const observerTeam = new Team({
+    teams.push({
       name: 'Observers',
+      teamId: 0,
       isObserver: true,
-      slots: Range(0, MAX_OBSERVERS)
-        .map(() => createClosed())
-        .toList(),
+      slots: Array.from({ length: MAX_OBSERVERS }, () => createClosed()),
+      hiddenSlots: [],
     })
-    teams = teams.push(observerTeam)
   }
 
-  const lobby = new Lobby({
+  const [hostTeamIndex, hostSlotIndex, hostSlot] = teams
+    .flatMap((team, teamIndex) =>
+      team.slots.map((slot, slotIndex): SlotWithIndexes => [teamIndex, slotIndex, slot]),
+    )
+    .find(([, , slot]) => slot.type === SlotType.Open)!
+
+  let host: Slot
+  if (!isUms(gameType)) {
+    host = createHuman(hostUserId, hostRace)
+  } else {
+    host = createHuman(hostUserId, hostSlot.race, hostSlot.hasForcedRace, hostSlot.playerId)
+  }
+  host = { ...host, region: hostRegion }
+
+  const lobby: Lobby = {
     id: makeSbLobbyId(encodePrettyId(randomUUID())),
     name,
     map,
     gameType,
     gameSubType: +gameSubType,
     teams,
-    host: new Slot(),
+    host,
     useLegacyLimits,
     visibility,
-  })
-  let host
-  const [hostTeamIndex, hostSlotIndex, hostSlot] = getLobbySlotsWithIndexes(lobby)
-    .filter(([teamIndex, slotIndex, slot]) => slot.type === SlotType.Open)
-    .min()!
-
-  if (!isUms(gameType)) {
-    host = createHuman(hostUserId, hostRace)
-  } else {
-    host = createHuman(hostUserId, hostSlot.race, hostSlot.hasForcedRace, hostSlot.playerId)
   }
-  host = host.set('region', hostRegion)
-  return addPlayer(lobby, hostTeamIndex, hostSlotIndex, host).set('host', host)
+  return addPlayer(lobby, hostTeamIndex, hostSlotIndex, host)
 }
 
 /**
@@ -295,7 +296,7 @@ function addPlayerAndControlledSlots(
   // The team which the new player is joining is empty (ie. it has only open and/or closed slots);
   // fill the whole team with either computer slots or controlled slots (leaving the slot of the new
   // player as is)
-  const team = lobby.teams.get(teamIndex)!
+  const team = lobby.teams[teamIndex]
   const slots = team.slots.map((currentSlot, currentSlotIndex) => {
     if (currentSlotIndex === slotIndex) return player
     if (player.type === SlotType.Computer) {
@@ -311,16 +312,20 @@ function addPlayerAndControlledSlots(
         : createControlledOpen(player.race, player.id)
     }
   })
-  return lobby.setIn(['teams', teamIndex, 'slots'], slots)
+  return produce(lobby, draft => {
+    draft.teams[teamIndex].slots = slots
+  })
 }
 
 export function addPlayer(lobby: Lobby, teamIndex: number, slotIndex: number, player: Slot): Lobby {
-  const team = lobby.teams.get(teamIndex)!
+  const team = lobby.teams[teamIndex]
   // The observer team never holds controlled slots, so someone arriving in an observer slot of a
   // team game must not trigger the controlled-slot fill an empty player team would get.
   return hasControlledOpens(lobby.gameType) && !team.isObserver && isTeamEmpty(team)
     ? addPlayerAndControlledSlots(lobby, teamIndex, slotIndex, player)
-    : lobby.setIn(['teams', teamIndex, 'slots', slotIndex], player)
+    : produce(lobby, draft => {
+        draft.teams[teamIndex].slots[slotIndex] = player
+      })
 }
 
 /** Updates the race of a particular player, returning the updated lobby. */
@@ -330,19 +335,24 @@ export function setRace(
   slotIndex: number,
   newRace: RaceChar,
 ): Lobby {
-  const team = lobby.teams.get(teamIndex)!
+  const team = lobby.teams[teamIndex]
   if (
     hasControlledOpens(lobby.gameType) &&
-    team.slots.count(slot => slot.type === SlotType.Computer) > 0
+    team.slots.some(slot => slot.type === SlotType.Computer)
   ) {
     // BW doesn't support computer teams in team melee having different races. Change all races
     // of a computer team at once.
     // The exact limitation is with some but not all slots being random, we could allow multiple
     // non-random races but the AI won't be able to take advantage of it anyway.
-    const slots = team.slots.map(slot => slot.set('race', newRace))
-    return lobby.setIn(['teams', teamIndex, 'slots'], slots)
+    return produce(lobby, draft => {
+      for (const slot of draft.teams[teamIndex].slots) {
+        slot.race = newRace
+      }
+    })
   } else {
-    return lobby.setIn(['teams', teamIndex, 'slots', slotIndex, 'race'], newRace)
+    return produce(lobby, draft => {
+      draft.teams[teamIndex].slots[slotIndex].race = newRace
+    })
   }
 }
 
@@ -352,11 +362,11 @@ export function setRace(
  * the updated lobby.
  */
 function removePlayerAndControlledSlots(lobby: Lobby, teamIndex: number, playerIndex: number) {
-  const team = lobby.teams.get(teamIndex)!
-  const id = team.slots.get(playerIndex)!.id
+  const team = lobby.teams[teamIndex]
+  const id = team.slots[playerIndex].id
   if (
-    team.slots.count(slot => slot.type === SlotType.Human) === 1 ||
-    team.slots.count(slot => slot.type === SlotType.Computer) > 0
+    team.slots.filter(slot => slot.type === SlotType.Human).length === 1 ||
+    team.slots.some(slot => slot.type === SlotType.Computer)
   ) {
     // The player that is leaving is alone in this team, so to remove them we replace the whole team
     // with either opened or closed slots. Same goes if we're removing a computer in team melee/ffa
@@ -364,7 +374,9 @@ function removePlayerAndControlledSlots(lobby: Lobby, teamIndex: number, playerI
     const slots = team.slots.map(currentSlot => {
       return currentSlot.type === SlotType.ControlledClosed ? createClosed() : createOpen()
     })
-    return lobby.setIn(['teams', teamIndex, 'slots'], slots)
+    return produce(lobby, draft => {
+      draft.teams[teamIndex].slots = slots
+    })
   } else {
     // The team which the player is leaving has other human players in it; find the new oldest human
     // player in the team and:
@@ -372,19 +384,18 @@ function removePlayerAndControlledSlots(lobby: Lobby, teamIndex: number, playerI
     //  2) update any controlled slots with controlledBy set to the leaver's ID to that ID
     const oldestInTeam = team.slots
       .filter(slot => slot.type === SlotType.Human && slot.id !== id)
-      .sortBy(p => p.joinedAt)
-      .first()!
-    return lobby.updateIn(['teams', teamIndex, 'slots'], slotsUntyped => {
-      const slots = slotsUntyped as List<Slot>
-      return slots.map(slot => {
-        if (slot.id === id) {
-          return createControlledOpen(slot.race, oldestInTeam.id)
-        } else if (slot.controlledBy === id) {
-          return slot.set('controlledBy', oldestInTeam.id)
-        } else {
-          return slot
-        }
-      })
+      .sort((a, b) => a.joinedAt - b.joinedAt)[0]
+    const slots = team.slots.map(slot => {
+      if (slot.id === id) {
+        return createControlledOpen(slot.race, oldestInTeam.id)
+      } else if (slot.controlledBy === id) {
+        return { ...slot, controlledBy: oldestInTeam.id }
+      } else {
+        return slot
+      }
+    })
+    return produce(lobby, draft => {
+      draft.teams[teamIndex].slots = slots
     })
   }
 }
@@ -405,7 +416,7 @@ export function removePlayer(
     // nothing removed, e.g. player wasn't in the lobby
     return lobby
   }
-  const team = lobby.teams.get(teamIndex)!
+  const team = lobby.teams[teamIndex]
   // A vacated slot is always left open for the next joiner; the host can close it if unwanted.
   // Observer slots carry no map data, so they get a plain open slot even in UMS. The observer
   // team also never holds controlled slots, so a departing observer skips the controlled-team
@@ -417,7 +428,9 @@ export function removePlayer(
   let updated =
     hasControlledOpens(lobby.gameType) && !team.isObserver
       ? removePlayerAndControlledSlots(lobby, teamIndex, slotIndex)
-      : lobby.setIn(['teams', teamIndex, 'slots', slotIndex], vacatedSlot)
+      : produce(lobby, draft => {
+          draft.teams[teamIndex].slots[slotIndex] = vacatedSlot
+        })
 
   if (humanSlotCount(updated) < 1) {
     return undefined
@@ -427,9 +440,10 @@ export function removePlayer(
     // The player we removed was the host, find a new host (the "oldest" player in lobby)
     const newHost = getLobbySlots(updated)
       .filter(slot => slot.type === SlotType.Human || slot.type === SlotType.Observer)
-      .sortBy(p => p.joinedAt)
-      .first()!
-    updated = updated.set('host', newHost)
+      .sort((a, b) => a.joinedAt - b.joinedAt)[0]
+    updated = produce(updated, draft => {
+      draft.host = newHost
+    })
   }
 
   return updated
@@ -458,43 +472,47 @@ export function movePlayerToSlot(
   destTeamIndex: number,
   destSlotIndex: number,
 ): Lobby {
-  const sourceTeam = lobby.teams.get(sourceTeamIndex)!
-  const destTeam = lobby.teams.get(destTeamIndex)!
-  const originalSlot = sourceTeam.slots.get(sourceSlotIndex)!
-  const destSlot = destTeam.slots.get(destSlotIndex)!
+  const sourceTeam = lobby.teams[sourceTeamIndex]
+  const destTeam = lobby.teams[destTeamIndex]
+  const originalSlot = sourceTeam.slots[sourceSlotIndex]
+  const destSlot = destTeam.slots[destSlotIndex]
 
   let movedSlot = originalSlot
   if (isUms(lobby.gameType)) {
-    movedSlot = movedSlot.set('playerId', destSlot.playerId)
+    movedSlot = { ...movedSlot, playerId: destSlot.playerId }
     movedSlot = destSlot.hasForcedRace
-      ? movedSlot.set('race', destSlot.race).set('hasForcedRace', true)
-      : movedSlot.set('hasForcedRace', false)
+      ? { ...movedSlot, race: destSlot.race, hasForcedRace: true }
+      : { ...movedSlot, hasForcedRace: false }
   }
   if (destTeam.isObserver) {
-    movedSlot = movedSlot.set('type', SlotType.Observer)
+    movedSlot = { ...movedSlot, type: SlotType.Observer }
   } else if (sourceTeam.isObserver) {
-    movedSlot = movedSlot.set('type', SlotType.Human)
+    movedSlot = { ...movedSlot, type: SlotType.Human }
   }
 
   let updated = lobby
   if (originalSlot.id === lobby.host.id) {
     // The lobby's host is a copy of their slot, so it has to follow along with any changes the move
     // made to it.
-    updated = updated.set('host', movedSlot)
+    updated = produce(updated, draft => {
+      draft.host = movedSlot
+    })
   }
 
   if (hasControlledOpens(lobby.gameType) && !destTeam.isObserver && isTeamEmpty(destTeam)) {
     updated = addPlayerAndControlledSlots(updated, destTeamIndex, destSlotIndex, movedSlot)
   } else {
-    updated = updated.setIn(['teams', destTeamIndex, 'slots', destSlotIndex], movedSlot)
+    updated = produce(updated, draft => {
+      draft.teams[destTeamIndex].slots[destSlotIndex] = movedSlot
+    })
   }
 
   if (hasControlledOpens(lobby.gameType) && !sourceTeam.isObserver) {
     if (sourceTeamIndex === destTeamIndex) {
-      updated = updated.setIn(
-        ['teams', sourceTeamIndex, 'slots', sourceSlotIndex],
-        createControlledOpen('r', destSlot.controlledBy!),
-      )
+      const controlledOpen = createControlledOpen('r', destSlot.controlledBy!)
+      updated = produce(updated, draft => {
+        draft.teams[sourceTeamIndex].slots[sourceSlotIndex] = controlledOpen
+      })
     } else {
       updated = removePlayerAndControlledSlots(updated, sourceTeamIndex, sourceSlotIndex)
     }
@@ -505,7 +523,9 @@ export function movePlayerToSlot(
       isUms(lobby.gameType) && !sourceTeam.isObserver
         ? createOpen(originalSlot.race, originalSlot.hasForcedRace, originalSlot.playerId)
         : createOpen()
-    updated = updated.setIn(['teams', sourceTeamIndex, 'slots', sourceSlotIndex], vacated)
+    updated = produce(updated, draft => {
+      draft.teams[sourceTeamIndex].slots[sourceSlotIndex] = vacated
+    })
   }
 
   return updated
@@ -517,18 +537,20 @@ export function movePlayerToSlot(
  * instead, as that operation has side-effects, unlike this one.
  */
 export function openSlot(lobby: Lobby, teamIndex: number, slotIndex: number): Lobby {
-  const slotToOpen = lobby.teams.get(teamIndex)!.slots.get(slotIndex)!
+  const slotToOpen = lobby.teams[teamIndex].slots[slotIndex]
 
   const openSlot = isUms(lobby.gameType)
     ? createOpen(slotToOpen.race, slotToOpen.hasForcedRace, slotToOpen.playerId)
     : createOpen()
   if (slotToOpen.type === SlotType.Closed) {
-    return lobby.setIn(['teams', teamIndex, 'slots', slotIndex], openSlot)
+    return produce(lobby, draft => {
+      draft.teams[teamIndex].slots[slotIndex] = openSlot
+    })
   } else if (slotToOpen.type === SlotType.ControlledClosed) {
-    return lobby.setIn(
-      ['teams', teamIndex, 'slots', slotIndex],
-      createControlledOpen(slotToOpen.race, slotToOpen.controlledBy!),
-    )
+    const controlledOpen = createControlledOpen(slotToOpen.race, slotToOpen.controlledBy!)
+    return produce(lobby, draft => {
+      draft.teams[teamIndex].slots[slotIndex] = controlledOpen
+    })
   } else {
     throw new Error('trying to open an invalid slot type: ' + slotToOpen.type)
   }
@@ -540,18 +562,20 @@ export function openSlot(lobby: Lobby, teamIndex: number, slotIndex: number): Lo
  * player from the slot and then close their slot with this function.
  */
 export function closeSlot(lobby: Lobby, teamIndex: number, slotIndex: number) {
-  const slotToClose = lobby.teams.get(teamIndex)!.slots.get(slotIndex)!
+  const slotToClose = lobby.teams[teamIndex].slots[slotIndex]
 
   const closedSlot = isUms(lobby.gameType)
     ? createClosed(slotToClose.race, slotToClose.hasForcedRace, slotToClose.playerId)
     : createClosed()
   if (slotToClose.type === SlotType.Open) {
-    return lobby.setIn(['teams', teamIndex, 'slots', slotIndex], closedSlot)
+    return produce(lobby, draft => {
+      draft.teams[teamIndex].slots[slotIndex] = closedSlot
+    })
   } else if (slotToClose.type === SlotType.ControlledOpen) {
-    return lobby.setIn(
-      ['teams', teamIndex, 'slots', slotIndex],
-      createControlledClosed(slotToClose.race, slotToClose.controlledBy!),
-    )
+    const controlledClosed = createControlledClosed(slotToClose.race, slotToClose.controlledBy!)
+    return produce(lobby, draft => {
+      draft.teams[teamIndex].slots[slotIndex] = controlledClosed
+    })
   } else {
     throw new Error('trying to close an invalid slot type: ' + slotToClose.type)
   }
@@ -567,9 +591,26 @@ function isSlotJoinable(slot: Slot): boolean {
  * can be joined directly, or failing that the first unoccupied one. Returns -1 if every slot is
  * occupied.
  */
-function findSlotToMoveInto(slots: List<Slot>): number {
+function findSlotToMoveInto(slots: ReadonlyArray<Slot>): number {
   const openIndex = slots.findIndex(isSlotJoinable)
   return openIndex !== -1 ? openIndex : slots.findIndex(isSlotUnoccupied)
+}
+
+/**
+ * Returns the item of `items` with the highest `score`, keeping the earlier item when two items
+ * score the same. Returns `undefined` if `items` is empty.
+ */
+function maxBy<T>(items: ReadonlyArray<T>, score: (item: T) => number): T | undefined {
+  let best: T | undefined
+  let bestScore = -Infinity
+  for (const item of items) {
+    const itemScore = score(item)
+    if (itemScore > bestScore) {
+      best = item
+      bestScore = itemScore
+    }
+  }
+  return best
 }
 
 /**
@@ -577,11 +618,11 @@ function findSlotToMoveInto(slots: List<Slot>): number {
  * came from.
  */
 export function makeObserver(lobby: Lobby, teamIndex: number, slotIndex: number): Lobby {
-  const team = lobby.teams.get(teamIndex)!
+  const team = lobby.teams[teamIndex]
   if (team.isObserver) {
     throw new Error("Trying to make an observer from obs team's slot")
   }
-  const slot = team.slots.get(slotIndex)!
+  const slot = team.slots[slotIndex]
   if (slot.type !== SlotType.Human) {
     throw new Error('Trying to make observer from an invalid slot type: ' + slot.type)
   }
@@ -614,7 +655,7 @@ export function removeObserver(lobby: Lobby, slotIndex: number): Lobby {
   if (obsTeamIndex === undefined) {
     throw new Error('Lobby does not allow observers')
   }
-  const slot = obsTeam!.slots.get(slotIndex)!
+  const slot = obsTeam!.slots[slotIndex]
   if (slot.type !== SlotType.Observer) {
     throw new Error('Trying to remove an observer from an invalid slot type: ' + slot.type)
   }
@@ -623,10 +664,10 @@ export function removeObserver(lobby: Lobby, slotIndex: number): Lobby {
     .map<[teamIndex: number, team: Team]>((team, teamIndex) => [teamIndex, team])
     .filter(([, team]) => !team.isObserver && team.slots.some(isSlotUnoccupied))
   const destTeam =
-    candidates
-      .filter(([, team]) => team.slots.some(isSlotJoinable))
-      .maxBy(([, team]) => team.slots.count(isSlotJoinable)) ??
-    candidates.maxBy(([, team]) => team.slots.count(isSlotUnoccupied))
+    maxBy(
+      candidates.filter(([, team]) => team.slots.some(isSlotJoinable)),
+      ([, team]) => team.slots.filter(isSlotJoinable).length,
+    ) ?? maxBy(candidates, ([, team]) => team.slots.filter(isSlotUnoccupied).length)
   if (!destTeam) {
     throw new Error('Cannot remove more observers')
   }

--- a/server/lib/wsapi/lobbies.test.ts
+++ b/server/lib/wsapi/lobbies.test.ts
@@ -413,7 +413,7 @@ describe('wsapi/lobbies', () => {
 
       lobby = lobbyApi.lobbies.get(makeSbLobbyId(id))!
       const [obsTeamIndex, obsTeam] = getObserverTeam(lobby)
-      const obsSlot = obsTeam!.slots.get(0)!
+      const obsSlot = obsTeam!.slots[0]
       expect(obsSlot.type).toBe('observer')
 
       // Closing an occupied slot kicks the occupant and then closes whatever their removal left
@@ -421,7 +421,7 @@ describe('wsapi/lobbies', () => {
       await lobbyApi.closeSlot(apiData(host, { slotId: obsSlot.id }), NOOP_NEXT)
 
       lobby = lobbyApi.lobbies.get(makeSbLobbyId(id))!
-      expect(lobby.teams.get(obsTeamIndex!)!.slots.get(0)!.type).toBe('closed')
+      expect(lobby.teams[obsTeamIndex!].slots[0].type).toBe('closed')
       expect(findSlotByUserId(lobby, JOINER_USER.id)[2]).toBeUndefined()
     })
   })

--- a/server/lib/wsapi/lobbies.ts
+++ b/server/lib/wsapi/lobbies.ts
@@ -1,5 +1,5 @@
 import errors from 'http-errors'
-import { Map, Record, Set } from 'immutable'
+import { Map as IMap } from 'immutable'
 import { NextFunc, NydusClient, NydusServer } from 'nydus'
 import { container } from 'tsyringe'
 import { ReadonlyDeep } from 'type-fest'
@@ -95,14 +95,14 @@ export function knownRegionOrUndefined(
   return region !== undefined && regions.some(r => r.id === region) ? region : undefined
 }
 
-class Countdown extends Record({
-  timer: undefined as Deferred<void> | undefined,
-}) {}
+interface Countdown {
+  timer?: Deferred<void>
+}
 
-class ListSubscription extends Record({
-  onUnsubscribe: undefined as (() => void) | undefined,
-  count: 0,
-}) {}
+interface ListSubscription {
+  onUnsubscribe?: () => void
+  count: number
+}
 
 function checkSubTypeValidity(gameType: GameType, gameSubType: number = 0, numSlots: number) {
   if (gameType === 'topVBottom') {
@@ -128,12 +128,12 @@ export class LobbyApi {
   readonly gameServerRegionsService = container.resolve(GameServerRegionsService)
   readonly netcodeV2Service = container.resolve(NetcodeV2Service)
 
-  lobbies = Map<SbLobbyId, Lobby>()
-  lobbyClients = Map<ClientSocketsGroup, SbLobbyId>()
-  lobbyBannedUsers = Map<SbLobbyId, Set<SbUserId>>()
-  lobbyCountdowns = Map<SbLobbyId, Countdown>()
-  loadingLobbies = Map<SbLobbyId, AbortController>()
-  subscribedSockets = Map<string, ListSubscription>()
+  readonly lobbies = new Map<SbLobbyId, Lobby>()
+  readonly lobbyClients = new Map<ClientSocketsGroup, SbLobbyId>()
+  readonly lobbyBannedUsers = new Map<SbLobbyId, Set<SbUserId>>()
+  readonly lobbyCountdowns = new Map<SbLobbyId, Countdown>()
+  readonly loadingLobbies = new Map<SbLobbyId, AbortController>()
+  readonly subscribedSockets = new Map<string, ListSubscription>()
   readonly lobbyPlayerNetwork = new LobbyPlayerNetworkStore()
 
   constructor(
@@ -160,51 +160,44 @@ export class LobbyApi {
   }
 
   @Api('/subscribe')
-  async subscribe(data: Map<string, any>, next: NextFunc) {
+  async subscribe(data: IMap<string, any>, next: NextFunc) {
     const socket = data.get('client')
-    if (this.subscribedSockets.has(socket.id)) {
-      this.subscribedSockets = this.subscribedSockets.updateIn(
-        [socket.id, 'count'],
-        c => (c as number) + 1,
-      )
+    const existingSubscription = this.subscribedSockets.get(socket.id)
+    if (existingSubscription) {
+      existingSubscription.count++
       return
     }
 
-    const summary = this.lobbies
-      .valueSeq()
+    const summary = [...this.lobbies.values()]
       .filter(l => l.visibility === 'listed')
       .map(l => Lobbies.toSummaryJson(l))
     this.nydus.subscribeClient(socket, MOUNT_BASE, { action: 'full', payload: summary })
 
     const onClose = () => {
       this.nydus.unsubscribeClient(socket, MOUNT_BASE)
-      this.subscribedSockets = this.subscribedSockets.delete(socket.id)
+      this.subscribedSockets.delete(socket.id)
     }
     socket.once('close', onClose)
-    const subscription = new ListSubscription({
+    this.subscribedSockets.set(socket.id, {
       onUnsubscribe: () => socket.removeListener('close', onClose),
       count: 1,
     })
-    this.subscribedSockets = this.subscribedSockets.set(socket.id, subscription)
   }
 
   @Api('/unsubscribe')
-  async unsubscribe(data: Map<string, any>, next: NextFunc) {
+  async unsubscribe(data: IMap<string, any>, next: NextFunc) {
     const socket = data.get('client') as NydusClient
-    if (!this.subscribedSockets.has(socket.id)) {
+    const subscription = this.subscribedSockets.get(socket.id)
+    if (!subscription) {
       throw new errors.Conflict('not subscribed')
     }
 
-    const subscription = this.subscribedSockets.get(socket.id)!
     if (subscription.count === 1) {
       this.nydus.unsubscribeClient(socket, MOUNT_BASE)
-      this.subscribedSockets = this.subscribedSockets.delete(socket.id)
+      this.subscribedSockets.delete(socket.id)
       subscription.onUnsubscribe?.()
     } else {
-      this.subscribedSockets = this.subscribedSockets.updateIn(
-        [socket.id, 'count'],
-        c => (c as number) - 1,
-      )
+      subscription.count--
     }
   }
 
@@ -223,7 +216,7 @@ export class LobbyApi {
       clientPubkey: isValidNetcodeV2Pubkey,
     }),
   )
-  async create(data: Map<string, any>, next: NextFunc) {
+  async create(data: IMap<string, any>, next: NextFunc) {
     const {
       name,
       map,
@@ -283,7 +276,7 @@ export class LobbyApi {
     // display-only, so duplicates outside the public list are harmless.
     if (
       lobbyVisibility === 'listed' &&
-      this.lobbies.some(l => l.visibility === 'listed' && l.name === name)
+      [...this.lobbies.values()].some(l => l.visibility === 'listed' && l.name === name)
     ) {
       throw Object.assign(new errors.Conflict('already another lobby with that name'), {
         body: { code: LobbyCreateErrorCode.NameTaken },
@@ -307,8 +300,8 @@ export class LobbyApi {
       throw new errors.Conflict('user is already active in a gameplay activity')
     }
 
-    this.lobbies = this.lobbies.set(lobby.id, lobby)
-    this.lobbyClients = this.lobbyClients.set(client, lobby.id)
+    this.lobbies.set(lobby.id, lobby)
+    this.lobbyClients.set(client, lobby.id)
     if (rttMs !== undefined || clientPubkey !== undefined) {
       this.lobbyPlayerNetwork.set(lobby.id, client.userId, { rttMs, netcodeV2Pubkey: clientPubkey })
     }
@@ -329,7 +322,7 @@ export class LobbyApi {
       clientPubkey: isValidNetcodeV2Pubkey,
     }),
   )
-  async join(data: Map<string, any>, next: NextFunc) {
+  async join(data: IMap<string, any>, next: NextFunc) {
     const { id, region, rttMs, clientPubkey } = data.get('body') as {
       id: SbLobbyId
       region?: GameServerRegionId
@@ -353,10 +346,7 @@ export class LobbyApi {
       throw Object.assign(err as Error, { body: { code: LobbyJoinErrorCode.AlreadyStarted } })
     }
 
-    if (
-      this.lobbyBannedUsers.has(lobby.id) &&
-      this.lobbyBannedUsers.get(lobby.id)!.includes(client.userId)
-    ) {
+    if (this.lobbyBannedUsers.get(lobby.id)?.has(client.userId)) {
       throw Object.assign(new errors.Conflict('user has been banned from this lobby'), {
         body: { code: LobbyJoinErrorCode.Banned },
       })
@@ -383,7 +373,7 @@ export class LobbyApi {
           )
         : Slots.createHuman(client.userId)
     }
-    player = player.set('region', joinRegion)
+    player = { ...player, region: joinRegion }
 
     let updated = Lobbies.addPlayer(lobby, teamIndex, slotIndex, player)
 
@@ -395,10 +385,10 @@ export class LobbyApi {
 
     // TODO(tec27): Fix map signing URL refreshing in a more general way, see #593
     const mapInfo = (await getMapInfos([lobby.map!.id]))[0]
-    updated = updated.set('map', mapInfo)
+    updated = { ...updated, map: mapInfo }
 
-    this.lobbies = this.lobbies.set(id, updated)
-    this.lobbyClients = this.lobbyClients.set(client, id)
+    this.lobbies.set(id, updated)
+    this.lobbyClients.set(client, id)
     if (rttMs !== undefined || clientPubkey !== undefined) {
       this.lobbyPlayerNetwork.set(id, client.userId, { rttMs, netcodeV2Pubkey: clientPubkey })
     }
@@ -430,11 +420,13 @@ export class LobbyApi {
    * it's safe to call on every occupancy change.
    */
   _warmLobbyRegions(lobby: Lobby) {
-    const regions = getHumanSlots(lobby)
-      .map(slot => slot.region)
-      .filter((region): region is GameServerRegionId => region !== undefined)
-      .toSet()
-      .toArray()
+    const regions = [
+      ...new Set(
+        getHumanSlots(lobby)
+          .map(slot => slot.region)
+          .filter((region): region is GameServerRegionId => region !== undefined),
+      ),
+    ]
     if (regions.length > 0) {
       this.netcodeV2Service.warmRegions(regions)
     }
@@ -451,11 +443,7 @@ export class LobbyApi {
         }
 
         try {
-          const userInfos = await findUsersById(
-            getHumanSlots(lobby)
-              .map(s => s.userId!)
-              .toArray(),
-          )
+          const userInfos = await findUsersById(getHumanSlots(lobby).map(s => s.userId!))
 
           return {
             type: 'init',
@@ -496,7 +484,7 @@ export class LobbyApi {
       text: nonEmptyString,
     }),
   )
-  async sendChat(data: Map<string, any>, next: NextFunc) {
+  async sendChat(data: IMap<string, any>, next: NextFunc) {
     const client = this.getClient(data)
     const lobby = this.getLobbyForClient(client)
     const time = Date.now()
@@ -531,7 +519,7 @@ export class LobbyApi {
       slotId: nonEmptyString,
     }),
   )
-  async addComputer(data: Map<string, any>, next: NextFunc) {
+  async addComputer(data: IMap<string, any>, next: NextFunc) {
     const client = this.getClient(data)
     const lobby = this.getLobbyForClient(client)
     const [, , player] = findSlotByUserId(lobby, client.userId)
@@ -550,7 +538,7 @@ export class LobbyApi {
     if (slotToAddComputer.type !== 'open' && slotToAddComputer.type !== 'closed') {
       throw new errors.BadRequest('invalid slot type')
     }
-    if (lobby.teams.get(teamIndex!)!.isObserver) {
+    if (lobby.teams[teamIndex!].isObserver) {
       // A computer can't watch a game, and the game itself has no concept of one in an observer
       // slot — it would just be silently absent.
       throw new errors.BadRequest('cannot add computer to an observer slot')
@@ -558,7 +546,7 @@ export class LobbyApi {
 
     const computer = Slots.createComputer()
     const updated = Lobbies.addPlayer(lobby, teamIndex!, slotIndex!, computer)
-    this.lobbies = this.lobbies.set(lobby.id, updated)
+    this.lobbies.set(lobby.id, updated)
     this._publishLobbyDiff(lobby, updated)
     this._warmLobbyRegions(updated)
   }
@@ -569,7 +557,7 @@ export class LobbyApi {
       slotId: nonEmptyString,
     }),
   )
-  async changeSlot(data: Map<string, any>, next: NextFunc) {
+  async changeSlot(data: IMap<string, any>, next: NextFunc) {
     const client = this.getClient(data)
     const lobby = this.getLobbyForClient(client)
     this.ensureLobbyNotTransient(lobby)
@@ -599,7 +587,7 @@ export class LobbyApi {
     } catch (err) {
       throw new errors.BadRequest((err as any).message)
     }
-    this.lobbies = this.lobbies.set(lobby.id, updated)
+    this.lobbies.set(lobby.id, updated)
     this._publishLobbyDiff(lobby, updated)
     this._warmLobbyRegions(updated)
   }
@@ -611,7 +599,7 @@ export class LobbyApi {
       race: validRace,
     }),
   )
-  async setRace(data: Map<string, any>, next: NextFunc) {
+  async setRace(data: IMap<string, any>, next: NextFunc) {
     const client = this.getClient(data)
     const lobby = this.getLobbyForClient(client)
     this.ensureLobbyNotLoading(lobby)
@@ -644,7 +632,7 @@ export class LobbyApi {
     }
 
     const updatedLobby = Lobbies.setRace(lobby, teamIndex!, slotIndex!, race)
-    this.lobbies = this.lobbies.set(lobby.id, updatedLobby)
+    this.lobbies.set(lobby.id, updatedLobby)
     this._publishLobbyDiff(lobby, updatedLobby)
   }
 
@@ -654,7 +642,7 @@ export class LobbyApi {
       slotId: nonEmptyString,
     }),
   )
-  async openSlot(data: Map<string, any>, next: NextFunc) {
+  async openSlot(data: IMap<string, any>, next: NextFunc) {
     const client = this.getClient(data)
     const lobby = this.getLobbyForClient(client)
     const [, , player] = findSlotByUserId(lobby, client.userId)
@@ -681,7 +669,7 @@ export class LobbyApi {
       throw new errors.BadRequest((err as any).message)
     }
 
-    this.lobbies = this.lobbies.set(lobby.id, updated)
+    this.lobbies.set(lobby.id, updated)
     this._publishLobbyDiff(lobby, updated)
   }
 
@@ -691,7 +679,7 @@ export class LobbyApi {
       slotId: nonEmptyString,
     }),
   )
-  async closeSlot(data: Map<string, any>, next: NextFunc) {
+  async closeSlot(data: IMap<string, any>, next: NextFunc) {
     const user = this.getUser(data)
     const client = this.getClient(data)
     const lobby = this.getLobbyForClient(client)
@@ -728,12 +716,12 @@ export class LobbyApi {
     } catch (err) {
       throw new errors.BadRequest((err as any).message)
     }
-    this.lobbies = this.lobbies.set(lobby.id, updated)
+    this.lobbies.set(lobby.id, updated)
     this._publishLobbyDiff(afterKick, updated)
   }
 
   @Api('/kickPlayer')
-  async kickPlayer(data: Map<string, any>, next: NextFunc) {
+  async kickPlayer(data: IMap<string, any>, next: NextFunc) {
     const user = this.getUser(data)
     const client = this.getClient(data)
     const lobby = this.getLobbyForClient(client)
@@ -768,7 +756,7 @@ export class LobbyApi {
       // NOTE(tec27): We know that removing a computer can never result in an empty lobby since a
       // human has to do it
       const updated = Lobbies.removePlayer(lobby, teamIndex, slotIndex, playerToKick)!
-      this.lobbies = this.lobbies.set(lobby.id, updated)
+      this.lobbies.set(lobby.id, updated)
       this._publishLobbyDiff(lobby, updated)
       this._warmLobbyRegions(updated)
     } else if (playerToKick.type === 'human' || playerToKick.type === 'observer') {
@@ -781,7 +769,7 @@ export class LobbyApi {
   }
 
   @Api('/banPlayer')
-  async banPlayer(data: Map<string, any>, next: NextFunc) {
+  async banPlayer(data: IMap<string, any>, next: NextFunc) {
     const client = this.getClient(data)
     const lobby = this.getLobbyForClient(client)
     const [, , player] = findSlotByUserId(lobby, client.userId)
@@ -797,9 +785,12 @@ export class LobbyApi {
       throw new errors.BadRequest('invalid slot type')
     }
 
-    this.lobbyBannedUsers = this.lobbyBannedUsers.update(lobby.id, Set(), val =>
-      val.add(playerToBan.userId!),
-    )
+    let bannedUsers = this.lobbyBannedUsers.get(lobby.id)
+    if (!bannedUsers) {
+      bannedUsers = new Set()
+      this.lobbyBannedUsers.set(lobby.id, bannedUsers)
+    }
+    bannedUsers.add(playerToBan.userId!)
 
     const clientToBan = this.activityRegistry.getClientForUser(playerToBan.userId!)
     if (!clientToBan) {
@@ -809,7 +800,7 @@ export class LobbyApi {
   }
 
   @Api('/makeObserver')
-  async makeObserver(data: Map<string, any>, next: NextFunc) {
+  async makeObserver(data: IMap<string, any>, next: NextFunc) {
     const client = this.getClient(data)
     const lobby = this.getLobbyForClient(client)
     const [, , player] = findSlotByUserId(lobby, client.userId)
@@ -828,13 +819,13 @@ export class LobbyApi {
     } catch (err) {
       throw new errors.BadRequest((err as any).message)
     }
-    this.lobbies = this.lobbies.set(lobby.id, updated)
+    this.lobbies.set(lobby.id, updated)
     this._publishLobbyDiff(lobby, updated)
     this._warmLobbyRegions(updated)
   }
 
   @Api('/removeObserver')
-  async removeObserver(data: Map<string, any>, next: NextFunc) {
+  async removeObserver(data: IMap<string, any>, next: NextFunc) {
     const client = this.getClient(data)
     const lobby = this.getLobbyForClient(client)
     const [, , player] = findSlotByUserId(lobby, client.userId)
@@ -846,7 +837,7 @@ export class LobbyApi {
     if (!slot) {
       throw new errors.BadRequest('invalid slot id')
     }
-    if (!lobby.teams.get(teamIndex!)?.isObserver) {
+    if (!lobby.teams[teamIndex!]?.isObserver) {
       throw new errors.BadRequest('Slot is not in the observer team')
     }
 
@@ -856,13 +847,13 @@ export class LobbyApi {
     } catch (err) {
       throw new errors.BadRequest((err as any).message)
     }
-    this.lobbies = this.lobbies.set(lobby.id, updated)
+    this.lobbies.set(lobby.id, updated)
     this._publishLobbyDiff(lobby, updated)
     this._warmLobbyRegions(updated)
   }
 
   @Api('/leave')
-  async leave(data: Map<string, any>, next: NextFunc) {
+  async leave(data: IMap<string, any>, next: NextFunc) {
     const user = this.getUser(data)
     const client = this.getActiveClientForUser(user.userId)
     const lobby = this.getLobbyForClient(client)
@@ -886,12 +877,12 @@ export class LobbyApi {
         type: 'leave',
         player,
       })
-      this.lobbies = this.lobbies.delete(lobby.id)
-      this.lobbyBannedUsers = this.lobbyBannedUsers.delete(lobby.id)
+      this.lobbies.delete(lobby.id)
+      this.lobbyBannedUsers.delete(lobby.id)
       this.lobbyPlayerNetwork.deleteLobby(lobby.id)
       this._publishListChange('delete', lobby)
     } else {
-      this.lobbies = this.lobbies.set(lobby.id, updatedLobby)
+      this.lobbies.set(lobby.id, updatedLobby)
       this.lobbyPlayerNetwork.deleteUser(lobby.id, client.userId)
       this._publishLobbyDiff(
         lobby,
@@ -901,7 +892,7 @@ export class LobbyApi {
       )
       this._warmLobbyRegions(updatedLobby)
     }
-    this.lobbyClients = this.lobbyClients.delete(client)
+    this.lobbyClients.delete(client)
     this.activityRegistry.unregisterClientForUser(client.userId)
 
     this._publishToUser(lobby, client.userId, {
@@ -924,7 +915,7 @@ export class LobbyApi {
   }
 
   @Api('/startCountdown')
-  async startCountdown(data: Map<string, any>, next: NextFunc) {
+  async startCountdown(data: IMap<string, any>, next: NextFunc) {
     const client = this.getClient(data)
     const lobby = this.getLobbyForClient(client)
     if (!hasOpposingSides(lobby)) {
@@ -942,10 +933,7 @@ export class LobbyApi {
     const countdownTimer = createDeferred<void>()
     countdownTimer.catch(swallowNonBuiltins)
     setTimeout(() => countdownTimer.resolve(), 5000)
-    this.lobbyCountdowns = this.lobbyCountdowns.set(
-      lobbyId,
-      new Countdown({ timer: countdownTimer }),
-    )
+    this.lobbyCountdowns.set(lobbyId, { timer: countdownTimer })
 
     this._publishTo(lobby, { type: 'startCountdown' })
     this._publishListChange('delete', lobby)
@@ -962,12 +950,11 @@ export class LobbyApi {
       lockedAlliances: false,
       observers: getLobbySlots(lobby)
         .filter(s => s.type === SlotType.Observer)
-        .map(s => s.userId!)
-        .toArray(),
+        .map(s => s.userId!),
       teams: lobby.teams
         // The observer team never contains participants, and an empty husk entry for it would
         // read as a real (empty) team to matchup/results consumers.
-        .filterNot(team => team.isObserver)
+        .filter(team => !team.isObserver)
         .map(team =>
           team.slots
             .filter(s => s.type === 'human' || s.type === 'computer' || s.type === 'umsComputer')
@@ -975,32 +962,28 @@ export class LobbyApi {
               id: s.userId ?? makeSbUserId(0),
               race: s.race,
               isComputer: s.type === 'computer' || s.type === 'umsComputer',
-            }))
-            .toArray(),
-        )
-        .toArray(),
+            })),
+        ),
     }
 
     let usersAtFault: SbUserId[] | undefined
     try {
       await countdownTimer
-      this.lobbyCountdowns = this.lobbyCountdowns.delete(lobbyId)
+      this.lobbyCountdowns.delete(lobbyId)
       const abortController = new AbortController()
-      this.loadingLobbies = this.loadingLobbies.set(lobbyId, abortController)
+      this.loadingLobbies.set(lobbyId, abortController)
 
       // Each occupant's collected network info, to merge into their `GameLoadPlayer`.
       const networkByUser = this.lobbyPlayerNetwork.getAll(lobbyId)
 
       const gameLoadResult = await this.gameLoader.loadGame({
-        players: getHumanSlots(lobby)
-          .map(s => ({
-            userId: s.userId!,
-            isObserver: s.type === SlotType.Observer,
-            region: s.region,
-            rttMs: networkByUser.get(s.userId!)?.rttMs,
-            netcodeV2Pubkey: networkByUser.get(s.userId!)?.netcodeV2Pubkey,
-          }))
-          .toArray(),
+        players: getHumanSlots(lobby).map(s => ({
+          userId: s.userId!,
+          isObserver: s.type === SlotType.Observer,
+          region: s.region,
+          rttMs: networkByUser.get(s.userId!)?.rttMs,
+          netcodeV2Pubkey: networkByUser.get(s.userId!)?.netcodeV2Pubkey,
+        })),
         playerInfos: getPlayerInfos(lobby),
         mapId: lobby.map!.id,
         gameConfig,
@@ -1054,7 +1037,7 @@ export class LobbyApi {
     }
 
     this.loadingLobbies.get(lobby.id)!.abort()
-    this.loadingLobbies = this.loadingLobbies.delete(lobby.id)
+    this.loadingLobbies.delete(lobby.id)
     this._publishTo(lobby, {
       type: 'cancelLoading',
       usersAtFault,
@@ -1078,12 +1061,12 @@ export class LobbyApi {
         user.unsubscribe(LobbyApi._getUserPath(lobby, user.userId))
         client.unsubscribe(LobbyApi._getPath(lobby))
         client.unsubscribe(LobbyApi._getClientPath(lobby, client))
-        this.lobbyClients = this.lobbyClients.delete(client)
+        this.lobbyClients.delete(client)
         this.activityRegistry.unregisterClientForUser(user.userId)
       })
-    this.lobbies = this.lobbies.delete(lobby.id)
-    this.lobbyBannedUsers = this.lobbyBannedUsers.delete(lobby.id)
-    this.loadingLobbies = this.loadingLobbies.delete(lobby.id)
+    this.lobbies.delete(lobby.id)
+    this.lobbyBannedUsers.delete(lobby.id)
+    this.loadingLobbies.delete(lobby.id)
     this.lobbyPlayerNetwork.deleteLobby(lobby.id)
   }
 
@@ -1095,7 +1078,7 @@ export class LobbyApi {
 
     const countdown = this.lobbyCountdowns.get(lobby.id)
     countdown?.timer?.reject(new CountdownCanceledError('Countdown cancelled'))
-    this.lobbyCountdowns = this.lobbyCountdowns.delete(lobby.id)
+    this.lobbyCountdowns.delete(lobby.id)
     this._publishTo(lobby, {
       type: 'cancelCountdown',
     })
@@ -1110,7 +1093,7 @@ export class LobbyApi {
       lobbyId: nonEmptyString,
     }),
   )
-  async getLobbyState(data: Map<string, any>, next: NextFunc) {
+  async getLobbyState(data: IMap<string, any>, next: NextFunc) {
     this.getClient(data)
     const { lobbyId } = data.get('body')
 
@@ -1129,7 +1112,7 @@ export class LobbyApi {
     return { lobbyId, lobbyState }
   }
 
-  getUser(data: Map<string, any>): UserSocketsGroup {
+  getUser(data: IMap<string, any>): UserSocketsGroup {
     const user = this.userSockets.getBySocket(data.get('client'))
     if (!user) throw new errors.Unauthorized('authorization required')
     return user
@@ -1147,7 +1130,7 @@ export class LobbyApi {
     return client
   }
 
-  getClient(data: Map<string, any>): ClientSocketsGroup {
+  getClient(data: IMap<string, any>): ClientSocketsGroup {
     const client = this.clientSockets.getCurrentClient(data.get('client'))
     if (!client) throw new errors.Unauthorized('authorization required')
     return client
@@ -1186,12 +1169,17 @@ export class LobbyApi {
 
   _getLobbiesCount() {
     // TODO(tec27): Ideally this would remove full lobbies?
-    return this.lobbies.count(
-      l =>
-        l.visibility === 'listed' &&
-        !this.lobbyCountdowns.has(l.id) &&
-        !this.loadingLobbies.has(l.id),
-    )
+    let count = 0
+    for (const lobby of this.lobbies.values()) {
+      if (
+        lobby.visibility === 'listed' &&
+        !this.lobbyCountdowns.has(lobby.id) &&
+        !this.loadingLobbies.has(lobby.id)
+      ) {
+        count += 1
+      }
+    }
+    return count
   }
 
   _publishLobbiesCount() {
@@ -1247,27 +1235,27 @@ export class LobbyApi {
       })
     }
 
-    const oldSlots = Set(getLobbySlots(oldLobby).map(oldSlot => oldSlot.id))
-    const newSlots = Set(getLobbySlots(newLobby).map(newSlot => newSlot.id))
-    const oldHumans = Set(getHumanSlots(oldLobby).map(oldHuman => oldHuman.id))
-    const same = oldSlots.intersect(newSlots)
-    const left = oldHumans.subtract(same)
-    const created = newSlots.subtract(same)
+    const oldSlots = new Set(getLobbySlots(oldLobby).map(oldSlot => oldSlot.id))
+    const newSlots = new Set(getLobbySlots(newLobby).map(newSlot => newSlot.id))
+    const oldHumans = new Set(getHumanSlots(oldLobby).map(oldHuman => oldHuman.id))
+    const same = new Set([...oldSlots].filter(id => newSlots.has(id)))
+    const left = [...oldHumans].filter(id => !same.has(id))
+    const created = [...newSlots].filter(id => !same.has(id))
 
-    const oldIdSlots = Map<string, [teamIndex: number, slotIndex: number, slot: Slot]>(
+    const oldIdSlots = new Map<string, [teamIndex: number, slotIndex: number, slot: Slot]>(
       getLobbySlotsWithIndexes(oldLobby).map(([teamIndex, slotIndex, slot]) => [
         slot.id,
         [teamIndex, slotIndex, slot],
       ]),
     )
-    const newIdSlots = Map<string, [teamIndex: number, slotIndex: number, slot: Slot]>(
+    const newIdSlots = new Map<string, [teamIndex: number, slotIndex: number, slot: Slot]>(
       getLobbySlotsWithIndexes(newLobby).map(([teamIndex, slotIndex, slot]) => [
         slot.id,
         [teamIndex, slotIndex, slot],
       ]),
     )
 
-    for (const id of left.values()) {
+    for (const id of left) {
       // These are the human slots that have left the lobby or were removed. Note that every `leave`
       // operation also triggers a `slotCreate` operation, which means that we don't have to set
       // slots on the client-side in response to this operation (since they'll be overriden in the
@@ -1292,7 +1280,7 @@ export class LobbyApi {
       }
     }
 
-    for (const id of created.values()) {
+    for (const id of created) {
       // These are all of the slots that were created in the new lobby compared to the old one. This
       // includes the slots that were created as a result of players leaving the lobby, moving to a
       // different slot, open/closing a slot, etc.
@@ -1311,7 +1299,7 @@ export class LobbyApi {
       diffEvents.push(slotCreatedEvent)
     }
 
-    for (const id of same.values()) {
+    for (const id of same) {
       const [oldTeamIndex, oldSlotIndex, oldSlot] = oldIdSlots.get(id)!
       const [newTeamIndex, newSlotIndex, newSlot] = newIdSlots.get(id)!
 


### PR DESCRIPTION
Converts the lobby domain model (\`Lobby\`/\`Team\`/\`Slot\`) from Immutable.js Records/Lists to plain readonly interfaces and arrays, ahead of the in-lobby feature work (settings mutability, bench, swap) so that logic isn't written against Records and converted later.

## What changed

- **\`common/lobbies\`**: \`Slot\`/\`Team\`/\`Lobby\` are plain readonly interfaces; slot factories return plain objects with the exact field defaults the Records had, so the JSON wire form is unchanged. Helper functions take/return plain arrays. \`SlotJson\` is now an alias of \`Slot\` (every field is JSON-safe).
- **\`server/lib/lobbies/lobby.ts\`**: nested updates go through immer's \`produce\`. This preserves the two semantics the wsapi diff layer relies on: unchanged teams/slots keep reference identity across updates, and no-op updates (e.g. setting a race to its current value) return the same lobby object.
- **\`server/lib/wsapi/lobbies.ts\`**: the class's own registries (\`lobbies\`, \`lobbyClients\`, \`lobbyBannedUsers\`, countdown/loading maps, list subscriptions) are plain JS \`Map\`/\`Set\` mutated in place; \`_publishLobbyDiff\`'s set algebra uses JS Sets built in deterministic slot order. The nydus \`data\` handler params stay Immutable Maps — that's the WS transport contract, which dissolves when lobby mutations move to HTTP.
- **Client**: the lobby reducer's \`info\` slice now stores the server's JSON wire form directly (the Record re-hydration is deleted); slot updates use immer. The outer \`LobbyRecord\`, chat list, and loading state deliberately stay Immutable — converting the reducers wholesale is a separate follow-up. \`lobby.tsx\` only needed accessor changes.

## Behavior fix surfaced by the conversion

\`getTeamNames()\` returns no entry for unnamed game types (melee/FFA/1v1), and the \`Team\` Record constructor silently coerced the resulting \`undefined\` team name to \`''\`. Plain objects don't coerce, so the fallback is now explicit — caught by differentially diffing normalized JSON output of the old and new model across melee/TvB/team-melee/UMS lobby configs and a 25-step operation sequence (all other output was byte-identical, including reference-identity behavior).

## Other behavior notes

- `createLobby`'s host-slot pick was `.min()` over `[teamIndex, slotIndex, slot]` tuples, which Immutable compares as strings — so a slot index of 10+ could sort before 2. It is now explicitly first-in-iteration-order (the intent), which only differs for UMS layouts with 10+ slots in a team.
- The client info reducer now no-ops positional updates that arrive while not in a lobby (a diff's trailing `slotCreate`/`hostChange` after your own removal event). The Record code silently built junk state there; the immer handlers initially threw — caught in review, now guarded and covered by reducer tests.

## Verification

- Full unit suite: 121 files / 1745 tests green (the 55-test lobby model suite and 25-test wsapi suite converted mechanically, no expectation changes).
- Typecheck + lint clean.
- Live 2-client run against the dev stack: create with observers, list join, race change, slot switch, host→observer and back (exercises the host-follows-move path), and a real game launch — both clients reached \`playing\` and the persisted \`games.config\` row matches the pre-conversion shape (teams, changed race, empty observers, \`gameSourceExtra\`).

Part of the lobby-redesign modernization workstream (M1b). Not included here: client reducers → \`immerKeyedReducer\` (M2) and the \`LobbyService\` extraction / WS→HTTP migration (M5), which build on this.
