### PR TITLE
Keep the copy-from-preset button out of the color preview

### DIFF
--- a/client/settings/game/team-color-settings.tsx
+++ b/client/settings/game/team-color-settings.tsx
@@ -255,11 +255,7 @@ const CollapsedNote = styled.div`
   color: var(--theme-on-surface-variant);
 `
 
-const RelativeCard = styled(Card)`
-  position: relative;
-`
-
-const TeamSchemeCard = styled(RelativeCard)`
+const TeamSchemeCard = styled(Card)`
   margin-bottom: 16px;
 `
 
@@ -314,10 +310,13 @@ const Preview = styled(TeamColorPreview)`
   flex-shrink: 0;
 `
 
-const CopyButtonContainer = styled.div`
-  position: absolute;
-  bottom: 16px;
-  right: 16px;
+// In flow rather than absolutely positioned in the card's corner: the right column's preview roster
+// reaches the card's bottom edge whenever it's the taller of the two columns, and an overlaid
+// button would sit on top of it.
+const CopyButtonRow = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 16px;
 `
 
 const CopyButtonAnchor = styled.div`
@@ -395,7 +394,7 @@ function CopyFromPresetButton<T extends string>({
   const [open, openPopover, closePopover] = usePopoverController({ refreshAnchorPos })
 
   return (
-    <CopyButtonContainer>
+    <CopyButtonRow>
       <CopyButtonAnchor ref={anchorRef}>
         <OutlinedButton
           label={t('settings.game.gameplay.teamColors.copyFromPreset', 'Copy from preset')}
@@ -429,7 +428,7 @@ function CopyFromPresetButton<T extends string>({
           </CopyMenuCaption>
         </CopyMenuList>
       </Popover>
-    </CopyButtonContainer>
+    </CopyButtonRow>
   )
 }
 
@@ -907,7 +906,7 @@ export function TeamColorSettings({
           </TeamSchemeCard>
         )}
 
-        <RelativeCard>
+        <Card>
           <SchemeContentRow>
             <SchemeColumn>
               <CardTitle>
@@ -1024,7 +1023,7 @@ export function TeamColorSettings({
           {isFfaCustom ? (
             <CopyFromPresetButton presets={ffaPresetCopyOptions} onSelect={handleCopyFfaPreset} />
           ) : null}
-        </RelativeCard>
+        </Card>
       </BelowMode>
     </>
   )


### PR DESCRIPTION
The "Copy from preset" button in Gameplay settings → Player colors overlapped the color preview's example player list.

### Cause

`CopyButtonContainer` was `position: absolute; bottom: 16px; right: 16px` inside the scheme card. The card's right column holds the preview (minimap plus the example player roster), and whenever that column is the taller of the two, its roster runs to the card's bottom edge — exactly where the overlaid button sits.

### Fix

The button now lives in normal flow as a right-aligned footer row under `SchemeContentRow`, so it reserves its own vertical space instead of floating over the column:

- `CopyButtonContainer` → `CopyButtonRow` (`display: flex; justify-content: flex-end; margin-top: 16px`). The card's 16px padding preserves the same right-edge alignment, so the button doesn't visibly move horizontally.
- `RelativeCard` is gone — its `position: relative` existed only to contain the absolute button. `TeamSchemeCard` now extends `Card` directly, and the individual-colors card uses `Card`.

Popover anchoring is untouched (`right`/`top` anchor, `right`/`bottom` origin), so the preset menu still opens upward from the button.

### Verification

Ran the Electron app against the renderer dev server and measured the rendered geometry over CDP on the Gameplay settings page, with both schemes set to the Custom preset so both buttons render. The button rect no longer intersects any of the 7 roster rows in either card:

| Card | Button rect | Overlapping roster rows |
| --- | --- | --- |
| Team colors | 789,566 → 976,606 | none |
| Individual colors | 789,1078 → 976,1118 | none |

Re-applying the old absolute positioning in the same live page reproduced the overlap, confirming this is the geometry the report describes.

`tsc --noEmit` and `eslint` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
