### PR TITLE
Add a dev page prototyping the profile stats sections

### DIFF
--- a/client/dev.tsx
+++ b/client/dev.tsx
@@ -12,6 +12,7 @@ import { DevPageMetadata } from './page-metadata/devonly/routes'
 import { DevReplays } from './replays/devonly/routes'
 import { DevStarcraft } from './starcraft/devonly/dev-starcraft'
 import { DevTwitch } from './twitch/devonly/dev-twitch'
+import { DevUsers } from './users/devonly/routes'
 
 const Container = styled.div`
   width: 100%;
@@ -53,6 +54,7 @@ export default function Dev() {
             ['Replay components', 'replays', DevReplays],
             ['Starcraft', 'starcraft', DevStarcraft],
             ['Twitch components', 'twitch', DevTwitch],
+            ['User components', 'users', DevUsers],
           ]}
         />
       </Content>

--- a/client/users/devonly/routes.tsx
+++ b/client/users/devonly/routes.tsx
@@ -1,0 +1,17 @@
+import { Link, Route, Switch } from 'wouter'
+import { StatsPageTest } from './stats-page-test'
+
+export function DevUsers() {
+  return (
+    <Switch>
+      <Route path='/dev/users/stats' component={StatsPageTest} />
+      <Route>
+        <ul>
+          <li>
+            <Link href='/dev/users/stats'>Stats page</Link>
+          </li>
+        </ul>
+      </Route>
+    </Switch>
+  )
+}

--- a/client/users/devonly/stats-data.ts
+++ b/client/users/devonly/stats-data.ts
@@ -205,6 +205,44 @@ function makeMode(
   }
 }
 
+export interface SeasonBands {
+  seasonId: number
+  /** Game index the season's span starts at. */
+  fromGame: number
+  /** Game index the span ends at, tiled against the next season so there's no gap. */
+  toGame: number
+  bands: DivisionBand[]
+}
+
+/**
+ * Bands per season rather than one set for the whole chart. Points restart every
+ * season and each season's bounds sit at its own bonus pool, so drawing one band set
+ * across an all-time view would judge every past season by the current pool — badly
+ * wrong early in a new season, when the pool is near zero and past totals tower over
+ * bounds that hadn't moved yet.
+ */
+export function seasonBandGroups(
+  history: ReadonlyArray<RatingPoint>,
+  solo: boolean,
+): SeasonBands[] {
+  const groups: SeasonBands[] = []
+  for (const season of SEASONS) {
+    const points = history.filter(p => p.season === season.id)
+    if (!points.length) continue
+    groups.push({
+      seasonId: season.id,
+      fromGame: points[0].game,
+      toGame: points[points.length - 1].game,
+      bands: divisionBands(solo, bonusPoolFor(season)),
+    })
+  }
+  // Butt each span against the next so the bands tile instead of leaving a gap.
+  for (let i = 0; i < groups.length - 1; i++) {
+    groups[i].toGame = groups[i + 1].fromGame
+  }
+  return groups
+}
+
 /** Game indices where a new season begins, for drawing boundary markers. */
 export function seasonBoundaries(history: ReadonlyArray<RatingPoint>): number[] {
   const out: number[] = []

--- a/client/users/devonly/stats-data.ts
+++ b/client/users/devonly/stats-data.ts
@@ -1,10 +1,15 @@
 import {
+  ALL_MATCHMAKING_TYPES,
   MatchmakingDivision,
+  MatchmakingType,
+  TEAM_SIZES,
   getDivisionColor,
   getDivisionsForPointsChange,
   getTotalBonusPool,
+  isSoloType,
 } from '../../../common/matchmaking'
 import { AssignedRaceChar } from '../../../common/races'
+import { SbUserId, makeSbUserId } from '../../../common/users/sb-user-id'
 
 /**
  * Mock data for the user stats dev page. Shaped like what the real queries would
@@ -31,8 +36,7 @@ export interface SeasonInfo {
 }
 
 export interface ModeStats {
-  key: string
-  label: string
+  type: MatchmakingType
   games: number
   rating: number
   seasonDelta: number
@@ -40,7 +44,7 @@ export interface ModeStats {
 }
 
 export interface RivalEntry {
-  userId: number
+  userId: SbUserId
   name: string
   games: number
   wins: number
@@ -171,8 +175,7 @@ function buildHistory(seed: number, targets: number[], totalGames: number): Rati
  * the chart underneath them.
  */
 function makeMode(
-  key: string,
-  label: string,
+  type: MatchmakingType,
   seed: number,
   targets: number[],
   totalGames: number,
@@ -187,8 +190,7 @@ function makeMode(
     : history[firstOfSeason - 1].rating
 
   return {
-    key,
-    label,
+    type,
     games: history.length,
     rating: Math.round(last.rating),
     seasonDelta: Math.round(last.rating - seasonStartRating),
@@ -206,10 +208,10 @@ export function seasonBoundaries(history: ReadonlyArray<RatingPoint>): number[] 
 }
 
 export const MODES: ReadonlyArray<ModeStats> = [
-  makeMode('1v1', 'Ranked 1v1', 20260730, [1771, 1804, 1918], 613),
-  makeMode('2v2', 'Ranked 2v2', 991, [1610, 1703, 1642], 96),
-  makeMode('2v2f', 'Ranked 2v2 Fastest', 4242, [1588, 1690, 1774], 214),
-  makeMode('3v3h', 'Ranked 3v3 Hunters', 8181, [1502, 1571, 1596], 132),
+  makeMode(MatchmakingType.Match1v1, 20260730, [1771, 1804, 1918], 613),
+  makeMode(MatchmakingType.Match2v2, 991, [1610, 1703, 1642], 96),
+  makeMode(MatchmakingType.Match2v2Fastest, 4242, [1588, 1690, 1774], 214),
+  makeMode(MatchmakingType.Match3v3Hunters, 8181, [1502, 1571, 1596], 132),
 ]
 
 /** Modes ordered so the player's most-played appears first. */
@@ -245,62 +247,84 @@ export function splitOnDiscontinuity(
 // --- Rivals ---------------------------------------------------------------
 
 export const BEST_ALLIES: ReadonlyArray<RivalEntry> = [
-  { userId: 4821, name: 'Nydus_Nomad', games: 61, wins: 44 },
-  { userId: 1190, name: 'PylonPusher', games: 28, wins: 19 },
-  { userId: 7734, name: 'SiegeCreep', games: 17, wins: 11 },
-  { userId: 2255, name: 'MacroMantis', games: 12, wins: 7 },
+  { userId: makeSbUserId(4821), name: 'Nydus_Nomad', games: 61, wins: 44 },
+  { userId: makeSbUserId(1190), name: 'PylonPusher', games: 28, wins: 19 },
+  { userId: makeSbUserId(7734), name: 'SiegeCreep', games: 17, wins: 11 },
+  { userId: makeSbUserId(2255), name: 'MacroMantis', games: 12, wins: 7 },
 ]
 
 export const RIVALS: ReadonlyArray<RivalEntry> = [
-  { userId: 9012, name: 'DarkSwarmDan', games: 74, wins: 39 },
-  { userId: 3376, name: 'ReaverRush', games: 52, wins: 30 },
-  { userId: 6640, name: 'TankLineTom', games: 41, wins: 17 },
-  { userId: 8123, name: 'LurkerLane', games: 33, wins: 18 },
+  { userId: makeSbUserId(9012), name: 'DarkSwarmDan', games: 74, wins: 39 },
+  { userId: makeSbUserId(3376), name: 'ReaverRush', games: 52, wins: 30 },
+  { userId: makeSbUserId(6640), name: 'TankLineTom', games: 41, wins: 17 },
+  { userId: makeSbUserId(8123), name: 'LurkerLane', games: 33, wins: 18 },
 ]
 
 export const TOUGHEST_OPPONENTS: ReadonlyArray<RivalEntry> = [
-  { userId: 5567, name: 'CarrierHasArrived', games: 22, wins: 4 },
-  { userId: 4402, name: 'GhostNukeGuy', games: 15, wins: 4 },
-  { userId: 6640, name: 'TankLineTom', games: 41, wins: 17 },
-  { userId: 7781, name: 'DefilerDiva', games: 11, wins: 5 },
+  { userId: makeSbUserId(5567), name: 'CarrierHasArrived', games: 22, wins: 4 },
+  { userId: makeSbUserId(4402), name: 'GhostNukeGuy', games: 15, wins: 4 },
+  { userId: makeSbUserId(6640), name: 'TankLineTom', games: 41, wins: 17 },
+  { userId: makeSbUserId(7781), name: 'DefilerDiva', games: 11, wins: 5 },
 ]
 
 // --- Matchups -------------------------------------------------------------
 
+/**
+ * Deliberately TPZ rather than the alphabetical order of `ALL_ASSIGNED_RACE_CHARS`:
+ * this is display order for the matrix axes, and TPZ is how races are conventionally
+ * listed for Brood War.
+ */
 export const MATRIX_RACES: ReadonlyArray<AssignedRaceChar> = ['t', 'p', 'z']
 
 export interface MapInfo {
   name: string
-  modes: string[]
+  modes: MatchmakingType[]
   seasons: number[]
 }
 
 export const MAP_POOL: ReadonlyArray<MapInfo> = [
-  { name: 'Fighting Spirit', modes: ['1v1', '2v2'], seasons: [1, 2, 3] },
-  { name: 'Polypoid', modes: ['1v1'], seasons: [1, 2, 3] },
-  { name: 'Eclipse', modes: ['1v1'], seasons: [1, 2] },
-  { name: 'Vermeer', modes: ['1v1'], seasons: [3] },
-  { name: 'Retro', modes: ['1v1'], seasons: [2, 3] },
-  { name: 'Circuit Breaker', modes: ['1v1'], seasons: [1] },
-  { name: 'Rush Hour', modes: ['2v2'], seasons: [2, 3] },
-  { name: 'Neo Sylphid', modes: ['2v2'], seasons: [1, 2] },
-  { name: 'Fastest Map Possible', modes: ['2v2f'], seasons: [1, 2, 3] },
-  { name: 'Ultra Fastest', modes: ['2v2f'], seasons: [3] },
-  { name: 'Hunters', modes: ['3v3h'], seasons: [1, 2, 3] },
-  { name: 'Deep Hunters', modes: ['3v3h'], seasons: [2, 3] },
+  {
+    name: 'Fighting Spirit',
+    modes: [MatchmakingType.Match1v1, MatchmakingType.Match2v2],
+    seasons: [1, 2, 3],
+  },
+  { name: 'Polypoid', modes: [MatchmakingType.Match1v1], seasons: [1, 2, 3] },
+  { name: 'Eclipse', modes: [MatchmakingType.Match1v1], seasons: [1, 2] },
+  { name: 'Vermeer', modes: [MatchmakingType.Match1v1], seasons: [3] },
+  { name: 'Retro', modes: [MatchmakingType.Match1v1], seasons: [2, 3] },
+  { name: 'Circuit Breaker', modes: [MatchmakingType.Match1v1], seasons: [1] },
+  { name: 'Rush Hour', modes: [MatchmakingType.Match2v2], seasons: [2, 3] },
+  { name: 'Neo Sylphid', modes: [MatchmakingType.Match2v2], seasons: [1, 2] },
+  {
+    name: 'Fastest Map Possible',
+    modes: [MatchmakingType.Match2v2Fastest],
+    seasons: [1, 2, 3],
+  },
+  { name: 'Ultra Fastest', modes: [MatchmakingType.Match2v2Fastest], seasons: [3] },
+  { name: 'Hunters', modes: [MatchmakingType.Match3v3Hunters], seasons: [1, 2, 3] },
+  { name: 'Deep Hunters', modes: [MatchmakingType.Match3v3Hunters], seasons: [2, 3] },
 ]
 
 export const ALL_MODES = 'all'
 export const ALL_SEASONS = 'all'
 export const ALL_MAPS = 'Overall'
 
-export function teamSizeFor(mode: string): number {
-  if (mode === '3v3h') return 3
-  if (mode === '2v2' || mode === '2v2f') return 2
-  return 1
+/** A matchup filter is either one matchmaking mode or every mode combined. */
+export type ModeFilter = MatchmakingType | typeof ALL_MODES
+
+/**
+ * Across all modes there is no single team size, so the combined view falls back to
+ * the 1v1 shape: your race against each opposing race, counting opponents individually.
+ */
+export function teamSizeFor(mode: ModeFilter): number {
+  return mode === ALL_MODES ? 1 : TEAM_SIZES[mode]
 }
 
-export function mapsFor(mode: string, season: string): string[] {
+export function isSoloFilter(mode: ModeFilter): boolean {
+  return mode === ALL_MODES ? true : isSoloType(mode)
+}
+
+export function mapsFor(mode: ModeFilter, season: string): string[] {
   return MAP_POOL.filter(
     m =>
       (mode === ALL_MODES || m.modes.includes(mode)) &&
@@ -334,12 +358,13 @@ export interface MatchupCell {
   wins: number
 }
 
-const MODE_TOTALS: Record<string, number> = {
-  all: 1055,
-  '1v1': 613,
-  '2v2': 96,
-  '2v2f': 214,
-  '3v3h': 132,
+const MODE_TOTALS: Record<ModeFilter, number> = {
+  [ALL_MODES]: MODES.reduce((sum, m) => sum + m.games, 0),
+  ...(Object.fromEntries(ALL_MATCHMAKING_TYPES.map(type => [type, 0])) as Record<
+    MatchmakingType,
+    number
+  >),
+  ...(Object.fromEntries(MODES.map(m => [m.type, m.games])) as Record<MatchmakingType, number>),
 }
 
 // This player mains Terran; ally races are near-random and opponents follow ladder
@@ -413,7 +438,7 @@ function poisson(lambda: number, r: () => number): number {
 }
 
 export function matchupCell(
-  mode: string,
+  mode: ModeFilter,
   season: string,
   map: string,
   row: AssignedRaceChar[],
@@ -438,7 +463,7 @@ export function matchupCell(
 }
 
 /** A map's win rate is the sum of its own matrix, so a label can't disagree with the grid. */
-export function mapStats(mode: string, season: string, map: string): MatchupCell {
+export function mapStats(mode: ModeFilter, season: string, map: string): MatchupCell {
   const combos = raceCombos(teamSizeFor(mode))
   let games = 0
   let wins = 0

--- a/client/users/devonly/stats-data.ts
+++ b/client/users/devonly/stats-data.ts
@@ -2,11 +2,11 @@ import {
   ALL_MATCHMAKING_TYPES,
   MatchmakingDivision,
   MatchmakingType,
+  POINTS_FOR_RATING_TARGET_FACTOR,
   TEAM_SIZES,
   getDivisionColor,
   getDivisionsForPointsChange,
   getTotalBonusPool,
-  isSoloType,
 } from '../../../common/matchmaking'
 import { AssignedRaceChar } from '../../../common/races'
 import { SbUserId, makeSbUserId } from '../../../common/users/sb-user-id'
@@ -84,7 +84,17 @@ export const CURRENT_SEASON = SEASONS[SEASONS.length - 1]
  * `low + bonusPool * factor`, so this is what positions the bands.
  */
 export function currentBonusPool(): number {
-  return getTotalBonusPool(new Date(), CURRENT_SEASON.startDate, CURRENT_SEASON.endDate)
+  return bonusPoolFor(CURRENT_SEASON)
+}
+
+/**
+ * The pool as it stood for a given season: at its end if it's over, at now if it's
+ * still running. Drawing a past season's points against today's bounds would judge
+ * them by thresholds that never applied.
+ */
+export function bonusPoolFor(season: SeasonInfo): number {
+  const at = new Date(Math.min(Date.now(), Number(season.endDate)))
+  return getTotalBonusPool(at, season.startDate, season.endDate)
 }
 
 /**
@@ -123,9 +133,6 @@ export function divisionBands(solo: boolean, bonusPool: number): DivisionBand[] 
   )
 }
 
-/** Points are expected to land near `rating * POINTS_FOR_RATING_TARGET_FACTOR`. */
-const POINTS_FACTOR = 4
-
 /** Deterministic PRNG so the dev page looks the same on every reload. */
 function rng(seed: number): () => number {
   let s = seed >>> 0
@@ -156,7 +163,7 @@ function buildHistory(seed: number, targets: number[], totalGames: number): Rati
     for (let g = 0; g < n; g++) {
       rating += (goal - rating) / Math.max(n - g, 1) + (r() - 0.5) * 34
 
-      const target = rating * POINTS_FACTOR
+      const target = rating * POINTS_FOR_RATING_TARGET_FACTOR
       // Unconverged players get catch-up points on top of the normal gain.
       const approach = points >= target * 0.92 ? 0.02 : 0.055
       points += (target - points) * approach + (r() - 0.5) * 46
@@ -182,12 +189,12 @@ function makeMode(
 ): ModeStats {
   const history = buildHistory(seed, targets, totalGames)
   const last = history[history.length - 1]
-  const currentSeasonId = SEASONS[SEASONS.length - 1].id
-  const firstOfSeason = history.findIndex(p => p.season === currentSeasonId)
-  // A reset season starts from scratch; otherwise it continues the previous rating.
-  const seasonStartRating = SEASONS[SEASONS.length - 1].resetMmr
-    ? 1500
-    : history[firstOfSeason - 1].rating
+  const firstOfSeason = history.findIndex(p => p.season === CURRENT_SEASON.id)
+  // A reset season starts from scratch, and so does a history that has no earlier
+  // game to carry a rating over from (findIndex gives -1 for a season never played,
+  // 0 for one the history starts in).
+  const seasonStartRating =
+    CURRENT_SEASON.resetMmr || firstOfSeason <= 0 ? 1500 : history[firstOfSeason - 1].rating
 
   return {
     type,
@@ -318,10 +325,6 @@ export type ModeFilter = MatchmakingType | typeof ALL_MODES
  */
 export function teamSizeFor(mode: ModeFilter): number {
   return mode === ALL_MODES ? 1 : TEAM_SIZES[mode]
-}
-
-export function isSoloFilter(mode: ModeFilter): boolean {
-  return mode === ALL_MODES ? true : isSoloType(mode)
 }
 
 export function mapsFor(mode: ModeFilter, season: string): string[] {

--- a/client/users/devonly/stats-data.ts
+++ b/client/users/devonly/stats-data.ts
@@ -1,5 +1,6 @@
 import {
   MatchmakingDivision,
+  getDivisionColor,
   getDivisionsForPointsChange,
   getTotalBonusPool,
 } from '../../../common/matchmaking'
@@ -21,12 +22,10 @@ export interface RatingPoint {
 export interface SeasonInfo {
   id: number
   name: string
-  /** Index of the first game played in this season. */
-  start: number
-  /** Index one past the last game played in this season. */
-  end: number
   /** Whether MMR was reset at the start of this season. */
   resetMmr: boolean
+  /** Roughly what fraction of a mode's games were played in this season. */
+  share: number
   startDate: Date
   endDate: Date
 }
@@ -51,27 +50,24 @@ export const SEASONS: ReadonlyArray<SeasonInfo> = [
   {
     id: 1,
     name: 'Season 1',
-    start: 0,
-    end: 234,
     resetMmr: true,
+    share: 0.38,
     startDate: new Date('2025-08-01T00:00:00Z'),
     endDate: new Date('2025-12-01T00:00:00Z'),
   },
   {
     id: 2,
     name: 'Season 2',
-    start: 234,
-    end: 465,
     resetMmr: false,
+    share: 0.38,
     startDate: new Date('2025-12-01T00:00:00Z'),
     endDate: new Date('2026-04-01T00:00:00Z'),
   },
   {
     id: 3,
     name: 'Season 3',
-    start: 465,
-    end: 613,
     resetMmr: true,
+    share: 0.24,
     startDate: new Date('2026-04-01T00:00:00Z'),
     endDate: new Date('2026-08-01T00:00:00Z'),
   },
@@ -88,31 +84,9 @@ export function currentBonusPool(): number {
 }
 
 /**
- * Dominant colour of each rank badge, sampled from the art in
- * `server/public/images/ranks/<division>-88px.png`. Sub-divisions of a tier share a
- * hue, so the opacity step below is what separates them.
+ * Fill weight climbs across the three sub-divisions of a tier. The tier colour is
+ * shared across its sub-divisions, so this step is what separates them.
  */
-const DIVISION_COLORS: Record<MatchmakingDivision, string> = {
-  [MatchmakingDivision.Unrated]: '#7d8385',
-  [MatchmakingDivision.Bronze1]: '#b97955',
-  [MatchmakingDivision.Bronze2]: '#dda88a',
-  [MatchmakingDivision.Bronze3]: '#dca889',
-  [MatchmakingDivision.Silver1]: '#7d8385',
-  [MatchmakingDivision.Silver2]: '#7c8385',
-  [MatchmakingDivision.Silver3]: '#7d8385',
-  [MatchmakingDivision.Gold1]: '#d8c479',
-  [MatchmakingDivision.Gold2]: '#d9c579',
-  [MatchmakingDivision.Gold3]: '#c4aa4d',
-  [MatchmakingDivision.Platinum1]: '#19a9ea',
-  [MatchmakingDivision.Platinum2]: '#19a9ea',
-  [MatchmakingDivision.Platinum3]: '#18a8ea',
-  [MatchmakingDivision.Diamond1]: '#dba8f8',
-  [MatchmakingDivision.Diamond2]: '#dca8f8',
-  [MatchmakingDivision.Diamond3]: '#dca8f8',
-  [MatchmakingDivision.Champion]: '#b73a18',
-}
-
-/** Fill weight climbs across the three sub-divisions of a tier. */
 function bandOpacity(division: MatchmakingDivision): number {
   if (division === MatchmakingDivision.Champion) return 0.24
   if (division.endsWith('2')) return 0.16
@@ -139,7 +113,7 @@ export function divisionBands(solo: boolean, bonusPool: number): DivisionBand[] 
       division,
       low,
       high,
-      color: DIVISION_COLORS[division],
+      color: getDivisionColor(division),
       opacity: bandOpacity(division),
     }),
   )
@@ -157,16 +131,22 @@ function rng(seed: number): () => number {
   }
 }
 
-function buildHistory(seed: number, targets: number[]): RatingPoint[] {
+/**
+ * Generates exactly `totalGames` points, split across the seasons by their share, so a
+ * mode's chart plots as many games as its header claims.
+ */
+function buildHistory(seed: number, targets: number[], totalGames: number): RatingPoint[] {
   const r = rng(seed)
   const out: RatingPoint[] = []
   let rating = 1500
+  let game = 0
 
   for (const [i, season] of SEASONS.entries()) {
     if (season.resetMmr) rating = 1500
     // Points are seasonal: they restart at 0 every season, even when MMR carries over.
     let points = 0
-    const n = season.end - season.start
+    // The last season takes the remainder so the total lands exactly on totalGames.
+    const n = i === SEASONS.length - 1 ? totalGames - game : Math.round(totalGames * season.share)
     const goal = targets[i]
 
     for (let g = 0; g < n; g++) {
@@ -179,45 +159,57 @@ function buildHistory(seed: number, targets: number[]): RatingPoint[] {
       points += 2.4 // bonus pool accrues whether or not it's earned in game
       if (points < 0) points = 0
 
-      out.push({ game: season.start + g, rating, points, season: season.id })
+      out.push({ game, rating, points, season: season.id })
+      game++
     }
   }
   return out
 }
 
+/**
+ * Builds a mode from its generated history, so the headline figures can't disagree with
+ * the chart underneath them.
+ */
+function makeMode(
+  key: string,
+  label: string,
+  seed: number,
+  targets: number[],
+  totalGames: number,
+): ModeStats {
+  const history = buildHistory(seed, targets, totalGames)
+  const last = history[history.length - 1]
+  const currentSeasonId = SEASONS[SEASONS.length - 1].id
+  const firstOfSeason = history.findIndex(p => p.season === currentSeasonId)
+  // A reset season starts from scratch; otherwise it continues the previous rating.
+  const seasonStartRating = SEASONS[SEASONS.length - 1].resetMmr
+    ? 1500
+    : history[firstOfSeason - 1].rating
+
+  return {
+    key,
+    label,
+    games: history.length,
+    rating: Math.round(last.rating),
+    seasonDelta: Math.round(last.rating - seasonStartRating),
+    history,
+  }
+}
+
+/** Game indices where a new season begins, for drawing boundary markers. */
+export function seasonBoundaries(history: ReadonlyArray<RatingPoint>): number[] {
+  const out: number[] = []
+  for (let i = 1; i < history.length; i++) {
+    if (history[i].season !== history[i - 1].season) out.push(history[i].game)
+  }
+  return out
+}
+
 export const MODES: ReadonlyArray<ModeStats> = [
-  {
-    key: '1v1',
-    label: 'Ranked 1v1',
-    games: 613,
-    rating: 1918,
-    seasonDelta: 418,
-    history: buildHistory(20260730, [1771, 1804, 1918]),
-  },
-  {
-    key: '2v2',
-    label: 'Ranked 2v2',
-    games: 96,
-    rating: 1642,
-    seasonDelta: -61,
-    history: buildHistory(991, [1610, 1703, 1642]),
-  },
-  {
-    key: '2v2f',
-    label: 'Ranked 2v2 Fastest',
-    games: 214,
-    rating: 1774,
-    seasonDelta: 193,
-    history: buildHistory(4242, [1588, 1690, 1774]),
-  },
-  {
-    key: '3v3h',
-    label: 'Ranked 3v3 Hunters',
-    games: 132,
-    rating: 1596,
-    seasonDelta: 25,
-    history: buildHistory(8181, [1502, 1571, 1596]),
-  },
+  makeMode('1v1', 'Ranked 1v1', 20260730, [1771, 1804, 1918], 613),
+  makeMode('2v2', 'Ranked 2v2', 991, [1610, 1703, 1642], 96),
+  makeMode('2v2f', 'Ranked 2v2 Fastest', 4242, [1588, 1690, 1774], 214),
+  makeMode('3v3h', 'Ranked 3v3 Hunters', 8181, [1502, 1571, 1596], 132),
 ]
 
 /** Modes ordered so the player's most-played appears first. */
@@ -234,13 +226,13 @@ export function splitOnDiscontinuity(
   history: ReadonlyArray<RatingPoint>,
   everyBoundary: boolean,
 ): RatingPoint[][] {
-  const breakAt = new Set(
-    SEASONS.filter((s, i) => (everyBoundary ? i > 0 : s.resetMmr)).map(s => s.start),
-  )
+  const resetSeasons = new Set(SEASONS.filter(s => s.resetMmr).map(s => s.id))
   const runs: RatingPoint[][] = []
   let current: RatingPoint[] = []
   for (const point of history) {
-    if (breakAt.has(point.game) && current.length) {
+    const previous = current[current.length - 1]
+    const crossedSeason = previous !== undefined && previous.season !== point.season
+    if (crossedSeason && (everyBoundary || resetSeasons.has(point.season))) {
       runs.push(current)
       current = []
     }

--- a/client/users/devonly/stats-data.ts
+++ b/client/users/devonly/stats-data.ts
@@ -1,0 +1,461 @@
+import {
+  MatchmakingDivision,
+  getDivisionsForPointsChange,
+  getTotalBonusPool,
+} from '../../../common/matchmaking'
+import { AssignedRaceChar } from '../../../common/races'
+
+/**
+ * Mock data for the user stats dev page. Shaped like what the real queries would
+ * return so the components can be swapped onto live data without changing props.
+ */
+
+export interface RatingPoint {
+  /** Index of the game within the player's history for this mode. */
+  game: number
+  rating: number
+  points: number
+  season: number
+}
+
+export interface SeasonInfo {
+  id: number
+  name: string
+  /** Index of the first game played in this season. */
+  start: number
+  /** Index one past the last game played in this season. */
+  end: number
+  /** Whether MMR was reset at the start of this season. */
+  resetMmr: boolean
+  startDate: Date
+  endDate: Date
+}
+
+export interface ModeStats {
+  key: string
+  label: string
+  games: number
+  rating: number
+  seasonDelta: number
+  history: RatingPoint[]
+}
+
+export interface RivalEntry {
+  userId: number
+  name: string
+  games: number
+  wins: number
+}
+
+export const SEASONS: ReadonlyArray<SeasonInfo> = [
+  {
+    id: 1,
+    name: 'Season 1',
+    start: 0,
+    end: 234,
+    resetMmr: true,
+    startDate: new Date('2025-08-01T00:00:00Z'),
+    endDate: new Date('2025-12-01T00:00:00Z'),
+  },
+  {
+    id: 2,
+    name: 'Season 2',
+    start: 234,
+    end: 465,
+    resetMmr: false,
+    startDate: new Date('2025-12-01T00:00:00Z'),
+    endDate: new Date('2026-04-01T00:00:00Z'),
+  },
+  {
+    id: 3,
+    name: 'Season 3',
+    start: 465,
+    end: 613,
+    resetMmr: true,
+    startDate: new Date('2026-04-01T00:00:00Z'),
+    endDate: new Date('2026-08-01T00:00:00Z'),
+  },
+]
+
+export const CURRENT_SEASON = SEASONS[SEASONS.length - 1]
+
+/**
+ * The bonus pool as it stands now, via the real accrual function. Division bounds are
+ * `low + bonusPool * factor`, so this is what positions the bands.
+ */
+export function currentBonusPool(): number {
+  return getTotalBonusPool(new Date(), CURRENT_SEASON.startDate, CURRENT_SEASON.endDate)
+}
+
+/**
+ * Dominant colour of each rank badge, sampled from the art in
+ * `server/public/images/ranks/<division>-88px.png`. Sub-divisions of a tier share a
+ * hue, so the opacity step below is what separates them.
+ */
+const DIVISION_COLORS: Record<MatchmakingDivision, string> = {
+  [MatchmakingDivision.Unrated]: '#7d8385',
+  [MatchmakingDivision.Bronze1]: '#b97955',
+  [MatchmakingDivision.Bronze2]: '#dda88a',
+  [MatchmakingDivision.Bronze3]: '#dca889',
+  [MatchmakingDivision.Silver1]: '#7d8385',
+  [MatchmakingDivision.Silver2]: '#7c8385',
+  [MatchmakingDivision.Silver3]: '#7d8385',
+  [MatchmakingDivision.Gold1]: '#d8c479',
+  [MatchmakingDivision.Gold2]: '#d9c579',
+  [MatchmakingDivision.Gold3]: '#c4aa4d',
+  [MatchmakingDivision.Platinum1]: '#19a9ea',
+  [MatchmakingDivision.Platinum2]: '#19a9ea',
+  [MatchmakingDivision.Platinum3]: '#18a8ea',
+  [MatchmakingDivision.Diamond1]: '#dba8f8',
+  [MatchmakingDivision.Diamond2]: '#dca8f8',
+  [MatchmakingDivision.Diamond3]: '#dca8f8',
+  [MatchmakingDivision.Champion]: '#b73a18',
+}
+
+/** Fill weight climbs across the three sub-divisions of a tier. */
+function bandOpacity(division: MatchmakingDivision): number {
+  if (division === MatchmakingDivision.Champion) return 0.24
+  if (division.endsWith('2')) return 0.16
+  if (division.endsWith('3')) return 0.21
+  return 0.11
+}
+
+export interface DivisionBand {
+  division: MatchmakingDivision
+  low: number
+  high: number
+  color: string
+  opacity: number
+}
+
+/**
+ * Every division with its points bounds at the given bonus pool. Bounds come from
+ * `getDivisionsForPointsChange` rather than a local copy of the table, so the bands
+ * can't drift away from what the matchmaker actually does.
+ */
+export function divisionBands(solo: boolean, bonusPool: number): DivisionBand[] {
+  return getDivisionsForPointsChange(solo, 0, Number.MAX_SAFE_INTEGER, bonusPool).map(
+    ([division, low, high]) => ({
+      division,
+      low,
+      high,
+      color: DIVISION_COLORS[division],
+      opacity: bandOpacity(division),
+    }),
+  )
+}
+
+/** Points are expected to land near `rating * POINTS_FOR_RATING_TARGET_FACTOR`. */
+const POINTS_FACTOR = 4
+
+/** Deterministic PRNG so the dev page looks the same on every reload. */
+function rng(seed: number): () => number {
+  let s = seed >>> 0
+  return () => {
+    s = (s * 1664525 + 1013904223) >>> 0
+    return s / 4294967296
+  }
+}
+
+function buildHistory(seed: number, targets: number[]): RatingPoint[] {
+  const r = rng(seed)
+  const out: RatingPoint[] = []
+  let rating = 1500
+
+  for (const [i, season] of SEASONS.entries()) {
+    if (season.resetMmr) rating = 1500
+    // Points are seasonal: they restart at 0 every season, even when MMR carries over.
+    let points = 0
+    const n = season.end - season.start
+    const goal = targets[i]
+
+    for (let g = 0; g < n; g++) {
+      rating += (goal - rating) / Math.max(n - g, 1) + (r() - 0.5) * 34
+
+      const target = rating * POINTS_FACTOR
+      // Unconverged players get catch-up points on top of the normal gain.
+      const approach = points >= target * 0.92 ? 0.02 : 0.055
+      points += (target - points) * approach + (r() - 0.5) * 46
+      points += 2.4 // bonus pool accrues whether or not it's earned in game
+      if (points < 0) points = 0
+
+      out.push({ game: season.start + g, rating, points, season: season.id })
+    }
+  }
+  return out
+}
+
+export const MODES: ReadonlyArray<ModeStats> = [
+  {
+    key: '1v1',
+    label: 'Ranked 1v1',
+    games: 613,
+    rating: 1918,
+    seasonDelta: 418,
+    history: buildHistory(20260730, [1771, 1804, 1918]),
+  },
+  {
+    key: '2v2',
+    label: 'Ranked 2v2',
+    games: 96,
+    rating: 1642,
+    seasonDelta: -61,
+    history: buildHistory(991, [1610, 1703, 1642]),
+  },
+  {
+    key: '2v2f',
+    label: 'Ranked 2v2 Fastest',
+    games: 214,
+    rating: 1774,
+    seasonDelta: 193,
+    history: buildHistory(4242, [1588, 1690, 1774]),
+  },
+  {
+    key: '3v3h',
+    label: 'Ranked 3v3 Hunters',
+    games: 132,
+    rating: 1596,
+    seasonDelta: 25,
+    history: buildHistory(8181, [1502, 1571, 1596]),
+  },
+]
+
+/** Modes ordered so the player's most-played appears first. */
+export const MODES_BY_PLAYTIME: ReadonlyArray<ModeStats> = MODES.slice().sort(
+  (a, b) => b.games - a.games,
+)
+
+/**
+ * Splits a history into runs that should be drawn as separate lines. Rating only
+ * breaks where a season reset it; points restart every season, so they always break
+ * at a boundary. Connecting across either draws a jump that never happened.
+ */
+export function splitOnDiscontinuity(
+  history: ReadonlyArray<RatingPoint>,
+  everyBoundary: boolean,
+): RatingPoint[][] {
+  const breakAt = new Set(
+    SEASONS.filter((s, i) => (everyBoundary ? i > 0 : s.resetMmr)).map(s => s.start),
+  )
+  const runs: RatingPoint[][] = []
+  let current: RatingPoint[] = []
+  for (const point of history) {
+    if (breakAt.has(point.game) && current.length) {
+      runs.push(current)
+      current = []
+    }
+    current.push(point)
+  }
+  if (current.length) runs.push(current)
+  return runs
+}
+
+// --- Rivals ---------------------------------------------------------------
+
+export const BEST_ALLIES: ReadonlyArray<RivalEntry> = [
+  { userId: 4821, name: 'Nydus_Nomad', games: 61, wins: 44 },
+  { userId: 1190, name: 'PylonPusher', games: 28, wins: 19 },
+  { userId: 7734, name: 'SiegeCreep', games: 17, wins: 11 },
+  { userId: 2255, name: 'MacroMantis', games: 12, wins: 7 },
+]
+
+export const RIVALS: ReadonlyArray<RivalEntry> = [
+  { userId: 9012, name: 'DarkSwarmDan', games: 74, wins: 39 },
+  { userId: 3376, name: 'ReaverRush', games: 52, wins: 30 },
+  { userId: 6640, name: 'TankLineTom', games: 41, wins: 17 },
+  { userId: 8123, name: 'LurkerLane', games: 33, wins: 18 },
+]
+
+export const TOUGHEST_OPPONENTS: ReadonlyArray<RivalEntry> = [
+  { userId: 5567, name: 'CarrierHasArrived', games: 22, wins: 4 },
+  { userId: 4402, name: 'GhostNukeGuy', games: 15, wins: 4 },
+  { userId: 6640, name: 'TankLineTom', games: 41, wins: 17 },
+  { userId: 7781, name: 'DefilerDiva', games: 11, wins: 5 },
+]
+
+// --- Matchups -------------------------------------------------------------
+
+export const MATRIX_RACES: ReadonlyArray<AssignedRaceChar> = ['t', 'p', 'z']
+
+export interface MapInfo {
+  name: string
+  modes: string[]
+  seasons: number[]
+}
+
+export const MAP_POOL: ReadonlyArray<MapInfo> = [
+  { name: 'Fighting Spirit', modes: ['1v1', '2v2'], seasons: [1, 2, 3] },
+  { name: 'Polypoid', modes: ['1v1'], seasons: [1, 2, 3] },
+  { name: 'Eclipse', modes: ['1v1'], seasons: [1, 2] },
+  { name: 'Vermeer', modes: ['1v1'], seasons: [3] },
+  { name: 'Retro', modes: ['1v1'], seasons: [2, 3] },
+  { name: 'Circuit Breaker', modes: ['1v1'], seasons: [1] },
+  { name: 'Rush Hour', modes: ['2v2'], seasons: [2, 3] },
+  { name: 'Neo Sylphid', modes: ['2v2'], seasons: [1, 2] },
+  { name: 'Fastest Map Possible', modes: ['2v2f'], seasons: [1, 2, 3] },
+  { name: 'Ultra Fastest', modes: ['2v2f'], seasons: [3] },
+  { name: 'Hunters', modes: ['3v3h'], seasons: [1, 2, 3] },
+  { name: 'Deep Hunters', modes: ['3v3h'], seasons: [2, 3] },
+]
+
+export const ALL_MODES = 'all'
+export const ALL_SEASONS = 'all'
+export const ALL_MAPS = 'Overall'
+
+export function teamSizeFor(mode: string): number {
+  if (mode === '3v3h') return 3
+  if (mode === '2v2' || mode === '2v2f') return 2
+  return 1
+}
+
+export function mapsFor(mode: string, season: string): string[] {
+  return MAP_POOL.filter(
+    m =>
+      (mode === ALL_MODES || m.modes.includes(mode)) &&
+      (season === ALL_SEASONS || m.seasons.includes(Number(season))),
+  ).map(m => m.name)
+}
+
+/**
+ * Race compositions of a given size, unordered: a team is identified by the races
+ * on it, not by who played which, so TP and PT are the same composition.
+ */
+export function raceCombos(size: number): AssignedRaceChar[][] {
+  const out: AssignedRaceChar[][] = []
+  const walk = (start: number, acc: AssignedRaceChar[]) => {
+    if (acc.length === size) {
+      out.push(acc.slice())
+      return
+    }
+    for (let i = start; i < MATRIX_RACES.length; i++) {
+      acc.push(MATRIX_RACES[i])
+      walk(i, acc)
+      acc.pop()
+    }
+  }
+  walk(0, [])
+  return out
+}
+
+export interface MatchupCell {
+  games: number
+  wins: number
+}
+
+const MODE_TOTALS: Record<string, number> = {
+  all: 1055,
+  '1v1': 613,
+  '2v2': 96,
+  '2v2f': 214,
+  '3v3h': 132,
+}
+
+// This player mains Terran; ally races are near-random and opponents follow ladder
+// population. Modelling that matters: a uniform spread makes a team matrix look far
+// better covered than it really is.
+const SELF_WEIGHT: Record<AssignedRaceChar, number> = { t: 0.62, p: 0.26, z: 0.12 }
+const ALLY_WEIGHT: Record<AssignedRaceChar, number> = { t: 0.34, p: 0.33, z: 0.33 }
+const OPP_WEIGHT: Record<AssignedRaceChar, number> = { t: 0.36, p: 0.34, z: 0.3 }
+
+function arrangements(parts: AssignedRaceChar[]): number {
+  const counts = new Map<AssignedRaceChar, number>()
+  for (const p of parts) counts.set(p, (counts.get(p) ?? 0) + 1)
+  let result = 1
+  for (let f = 2; f <= parts.length; f++) result *= f
+  for (const c of counts.values()) {
+    for (let g = 2; g <= c; g++) result /= g
+  }
+  return result
+}
+
+function multisetWeight(
+  parts: AssignedRaceChar[],
+  weights: Record<AssignedRaceChar, number>,
+): number {
+  if (!parts.length) return 1
+  let w = 1
+  for (const p of parts) w *= weights[p]
+  return w * arrangements(parts)
+}
+
+/** A comp doesn't record which member was you, so sum over the possibilities. */
+function rowWeight(parts: AssignedRaceChar[]): number {
+  const seen = new Set<AssignedRaceChar>()
+  let total = 0
+  for (const race of parts) {
+    if (seen.has(race)) continue
+    seen.add(race)
+    const rest = parts.slice()
+    rest.splice(rest.indexOf(race), 1)
+    total += SELF_WEIGHT[race] * multisetWeight(rest, ALLY_WEIGHT)
+  }
+  return total
+}
+
+function hashStr(s: string): number {
+  let h = 2166136261
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i)
+    h = Math.imul(h, 16777619) >>> 0
+  }
+  return h >>> 0
+}
+
+/** Game counts are a counting process, so draw them as one. */
+function poisson(lambda: number, r: () => number): number {
+  if (lambda <= 0) return 0
+  if (lambda < 30) {
+    const l = Math.exp(-lambda)
+    let k = 0
+    let p = 1
+    do {
+      k++
+      p *= r()
+    } while (p > l)
+    return k - 1
+  }
+  const u1 = Math.max(r(), 1e-9)
+  const u2 = r()
+  const z = Math.sqrt(-2 * Math.log(u1)) * Math.cos(2 * Math.PI * u2)
+  return Math.max(0, Math.round(lambda + z * Math.sqrt(lambda)))
+}
+
+export function matchupCell(
+  mode: string,
+  season: string,
+  map: string,
+  row: AssignedRaceChar[],
+  col: AssignedRaceChar[],
+): MatchupCell {
+  const key = `${mode}|${season}|${map}|${row.join('')}>${col.join('')}`
+  const r = rng(hashStr(key))
+  r()
+  r()
+
+  let scale = 0.18
+  if (map === ALL_MAPS) {
+    scale = season === ALL_SEASONS ? 1 : 0.4
+  }
+  const weight = rowWeight(row) * multisetWeight(col, OPP_WEIGHT)
+  const games = poisson((MODE_TOTALS[mode] ?? 300) * scale * weight, r)
+  if (games < 1) return { games: 0, wins: 0 }
+
+  const sameComp = row.join('') === col.join('')
+  const winRate = sameComp ? 0.46 + r() * 0.1 : 0.42 + r() * 0.28
+  return { games, wins: Math.round(games * winRate) }
+}
+
+/** A map's win rate is the sum of its own matrix, so a label can't disagree with the grid. */
+export function mapStats(mode: string, season: string, map: string): MatchupCell {
+  const combos = raceCombos(teamSizeFor(mode))
+  let games = 0
+  let wins = 0
+  for (const row of combos) {
+    for (const col of combos) {
+      const cell = matchupCell(mode, season, map, row, col)
+      games += cell.games
+      wins += cell.wins
+    }
+  }
+  return { games, wins }
+}

--- a/client/users/devonly/stats-data.ts
+++ b/client/users/devonly/stats-data.ts
@@ -4,8 +4,8 @@ import {
   MatchmakingType,
   POINTS_FOR_RATING_TARGET_FACTOR,
   TEAM_SIZES,
+  getAllDivisionsWithBounds,
   getDivisionColor,
-  getDivisionsForPointsChange,
   getTotalBonusPool,
 } from '../../../common/matchmaking'
 import { AssignedRaceChar } from '../../../common/races'
@@ -80,12 +80,11 @@ export const SEASONS: ReadonlyArray<SeasonInfo> = [
 export const CURRENT_SEASON = SEASONS[SEASONS.length - 1]
 
 /**
- * The bonus pool as it stands now, via the real accrual function. Division bounds are
- * `low + bonusPool * factor`, so this is what positions the bands.
+ * Newest first, for season pickers — the most recent season is what a player is
+ * usually after. `SEASONS` itself stays chronological, since the history generator
+ * and the band grouping both walk it in order.
  */
-export function currentBonusPool(): number {
-  return bonusPoolFor(CURRENT_SEASON)
-}
+export const SEASONS_NEWEST_FIRST: ReadonlyArray<SeasonInfo> = SEASONS.slice().reverse()
 
 /**
  * The pool as it stood for a given season: at its end if it's over, at now if it's
@@ -122,15 +121,13 @@ export interface DivisionBand {
  * can't drift away from what the matchmaker actually does.
  */
 export function divisionBands(solo: boolean, bonusPool: number): DivisionBand[] {
-  return getDivisionsForPointsChange(solo, 0, Number.MAX_SAFE_INTEGER, bonusPool).map(
-    ([division, low, high]) => ({
-      division,
-      low,
-      high,
-      color: getDivisionColor(division),
-      opacity: bandOpacity(division),
-    }),
-  )
+  return getAllDivisionsWithBounds(solo, bonusPool).map(([division, low, high]) => ({
+    division,
+    low,
+    high,
+    color: getDivisionColor(division),
+    opacity: bandOpacity(division),
+  }))
 }
 
 /** Deterministic PRNG so the dev page looks the same on every reload. */

--- a/client/users/devonly/stats-page-test.tsx
+++ b/client/users/devonly/stats-page-test.tsx
@@ -13,7 +13,7 @@ import {
 } from 'recharts'
 import styled from 'styled-components'
 import { MATCHMAKING_MODES, isSoloType } from '../../../common/matchmaking'
-import { AssignedRaceChar } from '../../../common/races'
+import { AssignedRaceChar, raceCharToLabel } from '../../../common/races'
 import { urlPath } from '../../../common/urls'
 import { MaterialIcon } from '../../icons/material/material-icon'
 import { buttonReset } from '../../material/button-reset'
@@ -37,7 +37,6 @@ import {
   ALL_MODES,
   ALL_SEASONS,
   BEST_ALLIES,
-  DivisionBand,
   MODES_BY_PLAYTIME,
   MatchupCell,
   ModeFilter,
@@ -46,14 +45,13 @@ import {
   RatingPoint,
   RivalEntry,
   SEASONS,
+  SeasonBands,
   TOUGHEST_OPPONENTS,
-  bonusPoolFor,
-  currentBonusPool,
-  divisionBands,
   mapStats,
   mapsFor,
   matchupCell,
   raceCombos,
+  seasonBandGroups,
   seasonBoundaries,
   splitOnDiscontinuity,
   teamSizeFor,
@@ -235,9 +233,8 @@ function ModeCardView({
   // Only offer seasons this mode was actually played in — on real data a player
   // will often have nothing for a given season, and an empty series has no chart.
   const playedSeasons = SEASONS.filter(s => mode.history.some(p => p.season === s.id))
-  // Bands must use the pool of the season being looked at, not today's.
-  const selectedSeason = SEASONS.find(s => String(s.id) === season)
-  const bonusPool = selectedSeason ? bonusPoolFor(selectedSeason) : currentBonusPool()
+  // One band set per season in view, each at that season's own bonus pool.
+  const bandGroups = metric === 'points' ? seasonBandGroups(history, isSoloType(mode.type)) : []
 
   return (
     <ModeCard>
@@ -282,7 +279,7 @@ function ModeCardView({
             showBoundaries={season === ALL_SEASONS}
             // Divisions are defined on points, and their bounds differ between solo
             // and team modes.
-            bands={metric === 'points' ? divisionBands(isSoloType(mode.type), bonusPool) : []}
+            bandGroups={bandGroups}
           />
         </CardBody>
       ) : undefined}
@@ -294,12 +291,12 @@ function RatingChart({
   runs,
   metric,
   showBoundaries,
-  bands,
+  bandGroups,
 }: {
   runs: RatingPoint[][]
   metric: Metric
   showBoundaries: boolean
-  bands: DivisionBand[]
+  bandGroups: SeasonBands[]
 }) {
   const all = runs.flat()
   if (!all.length) {
@@ -322,20 +319,25 @@ function RatingChart({
     <ChartArea>
       <ResponsiveContainer width='100%' height='100%'>
         <LineChart margin={{ top: 8, right: 8, bottom: 4, left: 0 }}>
-          {/* Bands first, so the grid and the series draw over them. */}
-          {bands
-            .filter(b => b.low < hi && b.high > lo)
-            .map(b => (
-              <ReferenceArea
-                key={b.division}
-                y1={Math.max(lo, b.low)}
-                y2={Math.min(hi, b.high)}
-                fill={b.color}
-                fillOpacity={b.opacity}
-                stroke='none'
-                ifOverflow='hidden'
-              />
-            ))}
+          {/* Bands first, so the grid and the series draw over them. Each season's
+              span carries its own bounds, at the pool that applied then. */}
+          {bandGroups.flatMap(group =>
+            group.bands
+              .filter(b => b.low < hi && b.high > lo)
+              .map(b => (
+                <ReferenceArea
+                  key={`${group.seasonId}-${b.division}`}
+                  x1={group.fromGame}
+                  x2={group.toGame}
+                  y1={Math.max(lo, b.low)}
+                  y2={Math.min(hi, b.high)}
+                  fill={b.color}
+                  fillOpacity={b.opacity}
+                  stroke='none'
+                  ifOverflow='hidden'
+                />
+              )),
+          )}
           <CartesianGrid stroke='var(--theme-outline-variant)' vertical={false} />
           <XAxis
             dataKey='game'
@@ -635,15 +637,10 @@ const Combo = styled.span`
   gap: 2px;
 `
 
-const RACE_LABELS: Record<AssignedRaceChar, string> = {
-  t: 'Terran',
-  p: 'Protoss',
-  z: 'Zerg',
-}
-
 function ComboLabel({ parts }: { parts: AssignedRaceChar[] }) {
+  const { t } = useTranslation()
   if (parts.length === 1) {
-    return <RaceChip $race={parts[0]}>{RACE_LABELS[parts[0]]}</RaceChip>
+    return <RaceChip $race={parts[0]}>{raceCharToLabel(parts[0], t)}</RaceChip>
   }
   return (
     <Combo>

--- a/client/users/devonly/stats-page-test.tsx
+++ b/client/users/devonly/stats-page-test.tsx
@@ -47,6 +47,7 @@ import {
   RivalEntry,
   SEASONS,
   TOUGHEST_OPPONENTS,
+  bonusPoolFor,
   currentBonusPool,
   divisionBands,
   mapStats,
@@ -223,6 +224,9 @@ function ModeCardView({
   // Only offer seasons this mode was actually played in — on real data a player
   // will often have nothing for a given season, and an empty series has no chart.
   const playedSeasons = SEASONS.filter(s => mode.history.some(p => p.season === s.id))
+  // Bands must use the pool of the season being looked at, not today's.
+  const selectedSeason = SEASONS.find(s => String(s.id) === season)
+  const bonusPool = selectedSeason ? bonusPoolFor(selectedSeason) : currentBonusPool()
 
   return (
     <ModeCard>
@@ -269,9 +273,7 @@ function ModeCardView({
             showBoundaries={season === ALL_SEASONS}
             // Divisions are defined on points, and their bounds differ between solo
             // and team modes.
-            bands={
-              metric === 'points' ? divisionBands(isSoloType(mode.type), currentBonusPool()) : []
-            }
+            bands={metric === 'points' ? divisionBands(isSoloType(mode.type), bonusPool) : []}
           />
         </CardBody>
       ) : undefined}

--- a/client/users/devonly/stats-page-test.tsx
+++ b/client/users/devonly/stats-page-test.tsx
@@ -44,7 +44,7 @@ import {
   RIVALS,
   RatingPoint,
   RivalEntry,
-  SEASONS,
+  SEASONS_NEWEST_FIRST,
   SeasonBands,
   TOUGHEST_OPPONENTS,
   mapStats,
@@ -232,7 +232,7 @@ function ModeCardView({
   const runs = splitOnDiscontinuity(history, metric === 'points')
   // Only offer seasons this mode was actually played in — on real data a player
   // will often have nothing for a given season, and an empty series has no chart.
-  const playedSeasons = SEASONS.filter(s => mode.history.some(p => p.season === s.id))
+  const playedSeasons = SEASONS_NEWEST_FIRST.filter(s => mode.history.some(p => p.season === s.id))
   // One band set per season in view, each at that season's own bonus pool.
   const bandGroups = metric === 'points' ? seasonBandGroups(history, isSoloType(mode.type)) : []
 
@@ -266,7 +266,11 @@ function ModeCardView({
               seasons a year, and a wrapping chip row stops being readable well
               before a long-lived account runs out of them. */}
           <Filter>
-            <Select value={season} label='Season' onChange={(value: string) => setSeason(value)}>
+            <Select
+              value={season}
+              label='Season'
+              allowErrors={false}
+              onChange={(value: string) => setSeason(value)}>
               <SelectOption value={ALL_SEASONS} text='All time' />
               {playedSeasons.map(s => (
                 <SelectOption key={s.id} value={String(s.id)} text={s.name} />
@@ -702,6 +706,7 @@ function MatchupsSection() {
           <Select
             value={mode}
             label='Game mode'
+            allowErrors={false}
             onChange={(value: ModeFilter) => {
               setMode(value)
               setMap(ALL_MAPS)
@@ -716,18 +721,23 @@ function MatchupsSection() {
           <Select
             value={season}
             label='Season'
+            allowErrors={false}
             onChange={(value: string) => {
               setSeason(value)
               setMap(ALL_MAPS)
             }}>
             <SelectOption value={ALL_SEASONS} text='Overall' />
-            {SEASONS.map(s => (
+            {SEASONS_NEWEST_FIRST.map(s => (
               <SelectOption key={s.id} value={String(s.id)} text={s.name} />
             ))}
           </Select>
         </Filter>
         <Filter $wide={true}>
-          <Select value={activeMap} label='Map' onChange={(value: string) => setMap(value)}>
+          <Select
+            value={activeMap}
+            label='Map'
+            allowErrors={false}
+            onChange={(value: string) => setMap(value)}>
             <SelectOption value={ALL_MAPS} text='Overall' />
             {availableMaps.map(m => (
               <SelectOption

--- a/client/users/devonly/stats-page-test.tsx
+++ b/client/users/devonly/stats-page-test.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import {
   CartesianGrid,
   Line,
@@ -11,6 +12,7 @@ import {
   YAxis,
 } from 'recharts'
 import styled from 'styled-components'
+import { MATCHMAKING_MODES, isSoloType } from '../../../common/matchmaking'
 import { AssignedRaceChar } from '../../../common/races'
 import { urlPath } from '../../../common/urls'
 import { MaterialIcon } from '../../icons/material/material-icon'
@@ -38,6 +40,7 @@ import {
   DivisionBand,
   MODES_BY_PLAYTIME,
   MatchupCell,
+  ModeFilter,
   ModeStats,
   RIVALS,
   RatingPoint,
@@ -173,19 +176,27 @@ const ChartArea = styled.div`
   height: 260px;
 `
 
+const EmptyChart = styled.div`
+  ${bodyMedium};
+  height: 260px;
+  display: grid;
+  place-items: center;
+  color: var(--theme-on-surface-variant);
+`
+
 type Metric = 'rating' | 'points'
 
 function RatingSection() {
-  const [open, setOpen] = useState<string>(MODES_BY_PLAYTIME[0].key)
+  const [open, setOpen] = useState<string>(MODES_BY_PLAYTIME[0].type)
 
   return (
     <ModeList>
       {MODES_BY_PLAYTIME.map(mode => (
         <ModeCardView
-          key={mode.key}
+          key={mode.type}
           mode={mode}
-          open={open === mode.key}
-          onToggle={() => setOpen(open === mode.key ? '' : mode.key)}
+          open={open === mode.type}
+          onToggle={() => setOpen(open === mode.type ? '' : mode.type)}
         />
       ))}
     </ModeList>
@@ -201,6 +212,7 @@ function ModeCardView({
   open: boolean
   onToggle: () => void
 }) {
+  const { t } = useTranslation()
   const [metric, setMetric] = useState<Metric>('rating')
   const [season, setSeason] = useState<string>(ALL_SEASONS)
 
@@ -208,12 +220,15 @@ function ModeCardView({
     season === ALL_SEASONS ? mode.history : mode.history.filter(p => p.season === Number(season))
   // Points restart every season; rating only breaks where a season reset it.
   const runs = splitOnDiscontinuity(history, metric === 'points')
+  // Only offer seasons this mode was actually played in — on real data a player
+  // will often have nothing for a given season, and an empty series has no chart.
+  const playedSeasons = SEASONS.filter(s => mode.history.some(p => p.season === s.id))
 
   return (
     <ModeCard>
       <ModeHeader onClick={onToggle} aria-expanded={open}>
         <Grow>
-          <ModeTitle>{mode.label}</ModeTitle>
+          <ModeTitle>{MATCHMAKING_MODES[mode.type].label(t)}</ModeTitle>
           <ModeSub>{mode.games} games</ModeSub>
         </Grow>
         <MetricColumn>
@@ -239,7 +254,7 @@ function ModeCardView({
             <Chip $active={season === ALL_SEASONS} onClick={() => setSeason(ALL_SEASONS)}>
               All time
             </Chip>
-            {SEASONS.map(s => (
+            {playedSeasons.map(s => (
               <Chip
                 key={s.id}
                 $active={season === String(s.id)}
@@ -254,7 +269,9 @@ function ModeCardView({
             showBoundaries={season === ALL_SEASONS}
             // Divisions are defined on points, and their bounds differ between solo
             // and team modes.
-            bands={metric === 'points' ? divisionBands(mode.key === '1v1', currentBonusPool()) : []}
+            bands={
+              metric === 'points' ? divisionBands(isSoloType(mode.type), currentBonusPool()) : []
+            }
           />
         </CardBody>
       ) : undefined}
@@ -274,9 +291,21 @@ function RatingChart({
   bands: DivisionBand[]
 }) {
   const all = runs.flat()
-  const values = all.map(p => (metric === 'points' ? p.points : p.rating))
-  const lo = metric === 'points' ? 0 : Math.floor((Math.min(...values) - 40) / 50) * 50
-  const hi = Math.ceil((Math.max(...values) + 60) / 50) * 50
+  if (!all.length) {
+    return <EmptyChart>No games in this range</EmptyChart>
+  }
+
+  // reduce rather than Math.min(...values): a spread passes one argument per point,
+  // which blows the call-argument limit on a long enough history.
+  let min = Infinity
+  let max = -Infinity
+  for (const point of all) {
+    const value = metric === 'points' ? point.points : point.rating
+    if (value < min) min = value
+    if (value > max) max = value
+  }
+  const lo = metric === 'points' ? 0 : Math.floor((min - 40) / 50) * 50
+  const hi = Math.ceil((max + 60) / 50) * 50
 
   return (
     <ChartArea>
@@ -638,7 +667,8 @@ function tintFor(cell: MatchupCell): string {
 }
 
 function MatchupsSection() {
-  const [mode, setMode] = useState<string>(ALL_MODES)
+  const { t } = useTranslation()
+  const [mode, setMode] = useState<ModeFilter>(ALL_MODES)
   const [season, setSeason] = useState<string>(ALL_SEASONS)
   const [map, setMap] = useState<string>(ALL_MAPS)
 
@@ -675,13 +705,13 @@ function MatchupsSection() {
           <Select
             value={mode}
             label='Game mode'
-            onChange={(value: string) => {
+            onChange={(value: ModeFilter) => {
               setMode(value)
               setMap(ALL_MAPS)
             }}>
             <SelectOption value={ALL_MODES} text='Overall' />
             {MODES_BY_PLAYTIME.map(m => (
-              <SelectOption key={m.key} value={m.key} text={m.label.replace(/^Ranked /, '')} />
+              <SelectOption key={m.type} value={m.type} text={MATCHMAKING_MODES[m.type].label(t)} />
             ))}
           </Select>
         </Filter>

--- a/client/users/devonly/stats-page-test.tsx
+++ b/client/users/devonly/stats-page-test.tsx
@@ -12,7 +12,10 @@ import {
 } from 'recharts'
 import styled from 'styled-components'
 import { AssignedRaceChar } from '../../../common/races'
+import { urlPath } from '../../../common/urls'
 import { MaterialIcon } from '../../icons/material/material-icon'
+import { buttonReset } from '../../material/button-reset'
+import { LinkButton } from '../../material/link-button'
 import { SelectOption } from '../../material/select/option'
 import { Select } from '../../material/select/select'
 import { TabItem, Tabs } from '../../material/tabs'
@@ -47,6 +50,7 @@ import {
   mapsFor,
   matchupCell,
   raceCombos,
+  seasonBoundaries,
   splitOnDiscontinuity,
   teamSizeFor,
 } from './stats-data'
@@ -86,17 +90,15 @@ const ModeCard = styled.div`
 `
 
 const ModeHeader = styled.button`
+  ${buttonReset};
   width: 100%;
   padding: 14px 16px;
   display: flex;
   align-items: center;
   gap: 16px;
 
-  background: none;
-  border: none;
   color: inherit;
   text-align: left;
-  cursor: pointer;
 
   &:hover {
     background: var(--theme-container);
@@ -118,7 +120,7 @@ const Grow = styled.div`
   min-width: 0;
 `
 
-const Metric = styled.div`
+const MetricColumn = styled.div`
   display: flex;
   flex-direction: column;
   align-items: flex-end;
@@ -154,10 +156,10 @@ const ChipRow = styled.div`
 `
 
 const Chip = styled.button<{ $active: boolean }>`
+  ${buttonReset};
   ${labelMedium};
   padding: 5px 12px;
   border-radius: 999px;
-  cursor: pointer;
 
   background: ${props => (props.$active ? 'var(--theme-container-highest)' : 'transparent')};
   border: 1px solid
@@ -214,12 +216,12 @@ function ModeCardView({
           <ModeTitle>{mode.label}</ModeTitle>
           <ModeSub>{mode.games} games</ModeSub>
         </Grow>
-        <Metric>
+        <MetricColumn>
           <MetricValue>{mode.rating}</MetricValue>
           <Delta $positive={mode.seasonDelta >= 0}>
             {mode.seasonDelta >= 0 ? '▲' : '▼'} {Math.abs(mode.seasonDelta)} this season
           </Delta>
-        </Metric>
+        </MetricColumn>
         <Caret $open={open} />
       </ModeHeader>
 
@@ -323,10 +325,10 @@ function RatingChart({
             ]}
           />
           {showBoundaries
-            ? SEASONS.slice(1).map(s => (
+            ? seasonBoundaries(all).map(game => (
                 <ReferenceLine
-                  key={s.id}
-                  x={s.start}
+                  key={game}
+                  x={game}
                   stroke='var(--theme-outline)'
                   strokeDasharray='4 4'
                 />
@@ -379,7 +381,9 @@ const PanelNote = styled.span`
   color: var(--theme-on-surface-variant);
 `
 
-const PlayerRow = styled.a`
+// LinkButton routes through wouter, so a click stays in the SPA instead of
+// hard-navigating out of it.
+const PlayerRow = styled(LinkButton)`
   display: flex;
   align-items: center;
   gap: 10px;
@@ -482,8 +486,7 @@ function RivalList({
         return (
           <PlayerRow
             key={`${title}-${entry.userId}`}
-            href={`/users/${entry.userId}/${entry.name}`}
-            title={`Go to ${entry.name}'s profile`}>
+            href={urlPath`/users/${entry.userId}/${entry.name}`}>
             <Avatar $color={AVATAR_COLORS[entry.userId % AVATAR_COLORS.length]}>
               {entry.name.charAt(0)}
             </Avatar>
@@ -571,7 +574,7 @@ const RowHead = styled.th`
   text-align: right;
 `
 
-const Cell = styled.td<{ $tint: string; $thin: boolean; $empty: boolean }>`
+const Cell = styled.td<{ $tint: string; $thin: boolean }>`
   box-sizing: border-box;
   min-width: 62px;
   padding: 7px 5px;
@@ -629,7 +632,9 @@ function tintFor(cell: MatchupCell): string {
   const rate = cell.wins / cell.games
   const d = Math.max(-0.28, Math.min(0.28, rate - 0.5))
   const alpha = ((Math.abs(d) / 0.28) * 0.3).toFixed(3)
-  return d >= 0 ? `rgba(105, 240, 174, ${alpha})` : `rgba(230, 96, 96, ${alpha})`
+  return d >= 0
+    ? `rgb(from var(--theme-positive) r g b / ${alpha})`
+    : `rgb(from var(--theme-negative) r g b / ${alpha})`
 }
 
 function MatchupsSection() {
@@ -743,8 +748,7 @@ function MatchupsSection() {
                     <Cell
                       key={col.join('')}
                       $tint={tintFor(cell)}
-                      $thin={cell.games > 0 && cell.games < 5}
-                      $empty={!cell.games}>
+                      $thin={cell.games > 0 && cell.games < 5}>
                       <CellRate $empty={!cell.games}>{cell.games ? `${rate}%` : '—'}</CellRate>
                       <CellRecord>
                         {cell.games ? `${cell.wins}–${cell.games - cell.wins}` : ''}

--- a/client/users/devonly/stats-page-test.tsx
+++ b/client/users/devonly/stats-page-test.tsx
@@ -78,6 +78,17 @@ const TabsArea = styled.div`
   max-width: 480px;
 `
 
+/**
+ * Selects are `width: 100%` of whatever contains them, and their dropdown arrow is
+ * absolutely positioned over the right edge. Without a width they collapse to fit a
+ * flex line and the value runs underneath the arrow, so give them one. Map values
+ * carry a win rate suffix and need the extra room.
+ */
+const Filter = styled.div<{ $wide?: boolean }>`
+  width: ${props => (props.$wide ? '288px' : '208px')};
+  max-width: 100%;
+`
+
 // --- Rating ---------------------------------------------------------------
 
 const ModeList = styled.div`
@@ -254,19 +265,17 @@ function ModeCardView({
               Points
             </Chip>
           </ChipRow>
-          <ChipRow>
-            <Chip $active={season === ALL_SEASONS} onClick={() => setSeason(ALL_SEASONS)}>
-              All time
-            </Chip>
-            {playedSeasons.map(s => (
-              <Chip
-                key={s.id}
-                $active={season === String(s.id)}
-                onClick={() => setSeason(String(s.id))}>
-                {s.name}
-              </Chip>
-            ))}
-          </ChipRow>
+          {/* A dropdown rather than a chip per season: ShieldBattery gains a few
+              seasons a year, and a wrapping chip row stops being readable well
+              before a long-lived account runs out of them. */}
+          <Filter>
+            <Select value={season} label='Season' onChange={(value: string) => setSeason(value)}>
+              <SelectOption value={ALL_SEASONS} text='All time' />
+              {playedSeasons.map(s => (
+                <SelectOption key={s.id} value={String(s.id)} text={s.name} />
+              ))}
+            </Select>
+          </Filter>
           <RatingChart
             runs={runs}
             metric={metric}
@@ -555,17 +564,6 @@ const Filters = styled.div`
   flex-wrap: wrap;
   gap: 16px;
   margin-bottom: 16px;
-`
-
-/**
- * Selects are `width: 100%` of whatever contains them, and their dropdown arrow is
- * absolutely positioned over the right edge. Without a width they collapse to fit a
- * flex line and the value runs underneath the arrow, so give them one. Map values
- * carry a win rate suffix and need the extra room.
- */
-const Filter = styled.div<{ $wide?: boolean }>`
-  width: ${props => (props.$wide ? '288px' : '208px')};
-  max-width: 100%;
 `
 
 const Coverage = styled.div`

--- a/client/users/devonly/stats-page-test.tsx
+++ b/client/users/devonly/stats-page-test.tsx
@@ -1,0 +1,784 @@
+import { useState } from 'react'
+import {
+  CartesianGrid,
+  Line,
+  LineChart,
+  ReferenceArea,
+  ReferenceLine,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts'
+import styled from 'styled-components'
+import { AssignedRaceChar } from '../../../common/races'
+import { MaterialIcon } from '../../icons/material/material-icon'
+import { SelectOption } from '../../material/select/option'
+import { Select } from '../../material/select/select'
+import { TabItem, Tabs } from '../../material/tabs'
+import { getRaceColor } from '../../styles/colors'
+import {
+  bodyMedium,
+  bodySmall,
+  labelMedium,
+  labelSmall,
+  singleLine,
+  titleLarge,
+  titleMedium,
+  titleSmall,
+} from '../../styles/typography'
+import {
+  ALL_MAPS,
+  ALL_MODES,
+  ALL_SEASONS,
+  BEST_ALLIES,
+  DivisionBand,
+  MODES_BY_PLAYTIME,
+  MatchupCell,
+  ModeStats,
+  RIVALS,
+  RatingPoint,
+  RivalEntry,
+  SEASONS,
+  TOUGHEST_OPPONENTS,
+  currentBonusPool,
+  divisionBands,
+  mapStats,
+  mapsFor,
+  matchupCell,
+  raceCombos,
+  splitOnDiscontinuity,
+  teamSizeFor,
+} from './stats-data'
+
+enum StatsSection {
+  Rating = 'rating',
+  Rivals = 'rivals',
+  Matchups = 'matchups',
+}
+
+const Container = styled.div`
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+`
+
+// Wrapped rather than styled(Tabs): styling the component directly erases its
+// generic parameter, which loses the type of the tab values.
+const TabsArea = styled.div`
+  max-width: 480px;
+`
+
+// --- Rating ---------------------------------------------------------------
+
+const ModeList = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+`
+
+const ModeCard = styled.div`
+  background: var(--theme-container-low);
+  border: 1px solid var(--theme-outline-variant);
+  border-radius: 8px;
+  overflow: hidden;
+`
+
+const ModeHeader = styled.button`
+  width: 100%;
+  padding: 14px 16px;
+  display: flex;
+  align-items: center;
+  gap: 16px;
+
+  background: none;
+  border: none;
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+
+  &:hover {
+    background: var(--theme-container);
+  }
+`
+
+const ModeTitle = styled.div`
+  ${titleMedium};
+  ${singleLine};
+`
+
+const ModeSub = styled.div`
+  ${bodySmall};
+  color: var(--theme-on-surface-variant);
+`
+
+const Grow = styled.div`
+  flex-grow: 1;
+  min-width: 0;
+`
+
+const Metric = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+`
+
+const MetricValue = styled.div`
+  ${titleLarge};
+  font-variant-numeric: tabular-nums;
+`
+
+const Delta = styled.div<{ $positive: boolean }>`
+  ${labelMedium};
+  font-variant-numeric: tabular-nums;
+  color: ${props => (props.$positive ? 'var(--theme-positive)' : 'var(--theme-negative)')};
+`
+
+const Caret = styled(MaterialIcon).attrs({ icon: 'expand_more' })<{ $open: boolean }>`
+  color: var(--theme-on-surface-variant);
+  transform: ${props => (props.$open ? 'rotate(180deg)' : 'none')};
+  transition: transform 150ms ease;
+`
+
+const CardBody = styled.div`
+  padding: 4px 16px 16px;
+  border-top: 1px solid var(--theme-outline-variant);
+`
+
+const ChipRow = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin: 12px 0;
+`
+
+const Chip = styled.button<{ $active: boolean }>`
+  ${labelMedium};
+  padding: 5px 12px;
+  border-radius: 999px;
+  cursor: pointer;
+
+  background: ${props => (props.$active ? 'var(--theme-container-highest)' : 'transparent')};
+  border: 1px solid
+    ${props => (props.$active ? 'var(--theme-primary)' : 'var(--theme-outline-variant)')};
+  color: ${props =>
+    props.$active ? 'var(--theme-on-surface)' : 'var(--theme-on-surface-variant)'};
+`
+
+const ChartArea = styled.div`
+  width: 100%;
+  height: 260px;
+`
+
+type Metric = 'rating' | 'points'
+
+function RatingSection() {
+  const [open, setOpen] = useState<string>(MODES_BY_PLAYTIME[0].key)
+
+  return (
+    <ModeList>
+      {MODES_BY_PLAYTIME.map(mode => (
+        <ModeCardView
+          key={mode.key}
+          mode={mode}
+          open={open === mode.key}
+          onToggle={() => setOpen(open === mode.key ? '' : mode.key)}
+        />
+      ))}
+    </ModeList>
+  )
+}
+
+function ModeCardView({
+  mode,
+  open,
+  onToggle,
+}: {
+  mode: ModeStats
+  open: boolean
+  onToggle: () => void
+}) {
+  const [metric, setMetric] = useState<Metric>('rating')
+  const [season, setSeason] = useState<string>(ALL_SEASONS)
+
+  const history =
+    season === ALL_SEASONS ? mode.history : mode.history.filter(p => p.season === Number(season))
+  // Points restart every season; rating only breaks where a season reset it.
+  const runs = splitOnDiscontinuity(history, metric === 'points')
+
+  return (
+    <ModeCard>
+      <ModeHeader onClick={onToggle} aria-expanded={open}>
+        <Grow>
+          <ModeTitle>{mode.label}</ModeTitle>
+          <ModeSub>{mode.games} games</ModeSub>
+        </Grow>
+        <Metric>
+          <MetricValue>{mode.rating}</MetricValue>
+          <Delta $positive={mode.seasonDelta >= 0}>
+            {mode.seasonDelta >= 0 ? '▲' : '▼'} {Math.abs(mode.seasonDelta)} this season
+          </Delta>
+        </Metric>
+        <Caret $open={open} />
+      </ModeHeader>
+
+      {open ? (
+        <CardBody>
+          <ChipRow>
+            <Chip $active={metric === 'rating'} onClick={() => setMetric('rating')}>
+              Rating
+            </Chip>
+            <Chip $active={metric === 'points'} onClick={() => setMetric('points')}>
+              Points
+            </Chip>
+          </ChipRow>
+          <ChipRow>
+            <Chip $active={season === ALL_SEASONS} onClick={() => setSeason(ALL_SEASONS)}>
+              All time
+            </Chip>
+            {SEASONS.map(s => (
+              <Chip
+                key={s.id}
+                $active={season === String(s.id)}
+                onClick={() => setSeason(String(s.id))}>
+                {s.name}
+              </Chip>
+            ))}
+          </ChipRow>
+          <RatingChart
+            runs={runs}
+            metric={metric}
+            showBoundaries={season === ALL_SEASONS}
+            // Divisions are defined on points, and their bounds differ between solo
+            // and team modes.
+            bands={metric === 'points' ? divisionBands(mode.key === '1v1', currentBonusPool()) : []}
+          />
+        </CardBody>
+      ) : undefined}
+    </ModeCard>
+  )
+}
+
+function RatingChart({
+  runs,
+  metric,
+  showBoundaries,
+  bands,
+}: {
+  runs: RatingPoint[][]
+  metric: Metric
+  showBoundaries: boolean
+  bands: DivisionBand[]
+}) {
+  const all = runs.flat()
+  const values = all.map(p => (metric === 'points' ? p.points : p.rating))
+  const lo = metric === 'points' ? 0 : Math.floor((Math.min(...values) - 40) / 50) * 50
+  const hi = Math.ceil((Math.max(...values) + 60) / 50) * 50
+
+  return (
+    <ChartArea>
+      <ResponsiveContainer width='100%' height='100%'>
+        <LineChart margin={{ top: 8, right: 8, bottom: 4, left: 0 }}>
+          {/* Bands first, so the grid and the series draw over them. */}
+          {bands
+            .filter(b => b.low < hi && b.high > lo)
+            .map(b => (
+              <ReferenceArea
+                key={b.division}
+                y1={Math.max(lo, b.low)}
+                y2={Math.min(hi, b.high)}
+                fill={b.color}
+                fillOpacity={b.opacity}
+                stroke='none'
+                ifOverflow='hidden'
+              />
+            ))}
+          <CartesianGrid stroke='var(--theme-outline-variant)' vertical={false} />
+          <XAxis
+            dataKey='game'
+            type='number'
+            domain={[all[0].game, all[all.length - 1].game]}
+            stroke='var(--theme-on-surface-variant)'
+            tick={{ fontSize: 12 }}
+            tickLine={false}
+          />
+          <YAxis
+            domain={[lo, hi]}
+            stroke='var(--theme-on-surface-variant)'
+            tick={{ fontSize: 12 }}
+            tickLine={false}
+            width={52}
+          />
+          <Tooltip
+            contentStyle={{
+              background: 'var(--theme-container-high)',
+              border: '1px solid var(--theme-outline-variant)',
+              borderRadius: '6px',
+            }}
+            labelFormatter={value => `Game ${String(value)}`}
+            formatter={value => [
+              Math.round(Number(value)),
+              metric === 'points' ? 'Points' : 'Rating',
+            ]}
+          />
+          {showBoundaries
+            ? SEASONS.slice(1).map(s => (
+                <ReferenceLine
+                  key={s.id}
+                  x={s.start}
+                  stroke='var(--theme-outline)'
+                  strokeDasharray='4 4'
+                />
+              ))
+            : undefined}
+          {/* One Line per run, so the series never connects across a reset. */}
+          {runs.map((run, i) => (
+            <Line
+              key={i}
+              data={run}
+              dataKey={metric}
+              type='monotone'
+              stroke={metric === 'points' ? 'var(--theme-color-zerg)' : 'var(--theme-color-terran)'}
+              strokeWidth={2}
+              dot={false}
+              isAnimationActive={false}
+            />
+          ))}
+        </LineChart>
+      </ResponsiveContainer>
+    </ChartArea>
+  )
+}
+
+// --- Rivals ---------------------------------------------------------------
+
+const RivalsGrid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 12px;
+`
+
+const RivalPanel = styled.div`
+  background: var(--theme-container-low);
+  border: 1px solid var(--theme-outline-variant);
+  border-radius: 8px;
+  padding: 14px 16px;
+`
+
+const PanelTitle = styled.div`
+  ${titleSmall};
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  margin-bottom: 8px;
+`
+
+const PanelNote = styled.span`
+  ${labelSmall};
+  color: var(--theme-on-surface-variant);
+`
+
+const PlayerRow = styled.a`
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 7px 8px;
+  margin: 0 -8px;
+  border-radius: 6px;
+  color: inherit;
+  text-decoration: none;
+
+  &:hover {
+    background: var(--theme-container);
+  }
+`
+
+const Avatar = styled.div<{ $color: string }>`
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  display: grid;
+  place-items: center;
+
+  ${labelMedium};
+  background: ${props => props.$color};
+  color: var(--theme-surface);
+`
+
+const PlayerName = styled.div`
+  ${bodyMedium};
+  ${singleLine};
+  flex-grow: 1;
+`
+
+const PlayerStat = styled.div`
+  text-align: right;
+  flex-shrink: 0;
+`
+
+const TONE_COLORS = {
+  positive: 'var(--theme-positive)',
+  negative: 'var(--theme-negative)',
+} as const
+
+const StatMain = styled.div<{ $tone?: keyof typeof TONE_COLORS }>`
+  ${bodyMedium};
+  font-variant-numeric: tabular-nums;
+  color: ${props => (props.$tone ? TONE_COLORS[props.$tone] : 'inherit')};
+`
+
+const StatSub = styled.div`
+  ${labelSmall};
+  color: var(--theme-on-surface-variant);
+  font-variant-numeric: tabular-nums;
+`
+
+const AVATAR_COLORS = [
+  'var(--theme-color-terran)',
+  'var(--theme-color-protoss)',
+  'var(--theme-color-zerg)',
+  'var(--theme-positive)',
+  'var(--theme-color-random)',
+  'var(--theme-amber)',
+]
+
+function RivalsSection() {
+  return (
+    <RivalsGrid>
+      <RivalList title='Best allies' note='min. 10 games together' entries={BEST_ALLIES} showRate />
+      <RivalList title='Rivals' note='most games played against' entries={RIVALS} />
+      <RivalList
+        title='Toughest opponents'
+        note='min. 10 games against'
+        entries={TOUGHEST_OPPONENTS}
+        showRate
+      />
+    </RivalsGrid>
+  )
+}
+
+function RivalList({
+  title,
+  note,
+  entries,
+  showRate,
+}: {
+  title: string
+  note: string
+  entries: ReadonlyArray<RivalEntry>
+  showRate?: boolean
+}) {
+  return (
+    <RivalPanel>
+      <PanelTitle>
+        {title}
+        <PanelNote>{note}</PanelNote>
+      </PanelTitle>
+      {entries.map(entry => {
+        const rate = Math.round((entry.wins / entry.games) * 100)
+        const losses = entry.games - entry.wins
+        return (
+          <PlayerRow
+            key={`${title}-${entry.userId}`}
+            href={`/users/${entry.userId}/${entry.name}`}
+            title={`Go to ${entry.name}'s profile`}>
+            <Avatar $color={AVATAR_COLORS[entry.userId % AVATAR_COLORS.length]}>
+              {entry.name.charAt(0)}
+            </Avatar>
+            <PlayerName>{entry.name}</PlayerName>
+            <PlayerStat>
+              {showRate ? (
+                <>
+                  <StatMain $tone={rate >= 50 ? 'positive' : 'negative'}>{rate}%</StatMain>
+                  <StatSub>
+                    {entry.wins}–{losses} · {entry.games} games
+                  </StatSub>
+                </>
+              ) : (
+                <>
+                  <StatMain>
+                    {entry.wins}–{losses}
+                  </StatMain>
+                  <StatSub>
+                    {rate}% · {entry.games} games
+                  </StatSub>
+                </>
+              )}
+            </PlayerStat>
+          </PlayerRow>
+        )
+      })}
+    </RivalPanel>
+  )
+}
+
+// --- Matchups -------------------------------------------------------------
+
+const Filters = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  margin-bottom: 16px;
+`
+
+/**
+ * Selects are `width: 100%` of whatever contains them, and their dropdown arrow is
+ * absolutely positioned over the right edge. Without a width they collapse to fit a
+ * flex line and the value runs underneath the arrow, so give them one. Map values
+ * carry a win rate suffix and need the extra room.
+ */
+const Filter = styled.div<{ $wide?: boolean }>`
+  width: ${props => (props.$wide ? '288px' : '208px')};
+  max-width: 100%;
+`
+
+const Coverage = styled.div`
+  ${labelSmall};
+  color: var(--theme-on-surface-variant);
+  margin-bottom: 10px;
+  font-variant-numeric: tabular-nums;
+`
+
+const MatrixScroll = styled.div`
+  overflow-x: auto;
+`
+
+const Matrix = styled.table`
+  border-collapse: separate;
+  border-spacing: 4px;
+  margin: 0 -4px;
+`
+
+const Corner = styled.th`
+  ${labelSmall};
+  color: var(--theme-on-surface-variant);
+  text-align: left;
+  width: 54px;
+  white-space: nowrap;
+`
+
+const ColHead = styled.th`
+  ${titleSmall};
+  padding: 4px 5px;
+  text-align: center;
+`
+
+const RowHead = styled.th`
+  ${titleSmall};
+  padding: 5px 7px;
+  text-align: right;
+`
+
+const Cell = styled.td<{ $tint: string; $thin: boolean; $empty: boolean }>`
+  box-sizing: border-box;
+  min-width: 62px;
+  padding: 7px 5px;
+  border-radius: 6px;
+  text-align: center;
+  background: ${props => props.$tint};
+  opacity: ${props => (props.$thin ? 0.55 : 1)};
+`
+
+const CellRate = styled.div<{ $empty: boolean }>`
+  ${titleSmall};
+  font-variant-numeric: tabular-nums;
+  color: ${props => (props.$empty ? 'var(--theme-on-surface-variant)' : 'inherit')};
+`
+
+const CellRecord = styled.div`
+  ${labelSmall};
+  color: var(--theme-on-surface-variant);
+  font-variant-numeric: tabular-nums;
+  min-height: 1.3em;
+`
+
+const RaceChip = styled.span<{ $race: AssignedRaceChar }>`
+  color: ${props => getRaceColor(props.$race)};
+`
+
+const Combo = styled.span`
+  display: inline-flex;
+  gap: 2px;
+`
+
+const RACE_LABELS: Record<AssignedRaceChar, string> = {
+  t: 'Terran',
+  p: 'Protoss',
+  z: 'Zerg',
+}
+
+function ComboLabel({ parts }: { parts: AssignedRaceChar[] }) {
+  if (parts.length === 1) {
+    return <RaceChip $race={parts[0]}>{RACE_LABELS[parts[0]]}</RaceChip>
+  }
+  return (
+    <Combo>
+      {parts.map((race, i) => (
+        <RaceChip key={i} $race={race}>
+          {race.toUpperCase()}
+        </RaceChip>
+      ))}
+    </Combo>
+  )
+}
+
+function tintFor(cell: MatchupCell): string {
+  if (!cell.games) return 'var(--theme-container)'
+  const rate = cell.wins / cell.games
+  const d = Math.max(-0.28, Math.min(0.28, rate - 0.5))
+  const alpha = ((Math.abs(d) / 0.28) * 0.3).toFixed(3)
+  return d >= 0 ? `rgba(105, 240, 174, ${alpha})` : `rgba(230, 96, 96, ${alpha})`
+}
+
+function MatchupsSection() {
+  const [mode, setMode] = useState<string>(ALL_MODES)
+  const [season, setSeason] = useState<string>(ALL_SEASONS)
+  const [map, setMap] = useState<string>(ALL_MAPS)
+
+  const availableMaps = mapsFor(mode, season)
+    .map(name => ({ name, stats: mapStats(mode, season, name) }))
+    .sort((a, b) => {
+      const rateA = a.stats.games ? a.stats.wins / a.stats.games : 0
+      const rateB = b.stats.games ? b.stats.wins / b.stats.games : 0
+      return rateB - rateA || b.stats.games - a.stats.games
+    })
+  // A map selection may not exist in a new mode/season pool.
+  const activeMap = availableMaps.some(m => m.name === map) ? map : ALL_MAPS
+
+  const combos = raceCombos(teamSizeFor(mode))
+  const isTeam = teamSizeFor(mode) > 1
+
+  let played = 0
+  let thin = 0
+  let best = 0
+  for (const row of combos) {
+    for (const col of combos) {
+      const cell = matchupCell(mode, season, activeMap, row, col)
+      if (cell.games) played++
+      if (cell.games && cell.games < 5) thin++
+      if (cell.games > best) best = cell.games
+    }
+  }
+  const total = combos.length * combos.length
+
+  return (
+    <div>
+      <Filters>
+        <Filter>
+          <Select
+            value={mode}
+            label='Game mode'
+            onChange={(value: string) => {
+              setMode(value)
+              setMap(ALL_MAPS)
+            }}>
+            <SelectOption value={ALL_MODES} text='Overall' />
+            {MODES_BY_PLAYTIME.map(m => (
+              <SelectOption key={m.key} value={m.key} text={m.label.replace(/^Ranked /, '')} />
+            ))}
+          </Select>
+        </Filter>
+        <Filter>
+          <Select
+            value={season}
+            label='Season'
+            onChange={(value: string) => {
+              setSeason(value)
+              setMap(ALL_MAPS)
+            }}>
+            <SelectOption value={ALL_SEASONS} text='Overall' />
+            {SEASONS.map(s => (
+              <SelectOption key={s.id} value={String(s.id)} text={s.name} />
+            ))}
+          </Select>
+        </Filter>
+        <Filter $wide={true}>
+          <Select value={activeMap} label='Map' onChange={(value: string) => setMap(value)}>
+            <SelectOption value={ALL_MAPS} text='Overall' />
+            {availableMaps.map(m => (
+              <SelectOption
+                key={m.name}
+                value={m.name}
+                text={`${m.name} — ${
+                  m.stats.games ? Math.round((m.stats.wins / m.stats.games) * 100) : 0
+                }%`}
+              />
+            ))}
+          </Select>
+        </Filter>
+      </Filters>
+
+      <Coverage>
+        {combos.length} × {combos.length} = {total} combinations · {played} played
+        {thin ? ` · ${thin} under 5 games` : ''} · best-sampled cell {best} games
+      </Coverage>
+
+      <MatrixScroll>
+        <Matrix>
+          <thead>
+            <tr>
+              <Corner>
+                <div>{isTeam ? 'team ↓' : 'you ↓'}</div>
+                <div>{isTeam ? 'opp →' : 'them →'}</div>
+              </Corner>
+              {combos.map(col => (
+                <ColHead key={col.join('')}>
+                  <ComboLabel parts={col} />
+                </ColHead>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {combos.map(row => (
+              <tr key={row.join('')}>
+                <RowHead>
+                  <ComboLabel parts={row} />
+                </RowHead>
+                {combos.map(col => {
+                  const cell = matchupCell(mode, season, activeMap, row, col)
+                  const rate = cell.games ? Math.round((cell.wins / cell.games) * 100) : 0
+                  return (
+                    <Cell
+                      key={col.join('')}
+                      $tint={tintFor(cell)}
+                      $thin={cell.games > 0 && cell.games < 5}
+                      $empty={!cell.games}>
+                      <CellRate $empty={!cell.games}>{cell.games ? `${rate}%` : '—'}</CellRate>
+                      <CellRecord>
+                        {cell.games ? `${cell.wins}–${cell.games - cell.wins}` : ''}
+                      </CellRecord>
+                    </Cell>
+                  )
+                })}
+              </tr>
+            ))}
+          </tbody>
+        </Matrix>
+      </MatrixScroll>
+    </div>
+  )
+}
+
+// --- Page -----------------------------------------------------------------
+
+export function StatsPageTest() {
+  const [section, setSection] = useState(StatsSection.Rating)
+
+  return (
+    <Container>
+      <TabsArea>
+        <Tabs activeTab={section} onChange={setSection}>
+          <TabItem value={StatsSection.Rating} text='Rating' />
+          <TabItem value={StatsSection.Rivals} text='Rivals' />
+          <TabItem value={StatsSection.Matchups} text='Matchups' />
+        </Tabs>
+      </TabsArea>
+
+      {section === StatsSection.Rating ? <RatingSection /> : undefined}
+      {section === StatsSection.Rivals ? <RivalsSection /> : undefined}
+      {section === StatsSection.Matchups ? <MatchupsSection /> : undefined}
+    </Container>
+  )
+}

--- a/common/matchmaking.ts
+++ b/common/matchmaking.ts
@@ -433,6 +433,19 @@ function addBonusPoolToDivisionBounds(
   ]
 }
 
+/**
+ * Returns every division with its points bounds at a given bonus pool, in ascending
+ * order. Intended for UI that needs the whole ladder at once (e.g. drawing division
+ * bands behind a points chart) rather than the division a particular value falls in.
+ */
+export function getAllDivisionsWithBounds(
+  solo: boolean,
+  bonusPool: number,
+): Array<Readonly<MatchmakingDivisionWithBounds>> {
+  const divisionsToPoints = solo ? DIVISIONS_TO_POINTS_SOLO : DIVISIONS_TO_POINTS_TEAM
+  return divisionsToPoints.map(b => addBonusPoolToDivisionBounds(b, bonusPool))
+}
+
 /** Converts a given points value into a matching `MatchmakingDivision`. */
 export function pointsToMatchmakingDivision(
   solo: boolean,

--- a/package.json
+++ b/package.json
@@ -122,6 +122,7 @@
     "pino-tee": "^0.4.0",
     "prom-client": "^15.1.3",
     "pug": "^3.0.4",
+    "recharts": "^3.10.0",
     "regexparam": "^3.0.0",
     "rimraf": "^6.1.3",
     "scm-extractor": "^1.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -193,6 +193,9 @@ importers:
       pug:
         specifier: ^3.0.4
         version: 3.0.4
+      recharts:
+        specifier: ^3.10.0
+        version: 3.10.0(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@17.0.2)(react@19.2.7)(redux@5.0.1)
       regexparam:
         specifier: ^3.0.0
         version: 3.0.0
@@ -3453,6 +3456,17 @@ packages:
     peerDependencies:
       redux: ^3.4.0 || ^4.0.0 || ^5.0.0
 
+  '@reduxjs/toolkit@2.12.0':
+    resolution: {integrity: sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw==}
+    peerDependencies:
+      react: ^16.9.0 || ^17.0.0 || ^18 || ^19
+      react-redux: ^7.2.1 || ^8.1.3 || ^9.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-redux:
+        optional: true
+
   '@repeaterjs/repeater@3.1.0':
     resolution: {integrity: sha512-TaoVksZRSx2KWYYpyLQtMQXXeS98VsgZImzW65xmiVgbYhXLk+aEsmzPLirqVuE4/XuUapH2iMtxUzaBNDzdSQ==}
 
@@ -3909,6 +3923,9 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
+  '@standard-schema/utils@0.3.0':
+    resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
+
   '@stylistic/eslint-plugin@5.10.0':
     resolution: {integrity: sha512-nPK52ZHvot8Ju/0A4ucSX1dcPV2/1clx0kLcH5wDmrE4naKso7TUC/voUyU1O9OTKTrR6MYip6LP0ogEMQ9jPQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -4107,8 +4124,35 @@ packages:
   '@types/css-tree@2.3.11':
     resolution: {integrity: sha512-aEokibJOI77uIlqoBOkVbaQGC9zII0A+JH1kcTNKW2CwyYWD8KM6qdo+4c77wD3wZOQfJuNWAr9M4hdk+YhDIg==}
 
+  '@types/d3-array@3.2.2':
+    resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
+
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-ease@3.0.2':
+    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-path@3.1.1':
+    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
+
+  '@types/d3-scale@4.0.9':
+    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
+
+  '@types/d3-shape@3.1.8':
+    resolution: {integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==}
+
   '@types/d3-time-format@4.0.3':
     resolution: {integrity: sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==}
+
+  '@types/d3-time@3.0.4':
+    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
+
+  '@types/d3-timer@3.0.2':
+    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
 
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
@@ -5577,12 +5621,44 @@ packages:
     resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
     engines: {node: '>=12'}
 
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.2:
+    resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
+
   d3-time-format@4.1.0:
     resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
     engines: {node: '>=12'}
 
   d3-time@3.1.0:
     resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
     engines: {node: '>=12'}
 
   data-uri-to-buffer@4.0.1:
@@ -5650,6 +5726,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js-light@2.5.1:
+    resolution: {integrity: sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==}
 
   decode-named-character-reference@1.3.0:
     resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
@@ -6077,6 +6156,9 @@ packages:
   es-to-primitive@1.3.0:
     resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
     engines: {node: '>= 0.4'}
+
+  es-toolkit@1.50.0:
+    resolution: {integrity: sha512-OyZKhUVvEep9ITEiwHn8GKnMRQIVqoSIX7WnRbkWgJkllCujilqP2rD0u979tkl8wqyc8ICwlc1UBVv/Sl1G6w==}
 
   es6-error@4.1.1:
     resolution: {integrity: sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==}
@@ -9195,6 +9277,14 @@ packages:
   real-require@1.0.0:
     resolution: {integrity: sha512-P4nbQYQfePJxRSmY+v/KINxVucm4NF3p3s7pJveMTtom52FR4YGltUQLB8idDXwDDWW+eYrWDFbuzUnjoWHF7g==}
 
+  recharts@3.10.0:
+    resolution: {integrity: sha512-wulMvfncpIlmu2uFtRU/mE5/+NiVtASXkw2KdwJTdHs3WsASX0WxZlX+rpKgyn5BDbIhkPtCpUKkB9XNK5KE0w==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-is: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   rechoir@0.8.0:
     resolution: {integrity: sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==}
     engines: {node: '>= 10.13.0'}
@@ -9304,6 +9394,9 @@ packages:
   resedit@1.7.2:
     resolution: {integrity: sha512-vHjcY2MlAITJhC0eRD/Vv8Vlgmu9Sd3LX9zZvtGzU5ZImdTN3+d6e/4mnTyV8vEbyf1sgNIrWxhWlrys52OkEA==}
     engines: {node: '>=12', npm: '>=6'}
+
+  reselect@5.2.0:
+    resolution: {integrity: sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==}
 
   resolve-alpn@1.2.1:
     resolution: {integrity: sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==}
@@ -10075,6 +10168,9 @@ packages:
   tiny-decoders@24.0.0:
     resolution: {integrity: sha512-nj0NiPVv3IrUyRQ85MWf2ppmHFykuEmAkBINUrMklHUooDMQ1RMYMv6RXnKq8nIWNsXJuS8Sa94H2dZLsnGLyg==}
 
+  tiny-invariant@1.3.3:
+    resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
+
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
@@ -10467,6 +10563,9 @@ packages:
 
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
+
+  victory-vendor@37.3.6:
+    resolution: {integrity: sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==}
 
   vinyl-contents@2.0.0:
     resolution: {integrity: sha512-cHq6NnGyi2pZ7xwdHSW1v4Jfnho4TEGtxZHw01cmnc8+i7jgR6bRnED/LbrKan/Q7CvVLbnvA5OepnhbpjBZ5Q==}
@@ -13903,6 +14002,18 @@ snapshots:
     dependencies:
       redux: 5.0.1
 
+  '@reduxjs/toolkit@2.12.0(react-redux@9.3.0(@types/react@19.2.17)(react@19.2.7)(redux@5.0.1))(react@19.2.7)':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@standard-schema/utils': 0.3.0
+      immer: 11.1.15
+      redux: 5.0.1
+      redux-thunk: 3.1.0(redux@5.0.1)
+      reselect: 5.2.0
+    optionalDependencies:
+      react: 19.2.7
+      react-redux: 9.3.0(@types/react@19.2.17)(react@19.2.7)(redux@5.0.1)
+
   '@repeaterjs/repeater@3.1.0': {}
 
   '@rolldown/binding-android-arm64@1.1.5':
@@ -14190,6 +14301,8 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
+  '@standard-schema/utils@0.3.0': {}
+
   '@stylistic/eslint-plugin@5.10.0(eslint@10.7.0(jiti@2.7.0))':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@10.7.0(jiti@2.7.0))
@@ -14387,7 +14500,31 @@ snapshots:
 
   '@types/css-tree@2.3.11': {}
 
+  '@types/d3-array@3.2.2': {}
+
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-ease@3.0.2': {}
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-path@3.1.1': {}
+
+  '@types/d3-scale@4.0.9':
+    dependencies:
+      '@types/d3-time': 3.0.4
+
+  '@types/d3-shape@3.1.8':
+    dependencies:
+      '@types/d3-path': 3.1.1
+
   '@types/d3-time-format@4.0.3': {}
+
+  '@types/d3-time@3.0.4': {}
+
+  '@types/d3-timer@3.0.2': {}
 
   '@types/debug@4.1.13':
     dependencies:
@@ -16204,6 +16341,30 @@ snapshots:
     dependencies:
       internmap: 2.0.3
 
+  d3-color@3.1.0: {}
+
+  d3-ease@3.0.1: {}
+
+  d3-format@3.1.2: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-path@3.1.0: {}
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
+
   d3-time-format@4.1.0:
     dependencies:
       d3-time: 3.1.0
@@ -16211,6 +16372,8 @@ snapshots:
   d3-time@3.1.0:
     dependencies:
       d3-array: 3.2.4
+
+  d3-timer@3.0.1: {}
 
   data-uri-to-buffer@4.0.1: {}
 
@@ -16264,6 +16427,8 @@ snapshots:
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js-light@2.5.1: {}
 
   decode-named-character-reference@1.3.0:
     dependencies:
@@ -16822,6 +16987,8 @@ snapshots:
       is-callable: 1.2.7
       is-date-object: 1.1.0
       is-symbol: 1.1.1
+
+  es-toolkit@1.50.0: {}
 
   es6-error@4.1.1:
     optional: true
@@ -20457,6 +20624,26 @@ snapshots:
 
   real-require@1.0.0: {}
 
+  recharts@3.10.0(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@17.0.2)(react@19.2.7)(redux@5.0.1):
+    dependencies:
+      '@reduxjs/toolkit': 2.12.0(react-redux@9.3.0(@types/react@19.2.17)(react@19.2.7)(redux@5.0.1))(react@19.2.7)
+      clsx: 2.1.1
+      decimal.js-light: 2.5.1
+      es-toolkit: 1.50.0
+      eventemitter3: 5.0.4
+      immer: 11.1.15
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      react-is: 17.0.2
+      react-redux: 9.3.0(@types/react@19.2.17)(react@19.2.7)(redux@5.0.1)
+      reselect: 5.2.0
+      tiny-invariant: 1.3.3
+      use-sync-external-store: 1.6.0(react@19.2.7)
+      victory-vendor: 37.3.6
+    transitivePeerDependencies:
+      - '@types/react'
+      - redux
+
   rechoir@0.8.0:
     dependencies:
       resolve: 1.22.12
@@ -20574,6 +20761,8 @@ snapshots:
   resedit@1.7.2:
     dependencies:
       pe-library: 0.4.1
+
+  reselect@5.2.0: {}
 
   resolve-alpn@1.2.1: {}
 
@@ -21556,6 +21745,8 @@ snapshots:
 
   tiny-decoders@24.0.0: {}
 
+  tiny-invariant@1.3.3: {}
+
   tinybench@2.9.0: {}
 
   tinyexec@1.2.4: {}
@@ -21952,6 +22143,23 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
+
+  victory-vendor@37.3.6:
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/d3-ease': 3.0.2
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-scale': 4.0.9
+      '@types/d3-shape': 3.1.8
+      '@types/d3-time': 3.0.4
+      '@types/d3-timer': 3.0.2
+      d3-array: 3.2.4
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-scale: 4.0.2
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-timer: 3.0.1
 
   vinyl-contents@2.0.0:
     dependencies:


### PR DESCRIPTION
Adds a devonly page at /dev/users/stats that mocks up the three sections proposed for the profile Stats tab: Rating, Rivals and Matchups. It runs on generated data, so nothing here is wired to real queries yet -- it exists to make the layout and the data shape reviewable before the server work starts.

Rating lists matchmaking modes ordered by lifetime games played, with the most-played expanded and the rest collapsed. Each mode charts rating or points over time. Two details the charts have to get right: the series is split into separate lines at each discontinuity, since rating only carries across a season that did not reset it while points restart every season, and the points view underlays ladder division bands. Those bands take their bounds from getDivisionsForPointsChange and their bonus pool from getTotalBonusPool rather than a local copy of the table, so they cannot drift away from the matchmaker. Band colours are sampled from the rank badge art.

Matchups renders a race matchup matrix filtered by mode, season and map. Both axes are unordered compositions, so a team is identified by the races on it rather than by who played which: 3x3 at 1v1, 6x6 at 2v2, 10x10 at 3v3. Cells under five games are de-emphasised and a coverage line reports how much of the grid a player has actually filled, which is the honest answer to whether the team matrices are worth building -- at 3v3 a 132-game player leaves 41 of 100 combinations empty and tops out at 8 games in the best one.

Adds recharts (3.x, the React 19 compatible line) as the charting library.

Refs #1269