### PR TITLE
Rename the player-color modes and drop the Classic FFA preset

### DIFF
--- a/app/settings.ts
+++ b/app/settings.ts
@@ -12,12 +12,19 @@ import {
   ScrSettings,
   StartingFog,
 } from '../common/settings/local-settings'
-import { cloneCustomTeamColors } from '../common/settings/team-colors'
+import { cloneCustomTeamColors, DEFAULT_FFA_COLORS } from '../common/settings/team-colors'
 import { findInstallPath } from './find-install-path'
 import log from './logger'
 
-const VERSION = 20
+const VERSION = 21
 const SCR_VERSION = 5
+
+/**
+ * The `ffaColorPreset` value of the removed `Classic` preset. Settings files written before version
+ * 21 can still hold it, so the migrations below name it explicitly rather than going through
+ * {@link FfaColorPreset}, which no longer has a member for it.
+ */
+const REMOVED_CLASSIC_FFA_PRESET = 'classic'
 
 async function findStarcraftPath() {
   let starcraftPath = await findInstallPath()
@@ -323,9 +330,10 @@ export class LocalSettingsManager extends SettingsManager<LocalSettings> {
 
     if (!settings.version || settings.version < 17) {
       log.verbose('Found settings version 16, migrating to version 17')
-      // The Pastel FFA preset was removed; anyone who had it selected falls back to Classic.
+      // The Pastel FFA preset was removed; anyone who had it selected falls back to Classic (itself
+      // removed later -- the version 21 migration below carries these users on to Custom).
       if ((settings.ffaColorPreset as string | undefined) === 'pastel') {
-        newSettings.ffaColorPreset = FfaColorPreset.Classic
+        newSettings.ffaColorPreset = REMOVED_CLASSIC_FFA_PRESET as FfaColorPreset
       }
     }
 
@@ -352,6 +360,21 @@ export class LocalSettingsManager extends SettingsManager<LocalSettings> {
       // rather than carried over, so every install starts on the 64-bit path.
       delete (newSettings as any).launch64Bit
       newSettings.launch32Bit = DEFAULT_LOCAL_SETTINGS.launch32Bit
+    }
+
+    if (!settings.version || settings.version < 21) {
+      log.verbose('Found settings version 20, migrating to version 21')
+      // The Classic FFA preset was removed. Move anyone who had it selected onto Custom seeded with
+      // Classic's colors, so the colors they actually play with don't change. This overwrites their
+      // stored `customFfaColors`, but that pool wasn't in use while Classic was selected, and
+      // silently recoloring their games would be the worse trade.
+      //
+      // Reads `newSettings` rather than `settings` so it also catches the Pastel -> Classic hop the
+      // version 17 migration above may have just made.
+      if ((newSettings.ffaColorPreset as string | undefined) === REMOVED_CLASSIC_FFA_PRESET) {
+        newSettings.ffaColorPreset = FfaColorPreset.Custom
+        newSettings.customFfaColors = [...DEFAULT_FFA_COLORS]
+      }
     }
 
     newSettings.version = VERSION

--- a/common/settings/default-settings.ts
+++ b/common/settings/default-settings.ts
@@ -10,7 +10,7 @@ import {
   TeamColorPreset,
   TeamColorUsage,
 } from './local-settings'
-import { cloneCustomTeamColors, FFA_COLOR_PRESETS, TEAM_COLOR_PRESETS } from './team-colors'
+import { cloneCustomTeamColors, DEFAULT_FFA_COLORS, TEAM_COLOR_PRESETS } from './team-colors'
 
 export const DEFAULT_LOCAL_SETTINGS: ReadonlyDeep<
   Omit<LocalSettings, keyof ShieldBatteryAppSettings>
@@ -28,13 +28,13 @@ export const DEFAULT_LOCAL_SETTINGS: ReadonlyDeep<
   minimapColorMode: MinimapColorMode.Standard,
   minimapTerrainHidden: false,
   teamColorPreset: TeamColorPreset.CoolVsWarm,
-  ffaColorPreset: FfaColorPreset.Classic,
+  ffaColorPreset: FfaColorPreset.Custom,
   teamColorUsage: TeamColorUsage.Always,
   shuffleColors: false,
   // Copied (rather than referencing the preset table directly) so this default can never be
   // aliased/mutated through the preset it was seeded from.
   customTeamColors: cloneCustomTeamColors(TEAM_COLOR_PRESETS[TeamColorPreset.LegacyDiplomacy]),
-  customFfaColors: [...FFA_COLOR_PRESETS[FfaColorPreset.Classic]],
+  customFfaColors: [...DEFAULT_FFA_COLORS],
   teamSelfColor: undefined,
   ffaSelfColor: undefined,
   legacyCursorSizing: false,

--- a/common/settings/local-settings.ts
+++ b/common/settings/local-settings.ts
@@ -63,11 +63,11 @@ export const ALL_MINIMAP_COLOR_MODES: Readonly<MinimapColorMode[]> = [
 export function getMinimapColorModeLabel(mode: MinimapColorMode, t: TFunction): string {
   switch (mode) {
     case MinimapColorMode.Standard:
-      return t('settings.game.gameplay.teamColors.mode.standard', 'Standard')
+      return t('settings.game.gameplay.teamColors.mode.standard', 'Use map defaults')
     case MinimapColorMode.PresetOnMinimapOnly:
-      return t('settings.game.gameplay.teamColors.mode.presetOnMinimap', 'Use preset on minimap')
+      return t('settings.game.gameplay.teamColors.mode.presetOnMinimap', 'Override minimap colors')
     case MinimapColorMode.Preset:
-      return t('settings.game.gameplay.teamColors.mode.presetEverywhere', 'Use preset everywhere')
+      return t('settings.game.gameplay.teamColors.mode.presetEverywhere', 'Override all colors')
     default:
       return assertUnreachable(mode)
   }
@@ -94,7 +94,6 @@ export const ALL_TEAM_COLOR_PRESETS: Readonly<TeamColorPreset[]> = Object.values
  * color values live in `common/settings/team-colors.ts`.
  */
 export enum FfaColorPreset {
-  Classic = 'classic',
   Jewel = 'jewel',
   Arcade = 'arcade',
   Resurrect = 'resurrect',

--- a/common/settings/team-colors.ts
+++ b/common/settings/team-colors.ts
@@ -119,20 +119,27 @@ export const TEAM_COLOR_PRESETS: ReadonlyDeep<
   },
 }
 
+/**
+ * Brood War's stock 8 player colors, in slot order -- the first 8 entries of {@link SC_COLORS}.
+ * This was the `Classic` FFA preset until that preset was removed; it lives on as the pool
+ * `customFfaColors` is seeded with, so a fresh install still starts on the familiar colors (now
+ * editable, since `Custom` is the default preset).
+ */
+export const DEFAULT_FFA_COLORS: ReadonlyArray<string> = [
+  '#F40404',
+  '#0C48CC',
+  '#2CB494',
+  '#88409C',
+  '#F88C14',
+  '#703014',
+  '#CCE0D0',
+  '#FCFC38',
+]
+
 /** The built-in FFA-axis color presets (every {@link FfaColorPreset} except `Custom`). */
 export const FFA_COLOR_PRESETS: ReadonlyDeep<
   Record<Exclude<FfaColorPreset, FfaColorPreset.Custom>, string[]>
 > = {
-  [FfaColorPreset.Classic]: [
-    '#F40404',
-    '#0C48CC',
-    '#2CB494',
-    '#88409C',
-    '#F88C14',
-    '#703014',
-    '#CCE0D0',
-    '#FCFC38',
-  ],
   [FfaColorPreset.Jewel]: [
     '#D23855', // Ruby
     '#396ED6', // Sapphire
@@ -461,8 +468,6 @@ export function getTeamColorPresetLabel(preset: TeamColorPreset, t: TFunction): 
 
 export function getFfaColorPresetLabel(preset: FfaColorPreset, t: TFunction): string {
   switch (preset) {
-    case FfaColorPreset.Classic:
-      return t('settings.game.gameplay.ffaColorPreset.classic', 'Classic')
     case FfaColorPreset.Jewel:
       return t('settings.game.gameplay.ffaColorPreset.jewel', 'Jewel')
     case FfaColorPreset.Arcade:

--- a/server/public/locales/en/global.json
+++ b/server/public/locales/en/global.json
@@ -1629,7 +1629,6 @@
         "ffaColorPreset": {
           "arcade": "Arcade",
           "attributionPrefix": "Palette: ",
-          "classic": "Classic",
           "colorblindSafe": "Colorblind-safe",
           "custom": "Custom",
           "jewel": "Jewel",
@@ -1705,11 +1704,11 @@
           "header": "Player colors",
           "label": "Mode",
           "mode": {
-            "presetEverywhere": "Use preset everywhere",
+            "presetEverywhere": "Override all colors",
             "presetEverywhereDesc": "Your color scheme on units and the minimap.",
-            "presetOnMinimap": "Use preset on minimap",
+            "presetOnMinimap": "Override minimap colors",
             "presetOnMinimapDesc": "Ally and enemy colors on the minimap only.",
-            "standard": "Standard",
+            "standard": "Use map defaults",
             "standardDesc": "StarCraft's normal colors. The settings below have no effect."
           },
           "offNote": "Off. Individual colors are used in every game.",

--- a/server/public/locales/es/global.json
+++ b/server/public/locales/es/global.json
@@ -1646,7 +1646,6 @@
         "ffaColorPreset": {
           "arcade": "Arcade",
           "attributionPrefix": "Paleta: ",
-          "classic": "Clásico",
           "colorblindSafe": "Apto para daltónicos",
           "custom": "Personalizado",
           "jewel": "Joya",
@@ -1722,11 +1721,11 @@
           "header": "Colores de los jugadores",
           "label": "Modo",
           "mode": {
-            "presetEverywhere": "Usar preajuste en todas partes",
+            "presetEverywhere": "Reemplazar todos los colores",
             "presetEverywhereDesc": "Tu esquema de colores en las unidades y el minimapa.",
-            "presetOnMinimap": "Usar preajuste en el minimapa",
+            "presetOnMinimap": "Reemplazar colores del minimapa",
             "presetOnMinimapDesc": "Colores de aliados y enemigos solo en el minimapa.",
-            "standard": "Estándar",
+            "standard": "Usar configuración predeterminada del mapa",
             "standardDesc": "Los colores normales de StarCraft. Los ajustes de abajo no tienen efecto."
           },
           "offNote": "Desactivado. Se usan los colores individuales en todas las partidas.",

--- a/server/public/locales/ko/global.json
+++ b/server/public/locales/ko/global.json
@@ -1612,7 +1612,6 @@
         "ffaColorPreset": {
           "arcade": "아케이드",
           "attributionPrefix": "팔레트: ",
-          "classic": "클래식",
           "colorblindSafe": "색약 친화",
           "custom": "커스텀",
           "jewel": "보석",
@@ -1688,11 +1687,11 @@
           "header": "플레이어 색상",
           "label": "모드",
           "mode": {
-            "presetEverywhere": "모든 곳에 프리셋 사용",
+            "presetEverywhere": "모든 색상 대체",
             "presetEverywhereDesc": "유닛과 미니맵에 내 색상 구성을 적용합니다.",
-            "presetOnMinimap": "미니맵에 프리셋 사용",
+            "presetOnMinimap": "미니맵 색상 대체",
             "presetOnMinimapDesc": "미니맵에서만 아군·적군 색상을 적용합니다.",
-            "standard": "표준",
+            "standard": "맵 기본 설정 사용",
             "standardDesc": "스타크래프트 기본 색상입니다. 아래 설정은 적용되지 않습니다."
           },
           "offNote": "꺼짐. 모든 게임에서 개인 색상이 사용됩니다.",

--- a/server/public/locales/ru/global.json
+++ b/server/public/locales/ru/global.json
@@ -1663,7 +1663,6 @@
         "ffaColorPreset": {
           "arcade": "Аркада",
           "attributionPrefix": "Палитра: ",
-          "classic": "Классика",
           "colorblindSafe": "Для дальтоников",
           "custom": "Свой",
           "jewel": "Самоцветы",
@@ -1739,11 +1738,11 @@
           "header": "Цвета игроков",
           "label": "Режим",
           "mode": {
-            "presetEverywhere": "Использовать пресет везде",
+            "presetEverywhere": "Заменить все цвета",
             "presetEverywhereDesc": "Ваша цветовая схема на юнитах и миникарте.",
-            "presetOnMinimap": "Использовать пресет на миникарте",
+            "presetOnMinimap": "Заменить цвета миникарты",
             "presetOnMinimapDesc": "Цвета союзников и врагов только на миникарте.",
-            "standard": "Стандартный",
+            "standard": "Использовать настройки карты по умолчанию",
             "standardDesc": "Обычные цвета StarCraft. Настройки ниже не действуют."
           },
           "offNote": "Выключено. Во всех играх используются индивидуальные цвета.",

--- a/server/public/locales/zh-Hans/global.json
+++ b/server/public/locales/zh-Hans/global.json
@@ -1612,7 +1612,6 @@
         "ffaColorPreset": {
           "arcade": "街机",
           "attributionPrefix": "调色板：",
-          "classic": "经典",
           "colorblindSafe": "色盲友好",
           "custom": "自定义",
           "jewel": "宝石",
@@ -1688,11 +1687,11 @@
           "header": "玩家颜色",
           "label": "模式",
           "mode": {
-            "presetEverywhere": "全部使用预设",
+            "presetEverywhere": "替换所有颜色",
             "presetEverywhereDesc": "您的配色方案应用于单位和小地图。",
-            "presetOnMinimap": "在小地图上使用预设",
+            "presetOnMinimap": "替换小地图颜色",
             "presetOnMinimapDesc": "盟友和敌人颜色仅应用于小地图。",
-            "standard": "标准",
+            "standard": "使用地图默认设置",
             "standardDesc": "星际争霸的普通颜色。下面的设置不会生效。"
           },
           "offNote": "已关闭。所有游戏均使用个人颜色。",


### PR DESCRIPTION
Three changes to Gameplay settings → Player colors.

### Mode labels

Relabelled to say what each mode does to your colors, rather than how they're sourced:

| Was | Now |
| --- | --- |
| Standard | Use map defaults |
| Use preset on minimap | Override minimap colors |
| Use preset everywhere | Override all colors |

### Classic FFA preset removed, Custom is now the default

`FfaColorPreset.Classic` is gone from the enum, `FFA_COLOR_PRESETS`, and `getFfaColorPresetLabel`. The Individual colors dropdown now reads Jewel, Arcade, Resurrect, Pear, Neon, Colorblind-safe, Custom.

Classic's palette was Brood War's stock 8 colors — which is also what `customFfaColors` is seeded with — so it survives as `DEFAULT_FFA_COLORS` in `common/settings/team-colors.ts`. A fresh install still starts on those familiar colors; they're just editable now instead of locked behind a preset.

### Settings migration (version 21)

Stored settings can still hold `"classic"`, which would index a preset that no longer exists and blow up `resolveFfaColors`. Version 21 moves those users onto Custom, seeded with Classic's palette so the colors they actually play with don't change.

That does overwrite their stored `customFfaColors`. It's a real trade: that pool wasn't in use while Classic was selected, and silently recolouring someone's games seemed worse than discarding an unused pool. The version 17 Pastel → Classic hop now chains into this one.

This started life as version 20 and was renumbered on rebase — `master` shipped its own version 20 (the 64-bit default, `c41bdd934`) in the meantime, which was the sole merge conflict on this branch.

### Translations

Re-run for es/ko/ru/zh-Hans via `tools/i18n-translate.ts`. The translated values are derived from "Replace …" and "Use Map Default Settings" rather than the terser English display strings, and use each language's own sentence case rather than transposing English Title Case.

| | standard | presetOnMinimap | presetEverywhere |
| --- | --- | --- | --- |
| en | Use map defaults | Override minimap colors | Override all colors |
| es | Usar configuración predeterminada del mapa | Reemplazar colores del minimapa | Reemplazar todos los colores |
| ko | 맵 기본 설정 사용 | 미니맵 색상 대체 | 모든 색상 대체 |
| ru | Использовать настройки карты по умолчанию | Заменить цвета миникарты | Заменить все цвета |
| zh-Hans | 使用地图默认设置 | 替换小地图颜色 | 替换所有颜色 |

The dead `ffaColorPreset.classic` key was removed from all five locale files.

### Verification

Ran the app against the renderer dev server and drove it over CDP:

- All three mode labels render in the dropdown.
- The Individual colors preset list is Jewel / Arcade / Resurrect / Pear / Neon / Colorblind-safe / Custom — no Classic, and "Classic" appears nowhere on the page.
- Migration checked against scratch `--user-data-dir`s seeded with `"ffaColorPreset": "classic"` and a deliberately distinctive grey `customFfaColors` pool, from both entry points: a version-19 file (runs master's version 20 then this one) and a version-20 file (runs only this one). Both came back `version: 21`, `"custom"`, with the grey pool replaced by Classic's palette; the version-19 case also picked up master's `launch64Bit` → `launch32Bit` change.

`tsc --noEmit`, `eslint` and the test suite (52 files, 635 tests) pass on the rebased branch. `i18n check` reports 0 orphans, 0 token drift and normalized formatting for every language; `i18n stale` is clean.

### Not included

Each language still has 19 pre-existing untranslated keys (`maps.local.uploadMapNoPlayerSlotsError`, `settings.game.input.*`, `users.profile.*`). They're unrelated to this change and left alone.

This branch is off `master` and does not include the button-overlap fix in #1404. The two touch different files and merge cleanly in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
