### PR TITLE
Reflect the resolved ladder mode into the URL when it names none

### DIFF
--- a/client/ladder/ladder.tsx
+++ b/client/ladder/ladder.tsx
@@ -48,7 +48,7 @@ import { Select } from '../material/select/select'
 import { elevationPlus1, elevationPlus2, elevationPlus3 } from '../material/shadows'
 import { Tooltip } from '../material/tooltip'
 import { useLocationSearchParam } from '../navigation/router-hooks'
-import { push } from '../navigation/routing'
+import { push, replace } from '../navigation/routing'
 import { LoadingDotsArea } from '../progress/dots'
 import { useValueAsRef } from '../react/state-hooks'
 import { useAppDispatch, useAppSelector } from '../redux-hooks'
@@ -204,7 +204,10 @@ export interface LadderProps {
  * Displays a ranked table of players on the ladder(s).
  */
 export function Ladder({ matchmakingType: routeType, seasonId }: LadderProps) {
-  const matchmakingType = routeType ?? savedLadderTab.getValue() ?? MatchmakingType.Match1v1
+  const savedType = savedLadderTab.getValue()
+  const matchmakingType =
+    routeType ??
+    (savedType && ALL_MATCHMAKING_TYPES.includes(savedType) ? savedType : MatchmakingType.Match1v1)
   useTrackPageView(urlPath`/ladder/${matchmakingType}`)
   const { t } = useTranslation()
   const dispatch = useAppDispatch()
@@ -351,6 +354,19 @@ export function Ladder({ matchmakingType: routeType, seasonId }: LadderProps) {
       debouncedSearch.cancel()
     }
   }, [currentSeasonIdRef, dispatch, matchmakingType, searchQuery, seasonId])
+
+  // A URL without a valid mode still renders the saved/default mode, so immediately reflect that
+  // mode into the URL. This keeps every history entry naming the mode it displays, ensuring
+  // back/forward traversal can't show content that disagrees with the URL.
+  useEffect(() => {
+    if (!routeType) {
+      replace(
+        urlPath`/ladder/${matchmakingType}` +
+          (seasonId ? urlPath`/${seasonId}` : '') +
+          location.search,
+      )
+    }
+  }, [routeType, matchmakingType, seasonId])
 
   useEffect(() => {
     if (routeType) {


### PR DESCRIPTION
#### Problem

The bare `/ladder/` URL renders the last-viewed mode from localStorage without reflecting it into the URL, so the address bar and the visible rankings could disagree. Repro: open `/ladder/` → click 2v2 BGH in the rail (URL becomes `/ladder/2v2bgh`, and the effect saves `2v2bgh` as the last-viewed tab) → press the mouse back button. The URL returns to `/ladder/`, but that now resolves to the *saved* tab, so the page keeps showing 2v2 BGH. (Behavior dates back to `5a1a9ec05`, which introduced the saved-tab fallback.)

#### Fix

When the URL names no valid mode, `Ladder` now immediately replace-navigates to the mode it resolved, preserving any season segment and query string. Every history entry then names the mode it displays, so back/forward traversal can never show content that disagrees with the URL. The localStorage value is also validated against `ALL_MATCHMAKING_TYPES` now, so a stale/garbage saved value falls back to 1v1 instead of leaking into the URL.

Since it's a replace rather than a push, no dead `/ladder/` entry is left in the back stack — a single back from the ladder page exits to the previous page.

One deliberate semantic shift: the saved "last viewed" tab now also updates on back/forward traversal (returning to a `/ladder/1v1` entry re-saves 1v1), since every visit is now a routed visit. It tracks what you last actually looked at.

#### Verification

Driven live in the Electron app:
- Opening Ladder from the nav (bare `/ladder/`) instantly normalizes to `/ladder/1v1` (or the saved tab); the nav highlight still matches via `routePattern='/ladder/*?'`.
- Click 2v2 BGH → `/ladder/2v2bgh`; back → `/ladder/1v1` with the 1v1 tab selected (the repro's mismatch is gone); forward → `/ladder/2v2bgh` showing 2v2 BGH.
- A fresh nav visit still resumes the last-viewed mode.
- A single back from the ladder page returns to the previous page.

`pnpm run typecheck` and eslint pass.