### PR TITLE
Remember and restore scroll positions on user profile pages

### DIFF
--- a/client/index.jsx
+++ b/client/index.jsx
@@ -11,6 +11,7 @@ import './dom/window-focus'
 import i18n, { detectedLocale, initI18next } from './i18n/i18next'
 import { getBestLanguage } from './i18n/language-detector'
 import log from './logging/logger'
+import { installHistoryEntryKeys } from './navigation/history-entry-key'
 import { fetchJson } from './network/fetch'
 import registerSocketHandlers from './network/socket-handlers'
 import { setServerConfig } from './server-config-storage'
@@ -22,6 +23,7 @@ window.__webpack_nonce__ = window.SB_CSP_NONCE
 
 enableArrayMethods()
 enableMapSet()
+installHistoryEntryKeys()
 
 window.addEventListener('error', event => {
   const messageText = event.error?.message ?? event.message

--- a/client/navigation/history-entry-key.test.ts
+++ b/client/navigation/history-entry-key.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, beforeEach, describe, expect, test } from 'vitest'
+import {
+  getHistoryEntryKey,
+  installHistoryEntryKeys,
+  resetHistoryEntryKeysForTesting,
+} from './history-entry-key'
+
+describe('history-entry-key', () => {
+  beforeEach(() => {
+    history.replaceState(null, '', '/a')
+    installHistoryEntryKeys()
+  })
+
+  afterEach(() => {
+    resetHistoryEntryKeysForTesting()
+  })
+
+  test('getHistoryEntryKey returns undefined for null state', () => {
+    expect(getHistoryEntryKey(null)).toBeUndefined()
+  })
+
+  test('getHistoryEntryKey returns undefined for a sentinel string state', () => {
+    expect(getHistoryEntryKey('SOME:sentinel')).toBeUndefined()
+  })
+
+  test('getHistoryEntryKey returns undefined for an object without the stamp', () => {
+    expect(getHistoryEntryKey({ foo: 'bar' })).toBeUndefined()
+  })
+
+  test('installing stamps the initial entry with a key', () => {
+    const key = getHistoryEntryKey()
+    expect(typeof key).toBe('string')
+  })
+
+  test('push with null state to a different pathname mints a fresh key', () => {
+    const firstKey = getHistoryEntryKey()
+
+    history.pushState(null, '', '/b')
+
+    const secondKey = getHistoryEntryKey()
+    expect(secondKey).toEqual(expect.any(String))
+    expect(secondKey).not.toBe(firstKey)
+  })
+
+  test('push with null state to the same pathname inherits the current key', () => {
+    const firstKey = getHistoryEntryKey()
+
+    history.pushState(null, '', '/a?page=2')
+
+    expect(getHistoryEntryKey()).toBe(firstKey)
+  })
+
+  test('push with null state and a hash-only url inherits the current key', () => {
+    const firstKey = getHistoryEntryKey()
+
+    history.pushState(null, '', '#section')
+
+    expect(getHistoryEntryKey()).toBe(firstKey)
+  })
+
+  test('push with a non-null state passes it through untouched', () => {
+    history.pushState('SETTINGS:open', '', '/a')
+
+    expect(history.state).toBe('SETTINGS:open')
+    expect(getHistoryEntryKey()).toBeUndefined()
+  })
+
+  test('push with a non-null state does not change the tracked visit key', () => {
+    const firstKey = getHistoryEntryKey()
+
+    history.pushState('SETTINGS:open', '', '/a')
+    // A subsequent null-state push on the same pathname should inherit the key that was current
+    // before the sentinel entry, not lose it.
+    history.pushState(null, '', '/a')
+
+    expect(getHistoryEntryKey()).toBe(firstKey)
+  })
+
+  test('replaceState with null state keeps the current entry key while changing the url', () => {
+    const firstKey = getHistoryEntryKey()
+
+    history.replaceState(null, '', '/a-corrected')
+
+    expect(getHistoryEntryKey()).toBe(firstKey)
+    expect(window.location.pathname).toBe('/a-corrected')
+  })
+
+  test('replaceState with a non-null state passes it through untouched', () => {
+    history.replaceState('SETTINGS:open', '', '/a')
+
+    expect(history.state).toBe('SETTINGS:open')
+    expect(getHistoryEntryKey()).toBeUndefined()
+  })
+
+  test('popstate resyncs the tracked visit key to the entry the browser traversed to', () => {
+    const firstKey = getHistoryEntryKey()
+
+    history.pushState(null, '', '/b')
+    expect(getHistoryEntryKey()).not.toBe(firstKey)
+
+    // A real back-traversal changes `history.state` without going through pushState/replaceState
+    // at all, then fires popstate; setting the state directly via a non-null replaceState (which
+    // passes through untouched and leaves the tracked key alone) reproduces that same moment.
+    history.replaceState({ __sbEntryKey: firstKey }, '', '/a')
+    window.dispatchEvent(new PopStateEvent('popstate'))
+
+    // With the tracked key resynced, a subsequent push back to the same pathname inherits it
+    // instead of minting a new one or reusing the stale key from the /b entry.
+    history.pushState(null, '', '/a')
+    expect(getHistoryEntryKey()).toBe(firstKey)
+  })
+
+  test('installHistoryEntryKeys is idempotent', () => {
+    const firstKey = getHistoryEntryKey()
+
+    installHistoryEntryKeys()
+    history.pushState(null, '', '/b')
+
+    expect(getHistoryEntryKey()).not.toBe(firstKey)
+  })
+})

--- a/client/navigation/history-entry-key.ts
+++ b/client/navigation/history-entry-key.ts
@@ -1,0 +1,137 @@
+/**
+ * Stamps every history entry with a per-entry "visit key" that mirrors the granularity browsers
+ * use for their own native scroll restoration: one key per entry in the back/forward stack, not
+ * one per pathname or logical page. A store keyed by this identifier restores on back/forward
+ * traversal to an entry (or to another entry that shares its visit) but starts fresh when a link
+ * push lands on a pathname that's already been visited under a different entry.
+ *
+ * Two kinds of transitions deliberately keep the current visit key instead of minting a new one:
+ *  - A push whose target pathname is unchanged from the current one (only the search string or
+ *    hash differs, or an overlay is pushed on top of the same URL) — this covers things like
+ *    filters/pagination expressed as search params, and full-screen overlays that sit on top of
+ *    the page underneath them.
+ *  - Any replace, regardless of pathname — this covers in-place URL corrections (e.g. a username
+ *    whose canonical casing gets patched into the URL) that should read as a continuation of the
+ *    same visit rather than a new one.
+ *
+ * Some parts of the app put an explicit sentinel value into `history.state` to track UI state
+ * (for example, marking a settings overlay as open) and later compare that value by identity. Stamping over such a value would break those comparisons, so a push or
+ * replace that's given a non-null state passes through completely untouched: no stamp is added,
+ * and the current visit key is left as-is. `getHistoryEntryKey` returns `undefined` for an entry
+ * like that; anything keyed off the visit simply has nothing to restore while it's current.
+ */
+
+const ENTRY_KEY_PROP = '__sbEntryKey'
+
+interface StampedState {
+  [ENTRY_KEY_PROP]: string
+}
+
+function isStampedState(state: unknown): state is StampedState {
+  return (
+    typeof state === 'object' &&
+    state !== null &&
+    typeof (state as Record<string, unknown>)[ENTRY_KEY_PROP] === 'string'
+  )
+}
+
+/**
+ * Returns the visit key stamped onto `state` (the current `history.state` by default), or
+ * `undefined` if it holds no stamp — either because it's an app-provided sentinel value, or
+ * because it's `null`/`undefined`.
+ */
+export function getHistoryEntryKey(state: unknown = history.state): string | undefined {
+  return isStampedState(state) ? state[ENTRY_KEY_PROP] : undefined
+}
+
+let currentVisitKey: string | undefined
+
+let installed = false
+let originalPushState: History['pushState'] | undefined
+let originalReplaceState: History['replaceState'] | undefined
+let onPopState: (() => void) | undefined
+
+/**
+ * Patches `history.pushState`/`replaceState` to stamp a visit key onto every entry that isn't
+ * carrying an app-provided state value, and tracks the current entry's key across navigation.
+ *
+ * This wraps whatever `pushState`/`replaceState` currently are, native or already patched by
+ * something else (e.g. a router that dispatches its own events around them), and always calls
+ * through to that implementation so its behavior is preserved; this module only decides what
+ * state object goes out and records the key of the entry that results.
+ */
+export function installHistoryEntryKeys(): void {
+  if (installed) {
+    return
+  }
+  installed = true
+
+  originalPushState = history.pushState.bind(history)
+  originalReplaceState = history.replaceState.bind(history)
+  const pushState = originalPushState
+  const replaceState = originalReplaceState
+
+  history.pushState = (state: unknown, unused: string, url?: string | URL | null): void => {
+    if (state != null) {
+      pushState(state, unused, url)
+      return
+    }
+
+    const fromPathname = window.location.pathname
+    const toPathname =
+      url == null || url === '' ? fromPathname : new URL(String(url), window.location.href).pathname
+
+    const key =
+      toPathname === fromPathname ? (currentVisitKey ?? crypto.randomUUID()) : crypto.randomUUID()
+
+    pushState({ [ENTRY_KEY_PROP]: key }, unused, url)
+    currentVisitKey = key
+  }
+
+  history.replaceState = (state: unknown, unused: string, url?: string | URL | null): void => {
+    if (state != null) {
+      replaceState(state, unused, url)
+      return
+    }
+
+    const key = getHistoryEntryKey() ?? currentVisitKey ?? crypto.randomUUID()
+
+    replaceState({ [ENTRY_KEY_PROP]: key }, unused, url)
+    currentVisitKey = key
+  }
+
+  onPopState = () => {
+    // Traversing onto an unkeyed sentinel entry (an overlay opened over some page) keeps the
+    // surrounding visit's key, since the page under the overlay hasn't changed.
+    currentVisitKey = getHistoryEntryKey() ?? currentVisitKey
+  }
+  window.addEventListener('popstate', onPopState)
+
+  if (history.state == null) {
+    history.replaceState(null, '')
+  }
+  currentVisitKey = getHistoryEntryKey()
+}
+
+/** Undoes {@link installHistoryEntryKeys} and clears its tracked state. Only for use in tests. */
+export function resetHistoryEntryKeysForTesting(): void {
+  if (!installed) {
+    return
+  }
+
+  if (originalPushState) {
+    history.pushState = originalPushState
+  }
+  if (originalReplaceState) {
+    history.replaceState = originalReplaceState
+  }
+  if (onPopState) {
+    window.removeEventListener('popstate', onPopState)
+  }
+
+  installed = false
+  originalPushState = undefined
+  originalReplaceState = undefined
+  onPopState = undefined
+  currentVisitKey = undefined
+}

--- a/client/navigation/router-hooks.ts
+++ b/client/navigation/router-hooks.ts
@@ -2,7 +2,9 @@ import { RefObject, useLayoutEffect } from 'react'
 import { useLocation } from 'wouter'
 import { useLocationProperty } from 'wouter/use-browser-location'
 import { useStableCallback } from '../react/state-hooks'
+import { getHistoryEntryKey } from './history-entry-key'
 import { replace } from './routing'
+import { createViewStateStore } from './view-state-store'
 
 /**
  * A hook that reads a search param with a given name from `window.location`, and allows changing
@@ -58,4 +60,72 @@ export function useScrollResetOnNavigate(ref: RefObject<Element | null>): void {
   useLayoutEffect(() => {
     ref.current?.scrollTo(0, 0)
   }, [pathname, ref])
+}
+
+const SCROLL_MEMORY_MAX_AGE_MS = 30 * 60 * 1000
+
+const scrollPositions = createViewStateStore<number>('scroll', {
+  maxAgeMs: SCROLL_MEMORY_MAX_AGE_MS,
+})
+
+/**
+ * Returns the current history entry's visit key, re-evaluating whenever a pushState, replaceState,
+ * or popstate can have changed which entry is current.
+ */
+function useHistoryEntryKey(): string | undefined {
+  return useLocationProperty(() => getHistoryEntryKey())
+}
+
+/**
+ * Remembers the scroll position of an element and restores it pre-paint, mirroring the browser's
+ * own scroll restoration: positions are keyed per history entry (per "visit"), so traversing back
+ * or forward to an entry resumes where the user left off, while following a link to a page visited
+ * earlier lands at the top, the same as a fresh visit would. Pushes that keep the same pathname
+ * (an overlay opened on top of the current page, a search-param update) and all replaces
+ * (in-place URL corrections) share the current visit key, so scroll continuity holds across those.
+ * An entry whose `history.state` holds an app-provided value has no visit key, and the hook does
+ * nothing while such an entry is current. Positions expire after 30 minutes and old entries fall
+ * out of a bounded shared store.
+ *
+ * Intended for scrollers rendered by a page component *inside* `CenteredContentContainer`-style
+ * containers whose built-in reset fires first: this hook's restore runs in the page's own layout
+ * effect, which fires after effects of components the page renders, so the restore wins over the
+ * reset with no visible flicker.
+ *
+ * The saved value comes from a scroll listener rather than reading `scrollTop` in the cleanup
+ * because, when navigation reuses the mounted page (same route pattern, different params), React
+ * has already committed the new page's DOM by the time the cleanup runs, so the element's live
+ * `scrollTop` may have been clamped by the new (possibly shorter or still-loading) content. Scroll
+ * events dispatch asynchronously, so the value the listener captured last is always from before
+ * that swap.
+ *
+ * Restoring into content that is currently shorter than the saved position clamps naturally;
+ * nothing re-restores if the content later grows.
+ */
+export function useScrollMemory(ref: RefObject<Element | null>): void {
+  const entryKey = useHistoryEntryKey()
+
+  useLayoutEffect(() => {
+    const elem = ref.current
+    if (!elem || entryKey === undefined) {
+      return undefined
+    }
+
+    let lastScrollTop = scrollPositions.get(entryKey)
+    if (lastScrollTop) {
+      elem.scrollTo(0, lastScrollTop)
+    }
+
+    const onScroll = () => {
+      lastScrollTop = elem.scrollTop
+    }
+    elem.addEventListener('scroll', onScroll, { passive: true })
+
+    return () => {
+      elem.removeEventListener('scroll', onScroll)
+      if (lastScrollTop !== undefined) {
+        scrollPositions.set(entryKey, lastScrollTop)
+      }
+    }
+  }, [entryKey, ref])
 }

--- a/client/navigation/view-state-store.test.ts
+++ b/client/navigation/view-state-store.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { createViewStateStore, resetViewStateForTesting } from './view-state-store'
+
+describe('view-state-store', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    resetViewStateForTesting()
+  })
+
+  test('get returns undefined for a missing key', () => {
+    const store = createViewStateStore<number>('test', { maxAgeMs: 1000 })
+    expect(store.get('missing')).toBeUndefined()
+  })
+
+  test('set then get returns the value', () => {
+    const store = createViewStateStore<number>('test', { maxAgeMs: 1000 })
+    store.set('a', 42)
+    expect(store.get('a')).toBe(42)
+  })
+
+  test('namespaces keep the same key string separate', () => {
+    const storeA = createViewStateStore<string>('ns-a', { maxAgeMs: 1000 })
+    const storeB = createViewStateStore<string>('ns-b', { maxAgeMs: 1000 })
+
+    storeA.set('shared-key', 'from-a')
+
+    expect(storeA.get('shared-key')).toBe('from-a')
+    expect(storeB.get('shared-key')).toBeUndefined()
+  })
+
+  test('entries expire after maxAgeMs', () => {
+    const store = createViewStateStore<number>('test', { maxAgeMs: 1000 })
+    store.set('a', 1)
+
+    vi.advanceTimersByTime(1001)
+
+    expect(store.get('a')).toBeUndefined()
+  })
+
+  test('entries are still present just under maxAgeMs', () => {
+    const store = createViewStateStore<number>('test', { maxAgeMs: 1000 })
+    store.set('a', 1)
+
+    vi.advanceTimersByTime(999)
+
+    expect(store.get('a')).toBe(1)
+  })
+
+  test('evicts the least-recently-used entry once past capacity', () => {
+    const store = createViewStateStore<number>('test', { maxAgeMs: 60 * 60 * 1000 })
+
+    for (let i = 0; i < 50; i++) {
+      store.set(`key-${i}`, i)
+    }
+    // Reading key-0 marks it as recently used, so it should survive the next eviction instead of
+    // the never-read key-1, even though key-1 was inserted later.
+    expect(store.get('key-0')).toBe(0)
+
+    store.set('key-50', 50)
+
+    expect(store.get('key-0')).toBe(0)
+    expect(store.get('key-1')).toBeUndefined()
+    expect(store.get('key-49')).toBe(49)
+    expect(store.get('key-50')).toBe(50)
+  })
+
+  test('set on an existing key refreshes both its value and its recency', () => {
+    const store = createViewStateStore<number>('test', { maxAgeMs: 60 * 60 * 1000 })
+
+    store.set('key-0', 0)
+    for (let i = 1; i < 50; i++) {
+      store.set(`key-${i}`, i)
+    }
+    // Re-set key-0 with a new value; this should also move it to most-recently-used.
+    store.set('key-0', 100)
+
+    store.set('key-50', 50)
+
+    expect(store.get('key-0')).toBe(100)
+    expect(store.get('key-1')).toBeUndefined()
+  })
+})

--- a/client/navigation/view-state-store.ts
+++ b/client/navigation/view-state-store.ts
@@ -1,0 +1,75 @@
+/**
+ * Module-level storage for transient view state (scroll positions, message windows, drafts, …)
+ * that should survive navigating away from a page and back within a session. It lives outside
+ * React/Redux/Jotai on purpose: writing to it must never trigger a render, and it's only read and
+ * written from effects, never during render (which keeps it safe under the React Compiler).
+ */
+
+const MAX_ENTRIES = 50
+
+interface StoredEntry {
+  value: unknown
+  savedAt: number
+}
+
+/**
+ * A single shared map so total retained view state is bounded as a whole; insertion order doubles
+ * as least-recently-used order because reads and writes re-insert.
+ */
+const entries = new Map<string, StoredEntry>()
+
+export interface ViewStateStore<T> {
+  get(key: string): T | undefined
+  set(key: string, value: T): void
+}
+
+/**
+ * Creates a typed view onto the shared store. `namespace` isolates one feature's keys from
+ * another's and must not contain ':'. Entries older than `maxAgeMs` are treated as absent. All
+ * consumers share one LRU with capacity `MAX_ENTRIES`, bounding the total memory retained across
+ * features (heavy use by one feature may evict another's oldest entries).
+ */
+export function createViewStateStore<T>(
+  namespace: string,
+  { maxAgeMs }: { maxAgeMs: number },
+): ViewStateStore<T> {
+  const fullKey = (key: string) => `${namespace}:${key}`
+
+  return {
+    get(key: string): T | undefined {
+      const full = fullKey(key)
+      const entry = entries.get(full)
+      if (!entry) {
+        return undefined
+      }
+
+      if (Date.now() - entry.savedAt > maxAgeMs) {
+        entries.delete(full)
+        return undefined
+      }
+
+      entries.delete(full)
+      entries.set(full, entry)
+
+      return entry.value as T
+    },
+
+    set(key: string, value: T): void {
+      const full = fullKey(key)
+      entries.delete(full)
+      entries.set(full, { value, savedAt: Date.now() })
+
+      if (entries.size > MAX_ENTRIES) {
+        const oldestKey = entries.keys().next().value
+        if (oldestKey !== undefined) {
+          entries.delete(oldestKey)
+        }
+      }
+    },
+  }
+}
+
+/** Removes all stored entries across every namespace. Only for use in tests. */
+export function resetViewStateForTesting(): void {
+  entries.clear()
+}

--- a/client/users/user-profile.tsx
+++ b/client/users/user-profile.tsx
@@ -22,6 +22,7 @@ import { RaceIcon } from '../lobbies/race-icon'
 import { FilledButton } from '../material/button'
 import { TabItem, Tabs } from '../material/tabs'
 import { CopyLinkButton } from '../navigation/copy-link-button'
+import { useScrollMemory } from '../navigation/router-hooks'
 import { replace } from '../navigation/routing'
 import { LoadingDotsArea } from '../progress/dots'
 import { useAppDispatch, useAppSelector } from '../redux-hooks'
@@ -311,6 +312,9 @@ export function UserProfilePage({
   // TODO(tec27): Build the title feature :)
   const title = t('users.titles.novice', 'Novice')
 
+  const scrollerRef = useRef<HTMLDivElement>(null)
+  useScrollMemory(scrollerRef)
+
   // `suspense: false` so a first (uncached) fetch doesn't suspend the profile page (blanking it
   // behind a loading fallback) just to resolve the optional Twitch channel/live state -- these
   // render in once they arrive. The poll below keeps the Live badge/banner consistent with the
@@ -364,7 +368,7 @@ export function UserProfilePage({
   }
 
   return (
-    <CenteredContentContainer>
+    <CenteredContentContainer ref={scrollerRef}>
       <TopSection>
         <AvatarCircle $isLive={isLive}>
           <StyledAvatar userId={user.id} showLiveIndicator={false} />


### PR DESCRIPTION
Adds the view-state store + `useScrollMemory` hook (Track 1, item 2 of the scroll-restoration plan) and applies it to profile pages.

- **`view-state-store.ts`**: module-level store for transient per-page view state — one shared LRU (capacity 50) with a per-namespace TTL, typed per consumer via `createViewStateStore<T>(namespace, { maxAgeMs })`. Deliberately outside React/Redux/Jotai: writes never trigger renders, and it is only touched from effects. Chat restoration can later add its own namespace with richer entries.
- **`history-entry-key.ts`**: patches `pushState`/`replaceState` to stamp a per-entry "visit key" into `history.state`, mirroring the granularity of the browser's own scroll restoration. Only entries pushed with a null state get stamped, so the app's existing sentinel values in `history.state` (settings overlay, navigation menus and traps) keep their identity comparisons. Pushes that stay on the same pathname and all replaces inherit the current key, so search-param updates, overlay entries, and in-place username spelling corrections read as a continuation of the same visit.
- **`useScrollMemory(ref)`**: saves an element's scroll position on leave and restores it pre-paint on return (30 min TTL), keyed by the current entry's visit key — traversing back/forward to an entry resumes where the user left off, while following a link to a previously visited page starts at the top like any fresh visit. It composes with the #1412 reset: the page-level restore effect fires after `CenteredContentContainer`'s internal reset, so memory-enabled pages win while everything else keeps resetting to top. The saved value comes from a passive scroll listener rather than a cleanup-time `scrollTop` read, since same-route navigations commit the new DOM before cleanups run and the live value can already be clamped by shorter content.

The Summary tab (redux-cached) restores exactly; match history/stats tabs still land at top until the game-list window cache (Track 1 item 4) lands.

Verified live in the Electron app: back/forward traversal to a profile entry restores the position exactly, while following a link to the same profile lands at the top like a fresh visit. Unit tests cover the store (LRU eviction, recency refresh on read, TTL, namespacing) and the entry-key stamping (fresh key on cross-pathname pushes, inheritance on same-pathname pushes and replaces, sentinel pass-through, popstate resync).
