### PR TITLE
Add video uploads to news posts

### DIFF
--- a/client/admin/admin-news.tsx
+++ b/client/admin/admin-news.tsx
@@ -26,6 +26,7 @@ import {
   applyMarkdownFormat,
   MarkdownFormatKind,
   MarkdownToolbar,
+  ToolbarButton,
 } from '../markdown/markdown-toolbar'
 import { FilledButton, IconButton, OutlinedButton, TextButton } from '../material/button'
 import { DateTimeTextField } from '../material/datetime-text-field'
@@ -1107,7 +1108,7 @@ function NewsEditor({ post }: { post: EditablePost | undefined }) {
       return
     }
     if (file.size > MAX_VIDEO_SIZE_BYTES) {
-      setVideoError(t('admin.news.form.videoTooLarge', 'That video is too large (max 100 MB).'))
+      setVideoError(t('admin.news.form.videoTooLarge', 'That video is too large (max 30 MB).'))
       return
     }
 
@@ -1294,11 +1295,12 @@ function NewsEditor({ post }: { post: EditablePost | undefined }) {
                   onChange={onImageFileSelected}
                   data-testid='news-inline-image-file-input'
                 />
-                <IconButton
+                <ToolbarButton
                   icon={<MaterialIcon icon='add_photo_alternate' />}
-                  title={t('admin.news.form.insertImage', 'Insert image')}
-                  onClick={() => imageFileInputRef.current?.click()}
+                  label={t('admin.news.form.insertImage', 'Insert image')}
+                  tooltipText={t('admin.news.form.insertImageTooltip', 'Insert image (up to 5 MB)')}
                   disabled={imageUploading}
+                  onClick={() => imageFileInputRef.current?.click()}
                 />
                 {imageUploading ? (
                   <CoverHint>{t('admin.news.form.imageUploading', 'Uploading…')}</CoverHint>
@@ -1310,11 +1312,15 @@ function NewsEditor({ post }: { post: EditablePost | undefined }) {
                   onChange={onVideoFileSelected}
                   data-testid='news-inline-video-file-input'
                 />
-                <IconButton
+                <ToolbarButton
                   icon={<MaterialIcon icon='videocam' />}
-                  title={t('admin.news.form.insertVideo', 'Insert video')}
-                  onClick={() => videoFileInputRef.current?.click()}
+                  label={t('admin.news.form.insertVideo', 'Insert video')}
+                  tooltipText={t(
+                    'admin.news.form.insertVideoTooltip',
+                    'Insert video (up to 30 MB)',
+                  )}
                   disabled={videoUploading}
+                  onClick={() => videoFileInputRef.current?.click()}
                 />
                 {videoUploading ? (
                   <CoverHint>{t('admin.news.form.videoUploading', 'Uploading…')}</CoverHint>

--- a/client/admin/admin-news.tsx
+++ b/client/admin/admin-news.tsx
@@ -7,7 +7,11 @@ import { Route, Switch } from 'wouter'
 import swallowNonBuiltins from '../../common/async/swallow-non-builtins'
 import { getErrorStack } from '../../common/errors'
 import { MAX_IMAGE_SIZE_BYTES } from '../../common/images'
-import { NewsImageUploadResponse } from '../../common/news'
+import {
+  MAX_VIDEO_SIZE_BYTES,
+  NewsImageUploadResponse,
+  NewsVideoUploadResponse,
+} from '../../common/news'
 import { apiUrl, urlPath } from '../../common/urls'
 import { useSelfUser } from '../auth/auth-utils'
 import { useForm, useFormCallbacks, ValidatorMap } from '../forms/form-hook'
@@ -973,6 +977,10 @@ function NewsEditor({ post }: { post: EditablePost | undefined }) {
   const [imageUploading, setImageUploading] = useState(false)
   const [imageError, setImageError] = useState<string | undefined>(undefined)
 
+  const videoFileInputRef = useRef<HTMLInputElement>(null)
+  const [videoUploading, setVideoUploading] = useState(false)
+  const [videoError, setVideoError] = useState<string | undefined>(undefined)
+
   const onCoverFileSelected = (event: ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0]
     // Reset the input so selecting the same file again still fires a change event.
@@ -1017,6 +1025,36 @@ function NewsEditor({ post }: { post: EditablePost | undefined }) {
     setCoverImageUrl(null)
   }
 
+  // Splices the uploaded file's URL into the content textarea as inline markdown, at the current
+  // cursor position. Shared by the image and video upload handlers: the inserted markdown syntax
+  // is identical for both, since the renderer branches on the URL's extension.
+  const insertUploadedMediaAtCursor = (url: string, filename: string) => {
+    // Read the content from the DOM element rather than the form state this closure captured
+    // when the upload started, so text typed while the upload was in flight isn't lost.
+    const textarea = contentInputRef.current
+    const currentContent = textarea?.value ?? getInputValue('content')
+    const selection =
+      textarea &&
+      contentEverFocusedRef.current &&
+      textarea.selectionStart !== null &&
+      textarea.selectionEnd !== null
+        ? { start: textarea.selectionStart, end: textarea.selectionEnd }
+        : undefined
+    const { content, cursor } = insertInlineImage(
+      currentContent,
+      url,
+      altTextFromFilename(filename),
+      selection,
+    )
+    setInputValue('content', content)
+    requestAnimationFrame(() => {
+      if (textarea) {
+        textarea.focus()
+        textarea.setSelectionRange(cursor, cursor)
+      }
+    })
+  }
+
   const onImageFileSelected = (event: ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0]
     // Reset the input so selecting the same file again still fires a change event.
@@ -1044,30 +1082,7 @@ function NewsEditor({ post }: { post: EditablePost | undefined }) {
     })
       .then(result => {
         setImageUploading(false)
-        // Read the content from the DOM element rather than the form state this closure captured
-        // when the upload started, so text typed while the upload was in flight isn't lost.
-        const textarea = contentInputRef.current
-        const currentContent = textarea?.value ?? getInputValue('content')
-        const selection =
-          textarea &&
-          contentEverFocusedRef.current &&
-          textarea.selectionStart !== null &&
-          textarea.selectionEnd !== null
-            ? { start: textarea.selectionStart, end: textarea.selectionEnd }
-            : undefined
-        const { content, cursor } = insertInlineImage(
-          currentContent,
-          result.url,
-          altTextFromFilename(file.name),
-          selection,
-        )
-        setInputValue('content', content)
-        requestAnimationFrame(() => {
-          if (textarea) {
-            textarea.focus()
-            textarea.setSelectionRange(cursor, cursor)
-          }
-        })
+        insertUploadedMediaAtCursor(result.url, file.name)
       })
       .catch(err => {
         setImageUploading(false)
@@ -1075,6 +1090,45 @@ function NewsEditor({ post }: { post: EditablePost | undefined }) {
           t('admin.news.form.imageUploadError', 'Something went wrong uploading the image.'),
         )
         logger.error(`Error uploading news inline image: ${getErrorStack(err)}`)
+      })
+  }
+
+  const onVideoFileSelected = (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0]
+    // Reset the input so selecting the same file again still fires a change event.
+    event.target.value = ''
+    if (!file) {
+      return
+    }
+    if (!file.type.startsWith('video/')) {
+      setVideoError(
+        t('admin.news.form.videoInvalidType', 'Please choose an mp4 or webm video file.'),
+      )
+      return
+    }
+    if (file.size > MAX_VIDEO_SIZE_BYTES) {
+      setVideoError(t('admin.news.form.videoTooLarge', 'That video is too large (max 100 MB).'))
+      return
+    }
+
+    setVideoError(undefined)
+    setVideoUploading(true)
+    const formData = new FormData()
+    formData.append('video', file)
+    fetchJson<NewsVideoUploadResponse>(apiUrl`news/videos`, {
+      method: 'POST',
+      body: formData,
+    })
+      .then(result => {
+        setVideoUploading(false)
+        insertUploadedMediaAtCursor(result.url, file.name)
+      })
+      .catch(err => {
+        setVideoUploading(false)
+        setVideoError(
+          t('admin.news.form.videoUploadError', 'Something went wrong uploading the video.'),
+        )
+        logger.error(`Error uploading news inline video: ${getErrorStack(err)}`)
       })
   }
 
@@ -1249,6 +1303,22 @@ function NewsEditor({ post }: { post: EditablePost | undefined }) {
                 {imageUploading ? (
                   <CoverHint>{t('admin.news.form.imageUploading', 'Uploading…')}</CoverHint>
                 ) : null}
+                <HiddenFileInput
+                  ref={videoFileInputRef}
+                  type='file'
+                  accept='video/mp4,video/webm'
+                  onChange={onVideoFileSelected}
+                  data-testid='news-inline-video-file-input'
+                />
+                <IconButton
+                  icon={<MaterialIcon icon='videocam' />}
+                  title={t('admin.news.form.insertVideo', 'Insert video')}
+                  onClick={() => videoFileInputRef.current?.click()}
+                  disabled={videoUploading}
+                />
+                {videoUploading ? (
+                  <CoverHint>{t('admin.news.form.videoUploading', 'Uploading…')}</CoverHint>
+                ) : null}
               </MarkdownToolbar>
               <ContentField
                 {...bindInput('content')}
@@ -1262,6 +1332,7 @@ function NewsEditor({ post }: { post: EditablePost | undefined }) {
                 maxRows={40}
               />
               {imageError ? <ErrorText>{imageError}</ErrorText> : null}
+              {videoError ? <ErrorText>{videoError}</ErrorText> : null}
             </EditorColumn>
             <MarkdownPreview source={getInputValue('content')} allowMedia={true} />
           </FormArea>
@@ -1349,7 +1420,7 @@ function NewsEditor({ post }: { post: EditablePost | undefined }) {
                   : t('admin.news.createPost', 'Create post')
               }
               onClick={submit}
-              disabled={fetching || coverUploading || imageUploading}
+              disabled={fetching || coverUploading || imageUploading || videoUploading}
             />
           </SaveRow>
         </Form>

--- a/client/markdown/markdown-toolbar.tsx
+++ b/client/markdown/markdown-toolbar.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 import { MaterialIcon } from '../icons/material/material-icon'
 import { IconButton } from '../material/button'
+import { Tooltip } from '../material/tooltip'
 
 export type MarkdownFormatKind =
   | 'heading'
@@ -320,6 +321,33 @@ const Divider = styled.span`
   background-color: var(--theme-outline-variant);
 `
 
+/**
+ * An icon button for use inside `MarkdownToolbar`, labeled with a material `Tooltip` (rather than
+ * a native `title`). `label` names the button for screen readers and is the tooltip text unless a
+ * more detailed `tooltipText` is given.
+ */
+export function ToolbarButton({
+  icon,
+  label,
+  tooltipText,
+  disabled,
+  onClick,
+}: {
+  icon: ReactNode
+  label: string
+  tooltipText?: string
+  disabled?: boolean
+  onClick: () => void
+}) {
+  return (
+    // The wrapped button is itself focusable, so the tooltip trigger must not add a second tab
+    // stop; focus events bubbling up from the button still show the tooltip for keyboard users.
+    <Tooltip text={tooltipText ?? label} position='top' tabIndex={-1}>
+      <IconButton icon={icon} ariaLabel={label} disabled={disabled} onClick={onClick} />
+    </Tooltip>
+  )
+}
+
 export function MarkdownToolbar({
   onFormat,
   disabled,
@@ -343,53 +371,53 @@ export function MarkdownToolbar({
         // re-rendering with it) visibly flicker.
         event.preventDefault()
       }}>
-      <IconButton
+      <ToolbarButton
         icon={<MaterialIcon icon='format_h2' />}
-        title={t('markdown.toolbar.heading', 'Heading')}
+        label={t('markdown.toolbar.heading', 'Heading')}
         disabled={disabled}
         onClick={() => onFormat('heading')}
       />
-      <IconButton
+      <ToolbarButton
         icon={<MaterialIcon icon='format_bold' />}
-        title={t('markdown.toolbar.bold', 'Bold')}
+        label={t('markdown.toolbar.bold', 'Bold')}
         disabled={disabled}
         onClick={() => onFormat('bold')}
       />
-      <IconButton
+      <ToolbarButton
         icon={<MaterialIcon icon='format_italic' />}
-        title={t('markdown.toolbar.italic', 'Italic')}
+        label={t('markdown.toolbar.italic', 'Italic')}
         disabled={disabled}
         onClick={() => onFormat('italic')}
       />
       <Divider />
-      <IconButton
+      <ToolbarButton
         icon={<MaterialIcon icon='format_quote' />}
-        title={t('markdown.toolbar.quote', 'Quote')}
+        label={t('markdown.toolbar.quote', 'Quote')}
         disabled={disabled}
         onClick={() => onFormat('quote')}
       />
-      <IconButton
+      <ToolbarButton
         icon={<MaterialIcon icon='format_list_bulleted' />}
-        title={t('markdown.toolbar.unorderedList', 'Bulleted list')}
+        label={t('markdown.toolbar.unorderedList', 'Bulleted list')}
         disabled={disabled}
         onClick={() => onFormat('unorderedList')}
       />
-      <IconButton
+      <ToolbarButton
         icon={<MaterialIcon icon='format_list_numbered' />}
-        title={t('markdown.toolbar.orderedList', 'Numbered list')}
+        label={t('markdown.toolbar.orderedList', 'Numbered list')}
         disabled={disabled}
         onClick={() => onFormat('orderedList')}
       />
-      <IconButton
+      <ToolbarButton
         icon={<MaterialIcon icon='horizontal_rule' />}
-        title={t('markdown.toolbar.horizontalRule', 'Divider')}
+        label={t('markdown.toolbar.horizontalRule', 'Divider')}
         disabled={disabled}
         onClick={() => onFormat('horizontalRule')}
       />
       <Divider />
-      <IconButton
+      <ToolbarButton
         icon={<MaterialIcon icon='link' />}
-        title={t('markdown.toolbar.link', 'Link')}
+        label={t('markdown.toolbar.link', 'Link')}
         disabled={disabled}
         onClick={() => onFormat('link')}
       />

--- a/client/markdown/markdown.tsx
+++ b/client/markdown/markdown.tsx
@@ -229,16 +229,24 @@ function MarkdownMedia({ src, alt, title }: { src?: string; alt?: string; title?
     return <ExternalLink href={src}>{alt || src}</ExternalLink>
   }
 
+  // Inline videos autoplay like the gifs they replace, but a viewer who has signaled they don't
+  // want that — OS-level reduced motion, or browser data-saver mode — gets click-to-play instead,
+  // since these files can be tens of megabytes and autoplay would force the full download on them.
+  const autoplay =
+    !window.matchMedia('(prefers-reduced-motion: reduce)').matches &&
+    !(navigator as { connection?: { saveData?: boolean } }).connection?.saveData
+
   return (
     <>
       {isVideoUrl(src) ? (
         <Video
           src={src}
-          autoPlay={true}
+          autoPlay={autoplay}
           loop={true}
           muted={true}
           playsInline={true}
           controls={true}
+          preload={autoplay ? undefined : 'metadata'}
         />
       ) : (
         <Image src={src} alt={alt ?? ''} loading='lazy' draggable={false} />

--- a/common/news.ts
+++ b/common/news.ts
@@ -41,7 +41,7 @@ export interface NewsImageUploadResponse {
 }
 
 /** Maximum size that we allow a news post video upload to be. */
-export const MAX_VIDEO_SIZE_BYTES = 100 * 1000 * 1000 // 100MB
+export const MAX_VIDEO_SIZE_BYTES = 30 * 1000 * 1000 // 30MB
 
 /**
  * Response returned after uploading a news video, used for inline videos embedded in post

--- a/common/news.ts
+++ b/common/news.ts
@@ -40,6 +40,20 @@ export interface NewsImageUploadResponse {
   smallUrl: string
 }
 
+/** Maximum size that we allow a news post video upload to be. */
+export const MAX_VIDEO_SIZE_BYTES = 100 * 1000 * 1000 // 100MB
+
+/**
+ * Response returned after uploading a news video, used for inline videos embedded in post
+ * markdown. Unlike images, videos get no resizing, so there is no small variant.
+ */
+export interface NewsVideoUploadResponse {
+  /** The file-store path of the uploaded video. */
+  path: string
+  /** A fully-qualified URL to the video. */
+  url: string
+}
+
 /** The public-assets path prefix under which the stock news fallback images live. */
 export const NEWS_STOCK_IMAGES_PATH_PREFIX = 'images/static-news/'
 

--- a/server/lib/files/videos.test.ts
+++ b/server/lib/files/videos.test.ts
@@ -1,0 +1,91 @@
+import { mkdtemp, rm, writeFile } from 'fs/promises'
+import { tmpdir } from 'os'
+import path from 'path'
+import { afterEach, beforeEach, describe, expect, test } from 'vitest'
+import { sniffVideoType } from './videos'
+
+describe('sniffVideoType', () => {
+  let dir: string
+
+  beforeEach(async () => {
+    dir = await mkdtemp(path.join(tmpdir(), 'sb-videos-test-'))
+  })
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true })
+  })
+
+  async function writeTempFile(name: string, data: Buffer): Promise<string> {
+    const filePath = path.join(dir, name)
+    await writeFile(filePath, data)
+    return filePath
+  }
+
+  test('detects mp4 from an ftyp box', async () => {
+    // A minimal mp4-like buffer: 4-byte box size, `ftyp`, then some padding bytes.
+    const buf = Buffer.concat([
+      Buffer.from([0x00, 0x00, 0x00, 0x18]),
+      Buffer.from('ftyp', 'ascii'),
+      Buffer.from('isom', 'ascii'),
+      Buffer.alloc(16),
+    ])
+    const filePath = await writeTempFile('video.mp4', buf)
+
+    expect(await sniffVideoType(filePath)).toBe('mp4')
+  })
+
+  test('detects webm from EBML magic plus a webm DocType', async () => {
+    const buf = Buffer.concat([
+      Buffer.from([0x1a, 0x45, 0xdf, 0xa3]),
+      // A stand-in for the EBML header elements leading up to the DocType string; real files
+      // have DocType-id/size bytes here, but the sniffer only looks for the substring.
+      Buffer.from([0x01, 0x02, 0x03, 0x04]),
+      Buffer.from('webm', 'ascii'),
+      Buffer.alloc(8),
+    ])
+    const filePath = await writeTempFile('video.webm', buf)
+
+    expect(await sniffVideoType(filePath)).toBe('webm')
+  })
+
+  test('rejects EBML magic without a webm DocType (e.g. a Matroska .mkv file)', async () => {
+    const buf = Buffer.concat([
+      Buffer.from([0x1a, 0x45, 0xdf, 0xa3]),
+      Buffer.from([0x01, 0x02, 0x03, 0x04]),
+      Buffer.from('matroska', 'ascii'),
+      Buffer.alloc(8),
+    ])
+    const filePath = await writeTempFile('video.mkv', buf)
+
+    expect(await sniffVideoType(filePath)).toBeUndefined()
+  })
+
+  test('rejects a PNG-magic buffer', async () => {
+    const buf = Buffer.concat([
+      Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+      Buffer.alloc(16),
+    ])
+    const filePath = await writeTempFile('image.png', buf)
+
+    expect(await sniffVideoType(filePath)).toBeUndefined()
+  })
+
+  test('rejects random garbage', async () => {
+    const buf = Buffer.from('this is definitely not a video file, just plain text padding here')
+    const filePath = await writeTempFile('garbage.bin', buf)
+
+    expect(await sniffVideoType(filePath)).toBeUndefined()
+  })
+
+  test('rejects an empty file', async () => {
+    const filePath = await writeTempFile('empty.bin', Buffer.alloc(0))
+
+    expect(await sniffVideoType(filePath)).toBeUndefined()
+  })
+
+  test('rejects a file shorter than the magic lengths', async () => {
+    const filePath = await writeTempFile('short.bin', Buffer.from([0x1a, 0x45, 0xdf]))
+
+    expect(await sniffVideoType(filePath)).toBeUndefined()
+  })
+})

--- a/server/lib/files/videos.test.ts
+++ b/server/lib/files/videos.test.ts
@@ -21,17 +21,84 @@ describe('sniffVideoType', () => {
     return filePath
   }
 
-  test('detects mp4 from an ftyp box', async () => {
-    // A minimal mp4-like buffer: 4-byte box size, `ftyp`, then some padding bytes.
-    const buf = Buffer.concat([
-      Buffer.from([0x00, 0x00, 0x00, 0x18]),
+  /**
+   * Builds a synthetic `ftyp` box: a 4-byte big-endian box size, the `ftyp` type, a 4-byte major
+   * brand, a 4-byte (zeroed) minor version, and then the given compatible brands, each 4 bytes.
+   */
+  function makeFtypBox(majorBrand: string, compatibleBrands: string[] = []): Buffer {
+    const size = 16 + compatibleBrands.length * 4
+    const sizeBytes = Buffer.alloc(4)
+    sizeBytes.writeUInt32BE(size, 0)
+
+    return Buffer.concat([
+      sizeBytes,
       Buffer.from('ftyp', 'ascii'),
-      Buffer.from('isom', 'ascii'),
-      Buffer.alloc(16),
+      Buffer.from(majorBrand, 'ascii'),
+      Buffer.alloc(4), // minor version, unused
+      ...compatibleBrands.map(brand => Buffer.from(brand, 'ascii')),
     ])
+  }
+
+  test('detects mp4 from an ftyp box', async () => {
+    // A minimal mp4-like buffer: 4-byte box size, `ftyp`, an allowlisted major brand, then some
+    // padding bytes.
+    const buf = Buffer.concat([makeFtypBox('isom'), Buffer.alloc(16)])
     const filePath = await writeTempFile('video.mp4', buf)
 
     expect(await sniffVideoType(filePath)).toBe('mp4')
+  })
+
+  test('accepts an ffmpeg-style mp4 with major brand isom and compatible brands', async () => {
+    const buf = Buffer.concat([makeFtypBox('isom', ['iso2', 'avc1', 'mp41']), Buffer.alloc(16)])
+    const filePath = await writeTempFile('video.mp4', buf)
+
+    expect(await sniffVideoType(filePath)).toBe('mp4')
+  })
+
+  test('accepts an mp4 with major brand mp42 and no compatible brands', async () => {
+    const buf = Buffer.concat([makeFtypBox('mp42'), Buffer.alloc(16)])
+    const filePath = await writeTempFile('video.mp4', buf)
+
+    expect(await sniffVideoType(filePath)).toBe('mp4')
+  })
+
+  test('accepts an mp4 whose major brand is unrecognized but a compatible brand is allowlisted', async () => {
+    const buf = Buffer.concat([makeFtypBox('f4v ', ['isom']), Buffer.alloc(16)])
+    const filePath = await writeTempFile('video.mp4', buf)
+
+    expect(await sniffVideoType(filePath)).toBe('mp4')
+  })
+
+  test('rejects a QuickTime .mov file', async () => {
+    const buf = Buffer.concat([makeFtypBox('qt  '), Buffer.alloc(16)])
+    const filePath = await writeTempFile('video.mov', buf)
+
+    expect(await sniffVideoType(filePath)).toBeUndefined()
+  })
+
+  test('rejects a HEIC image', async () => {
+    const buf = Buffer.concat([makeFtypBox('mif1', ['heic']), Buffer.alloc(16)])
+    const filePath = await writeTempFile('image.heic', buf)
+
+    expect(await sniffVideoType(filePath)).toBeUndefined()
+  })
+
+  test('rejects an AVIF image', async () => {
+    const buf = Buffer.concat([makeFtypBox('avif', ['mif1', 'miaf']), Buffer.alloc(16)])
+    const filePath = await writeTempFile('image.avif', buf)
+
+    expect(await sniffVideoType(filePath)).toBeUndefined()
+  })
+
+  test('rejects a truncated ftyp box with no room for a major brand', async () => {
+    const buf = Buffer.concat([
+      Buffer.from([0x00, 0x00, 0x00, 0x08]),
+      Buffer.from('ftyp', 'ascii'),
+      Buffer.alloc(16),
+    ])
+    const filePath = await writeTempFile('truncated.bin', buf)
+
+    expect(await sniffVideoType(filePath)).toBeUndefined()
   })
 
   test('detects webm from EBML magic plus a webm DocType', async () => {

--- a/server/lib/files/videos.ts
+++ b/server/lib/files/videos.ts
@@ -1,0 +1,49 @@
+import { open } from 'fs/promises'
+
+/** How many bytes of a candidate video file we inspect to determine its container format. */
+const SNIFF_BYTES = 4096
+
+/** The minimum number of bytes needed to identify either supported container format. */
+const MIN_SNIFF_BYTES = 12
+
+const MP4_FTYP_OFFSET = 4
+const MP4_FTYP = Buffer.from('ftyp', 'ascii')
+
+// The first 4 bytes of every EBML document (Matroska and WebM alike): this magic alone does not
+// distinguish a WebM file from a plain Matroska (.mkv) file, since WebM is a constrained profile
+// of the Matroska container.
+const EBML_MAGIC = Buffer.from([0x1a, 0x45, 0xdf, 0xa3])
+// The EBML DocType element's value for WebM specifically; its presence somewhere in the sniffed
+// header is what distinguishes an actual WebM file from a generic Matroska one.
+const WEBM_DOCTYPE = Buffer.from('webm', 'ascii')
+
+/**
+ * Reads only the first `SNIFF_BYTES` of the file at `filePath` (never the whole file, since
+ * uploads can be up to 100MB) and determines whether it looks like an mp4 or webm video based on
+ * its container magic bytes. Returns `undefined` if the file doesn't match either format.
+ */
+export async function sniffVideoType(filePath: string): Promise<'mp4' | 'webm' | undefined> {
+  const handle = await open(filePath, 'r')
+  try {
+    const buf = Buffer.alloc(SNIFF_BYTES)
+    const { bytesRead } = await handle.read(buf, 0, SNIFF_BYTES, 0)
+    if (bytesRead < MIN_SNIFF_BYTES) {
+      return undefined
+    }
+    const header = buf.subarray(0, bytesRead)
+
+    // mp4: the first box is a 4-byte size followed by a 4-byte ASCII type, so the type sits at
+    // offset 4 for the very first box (typically an `ftyp` box for a well-formed mp4).
+    if (header.subarray(MP4_FTYP_OFFSET, MP4_FTYP_OFFSET + 4).equals(MP4_FTYP)) {
+      return 'mp4'
+    }
+
+    if (header.subarray(0, EBML_MAGIC.length).equals(EBML_MAGIC) && header.includes(WEBM_DOCTYPE)) {
+      return 'webm'
+    }
+
+    return undefined
+  } finally {
+    await handle.close()
+  }
+}

--- a/server/lib/files/videos.ts
+++ b/server/lib/files/videos.ts
@@ -8,6 +8,26 @@ const MIN_SNIFF_BYTES = 12
 
 const MP4_FTYP_OFFSET = 4
 const MP4_FTYP = Buffer.from('ftyp', 'ascii')
+const MP4_MAJOR_BRAND_OFFSET = 8
+const MP4_COMPATIBLE_BRANDS_OFFSET = 16
+
+// An `ftyp` box's "brand" codes that indicate an actual mp4-family file (ISO base media / MPEG-4
+// Part 14, or a variant of it, such as the fragmented/DASH profile or Apple's iTunes `M4V `).
+// Brand codes not in this set belong to other ISO-BMFF-based formats that also use an `ftyp` box
+// (see the comment below on why that box alone isn't sufficient to identify mp4).
+const MP4_ALLOWED_BRANDS: ReadonlySet<string> = new Set([
+  'isom',
+  'iso2',
+  'iso3',
+  'iso4',
+  'iso5',
+  'iso6',
+  'mp41',
+  'mp42',
+  'avc1',
+  'dash',
+  'M4V ',
+])
 
 // The first 4 bytes of every EBML document (Matroska and WebM alike): this magic alone does not
 // distinguish a WebM file from a plain Matroska (.mkv) file, since WebM is a constrained profile
@@ -19,8 +39,9 @@ const WEBM_DOCTYPE = Buffer.from('webm', 'ascii')
 
 /**
  * Reads only the first `SNIFF_BYTES` of the file at `filePath` (never the whole file, since
- * uploads can be up to 100MB) and determines whether it looks like an mp4 or webm video based on
- * its container magic bytes. Returns `undefined` if the file doesn't match either format.
+ * uploads can be tens of megabytes) and determines whether it looks like an mp4 or webm video
+ * based on its container magic bytes. Returns `undefined` if the file doesn't match either
+ * format.
  */
 export async function sniffVideoType(filePath: string): Promise<'mp4' | 'webm' | undefined> {
   const handle = await open(filePath, 'r')
@@ -33,9 +54,34 @@ export async function sniffVideoType(filePath: string): Promise<'mp4' | 'webm' |
     const header = buf.subarray(0, bytesRead)
 
     // mp4: the first box is a 4-byte size followed by a 4-byte ASCII type, so the type sits at
-    // offset 4 for the very first box (typically an `ftyp` box for a well-formed mp4).
+    // offset 4 for the very first box (typically an `ftyp` box for a well-formed mp4). An `ftyp`
+    // box by itself doesn't identify mp4, though: every file in the ISO base media format family
+    // starts with one, including QuickTime `.mov`, 3GP, and HEIC/AVIF images — they only differ
+    // in which "brand" codes the box declares. So a match here just means "parse the box and
+    // check its brands next," not "this is an mp4."
     if (header.subarray(MP4_FTYP_OFFSET, MP4_FTYP_OFFSET + 4).equals(MP4_FTYP)) {
-      return 'mp4'
+      const boxSize = header.readUInt32BE(0)
+      // A well-formed ftyp box is an 8-byte header, a 4-byte major brand, a 4-byte minor version,
+      // and then zero or more 4-byte compatible brands, so its declared size must be at least 16
+      // and a multiple of 4; anything else is a malformed or degenerate box we can't trust.
+      if (boxSize >= 16 && boxSize % 4 === 0) {
+        // The box can legitimately extend well past what we sniffed (most of an mp4's bytes live
+        // in boxes that come after `ftyp`), so clamp the scan to whichever end comes first rather
+        // than rejecting the file for having a box larger than the sniffed header.
+        const boxEnd = Math.min(boxSize, header.length)
+
+        const brands = new Set<string>()
+        brands.add(
+          header.subarray(MP4_MAJOR_BRAND_OFFSET, MP4_MAJOR_BRAND_OFFSET + 4).toString('ascii'),
+        )
+        for (let offset = MP4_COMPATIBLE_BRANDS_OFFSET; offset + 4 <= boxEnd; offset += 4) {
+          brands.add(header.subarray(offset, offset + 4).toString('ascii'))
+        }
+
+        if (Array.from(brands).some(brand => MP4_ALLOWED_BRANDS.has(brand))) {
+          return 'mp4'
+        }
+      }
     }
 
     if (header.subarray(0, EBML_MAGIC.length).equals(EBML_MAGIC) && header.includes(WEBM_DOCTYPE)) {

--- a/server/lib/news/news-api.ts
+++ b/server/lib/news/news-api.ts
@@ -1,12 +1,18 @@
 import { RouterContext } from '@koa/router'
+import { createReadStream } from 'fs'
 import httpErrors from 'http-errors'
 import mime from 'mime'
 import sharp, { FormatEnum } from 'sharp'
 import { MAX_IMAGE_SIZE_BYTES } from '../../../common/images'
-import { NewsImageUploadResponse } from '../../../common/news'
+import {
+  MAX_VIDEO_SIZE_BYTES,
+  NewsImageUploadResponse,
+  NewsVideoUploadResponse,
+} from '../../../common/news'
 import { getUrl, writeFile } from '../files'
 import { handleMultipartFiles } from '../files/handle-multipart-files'
 import { createImagePath } from '../files/images'
+import { sniffVideoType } from '../files/videos'
 import { httpApi } from '../http/http-api'
 import { httpBefore, httpPost } from '../http/route-decorators'
 import { checkAllPermissions } from '../permissions/check-permissions'
@@ -18,6 +24,12 @@ import { smallVariantPath } from './news-image-paths'
 const imageUploadThrottle = createThrottle('newsimages', {
   rate: 5,
   burst: 10,
+  window: 60000,
+})
+
+const videoUploadThrottle = createThrottle('newsvideos', {
+  rate: 2,
+  burst: 4,
   window: 60000,
 })
 
@@ -77,5 +89,34 @@ export class NewsApi {
     ])
 
     return { path, url: getUrl(path), smallUrl: getUrl(smallPath) }
+  }
+
+  @httpPost('/videos')
+  @httpBefore(
+    ensureLoggedIn,
+    checkAllPermissions('manageNews'),
+    throttleMiddleware(videoUploadThrottle, throttleByUser),
+    handleMultipartFiles(MAX_VIDEO_SIZE_BYTES),
+  )
+  async uploadVideo(ctx: RouterContext): Promise<NewsVideoUploadResponse> {
+    const videoFile = ctx.request.files?.video
+    if (!videoFile) {
+      throw new httpErrors.BadRequest('a video file must be provided')
+    }
+    if (Array.isArray(videoFile)) {
+      throw new httpErrors.BadRequest('only one video file can be uploaded')
+    }
+
+    const type = await sniffVideoType(videoFile.filepath)
+    if (!type) {
+      throw new httpErrors.UnsupportedMediaType('only mp4 and webm videos are supported')
+    }
+
+    const path = createImagePath('news-videos', type)
+    const stream = createReadStream(videoFile.filepath)
+
+    await writeFile(path, stream, { acl: 'public-read', type: mime.getType(type) ?? undefined })
+
+    return { path, url: getUrl(path) }
   }
 }

--- a/server/lib/news/news-api.ts
+++ b/server/lib/news/news-api.ts
@@ -115,6 +115,9 @@ export class NewsApi {
     const path = createImagePath('news-videos', type)
     const stream = createReadStream(videoFile.filepath)
 
+    // TODO: Uploaded videos that never end up referenced by a saved post are never cleaned up
+    // and sit in the file store forever. If orphaned uploads become a storage problem, track
+    // upload references and garbage-collect unreferenced files.
     await writeFile(path, stream, { acl: 'public-read', type: mime.getType(type) ?? undefined })
 
     return { path, url: getUrl(path) }

--- a/server/public/locales/en/global.json
+++ b/server/public/locales/en/global.json
@@ -47,6 +47,7 @@
         "imageUploadError": "Something went wrong uploading the image.",
         "imageUploading": "Uploading…",
         "insertImage": "Insert image",
+        "insertVideo": "Insert video",
         "publish": "Publish",
         "publishDraft": "Draft (not published)",
         "publishNow": "Publish now",
@@ -57,7 +58,11 @@
         "summary": "Summary",
         "summaryRequired": "Summary is required",
         "title": "Title",
-        "titleRequired": "Title is required"
+        "titleRequired": "Title is required",
+        "videoInvalidType": "Please choose an mp4 or webm video file.",
+        "videoTooLarge": "That video is too large (max 100 MB).",
+        "videoUploadError": "Something went wrong uploading the video.",
+        "videoUploading": "Uploading…"
       },
       "history": {
         "by": "by ",

--- a/server/public/locales/en/global.json
+++ b/server/public/locales/en/global.json
@@ -47,7 +47,9 @@
         "imageUploadError": "Something went wrong uploading the image.",
         "imageUploading": "Uploading…",
         "insertImage": "Insert image",
+        "insertImageTooltip": "Insert image (up to 5 MB)",
         "insertVideo": "Insert video",
+        "insertVideoTooltip": "Insert video (up to 30 MB)",
         "publish": "Publish",
         "publishDraft": "Draft (not published)",
         "publishNow": "Publish now",
@@ -60,7 +62,7 @@
         "title": "Title",
         "titleRequired": "Title is required",
         "videoInvalidType": "Please choose an mp4 or webm video file.",
-        "videoTooLarge": "That video is too large (max 100 MB).",
+        "videoTooLarge": "That video is too large (max 30 MB).",
         "videoUploadError": "Something went wrong uploading the video.",
         "videoUploading": "Uploading…"
       },


### PR DESCRIPTION
## What

News post markdown already renders same-origin `.mp4`/`.webm` URLs (written with image syntax) as inline `<video>` elements, but there was no way to actually get a video into the file store — the only news upload endpoint pipes everything through sharp. This adds the missing upload path:

- **`POST /api/1/news/videos`** — admin-only (`manageNews`), own throttle (2/min, burst 4), 30MB cap. The file is validated by container magic bytes and streamed from the multipart temp file straight into the file store with the correct `ContentType` — no buffering the whole file in memory, no transcoding, no small variant.
- **mp4 validation parses the `ftyp` box's brands** (major + compatible) against an mp4-family allowlist, because the box's mere presence is shared by every ISO-BMFF format — QuickTime `.mov`, HEIC/AVIF images all open with one. webm requires the EBML magic **plus** the `webm` DocType string, so plain Matroska `.mkv` is rejected. `sniffVideoType()` lives in `server/lib/files/videos.ts` with unit tests; it reads only the first 4KB of the upload.
- **Insert video** toolbar button in the admin news editor, mirroring the Insert image flow (accepts `video/mp4,video/webm`, its own uploading/error state, Save disabled while an upload is in flight). The cursor-insertion logic the two flows share is extracted into one helper.
- **All markdown toolbar buttons now use the material `Tooltip`** via a shared `ToolbarButton` component instead of the native `title` attribute, with size guidance on the image/video upload buttons ("up to 5 MB" / "up to 30 MB"). The tooltip trigger passes `tabIndex={-1}` so wrapping an already-focusable button doesn't add a second tab stop.
- **Autoplay respects viewer signals**: inline videos still autoplay muted+looped like the gifs they replace, but viewers with `prefers-reduced-motion: reduce` or browser data-saver enabled get click-to-play with `preload='metadata'` instead. (The 30MB cap is sized with autoplay in mind — every page view downloads the full file.)
- Uploads that never end up referenced by a saved post are never cleaned up; noted as a TODO on the endpoint rather than solved here.

## Verification

- Unit tests (14/14 on the sniffer, including `.mov`/HEIC/AVIF/truncated-box rejection), `typecheck`, `lint` all clean; translation catalogs regenerated.
- Live against the dev server with the client's real multipart encoding: mp4/webm → 200, garbage bytes → 415, missing field → 400, non-admin → 403; the stored file round-trips byte-identical and serves as `video/mp4`. (This pass predates the brand-allowlist tightening; the sniffer behavior changes since then are covered by the unit tests.)
- Browser pass through the real admin form: selecting a file uploads it, splices `![alt](url)` into the content at the cursor, and the preview pane renders a playing `<video>`.
