### PR TITLE
Remember and restore scroll positions in the replay library

### DIFF
--- a/client/navigation/virtuoso-scroll-memory.ts
+++ b/client/navigation/virtuoso-scroll-memory.ts
@@ -107,7 +107,14 @@ export function useVirtuosoScrollMemory(
     let lastSnapshot = saved?.snapshot
     const onScroll = () => {
       lastScrollTop = containerElem.scrollTop
-      virtuosoRef.current?.getState(state => {
+      // With no list mounted right now (e.g. its data was cleared while new contents load), any
+      // previously captured snapshot describes content this scroll position no longer refers to.
+      // Drop it so the two are always saved as a consistent pair.
+      if (!virtuosoRef.current) {
+        lastSnapshot = undefined
+        return
+      }
+      virtuosoRef.current.getState(state => {
         // Only the size ranges are usable from getState (see the note on snapshots above); the
         // list-relative offset is derived from where virtuoso's scroller element sits within the
         // container's content.

--- a/client/replays/replay-library-helpers.test.ts
+++ b/client/replays/replay-library-helpers.test.ts
@@ -3,11 +3,11 @@ import { RaceChar } from '../../common/races'
 import { ReplayLibraryEntry, ReplayLibraryPlayer } from '../../common/replays-library'
 import { makeSbUserId } from '../../common/users/sb-user-id'
 import {
-  encodeView,
+  encodeViewPathname,
   getReplayDisplayTeams,
   groupReplaysByDay,
   isManualPlaylistOrder,
-  parseView,
+  parseViewPathname,
   playersToDisplayTeams,
   shouldShowTeamLabels,
 } from './replay-library-helpers'
@@ -232,33 +232,41 @@ describe('groupReplaysByDay', () => {
   })
 })
 
-describe('parseView / encodeView', () => {
-  test('parses an empty value as the "all" view', () => {
-    expect(parseView('')).toEqual({ kind: 'all' })
+describe('parseViewPathname / encodeViewPathname', () => {
+  test('parses "/replays" and "/replays/" as the "all" view', () => {
+    expect(parseViewPathname('/replays')).toEqual({ kind: 'all' })
+    expect(parseViewPathname('/replays/')).toEqual({ kind: 'all' })
   })
 
-  test('parses "bookmarked" as the bookmarked view', () => {
-    expect(parseView('bookmarked')).toEqual({ kind: 'bookmarked' })
+  test('parses "/replays/bookmarked" and its trailing-slash form as the bookmarked view', () => {
+    expect(parseViewPathname('/replays/bookmarked')).toEqual({ kind: 'bookmarked' })
+    expect(parseViewPathname('/replays/bookmarked/')).toEqual({ kind: 'bookmarked' })
   })
 
-  test('parses "pl-<id>" as a playlist view', () => {
-    expect(parseView('pl-42')).toEqual({ kind: 'playlist', id: 42 })
+  test('parses "/replays/playlists/<id>" as a playlist view', () => {
+    expect(parseViewPathname('/replays/playlists/42')).toEqual({ kind: 'playlist', id: 42 })
   })
 
-  test('falls back to "all" for malformed playlist ids', () => {
-    expect(parseView('pl-notanumber')).toEqual({ kind: 'all' })
-    expect(parseView('pl-')).toEqual({ kind: 'all' })
+  test('falls back to "all" for a playlists subpath missing an id', () => {
+    expect(parseViewPathname('/replays/playlists')).toEqual({ kind: 'all' })
   })
 
-  test('falls back to "all" for unrecognized values', () => {
-    expect(parseView('something-else')).toEqual({ kind: 'all' })
+  test('falls back to "all" for a malformed playlist id', () => {
+    expect(parseViewPathname('/replays/playlists/notanumber')).toEqual({ kind: 'all' })
   })
 
-  test('round-trips through encodeView', () => {
-    expect(encodeView({ kind: 'all' })).toBe('')
-    expect(encodeView({ kind: 'bookmarked' })).toBe('bookmarked')
-    expect(encodeView({ kind: 'playlist', id: 42 })).toBe('pl-42')
-    expect(parseView(encodeView({ kind: 'playlist', id: 7 }))).toEqual({
+  test('falls back to "all" for an unrecognized subpath', () => {
+    expect(parseViewPathname('/replays/something-else')).toEqual({ kind: 'all' })
+  })
+
+  test('encodes each view kind to its canonical pathname', () => {
+    expect(encodeViewPathname({ kind: 'all' })).toBe('/replays')
+    expect(encodeViewPathname({ kind: 'bookmarked' })).toBe('/replays/bookmarked')
+    expect(encodeViewPathname({ kind: 'playlist', id: 42 })).toBe('/replays/playlists/42')
+  })
+
+  test('round-trips a playlist view through encode then parse', () => {
+    expect(parseViewPathname(encodeViewPathname({ kind: 'playlist', id: 7 }))).toEqual({
       kind: 'playlist',
       id: 7,
     })

--- a/client/replays/replay-library-helpers.ts
+++ b/client/replays/replay-library-helpers.ts
@@ -1,22 +1,32 @@
 import { assertUnreachable } from '../../common/assert-unreachable'
 import { ReplayLibraryEntry, ReplayLibraryPlayer } from '../../common/replays-library'
+import { urlPath } from '../../common/urls'
 import { SbUserId } from '../../common/users/sb-user-id'
 import { startOfLocalDay } from '../games/day-header'
 import { PlayerTeamsDisplayPlayer } from '../games/player-teams-display'
 
-/** Which subset of the library the rail is currently pointed at, driven by the `view` URL param. */
+/** Which subset of the library the rail is currently pointed at, addressed by the `/replays…` pathname. */
 export type LibraryView =
   { kind: 'all' } | { kind: 'bookmarked' } | { kind: 'playlist'; id: number }
 
-const PLAYLIST_VIEW_PREFIX = 'pl-'
+/**
+ * Parses a pathname under `/replays` into the `LibraryView` it addresses:
+ * - `/replays` (and `/replays/`) -> the whole library (`all`)
+ * - `/replays/bookmarked` -> `bookmarked`
+ * - `/replays/playlists/<id>` -> `playlist` with that id
+ *
+ * Trailing slashes are tolerated. Anything else — an unparseable playlist id, an unrecognized
+ * subpath, extra segments — falls back to `all`; callers that need the URL itself to reflect that
+ * fallback canonicalize it separately (see `encodeViewPathname`).
+ */
+export function parseViewPathname(pathname: string): LibraryView {
+  const segments = pathname.split('/').filter(segment => segment.length > 0)
 
-/** Parses the `view` URL param into a `LibraryView`. Unrecognized/malformed values fall back to `all`. */
-export function parseView(value: string): LibraryView {
-  if (value === 'bookmarked') {
+  if (segments.length === 2 && segments[1] === 'bookmarked') {
     return { kind: 'bookmarked' }
   }
-  if (value.startsWith(PLAYLIST_VIEW_PREFIX)) {
-    const id = Number.parseInt(value.slice(PLAYLIST_VIEW_PREFIX.length), 10)
+  if (segments.length === 3 && segments[1] === 'playlists') {
+    const id = Number.parseInt(segments[2], 10)
     if (Number.isFinite(id)) {
       return { kind: 'playlist', id }
     }
@@ -24,15 +34,18 @@ export function parseView(value: string): LibraryView {
   return { kind: 'all' }
 }
 
-/** Encodes a `LibraryView` back into the `view` URL param (empty string for the default `all`). */
-export function encodeView(view: LibraryView): string {
+/**
+ * Encodes a `LibraryView` into its canonical `/replays…` pathname (the form `parseViewPathname`
+ * parses back to the same view).
+ */
+export function encodeViewPathname(view: LibraryView): string {
   switch (view.kind) {
     case 'all':
-      return ''
+      return '/replays'
     case 'bookmarked':
-      return 'bookmarked'
+      return '/replays/bookmarked'
     case 'playlist':
-      return `${PLAYLIST_VIEW_PREFIX}${view.id}`
+      return urlPath`/replays/playlists/${view.id}`
     default:
       return assertUnreachable(view)
   }

--- a/client/replays/replay-library.tsx
+++ b/client/replays/replay-library.tsx
@@ -48,6 +48,7 @@ import { Popover, usePopoverController } from '../material/popover'
 import { Ripple } from '../material/ripple'
 import { Tooltip } from '../material/tooltip'
 import { useHistoryEntryKey, useLocationSearchParam } from '../navigation/router-hooks'
+import { push, replace } from '../navigation/routing'
 import { createViewStateStore } from '../navigation/view-state-store'
 import { useVirtuosoScrollMemory } from '../navigation/virtuoso-scroll-memory'
 import { useRefreshToken } from '../network/refresh-token'
@@ -64,12 +65,11 @@ import {
   ReplayInspector,
 } from './replay-inspector'
 import {
-  encodeView,
+  encodeViewPathname,
   getReplayDisplayTeams,
   groupReplaysByDay,
   isManualPlaylistOrder,
   LibraryView,
-  parseView,
   playersToDisplayTeams,
 } from './replay-library-helpers'
 import { ReplayLibraryRail } from './replay-library-rail'
@@ -378,7 +378,11 @@ function ReplayListEntry({
 
 // ---- Main component --------------------------------------------------------------------------
 
-export function ReplayLibrary() {
+export interface ReplayLibraryProps {
+  view: LibraryView
+}
+
+export function ReplayLibrary({ view }: ReplayLibraryProps) {
   const { t } = useTranslation()
   const dispatch = useAppDispatch()
 
@@ -421,9 +425,10 @@ export function ReplayLibrary() {
     },
   }))
   const restoredSnapshot = useVirtuosoScrollMemory(scrollParent, virtuosoStateRef)
-  // A filter/sort/view change replaces the URL in place, keeping the same visit key, so the
-  // snapshot captured for this entry no longer matches the list contents once any reset happens —
-  // after that it must not re-apply when the (remounting) list comes back with new data.
+  // A filter/sort change replaces the URL in place, keeping the same visit key, so the snapshot
+  // captured for this entry no longer matches the list contents once any reset happens — after
+  // that it must not re-apply when the (remounting) list comes back with new data. View changes
+  // don't hit this: they push a new pathname and remount the component under a new visit.
   const [snapshotInvalidated, setSnapshotInvalidated] = useState(false)
   const restoreStateFrom = snapshotInvalidated ? undefined : restoredSnapshot
 
@@ -444,7 +449,6 @@ export function ReplayLibrary() {
   const [formatParam, setFormatParam] = useLocationSearchParam('format')
   const [matchupParam, setMatchupParam] = useLocationSearchParam('matchup')
   const [gameTypeParam, setGameTypeParam] = useLocationSearchParam('gameType')
-  const [viewParam, setViewParam] = useLocationSearchParam('view')
   const [startDate, setStartDateParam] = useLocationSearchParam('startDate')
   const [endDate, setEndDateParam] = useLocationSearchParam('endDate')
 
@@ -453,7 +457,6 @@ export function ReplayLibrary() {
   const format = parseFormat(formatParam)
   const matchup = parseMatchup(matchupParam, format)
   const gameType = parseModeFilter(gameTypeParam)
-  const view = parseView(viewParam)
 
   const computerLabel = t('game.playerName.computer', 'Computer')
   const bookmarkTitle = t('replays.library.bookmark', 'Bookmark')
@@ -551,7 +554,8 @@ export function ReplayLibrary() {
 
   // Fetches the playlists for the rail. Called once on mount and again (debounced) on every index
   // change. Doubles as the consistency check for the current view: if the playlist being viewed no
-  // longer exists (deleted, or a stale URL), we fall back to the whole library.
+  // longer exists (deleted, or a stale URL), the URL is corrected in place to the whole library —
+  // the replace keeps the visit key while the parent's view-keyed remount swaps in a fresh instance.
   const fetchPlaylists = useEffectEvent(() => {
     ipcRenderer
       .invoke('replayLibraryListPlaylists')
@@ -559,8 +563,7 @@ export function ReplayLibrary() {
         if (!result) return
         setPlaylists(result)
         if (view.kind === 'playlist' && !result.some(p => p.id === view.id)) {
-          setViewParam('')
-          reset()
+          replace(encodeViewPathname({ kind: 'all' }) + window.location.search)
         }
       })
       .catch(swallowNonBuiltins)
@@ -1056,10 +1059,16 @@ export function ReplayLibrary() {
             backfill={railBackfill}
             playlists={playlists}
             onSelectView={v => {
-              const encoded = encodeView(v)
-              if (encoded === viewParam) return
-              setViewParam(encoded)
-              reset()
+              const pathname = encodeViewPathname(v)
+              if (pathname === encodeViewPathname(view)) {
+                return
+              }
+              // A view change is a navigation to a new place: pushing a different pathname mints a
+              // new history entry and visit key, and the parent remounts this component keyed on
+              // the view pathname, so the outgoing visit's entry window/scroll/selection save in
+              // unmount cleanups and the new visit starts clean (which is why there's no `reset()`
+              // here). The current filters ride along in the search string.
+              push(pathname + window.location.search)
             }}
           />
 

--- a/client/replays/replay-library.tsx
+++ b/client/replays/replay-library.tsx
@@ -100,6 +100,19 @@ const focusedIdCache = createViewStateStore<number>('replay-library-selection', 
   maxAgeMs: WINDOW_MAX_AGE_MS,
 })
 
+interface RailSnapshot {
+  status: ReplayLibraryStatus | undefined
+  backfill: ReplayBackfillProgress | undefined
+  playlists: ReadonlyArray<ReplayPlaylist>
+}
+
+// The rail's data (index counts, backfill progress, playlists) is library-wide rather than
+// per-visit, but it's fetched and owned by `ReplayLibrary`, which remounts on every view change
+// (keyed in `ReplaysRoot`). Seeding each mount from the previous instance's latest values keeps
+// the rail stable across that remount — without it, the rail would blank (counts at zero, playlist
+// rows gone) until the mount-time fetches answer. The fetches still run and replace the seed.
+let railSnapshot: RailSnapshot = { status: undefined, backfill: undefined, playlists: [] }
+
 function parseDuration(value: string): GameDurationFilter {
   return Object.values(GameDurationFilter).includes(value as GameDurationFilter)
     ? (value as GameDurationFilter)
@@ -398,13 +411,17 @@ export function ReplayLibrary({ view }: ReplayLibraryProps) {
   )
   const [total, setTotal] = useState<number | undefined>(initialWindow?.total)
   const [isLoadingNext, setIsLoadingNext] = useState(false)
-  const [status, setStatus] = useState<ReplayLibraryStatus>()
-  const [backfill, setBackfill] = useState<ReplayBackfillProgress>()
+  const [status, setStatus] = useState<ReplayLibraryStatus | undefined>(() => railSnapshot.status)
+  const [backfill, setBackfill] = useState<ReplayBackfillProgress | undefined>(
+    () => railSnapshot.backfill,
+  )
   // Set when the status query rejects, which in practice means the main-process replay library
   // service failed to start (e.g. the SQLite module couldn't load) and none of its IPC handlers are
   // registered — so every query would hang. We surface that instead of spinning forever.
   const [unavailable, setUnavailable] = useState(false)
-  const [playlists, setPlaylists] = useState<ReadonlyArray<ReplayPlaylist>>([])
+  const [playlists, setPlaylists] = useState<ReadonlyArray<ReplayPlaylist>>(
+    () => railSnapshot.playlists,
+  )
   // Bumped on every index change so entry-scoped fetches (e.g. the inspector's playlist
   // membership) know to refresh.
   const [changeToken, setChangeToken] = useState(0)
@@ -601,6 +618,12 @@ export function ReplayLibrary({ view }: ReplayLibraryProps) {
       ipcRenderer.removeAllListeners('replayLibraryBackfillProgress')
     }
   }, [initialWindow])
+
+  // Mirrored on every change (rather than written through in each setter) so functional updates —
+  // e.g. the optimistic bookmark-count bump in `toggleBookmark` — are captured too.
+  useEffect(() => {
+    railSnapshot = { status, backfill, playlists }
+  }, [status, backfill, playlists])
 
   useEffect(() => {
     if (entryKey === undefined) {

--- a/client/replays/replay-library.tsx
+++ b/client/replays/replay-library.tsx
@@ -47,7 +47,9 @@ import { MenuList } from '../material/menu/menu'
 import { Popover, usePopoverController } from '../material/popover'
 import { Ripple } from '../material/ripple'
 import { Tooltip } from '../material/tooltip'
-import { useLocationSearchParam } from '../navigation/router-hooks'
+import { useHistoryEntryKey, useLocationSearchParam } from '../navigation/router-hooks'
+import { createViewStateStore } from '../navigation/view-state-store'
+import { useVirtuosoScrollMemory } from '../navigation/virtuoso-scroll-memory'
 import { useRefreshToken } from '../network/refresh-token'
 import { LoadingDotsArea } from '../progress/dots'
 import { useUserLocalStorageValue } from '../react/state-hooks'
@@ -79,6 +81,24 @@ const ENTER_NUMPAD = 'NumpadEnter'
 
 /** Number of replay entries fetched per infinite-scroll chunk. */
 const LOAD_CHUNK_SIZE = 100
+
+// TTL must match useVirtuosoScrollMemory's: the saved scroll state and the saved entry window
+// restore together, and a scroll restored into a missing window would clamp against a single
+// fresh page. Both are stamped when the user leaves the page.
+const WINDOW_MAX_AGE_MS = 30 * 60 * 1000
+
+interface ReplayListWindow {
+  entries: ReadonlyArray<ReplayLibraryEntry>
+  total: number | undefined
+}
+
+const windowCache = createViewStateStore<ReplayListWindow>('replay-library', {
+  maxAgeMs: WINDOW_MAX_AGE_MS,
+})
+
+const focusedIdCache = createViewStateStore<number>('replay-library-selection', {
+  maxAgeMs: WINDOW_MAX_AGE_MS,
+})
 
 function parseDuration(value: string): GameDurationFilter {
   return Object.values(GameDurationFilter).includes(value as GameDurationFilter)
@@ -362,8 +382,17 @@ export function ReplayLibrary() {
   const { t } = useTranslation()
   const dispatch = useAppDispatch()
 
-  const [entries, setEntries] = useState<ReadonlyArray<ReplayLibraryEntry>>()
-  const [total, setTotal] = useState<number>()
+  const entryKey = useHistoryEntryKey()
+  // Read once per mount: the store contract allows a lazy initializer since it runs at most once
+  // and so never re-reads on a re-render.
+  const [initialWindow] = useState(() =>
+    entryKey !== undefined ? windowCache.get(entryKey) : undefined,
+  )
+
+  const [entries, setEntries] = useState<ReadonlyArray<ReplayLibraryEntry> | undefined>(
+    initialWindow?.entries,
+  )
+  const [total, setTotal] = useState<number | undefined>(initialWindow?.total)
   const [isLoadingNext, setIsLoadingNext] = useState(false)
   const [status, setStatus] = useState<ReplayLibraryStatus>()
   const [backfill, setBackfill] = useState<ReplayBackfillProgress>()
@@ -377,10 +406,26 @@ export function ReplayLibrary() {
   const [changeToken, setChangeToken] = useState(0)
   const [observerToken, restartObserver] = useRefreshToken()
 
-  const [focusedId, setFocusedId] = useState<number>()
+  const [focusedId, setFocusedId] = useState<number | undefined>(() =>
+    entryKey !== undefined ? focusedIdCache.get(entryKey) : undefined,
+  )
   const [scrollParent, setScrollParent] = useState<HTMLElement | null>(null)
   const groupedRef = useRef<GroupedVirtuosoHandle>(null)
   const flatRef = useRef<VirtuosoHandle>(null)
+
+  // Only one of the two lists is mounted at a time (see `useFlatList`), so state capture reads
+  // whichever handle is live.
+  const [virtuosoStateRef] = useState(() => ({
+    get current(): GroupedVirtuosoHandle | VirtuosoHandle | null {
+      return groupedRef.current ?? flatRef.current
+    },
+  }))
+  const restoredSnapshot = useVirtuosoScrollMemory(scrollParent, virtuosoStateRef)
+  // A filter/sort/view change replaces the URL in place, keeping the same visit key, so the
+  // snapshot captured for this entry no longer matches the list contents once any reset happens —
+  // after that it must not re-apply when the (remounting) list comes back with new data.
+  const [snapshotInvalidated, setSnapshotInvalidated] = useState(false)
+  const restoreStateFrom = snapshotInvalidated ? undefined : restoredSnapshot
 
   // Right-click on a row selects it and opens this menu at the cursor, offering the same actions
   // as the inspector's overflow menu.
@@ -443,6 +488,7 @@ export function ReplayLibrary() {
     setEntries(undefined)
     setTotal(undefined)
     setIsLoadingNext(false)
+    setSnapshotInvalidated(true)
     restartObserver()
   }
 
@@ -524,6 +570,13 @@ export function ReplayLibrary() {
   useEffect(() => {
     fetchStatus()
     fetchPlaylists()
+    if (initialWindow !== undefined) {
+      // The index can change while the page is unmounted (files added/removed, backfill progress)
+      // with nothing listening for the change events, so a restored window is re-queried
+      // immediately; the wholesale replacement keeps the restored scroll position.
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- one-time refresh of a restored window on mount
+      refreshLoadedWindow()
+    }
 
     const handleChanged = debounce(() => {
       refreshLoadedWindow()
@@ -544,7 +597,42 @@ export function ReplayLibrary() {
       ipcRenderer.removeAllListeners('replayLibraryChanged')
       ipcRenderer.removeAllListeners('replayLibraryBackfillProgress')
     }
-  }, [])
+  }, [initialWindow])
+
+  useEffect(() => {
+    if (entryKey === undefined) {
+      return undefined
+    }
+
+    // Written at cleanup time (unmount), not as `entries`/`total` change: the store stamps its TTL
+    // at write time, and this needs to match when the scroll state is saved — also at unmount — so
+    // the two entries expire together.
+    return () => {
+      if (entries !== undefined) {
+        windowCache.set(entryKey, { entries, total })
+      } else {
+        // `reset()` (a filter/sort/view change) clears `entries` while replacing the URL in place
+        // under the same visit key. If the user leaves before the first page under the new filters
+        // arrives, the old filters' entry must not survive to be restored against the new URL.
+        windowCache.delete(entryKey)
+      }
+    }
+  }, [entryKey, entries, total])
+
+  useEffect(() => {
+    if (entryKey === undefined) {
+      return undefined
+    }
+
+    // Cleanup-time write, matching the window save's timing: a selection is never un-made (a
+    // restored id absent from the current list just falls back to the first row), so unlike the
+    // entry window there's nothing to delete here.
+    return () => {
+      if (focusedId !== undefined) {
+        focusedIdCache.set(entryKey, focusedId)
+      }
+    }
+  }, [entryKey, focusedId])
 
   const loadedEntries = entries ?? []
   const focusedEntry = loadedEntries.find(e => e.id === focusedId) ?? loadedEntries[0]
@@ -846,6 +934,7 @@ export function ReplayLibrary() {
         key='flat'
         ref={flatRef}
         customScrollParent={scrollParent}
+        restoreStateFrom={restoreStateFrom}
         totalCount={loadedEntries.length}
         itemContent={renderRow}
       />
@@ -854,6 +943,7 @@ export function ReplayLibrary() {
         key='grouped'
         ref={groupedRef}
         customScrollParent={scrollParent}
+        restoreStateFrom={restoreStateFrom}
         groupCounts={groupCounts}
         groupContent={index => {
           const group = dayGroups[index]

--- a/client/replays/replays-root.tsx
+++ b/client/replays/replays-root.tsx
@@ -1,12 +1,40 @@
-import { lazy } from 'react'
+import { lazy, useLayoutEffect } from 'react'
+import { useLocation } from 'wouter'
 import { useTrackPageView } from '../analytics/analytics'
 import { OnlyInAppPage } from '../download/only-in-app'
+import { replace } from '../navigation/routing'
+import { encodeViewPathname, parseViewPathname } from './replay-library-helpers'
 
 const LoadableReplayLibrary = lazy(async () => ({
   default: (await import('./replay-library')).ReplayLibrary,
 }))
 
 export function ReplaysRoot() {
-  useTrackPageView('/replays')
-  return IS_ELECTRON ? <LoadableReplayLibrary /> : <OnlyInAppPage />
+  const [pathname] = useLocation()
+  const view = parseViewPathname(pathname)
+  const canonicalPathname = encodeViewPathname(view)
+
+  useTrackPageView(canonicalPathname)
+
+  useLayoutEffect(() => {
+    // Malformed subpaths parse as a coarser view than they spell, so the URL is corrected in place
+    // to the canonical pathname of what's actually rendered. A bare trailing slash is tolerated
+    // as-is: the strip-compare makes `/replays/` equal to its canonical form, so e.g. the app-bar
+    // link's trailing-slash URL isn't churned.
+    if (pathname.replace(/\/+$/, '') !== canonicalPathname) {
+      replace(canonicalPathname + window.location.search)
+    }
+  }, [pathname, canonicalPathname])
+
+  return IS_ELECTRON ? (
+    // Each view is its own place: a view change pushes a different pathname, which mints a new
+    // history entry and visit key (see `history-entry-key.ts`), and this key remounts the library
+    // with it, so all of its once-per-mount per-visit state (restored entry window, scroll
+    // snapshot, focused row) saves for the outgoing visit in unmount cleanups and starts fresh for
+    // the new one. Filter/sort changes replace the URL under the same pathname and visit, so they
+    // keep the instance.
+    <LoadableReplayLibrary key={canonicalPathname} view={view} />
+  ) : (
+    <OnlyInAppPage />
+  )
 }


### PR DESCRIPTION
Item 5 of the scroll-restoration track: the replay library adopts `useVirtuosoScrollMemory` (the same per-history-entry restoration the ladder table uses) plus a per-visit window cache of the loaded entries, so traversing back/forward restores the accumulated list, the scroll position, and the focused replay instantly — while a fresh link push still starts clean at the top.

- Only one of the two list modes (flat `Virtuoso` / `GroupedVirtuoso`) is mounted at a time, so a small getter ref resolves to whichever handle is live, and the returned snapshot feeds `restoreStateFrom` on both.
- The entry window (`replay-library` namespace) and focused id (`replay-library-selection`) are written when the user leaves the page, matching the scroll save's timing so the entries expire together (30min TTL). A filter/sort/view change — which replaces the URL under the same visit key — deletes the stale window instead, and also disarms the mount snapshot so the remounting list can't re-apply a position captured against different contents.
- A restored window re-queries itself once on mount (via the existing `refreshLoadedWindow`), since the index can change while the page is unmounted with nothing listening for the change events; the wholesale replacement keeps the restored scroll position.
- The shared hook now drops its pending snapshot when a scroll event fires while no list is mounted (e.g. data cleared by a filter change), so a scroll position and a snapshot describing different content are never saved as a pair.

Verified live in the Electron app against an 11k-replay library: 300-row three-page window + scrollTop (30,056px) + selected row and inspector restored on back with zero refetch collapse, in both grouped and flat (duration-sort) modes; fresh push starts at the top with one page; a sort change on a restored mount resets cleanly to the top with no stale deep-jump, and leaving/returning after it restores the new state; ladder restore re-verified unaffected by the hook change.