### PR TITLE
Open links to stored content in a new window instead of in-app

### DIFF
--- a/client/navigation/external-link.test.ts
+++ b/client/navigation/external-link.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, test } from 'vitest'
+import { setServerConfig } from '../server-config-storage'
+import { isSbContentUrl } from './external-link'
+
+describe('isSbContentUrl', () => {
+  describe('CDN-style public assets config', () => {
+    beforeEach(() => {
+      setServerConfig({
+        publicAssetsUrl: 'https://cdn.shieldbattery.net/public/',
+        graphqlOrigin: 'https://gql.shieldbattery.net/',
+      })
+    })
+
+    test('returns true for an uploaded file at the CDN origin root', () => {
+      expect(isSbContentUrl(new URL('https://cdn.shieldbattery.net/news/abc/video.mp4'))).toBe(true)
+    })
+
+    test('returns true for a public asset under the configured path', () => {
+      expect(isSbContentUrl(new URL('https://cdn.shieldbattery.net/public/images/logo.svg'))).toBe(
+        true,
+      )
+    })
+
+    test('returns true for the server-origin file store', () => {
+      expect(isSbContentUrl(new URL('https://shieldbattery.net/files/news/abc/img.png'))).toBe(true)
+    })
+
+    test('returns false for an app route on the server origin', () => {
+      expect(isSbContentUrl(new URL('https://shieldbattery.net/ladder'))).toBe(false)
+    })
+
+    test('returns false when /files/ is not a whole path segment', () => {
+      expect(isSbContentUrl(new URL('https://shieldbattery.net/files-extra/x.png'))).toBe(false)
+    })
+
+    test('returns false for a foreign origin', () => {
+      expect(isSbContentUrl(new URL('https://example.com/files/x.png'))).toBe(false)
+    })
+
+    test('is case-insensitive on origin', () => {
+      expect(isSbContentUrl(new URL('https://CDN.shieldbattery.net/x.mp4'))).toBe(true)
+    })
+  })
+
+  describe('local-filesystem-style public assets config (same origin as server)', () => {
+    beforeEach(() => {
+      setServerConfig({
+        publicAssetsUrl: 'https://shieldbattery.net/',
+        graphqlOrigin: 'https://gql.shieldbattery.net/',
+      })
+    })
+
+    test('returns true for the server-origin file store', () => {
+      expect(isSbContentUrl(new URL('https://shieldbattery.net/files/news/abc/img.png'))).toBe(true)
+    })
+
+    test('returns false for an app route, even though the assets origin matches the server', () => {
+      expect(isSbContentUrl(new URL('https://shieldbattery.net/ladder'))).toBe(false)
+    })
+  })
+})

--- a/client/navigation/external-link.tsx
+++ b/client/navigation/external-link.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import { useMemo } from 'react'
 import logger from '../logging/logger'
 import { maybeOpenExternalLinkDialog } from '../messaging/action-creators'
-import { getServerOrigin, makeServerUrl } from '../network/server-url'
+import { getServerOrigin, makePublicAssetUrl, makeServerUrl } from '../network/server-url'
 import { useAppDispatch } from '../redux-hooks'
 import { push } from './routing'
 
@@ -23,16 +23,43 @@ export function isShieldBatteryUrl(url: URL): boolean {
 }
 
 /**
+ * Returns whether `url` points at stored content (uploaded files or public assets) rather than an
+ * app page: either the server's own file store (mounted at `/files/` on the server origin), or the
+ * public assets host when that's an origin of its own (e.g. a CDN). The app router has no routes
+ * for content URLs, so in-app navigation to one just falls through to the index page; they also
+ * shouldn't trigger the leaving-ShieldBattery warning, since they're our own content.
+ */
+export function isSbContentUrl(url: URL): boolean {
+  const urlOrigin = url.origin.toLowerCase()
+  const serverOrigin = getServerOrigin().toLowerCase()
+  if (urlOrigin === serverOrigin && url.pathname.startsWith('/files/')) {
+    return true
+  }
+
+  try {
+    const assetsOrigin = new URL(makePublicAssetUrl('/')).origin.toLowerCase()
+    return urlOrigin === assetsOrigin && assetsOrigin !== serverOrigin
+  } catch {
+    return false
+  }
+}
+
+/**
  * A link that may point to an external (non-ShieldBattery) site. If it does, users will be warned
  * about the navigation before a new window opens. If it points to a ShieldBattery URL, users will
- * not be warned and it will open in this window unless `forceNewWindow` is `true`.
+ * not be warned and it will open in this window unless `forceNewWindow` is `true`. ShieldBattery
+ * content URLs (uploaded files/public assets) open in a new window without a warning, since the
+ * app has no page of its own to show them on.
  */
 export function ExternalLink({ href, children, className, forceNewWindow }: ExternalLinkProps) {
   const dispatch = useAppDispatch()
 
-  const url = useMemo(() => {
+  const { url, isContent } = useMemo(() => {
     try {
       const url = new URL(href)
+      if (isSbContentUrl(url)) {
+        return { url, isContent: true }
+      }
       if (IS_ELECTRON && isShieldBatteryUrl(url)) {
         // NOTE(tec27): The code flow is a bit weird here but it is convenient: we generate a new
         // URL so that Electron will navigate to the right spot if we're not opening a new window,
@@ -40,14 +67,27 @@ export function ExternalLink({ href, children, className, forceNewWindow }: Exte
         // external URL (which will be the href on the anchor tag)
         // NOTE(tec27): As of Chrome 130+, we can't simply set the proto of a URL object to a custom
         // scheme any more, so we have to collect all the parts ourselves
-        return new URL(`${ELECTRON_PROTO}//${ELECTRON_HOST}${url.pathname}${url.search}${url.hash}`)
+        return {
+          url: new URL(
+            `${ELECTRON_PROTO}//${ELECTRON_HOST}${url.pathname}${url.search}${url.hash}`,
+          ),
+          isContent: false,
+        }
       }
-      return url
+      return { url, isContent: false }
     } catch (err) {
       logger.error(`Tried to render link with invalid URL: ${href}`)
-      return undefined
+      return { url: undefined, isContent: false }
     }
   }, [href])
+
+  if (isContent) {
+    return (
+      <a className={className} href={href} target='_blank' rel='noopener'>
+        {children}
+      </a>
+    )
+  }
 
   const isInternal = url && isShieldBatteryUrl(url)
 


### PR DESCRIPTION
## Problem

Links rendered through `ExternalLink` (e.g. markdown links in news posts, chat) treat any URL whose origin matches the server origin as an internal app route and SPA-navigate to it. Uploaded files are served from the server origin under `/files/` when using the local filesystem file store, and the client router has no route for that path — so clicking a link to an uploaded file (for example, a news image/video whose markdown was edited from `![](url)` into `[](url)`) falls through to the catch-all route and lands the user on the home page.

In production the same files live on the CDN origin instead, which `ExternalLink` classifies as a foreign site — so clicking them shows the "leaving ShieldBattery" warning dialog for our own content.

## Fix

Adds `isSbContentUrl()`: a URL counts as stored content if it is on the server origin under `/files/`, or on the public-assets origin when that is an origin of its own (the CDN case; guarded so the filesystem-store config, where the assets origin *is* the server origin, does not misclassify app routes). Content links render as a plain `target="_blank"` anchor — no SPA push and no external-site warning. In the Electron app, `target="_blank"` http(s) URLs already go through `setWindowOpenHandler` → `shell.openExternal`, so content opens in the OS browser.

Includes unit tests for the classification covering both file-store configurations.
