### PR TITLE
Remember and restore game lists across navigations

### DIFF
--- a/client/games/game-list-view.tsx
+++ b/client/games/game-list-view.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 import {
@@ -13,7 +13,8 @@ import { useContextMenu } from '../dom/use-context-menu'
 import { useKeyListener } from '../keyboard/key-listener'
 import InfiniteScrollList from '../lists/infinite-scroll-list'
 import { Popover } from '../material/popover'
-import { useLocationSearchParam } from '../navigation/router-hooks'
+import { useHistoryEntryKey, useLocationSearchParam } from '../navigation/router-hooks'
+import { createViewStateStore } from '../navigation/view-state-store'
 import { useUserLocalStorageValue } from '../react/state-hooks'
 import { bodyLarge } from '../styles/typography'
 import { navigateToGameResults } from './action-creators'
@@ -54,6 +55,12 @@ const ListColumn = styled.div`
   flex-grow: 1;
   min-width: 0;
 `
+
+const SELECTION_MEMORY_MAX_AGE_MS = 30 * 60 * 1000
+
+const selectedIdCache = createViewStateStore<string>('game-list-selection', {
+  maxAgeMs: SELECTION_MEMORY_MAX_AGE_MS,
+})
 
 /** The normalized, ready-to-request filter values a game list view is currently showing. */
 export interface GameListFilters {
@@ -143,7 +150,12 @@ export function GameListView({
   const format = parseFormat(formatParam)
   const matchup = parseMatchup(matchupParam, format)
 
-  const [selectedId, setSelectedId] = useState<string>()
+  const entryKey = useHistoryEntryKey()
+  // Read once per mount: a lazy initializer runs at most once, so this never re-reads the store on
+  // a re-render.
+  const [selectedId, setSelectedId] = useState<string | undefined>(() =>
+    entryKey !== undefined ? selectedIdCache.get(entryKey) : undefined,
+  )
   const rowElemsRef = useRef(new Map<string, HTMLDivElement>())
 
   // Remembered per-user and shared across the replay library, games page, match history, and league
@@ -175,6 +187,21 @@ export function GameListView({
 
   const { games, hasMoreGames, isLoadingMore, searchError, refreshToken, reset, onLoadMore } =
     useGameListSearch(loadPageForSearch)
+
+  useEffect(() => {
+    if (entryKey === undefined) {
+      return undefined
+    }
+
+    // Cleanup-time write, matching `useScrollMemory`'s timing: a selection is never un-made (a
+    // restored id absent from the current list just falls back to `games[0]` below), so unlike the
+    // game-id window there's nothing to delete here.
+    return () => {
+      if (selectedId !== undefined) {
+        selectedIdCache.set(entryKey, selectedId)
+      }
+    }
+  }, [entryKey, selectedId])
 
   const selectedGame = games.find(g => g.id === selectedId) ?? games[0]
   const selectedIndex = selectedGame ? games.findIndex(g => g.id === selectedGame.id) : -1

--- a/client/games/game-list.tsx
+++ b/client/games/game-list.tsx
@@ -1,10 +1,11 @@
+import { useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 import { useQuery } from 'urql'
 import { GameSourceFilter } from '../../common/games/game-filters'
 import { FragmentType, graphql, useFragment } from '../gql'
 import { elevationPlus1 } from '../material/shadows'
-import { useLocationSearchParam } from '../navigation/router-hooks'
+import { useLocationSearchParam, useScrollMemory } from '../navigation/router-hooks'
 import { useAppDispatch } from '../redux-hooks'
 import { CenteredContentContainer } from '../styles/centered-container'
 import { ContainerLevel, containerStyles } from '../styles/colors'
@@ -70,6 +71,9 @@ export function GameList() {
   const { t } = useTranslation()
   const dispatch = useAppDispatch()
 
+  const scrollerRef = useRef<HTMLDivElement>(null)
+  useScrollMemory(scrollerRef)
+
   // TODO(marko): Figure out if we particularly care about the errors when loading this, since we're
   // hiding the live games feed if there are no live games anyway.
   // TODO(marko): This is a one-shot query (nothing re-executes it), so finished games linger in the
@@ -104,7 +108,7 @@ export function GameList() {
   }
 
   return (
-    <CenteredContentContainer $fullWidth={true} data-content-fullbleed=''>
+    <CenteredContentContainer $fullWidth={true} data-content-fullbleed='' ref={scrollerRef}>
       <PageColumn>
         {showLiveGames ? <LiveGamesFeed query={data} /> : null}
 

--- a/client/games/use-game-list-search.test.tsx
+++ b/client/games/use-game-list-search.test.tsx
@@ -1,0 +1,187 @@
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import type { GameRecordJson } from '../../common/games/games'
+import { resetViewStateForTesting } from '../navigation/view-state-store'
+import { GameListSearchPage, useGameListSearch } from './use-game-list-search'
+
+// The hook only reads `useHistoryEntryKey` from router-hooks, so that's all this mocks. The test
+// drives it through a plain module-scope variable rather than a per-test mock return value, since
+// the entry key needs to change independently of any particular render.
+let currentEntryKey: string | undefined
+
+vi.mock('../navigation/router-hooks', () => ({
+  useHistoryEntryKey: () => currentEntryKey,
+}))
+
+// The hook only reads `s.games.byId` from the store, so the fake state below is the minimal shape
+// that satisfies it; populated per test with stub records for whatever ids the pages return.
+const fakeGamesById = new Map<string, GameRecordJson>()
+
+vi.mock('../redux-hooks', () => ({
+  useAppSelector: (
+    selector: (state: { games: { byId: Map<string, GameRecordJson> } }) => unknown,
+  ) => selector({ games: { byId: fakeGamesById } }),
+}))
+
+function addStubGames(...ids: string[]) {
+  for (const id of ids) {
+    fakeGamesById.set(id, { id } as GameRecordJson)
+  }
+}
+
+interface PendingLoad {
+  resolve: (page: GameListSearchPage) => void
+  reject: (err: unknown) => void
+}
+
+/** A `loadPage` mock whose calls are queued up for the test to resolve/reject one at a time. */
+function makeLoadPage() {
+  const pending: PendingLoad[] = []
+  const loadPage = vi.fn((_offset: number, _signal: AbortSignal): Promise<GameListSearchPage> => {
+    return new Promise<GameListSearchPage>((resolve, reject) => {
+      pending.push({ resolve, reject })
+    })
+  })
+  return { loadPage, pending }
+}
+
+/** Resolves the given pending load and lets its state updates commit before returning. */
+async function resolveLoad(load: PendingLoad, page: GameListSearchPage) {
+  await act(async () => {
+    load.resolve(page)
+    await Promise.resolve()
+  })
+}
+
+describe('client/games/use-game-list-search', () => {
+  beforeEach(() => {
+    currentEntryKey = undefined
+    fakeGamesById.clear()
+    resetViewStateForTesting()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  test('restores the accumulated window on remount under the same entry key, with no refetch', async () => {
+    currentEntryKey = 'visit-1'
+    addStubGames('g1', 'g2')
+
+    const { loadPage, pending } = makeLoadPage()
+    const { result, unmount } = renderHook(() => useGameListSearch(loadPage))
+
+    act(() => {
+      result.current.onLoadMore()
+    })
+    await resolveLoad(pending[0], { gameIds: ['g1', 'g2'], hasMoreGames: true })
+
+    expect(result.current.games.map(g => g.id)).toEqual(['g1', 'g2'])
+    unmount()
+
+    const { loadPage: loadPageAfter } = makeLoadPage()
+    const { result: remounted } = renderHook(() => useGameListSearch(loadPageAfter))
+
+    expect(remounted.current.games.map(g => g.id)).toEqual(['g1', 'g2'])
+    expect(remounted.current.hasMoreGames).toBe(true)
+    expect(loadPageAfter).not.toHaveBeenCalled()
+  })
+
+  test('starts empty on remount under a different entry key', async () => {
+    currentEntryKey = 'visit-1'
+    addStubGames('g1')
+
+    const { loadPage, pending } = makeLoadPage()
+    const { result, unmount } = renderHook(() => useGameListSearch(loadPage))
+
+    act(() => {
+      result.current.onLoadMore()
+    })
+    await resolveLoad(pending[0], { gameIds: ['g1'], hasMoreGames: false })
+    unmount()
+
+    currentEntryKey = 'visit-2'
+    const { loadPage: loadPageOther } = makeLoadPage()
+    const { result: other } = renderHook(() => useGameListSearch(loadPageOther))
+
+    expect(other.current.games).toEqual([])
+    expect(other.current.hasMoreGames).toBe(true)
+  })
+
+  test('reset() followed by unmount before the next page resolves deletes the entry', async () => {
+    currentEntryKey = 'visit-1'
+    addStubGames('g1')
+
+    // Establish a saved window first, so there's something for reset() to actually clear.
+    const { loadPage, pending } = makeLoadPage()
+    const first = renderHook(() => useGameListSearch(loadPage))
+    act(() => {
+      first.result.current.onLoadMore()
+    })
+    await resolveLoad(pending[0], { gameIds: ['g1'], hasMoreGames: true })
+    first.unmount()
+
+    // Remount under the same key (restoring the window above), then change filters and leave again
+    // before the new filters' first page comes back.
+    const { loadPage: loadPageB, pending: pendingB } = makeLoadPage()
+    const second = renderHook(() => useGameListSearch(loadPageB))
+    expect(second.result.current.games.map(g => g.id)).toEqual(['g1'])
+
+    act(() => {
+      second.result.current.reset()
+    })
+    act(() => {
+      second.result.current.onLoadMore()
+    })
+    expect(pendingB.length).toBe(1)
+    second.unmount()
+
+    const { loadPage: loadPageC } = makeLoadPage()
+    const third = renderHook(() => useGameListSearch(loadPageC))
+
+    expect(third.result.current.games).toEqual([])
+    expect(third.result.current.hasMoreGames).toBe(true)
+  })
+
+  test('saves nothing when the entry key is undefined throughout', async () => {
+    currentEntryKey = undefined
+    addStubGames('g1')
+
+    const { loadPage, pending } = makeLoadPage()
+    const { result, unmount } = renderHook(() => useGameListSearch(loadPage))
+
+    act(() => {
+      result.current.onLoadMore()
+    })
+    await resolveLoad(pending[0], { gameIds: ['g1'], hasMoreGames: true })
+    unmount()
+
+    const { loadPage: loadPageAfter } = makeLoadPage()
+    const { result: other } = renderHook(() => useGameListSearch(loadPageAfter))
+
+    expect(other.current.games).toEqual([])
+    expect(other.current.hasMoreGames).toBe(true)
+  })
+
+  test('a restored window past its 30-minute TTL is treated as absent', async () => {
+    vi.useFakeTimers()
+    currentEntryKey = 'visit-1'
+    addStubGames('g1')
+
+    const { loadPage, pending } = makeLoadPage()
+    const { result, unmount } = renderHook(() => useGameListSearch(loadPage))
+    act(() => {
+      result.current.onLoadMore()
+    })
+    await resolveLoad(pending[0], { gameIds: ['g1'], hasMoreGames: true })
+    unmount()
+
+    vi.advanceTimersByTime(31 * 60 * 1000)
+
+    const { loadPage: loadPageAfter } = makeLoadPage()
+    const { result: other } = renderHook(() => useGameListSearch(loadPageAfter))
+
+    expect(other.current.games).toEqual([])
+    expect(other.current.hasMoreGames).toBe(true)
+  })
+})

--- a/client/games/use-game-list-search.ts
+++ b/client/games/use-game-list-search.ts
@@ -1,6 +1,8 @@
 import { useEffect, useRef, useState } from 'react'
 import { ReadonlyDeep } from 'type-fest'
 import { GameRecordJson } from '../../common/games/games'
+import { useHistoryEntryKey } from '../navigation/router-hooks'
+import { createViewStateStore } from '../navigation/view-state-store'
 import { useRefreshToken } from '../network/refresh-token'
 import { useAppSelector } from '../redux-hooks'
 
@@ -9,6 +11,20 @@ export interface GameListSearchPage {
   gameIds: string[]
   hasMoreGames: boolean
 }
+
+// TTL must match useScrollMemory's: the saved scroll position and the saved window restore
+// together, and a scroll restored into a missing window would clamp against a single fresh page.
+// Both are stamped when the user leaves the page.
+const WINDOW_MAX_AGE_MS = 30 * 60 * 1000
+
+interface GameListWindow {
+  gameIds: string[]
+  hasMoreGames: boolean
+}
+
+const windowCache = createViewStateStore<GameListWindow>('game-list', {
+  maxAgeMs: WINDOW_MAX_AGE_MS,
+})
 
 export interface UseGameListSearchResult {
   games: ReadonlyArray<ReadonlyDeep<GameRecordJson>>
@@ -36,12 +52,26 @@ export interface UseGameListSearchResult {
  * whatever `loadPage`'s returned promise eventually does (matching how `abortableThunk` itself
  * skips `onSuccess`/`onError` for a canceled request), so a stale response from a superseded page
  * load never corrupts the accumulated results.
+ *
+ * The accumulated window is remembered per history entry (per "visit"), mirroring `useScrollMemory`:
+ * traversing back or forward to an entry resumes the list it had accumulated with no refetch, while
+ * a fresh link push starts empty. A restored window is exactly as stale as it was when the user left
+ * — like the browser's own back/forward cache — and the next `onLoadMore` simply continues paging
+ * from its end. The cached ids stay resolvable because `games.byId` never evicts entries within a
+ * session.
  */
 export function useGameListSearch(
   loadPage: (offset: number, signal: AbortSignal) => Promise<GameListSearchPage>,
 ): UseGameListSearchResult {
-  const [gameIds, setGameIds] = useState<string[]>()
-  const [hasMoreGames, setHasMoreGames] = useState(true)
+  const entryKey = useHistoryEntryKey()
+  // Read once per mount: the store contract allows a lazy initializer since it runs at most once
+  // and so never re-reads on a re-render.
+  const [initialWindow] = useState(() =>
+    entryKey !== undefined ? windowCache.get(entryKey) : undefined,
+  )
+
+  const [gameIds, setGameIds] = useState<string[] | undefined>(initialWindow?.gameIds)
+  const [hasMoreGames, setHasMoreGames] = useState(initialWindow?.hasMoreGames ?? true)
   const [isLoadingMore, setIsLoadingMore] = useState(false)
   const [searchError, setSearchError] = useState<Error>()
   const abortControllerRef = useRef<AbortController>(undefined)
@@ -95,6 +125,28 @@ export function useGameListSearch(
   useEffect(() => {
     return () => abortControllerRef.current?.abort()
   }, [])
+
+  useEffect(() => {
+    if (entryKey === undefined) {
+      return undefined
+    }
+
+    // Written at cleanup time (unmount), not as `gameIds`/`hasMoreGames` change: the store stamps
+    // its TTL at write time, and this needs to match when `useScrollMemory` saves the scroll
+    // position — also at unmount — so the two entries expire together. Writing on every data change
+    // instead would stamp the last page load, which can be long before the user actually leaves,
+    // letting the window expire while the scroll position it's paired with still lives.
+    return () => {
+      if (gameIds !== undefined) {
+        windowCache.set(entryKey, { gameIds, hasMoreGames })
+      } else {
+        // `reset()` (a filter change) clears `gameIds` while replacing the URL in place under the
+        // same visit key. If the user leaves before the first page under the new filters arrives,
+        // the old filters' entry must not survive to be restored against the new URL.
+        windowCache.delete(entryKey)
+      }
+    }
+  }, [entryKey, gameIds, hasMoreGames])
 
   return { games, hasMoreGames, isLoadingMore, searchError, refreshToken, reset, onLoadMore }
 }

--- a/client/leagues/league-details.tsx
+++ b/client/leagues/league-details.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 import { TableVirtuoso } from 'react-virtuoso'
 import slug from 'slug'
@@ -34,10 +34,12 @@ import { TabItem, Tabs } from '../material/tabs'
 import { Tooltip } from '../material/tooltip'
 import { CopyLinkButton } from '../navigation/copy-link-button'
 import { ExternalLink } from '../navigation/external-link'
+import { useScrollMemory } from '../navigation/router-hooks'
 import { replace } from '../navigation/routing'
 import { isFetchError } from '../network/fetch-errors'
 import { LoadingDotsArea } from '../progress/dots'
 import { useNow } from '../react/date-hooks'
+import { useMultiplexRef } from '../react/refs'
 import { useImmerState, useStableCallback } from '../react/state-hooks'
 import { useAppDispatch, useAppSelector } from '../redux-hooks'
 import { useSnackbarController } from '../snackbars/snackbar-overlay'
@@ -82,6 +84,13 @@ const PageRoot = styled.div`
 
 export function LeagueDetailsPage() {
   const [containerElem, setContainerElem] = useState<HTMLDivElement | null>(null)
+  const scrollerRef = useRef<HTMLDivElement>(null)
+  useScrollMemory(scrollerRef)
+  // The Leaderboard tab renders a virtualized table whose full height isn't in the DOM at mount, so
+  // a restore targeting a position inside it clamps toward the top; positions on the other tabs
+  // restore normally.
+  const rootRef = useMultiplexRef<HTMLDivElement>(setContainerElem, scrollerRef)
+
   const [match, params] = useRoute('/leagues/:routeId/:slugStr?/:subPage?')
   const { routeId, slugStr } = params ?? {}
   const id = routeId ? fromRouteLeagueId(makeRouteLeagueId(routeId)) : undefined
@@ -105,7 +114,7 @@ export function LeagueDetailsPage() {
   }
 
   return (
-    <PageRoot ref={setContainerElem}>
+    <PageRoot ref={rootRef}>
       <LeagueDetails id={id!} subPage={subPage} container={containerElem} />
     </PageRoot>
   )
@@ -366,7 +375,7 @@ export function LeagueDetails({ id, subPage, container }: LeagueDetailsProps) {
       content = <Leaderboard league={league} container={container} />
       break
     case DetailsSubPage.Games:
-      content = <LeagueGames leagueId={id} />
+      content = <LeagueGames key={id} leagueId={id} />
       break
     default:
       assertUnreachable(activeTab)

--- a/client/navigation/view-state-store.test.ts
+++ b/client/navigation/view-state-store.test.ts
@@ -64,6 +64,24 @@ describe('view-state-store', () => {
     expect(store.get('key-50')).toBe(50)
   })
 
+  test('delete removes an entry so get returns undefined', () => {
+    const store = createViewStateStore<number>('test', { maxAgeMs: 1000 })
+    store.set('a', 42)
+
+    store.delete('a')
+
+    expect(store.get('a')).toBeUndefined()
+  })
+
+  test('deleting a missing key is a no-op and does not disturb other entries', () => {
+    const store = createViewStateStore<number>('test', { maxAgeMs: 1000 })
+    store.set('a', 42)
+
+    store.delete('missing')
+
+    expect(store.get('a')).toBe(42)
+  })
+
   test('set on an existing key refreshes both its value and its recency', () => {
     const store = createViewStateStore<number>('test', { maxAgeMs: 60 * 60 * 1000 })
 

--- a/client/navigation/view-state-store.ts
+++ b/client/navigation/view-state-store.ts
@@ -23,6 +23,8 @@ const entries = new Map<string, StoredEntry>()
 export interface ViewStateStore<T> {
   get(key: string): T | undefined
   set(key: string, value: T): void
+  /** Removes a stored entry, if one exists. */
+  delete(key: string): void
 }
 
 /**
@@ -67,6 +69,10 @@ export function createViewStateStore<T>(
           entries.delete(oldestKey)
         }
       }
+    },
+
+    delete(key: string): void {
+      entries.delete(fullKey(key))
     },
   }
 }

--- a/client/users/user-profile.tsx
+++ b/client/users/user-profile.tsx
@@ -338,7 +338,9 @@ export function UserProfilePage({
       break
 
     case UserProfileSubPage.MatchHistory:
-      content = <ConnectedMatchHistory userId={user.id} />
+      // Keyed by user id so switching to a different user's profile remounts the list instead of
+      // carrying over the previous user's accumulated games and scroll-restore window.
+      content = <ConnectedMatchHistory key={user.id} userId={user.id} />
       break
 
     case UserProfileSubPage.Stats:


### PR DESCRIPTION
Item 4 of the scroll-restoration track: the shared games-list UI (games page, profile match history, league games tab) now remembers its accumulated page window per history-entry visit key — the same keying `useScrollMemory` uses — so traversing back/forward restores the full loaded list instantly with **zero refetch**, while a fresh link push still starts clean at the top.

- `useGameListSearch` seeds its state from a new `game-list` view-state namespace and saves it when the user leaves the page (matching the scroll position's save timing, so the two entries expire together — 30min TTL). A filter change, which replaces the URL under the same visit key, deletes the stale entry instead.
- The selected game rides along in a `game-list-selection` namespace, so the side panel comes back showing what the user had selected (falling back to the first game if it's no longer in the window).
- `useScrollMemory` is now applied on the games page and the league details page (profiles already had it). On the league leaderboard tab a deep restore just clamps to the top until that tab adopts `useVirtuosoScrollMemory` (the deferred follow-up).
- `ConnectedMatchHistory`/`LeagueGames` are keyed by entity id so same-route entity changes can't carry one entity's accumulated list into another's view.
- `ViewStateStore` gains a `delete()` method to support the filter-reset path.

Verified live in the Electron app: games page (two-page window of 53 rows + scrollTop + selection restored on back, no `/api/1/games/list` request; fresh push refetches from offset 0 at the top), match history round-trip, and a filtered (`?source=ranked`) round-trip restoring the filtered window against the replaced URL. Unit tests cover the restore/fresh-key/reset-delete/TTL paths.