### PR TITLE
Record which team each player was on in games_users

### DIFF
--- a/migrations/20260803130000_add_games_users_team.sql
+++ b/migrations/20260803130000_add_games_users_team.sql
@@ -1,0 +1,27 @@
+-- Adds the team a user was on for a game, denormalized from `games.config->'teams'`.
+--
+-- `games_users` records what a player did but not which side they did it on, so anything that
+-- needs ally-vs-opponent has to read the config JSONB for every game a user has played -- a wide
+-- row fetched to recover one bit per participant. That's what makes per-player team stats
+-- (matchups for team modes, rivals) expensive today, and the cost grows with `games` even though
+-- the answer doesn't.
+--
+-- Nullable, deliberately, for three separate reasons:
+--   * rows written before this column existed, until the backfill has run;
+--   * games whose teams can't be determined at all -- `getTeamsFromConfig` returns null for Melee
+--     with more than two players, where "team" has no meaning;
+--   * rows written by old application code during the deploy window.
+-- Readers must therefore treat NULL as "unknown", never as a team.
+--
+-- The value is the index into `getTeamsFromConfig`'s result, which is the same derivation
+-- `selected_matchup` and `assigned_matchup` are computed from -- so a row's team and its game's
+-- matchup string can't disagree about how the game was divided. Note that this index does NOT
+-- correspond to a side of the matchup string: `computeMatchupString` sorts the teams before
+-- joining them, so team 0 is not reliably the left half.
+--
+-- NOTE: This migration intentionally only does the (instant) DDL. Adding a nullable column with no
+-- default is a metadata-only change in Postgres, so it takes no meaningful lock and doesn't rewrite
+-- the table. Backfilling the existing rows is done separately and out-of-band via
+-- tools/backfill-teams.sql so we don't lock a hot table for the duration of rewriting every row.
+
+ALTER TABLE games_users ADD COLUMN team smallint;

--- a/server/lib/games/registration.test.ts
+++ b/server/lib/games/registration.test.ts
@@ -3,7 +3,7 @@ import { GameConfigPlayer, GameSource, LobbyGameConfig } from '../../../common/g
 import { GameType } from '../../../common/games/game-type'
 import { makeSbMapId } from '../../../common/maps'
 import { asMockedFunction } from '../../../common/testing/mocks'
-import { makeSbUserId } from '../../../common/users/sb-user-id'
+import { SbUserId, makeSbUserId } from '../../../common/users/sb-user-id'
 import { createGameUserRecord } from '../models/games-users'
 import { createGameRecord } from './game-models'
 import { registerGame } from './registration'
@@ -20,7 +20,17 @@ vi.mock('../models/games-users', () => ({
 
 const p1 = makeSbUserId(1)
 const p2 = makeSbUserId(2)
+const p3 = makeSbUserId(3)
+const p4 = makeSbUserId(4)
 const mapId = makeSbMapId('1')
+
+/** The `team` value the given user's record was created with. */
+function teamFor(userId: SbUserId): number | null | undefined {
+  const call = asMockedFunction(createGameUserRecord).mock.calls.find(
+    ([, data]) => data.userId === userId,
+  )
+  return call?.[1].team
+}
 
 function lobbyConfig(teams: GameConfigPlayer[][]): LobbyGameConfig {
   return {
@@ -90,5 +100,73 @@ describe('games/registration/registerGame', () => {
       expect.anything(),
       expect.objectContaining({ userId: p1 }),
     )
+  })
+
+  test('records each player’s team index', async () => {
+    const config = lobbyConfig([
+      [
+        { id: p1, race: 't', isComputer: false },
+        { id: p3, race: 'p', isComputer: false },
+      ],
+      [
+        { id: p2, race: 'z', isComputer: false },
+        { id: p4, race: 'p', isComputer: false },
+      ],
+    ])
+
+    await registerGame(mapId, config)
+
+    expect(teamFor(p1)).toBe(0)
+    expect(teamFor(p3)).toBe(0)
+    expect(teamFor(p2)).toBe(1)
+    expect(teamFor(p4)).toBe(1)
+  })
+
+  test('records teams for a 1v1 split out of a single two-player team', async () => {
+    // `getTeamsFromConfig` splits this shape into two teams of one, and the team recorded has to
+    // follow that same split -- otherwise a row's team and its game's matchup string would be
+    // describing different divisions of the same game.
+    const config = lobbyConfig([
+      [
+        { id: p1, race: 't', isComputer: false },
+        { id: p2, race: 'z', isComputer: false },
+      ],
+    ])
+
+    await registerGame(mapId, config)
+
+    expect(teamFor(p1)).toBe(0)
+    expect(teamFor(p2)).toBe(1)
+  })
+
+  test('records no team when the game has none to determine', async () => {
+    // Melee with more than two players in one team: `getTeamsFromConfig` gives up, and so does
+    // this rather than inventing a division. NULL means unknown, not team zero.
+    const config = lobbyConfig([
+      [
+        { id: p1, race: 't', isComputer: false },
+        { id: p2, race: 'z', isComputer: false },
+        { id: p3, race: 'p', isComputer: false },
+      ],
+    ])
+
+    await registerGame(mapId, config)
+
+    expect(teamFor(p1)).toBeNull()
+    expect(teamFor(p2)).toBeNull()
+    expect(teamFor(p3)).toBeNull()
+  })
+
+  test('records the team of a human sharing a team with a computer player', async () => {
+    // The computer gets no row, but it does occupy a slot -- the human's team index still has to
+    // be its position among the config's teams, not among the rows that got written.
+    const config = lobbyConfig([
+      [{ id: p1, race: 't', isComputer: true }],
+      [{ id: p2, race: 'z', isComputer: false }],
+    ])
+
+    await registerGame(mapId, config)
+
+    expect(teamFor(p2)).toBe(1)
   })
 })

--- a/server/lib/games/registration.ts
+++ b/server/lib/games/registration.ts
@@ -1,6 +1,7 @@
 import { GameConfig } from '../../../common/games/configuration'
 import { computeMatchupString, getTeamsFromConfig } from '../../../common/games/matchups'
 import { SbMapId } from '../../../common/maps'
+import { SbUserId } from '../../../common/users/sb-user-id'
 import transact from '../db/transaction'
 import { createGameUserRecord } from '../models/games-users'
 import { createGameRecord } from './game-models'
@@ -48,6 +49,19 @@ export async function registerGame(mapId: SbMapId, gameConfig: GameConfig, start
     ? computeMatchupString(teams.map(team => team.map(p => p.race)))
     : null
 
+  // Which team each player was on, denormalized onto their row so that reading ally-vs-opponent
+  // later doesn't mean fetching this game's config back out of JSONB.
+  //
+  // Derived from the same `teams` the matchup string is, so the two can't disagree about how the
+  // game was divided. Stays empty when `getTeamsFromConfig` returns null (Melee with more than two
+  // players, where there are no teams to record), leaving those rows NULL rather than guessing.
+  const teamByPlayer = new Map<SbUserId, number>()
+  for (const [index, team] of (teams ?? []).entries()) {
+    for (const player of team) {
+      teamByPlayer.set(player.id, index)
+    }
+  }
+
   // NOTE(tec27): the value here makes the linter happy, but this will actually be set in the
   // transaction below
   let gameId = ''
@@ -66,6 +80,7 @@ export async function registerGame(mapId: SbMapId, gameConfig: GameConfig, start
         startTime,
         selectedRace: p.race,
         resultCode: resultCodes.get(p.id)!,
+        team: teamByPlayer.get(p.id) ?? null,
       })
     }
   })

--- a/server/lib/models/games-users.ts
+++ b/server/lib/models/games-users.ts
@@ -56,6 +56,16 @@ export interface GameUserRecord {
   assignedRace: AssignedRaceChar | null
   result: ReconciledResult | null
   apm: number | null
+  /**
+   * Which team this user was on, as an index into `getTeamsFromConfig`'s result for the game's
+   * config. `null` where it isn't known: rows predating the column and not yet backfilled, and
+   * games with no determinable teams (Melee with more than two players). Treat `null` as unknown
+   * rather than as a team.
+   *
+   * Note this is not a side of the game's matchup string -- `computeMatchupString` sorts the teams
+   * before joining, so team 0 isn't reliably that string's left half.
+   */
+  team: number | null
   replayFileId: string | null
   /** How this user's slot departed mid-game (left/dropped), or null if never recorded. */
   departureKind: DepartureKind | null
@@ -77,7 +87,7 @@ type DbGameUser = Dbify<GameUserRecord>
 
 export type CreateGameUserRecordData = Pick<
   GameUserRecord,
-  'userId' | 'gameId' | 'startTime' | 'selectedRace' | 'resultCode'
+  'userId' | 'gameId' | 'startTime' | 'selectedRace' | 'resultCode' | 'team'
 >
 
 /**
@@ -87,15 +97,15 @@ export type CreateGameUserRecordData = Pick<
  */
 export async function createGameUserRecord(
   client: DbClient,
-  { userId, gameId, startTime, selectedRace, resultCode }: CreateGameUserRecordData,
+  { userId, gameId, startTime, selectedRace, resultCode, team }: CreateGameUserRecordData,
 ) {
   return client.query(sql`
     INSERT INTO games_users (
       user_id, game_id, start_time, selected_race, result_code, reported_results, reported_at,
-      assigned_race, result, apm
+      assigned_race, result, apm, team
     ) VALUES (
       ${userId}, ${gameId}, ${startTime}, ${selectedRace}, ${resultCode}, NULL, NULL,
-      NULL, NULL, NULL
+      NULL, NULL, NULL, ${team}
     )
   `)
 }
@@ -145,6 +155,7 @@ export async function getUserGameRecord(
       assignedRace: row.assigned_race,
       result: row.result,
       apm: row.apm,
+      team: row.team,
       replayFileId: row.replay_file_id,
       departureKind: row.departure_kind,
       departureTime: row.departure_time,

--- a/tools/backfill-teams.sql
+++ b/tools/backfill-teams.sql
@@ -1,0 +1,153 @@
+-- Backfills games_users.team from the historical config JSONB. Run this AFTER the
+-- 20260803130000_add_games_users_team migration has been applied and the new application code has
+-- been deployed.
+--
+-- Why this isn't part of the migration: backfilling touches every row in `games_users`, and we
+-- don't want to hold a lock on that table for the whole duration. This processes the games in
+-- id-range batches, committing after each batch so locks are released and normal traffic can
+-- interleave between batches.
+--
+-- It is idempotent and safe to re-run: a row is only written when the computed team actually
+-- differs from what's stored. Running it again after the deploy has settled therefore doubles as a
+-- cheap catch-up pass for any games registered by old code during the deploy window (which would
+-- otherwise keep NULL teams forever).
+--
+-- The team derivation deliberately mirrors getTeamsFromConfig() in common/games/matchups.ts, the
+-- same way backfill-matchups.sql does -- the two columns describe the same division of the same
+-- game, so they have to be computed the same way or a row's team and its game's matchup string
+-- will disagree.
+--
+-- Games with no determinable teams (Melee with more than two players) are skipped, leaving their
+-- rows NULL. NULL means "unknown", never team zero.
+--
+-- Usage (psql, and NOT wrapped in an explicit transaction, so the per-batch COMMITs can take
+-- effect):
+--   \i tools/backfill-teams.sql                -- installs/updates the procedure
+--   CALL backfill_teams(dry_run => true);      -- report how many rows *would* change, no writes
+--   CALL backfill_teams();                     -- run it for real (5000-game batches)
+--   CALL backfill_teams(batch_size => 20000);  -- larger batches
+--
+-- The procedure is left installed afterwards. Clean it up when you're done with:
+--   DROP PROCEDURE backfill_teams(int, boolean);
+
+CREATE OR REPLACE PROCEDURE backfill_teams(batch_size int DEFAULT 5000, dry_run boolean DEFAULT false)
+LANGUAGE plpgsql AS $$
+DECLARE
+  r RECORD;
+  last_id uuid := '00000000-0000-0000-0000-000000000000';
+  batch_last_id uuid;
+  non_empty_teams jsonb[];
+  teams_for_matchup jsonb[];
+  teams_count int;
+  is_1v1_single_team boolean;
+  team jsonb;
+  player_ids int[];
+  team_indexes smallint[];
+  team_index smallint;
+  affected bigint;
+  would_change bigint;
+  processed bigint := 0;
+  changed bigint := 0;
+BEGIN
+  LOOP
+    batch_last_id := NULL;
+
+    FOR r IN
+      SELECT id, config
+      FROM games
+      WHERE id > last_id
+      ORDER BY id
+      LIMIT batch_size
+    LOOP
+      batch_last_id := r.id;
+      processed := processed + 1;
+
+      is_1v1_single_team := false;
+
+      -- Drop empty teams (e.g. observer teams in melee lobbies serialize as []) before working out
+      -- the real layout. This mirrors getTeamsFromConfig() in common/games/matchups.ts.
+      non_empty_teams := ARRAY(
+        SELECT t
+        FROM jsonb_array_elements(r.config->'teams') AS t
+        WHERE jsonb_array_length(t) > 0
+      );
+      teams_count := coalesce(array_length(non_empty_teams, 1), 0);
+
+      IF teams_count = 1 THEN
+        IF jsonb_array_length(non_empty_teams[1]) = 2 THEN
+          -- 1v1 stored as a single team of 2 - split into two single-player teams
+          is_1v1_single_team := true;
+        ELSE
+          -- Melee with != 2 players, can't determine teams; leave team NULL
+          teams_count := 0;
+        END IF;
+      END IF;
+
+      CONTINUE WHEN teams_count < 2 AND NOT is_1v1_single_team;
+
+      IF is_1v1_single_team THEN
+        teams_for_matchup := ARRAY[
+          jsonb_build_array(non_empty_teams[1]->0),
+          jsonb_build_array(non_empty_teams[1]->1)
+        ];
+      ELSE
+        teams_for_matchup := non_empty_teams;
+      END IF;
+
+      -- Flatten to parallel (user_id, team) arrays so the whole game is one statement rather than
+      -- one per player. Computer players are included here and simply match no row -- they have no
+      -- games_users entry -- which keeps the team indexes aligned with the config's teams rather
+      -- than with the subset of players that got rows.
+      player_ids := ARRAY[]::int[];
+      team_indexes := ARRAY[]::smallint[];
+      team_index := 0;
+      FOREACH team IN ARRAY teams_for_matchup LOOP
+        FOR j IN 0..(jsonb_array_length(team) - 1) LOOP
+          player_ids := array_append(player_ids, (team->j->>'id')::int);
+          team_indexes := array_append(team_indexes, team_index);
+        END LOOP;
+        team_index := team_index + 1;
+      END LOOP;
+
+      IF dry_run THEN
+        SELECT count(*)
+        INTO would_change
+        FROM games_users gu
+        JOIN unnest(player_ids, team_indexes) AS v(user_id, team) ON gu.user_id = v.user_id
+        WHERE gu.game_id = r.id AND gu.team IS DISTINCT FROM v.team;
+
+        IF would_change > 0 THEN
+          changed := changed + 1;
+        END IF;
+      ELSE
+        UPDATE games_users gu
+        SET team = v.team
+        FROM unnest(player_ids, team_indexes) AS v(user_id, team)
+        WHERE gu.game_id = r.id
+          AND gu.user_id = v.user_id
+          AND gu.team IS DISTINCT FROM v.team;
+
+        GET DIAGNOSTICS affected = ROW_COUNT;
+        IF affected > 0 THEN
+          changed := changed + 1;
+        END IF;
+      END IF;
+    END LOOP;
+
+    -- No rows came back, we've reached the end of the table.
+    EXIT WHEN batch_last_id IS NULL;
+
+    last_id := batch_last_id;
+    IF NOT dry_run THEN
+      COMMIT;
+      RAISE NOTICE 'backfill_teams: processed % games (% changed so far)', processed, changed;
+    END IF;
+  END LOOP;
+
+  IF dry_run THEN
+    RAISE NOTICE 'backfill_teams dry run: % of % games would change', changed, processed;
+  ELSE
+    RAISE NOTICE 'backfill_teams: done, updated % of % games', changed, processed;
+  END IF;
+END;
+$$;

--- a/tools/backfill-teams.sql
+++ b/tools/backfill-teams.sql
@@ -48,6 +48,7 @@ DECLARE
   would_change bigint;
   processed bigint := 0;
   changed bigint := 0;
+  undeterminable bigint := 0;
 BEGIN
   LOOP
     batch_last_id := NULL;
@@ -66,10 +67,21 @@ BEGIN
 
       -- Drop empty teams (e.g. observer teams in melee lobbies serialize as []) before working out
       -- the real layout. This mirrors getTeamsFromConfig() in common/games/matchups.ts.
+      --
+      -- The type guards are not paranoia: `games` is long-lived and `config` is schemaless, so a
+      -- historical row whose `teams` is missing, null, an object or a scalar is entirely possible.
+      -- `jsonb_array_elements` raises on those rather than returning nothing, which would abort the
+      -- whole backfill part-way through -- committed batches kept, the rest never processed. Each
+      -- unusable shape is counted and skipped instead.
+      IF jsonb_typeof(r.config->'teams') <> 'array' THEN
+        undeterminable := undeterminable + 1;
+        CONTINUE;
+      END IF;
+
       non_empty_teams := ARRAY(
         SELECT t
         FROM jsonb_array_elements(r.config->'teams') AS t
-        WHERE jsonb_array_length(t) > 0
+        WHERE jsonb_typeof(t) = 'array' AND jsonb_array_length(t) > 0
       );
       teams_count := coalesce(array_length(non_empty_teams, 1), 0);
 
@@ -83,7 +95,10 @@ BEGIN
         END IF;
       END IF;
 
-      CONTINUE WHEN teams_count < 2 AND NOT is_1v1_single_team;
+      IF teams_count < 2 AND NOT is_1v1_single_team THEN
+        undeterminable := undeterminable + 1;
+        CONTINUE;
+      END IF;
 
       IF is_1v1_single_team THEN
         teams_for_matchup := ARRAY[
@@ -144,10 +159,15 @@ BEGIN
     END IF;
   END LOOP;
 
+  -- `undeterminable` is the number worth reading before running this for real: those games have no
+  -- team layout to recover, so their rows stay NULL however many times this is run. A large count
+  -- means the historical data is shaped differently than expected, not that the backfill failed.
   IF dry_run THEN
-    RAISE NOTICE 'backfill_teams dry run: % of % games would change', changed, processed;
+    RAISE NOTICE 'backfill_teams dry run: % of % games would change (% have no determinable teams)',
+      changed, processed, undeterminable;
   ELSE
-    RAISE NOTICE 'backfill_teams: done, updated % of % games', changed, processed;
+    RAISE NOTICE 'backfill_teams: done, updated % of % games (% have no determinable teams)',
+      changed, processed, undeterminable;
   END IF;
 END;
 $$;


### PR DESCRIPTION
Adds `games_users.team`, per the schema question raised on #1269. tec27 OK'd the column separately.

## Why

`games_users` records what a player did but not which side they did it on. Anything needing ally-vs-opponent — team matchups, rivals — has to read `games.config->'teams'` for every game a user has played, fetching a wide row to recover one bit per participant. That was measured on #1269 at ~72 ms warm for a 12,600-game history, and it gets slower as `games` grows even though the answer doesn't.

## Where the value comes from

Written at registration, where [`getTeamsFromConfig`](https://github.com/ShieldBattery/ShieldBattery/blob/master/server/lib/games/registration.ts) has *already* run to produce `selected_matchup` and the `games_users` rows are created in the same transaction. Deriving both from the same `teams` means a row's team and its game's matchup string can't disagree about how the game was divided.

**Nullable, for three separate reasons**: rows predating the column, games with no determinable teams (Melee with more than two players, where `getTeamsFromConfig` returns null), and rows written by old code during the deploy window. Readers must treat NULL as *unknown*, never as team zero.

**One thing to know before building on this:** the team index is **not** a side of the matchup string. `computeMatchupString` sorts the teams before joining, so team 0 is not reliably the left half of `pt-pz`. Anything reconstructing sides should group the game's rows by team rather than assume a correspondence.

## Rollout

Follows the `20260212000000_add_matchup_columns` precedent exactly:

- **DDL-only migration.** A nullable column with no default is metadata-only in Postgres — no table rewrite, no meaningful lock.
- **`tools/backfill-teams.sql`** does the rows out of band, batched by game id with a COMMIT per batch so locks release and normal traffic interleaves. Idempotent, so a second run doubles as a catch-up for games registered by old code mid-deploy.

The backfill reimplements `getTeamsFromConfig` the same way `backfill-matchups.sql` does, so the two columns can't drift apart.

## Verification

Run against the dev database rather than reasoned about:

- **1080 rows backfilled, then cross-checked against each game's config by a different route than the backfill computes it** (direct jsonb path lookup vs. the backfill's flattening). 1080/1080 correct, 0 mismatched, 0 users found in a team other than the one recorded.
- **Idempotent**: a re-run changes 0 of 480. Clearing and re-deriving reproduces the same values.
- **Edge cases** not present in seeded data, each checked and cleaned up: Melee-with-three stays NULL; a 1v1 stored as one team of two splits into 0/1; an empty observer team is dropped *before* indexing rather than shifting everyone up one; a human sharing a game with a computer keeps its config team index rather than its position among written rows.
- **Legacy config shapes**: `teams` missing, null, an object, a scalar, an empty array, a player entry with no id, and an empty config. All skipped and counted rather than erroring — see below.
- 1796 JS tests (8 new), typecheck, lint, `cargo test`, `sqlx prepare --check` clean.

## Two notes

**The backfill originally aborted on legacy shapes.** `jsonb_array_elements` raises on a non-array rather than returning nothing, so a single historical row with an odd `teams` would kill the run part-way — committed batches kept, everything after never processed. Fixed in a5ba5c3c, with each unusable shape counted and reported. That count is the number worth reading before running it for real: those rows stay NULL however many times it runs, so a large count means the historical data is shaped differently than expected rather than that the backfill failed.

**`tools/backfill-matchups.sql` has the identical unguarded call** and fails the same way — I reproduced it. That's pre-existing and shipped, so I've left it alone rather than widening this PR, but it's worth a follow-up since it's a crash waiting on whatever the oldest rows look like.

## Not included

Nothing reads the column yet. The consumer (team matchups) is on a separate branch, currently a draft in #1397. Happy to hold this until that's ready if you'd rather the column didn't land unused.
