### PR TITLE
Don't overlay the player list over the map thumbnail in the mini match history

### DIFF
--- a/client/users/mini-match-history.tsx
+++ b/client/users/mini-match-history.tsx
@@ -216,16 +216,15 @@ const GamePreviewRoot = styled.div`
 `
 
 const GamePreviewDetails = styled.div`
-  position: relative;
   width: 100%;
   flex-grow: 1;
   padding: 16px 16px 20px;
 
   display: flex;
   flex-direction: column;
+  gap: 16px;
 
-  --_surface-bg: var(--theme-container-low);
-  background-color: var(--_surface-bg);
+  background-color: var(--theme-container-low);
   border-radius: 4px;
 `
 
@@ -236,20 +235,7 @@ const NoGameText = styled.div`
 `
 
 const StyledGamePlayersDisplay = styled(GamePlayersDisplay)`
-  position: absolute;
-  bottom: 12px; /* 12px + 8px from player bottom margin = 20px */
-  left: 16px;
-  right: 16px;
-
-  padding-top: 24px;
-
-  background: linear-gradient(
-    to bottom,
-    rgb(from var(--_surface-bg) r g b / 0),
-    rgb(from var(--_surface-bg) r g b / 50%) 12px,
-    rgb(from var(--_surface-bg) r g b / 80%) 80%,
-    rgb(from var(--_surface-bg) r g b) 92%
-  );
+  margin-top: auto;
 `
 
 const StyledMapThumbnail = styled(ReduxMapThumbnail)`

--- a/client/users/mini-match-history.tsx
+++ b/client/users/mini-match-history.tsx
@@ -26,6 +26,7 @@ const MatchHistoryRoot = styled.div`
   padding: 0 24px 0 8px;
 
   display: flex;
+  align-items: flex-start;
 `
 
 const GameList = styled.div`
@@ -234,10 +235,6 @@ const NoGameText = styled.div`
   text-align: center;
 `
 
-const StyledGamePlayersDisplay = styled(GamePlayersDisplay)`
-  margin-top: auto;
-`
-
 const StyledMapThumbnail = styled(ReduxMapThumbnail)`
   height: auto;
 `
@@ -273,7 +270,7 @@ export function ConnectedGamePreview({ game, forUserId }: ConnectedGamePreviewPr
     <GamePreviewRoot>
       <GamePreviewDetails>
         {mapId ? <StyledMapThumbnail key={mapId} mapId={mapId} size={256} showInfoLayer /> : null}
-        <StyledGamePlayersDisplay game={game} forUserId={forUserId} />
+        <GamePlayersDisplay game={game} forUserId={forUserId} />
       </GamePreviewDetails>
       <TextButton
         label={t('user.miniMatchHistory.viewDetails', 'View details')}


### PR DESCRIPTION
Lays out the player list in normal flow below the map thumbnail (pushed to the bottom with flex `margin-top: auto` and a `gap`), instead of absolutely positioning it over the thumbnail with a gradient fade.