### PR TITLE
Add a jump-to-bottom button to chat message lists

### DIFF
--- a/client/messaging/chat.tsx
+++ b/client/messaging/chat.tsx
@@ -1,11 +1,16 @@
+import { AnimatePresence, Transition, Variants } from 'motion/react'
+import * as m from 'motion/react-m'
 import * as React from 'react'
 import { useCallback, useContext, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 import { Merge, Simplify } from 'type-fest'
 import { SbUserId } from '../../common/users/sb-user-id'
+import { MaterialIcon } from '../icons/material/material-icon'
+import { IconButton } from '../material/button'
 import { MenuItem, MenuItemProps } from '../material/menu/item'
 import { MenuItemSymbol, MenuItemType } from '../material/menu/menu-item-symbol'
+import { elevationPlus2 } from '../material/shadows'
 import { MessageInput, MessageInputHandle, MessageInputProps } from '../messaging/message-input'
 import { MessageList, MessageListProps } from '../messaging/message-list'
 import { useAppDispatch } from '../redux-hooks'
@@ -18,6 +23,12 @@ import {
 import { ChatContext } from './chat-context'
 import { DefaultMessageMenu, MessageMenuComponent } from './message-context-menu'
 
+/**
+ * How far above the bottom of the message list, in pixels, the user must scroll before the
+ * jump-to-bottom button appears.
+ */
+const JUMP_TO_BOTTOM_THRESHOLD_PX = 160
+
 const MessagesAndInput = styled.div`
   position: relative;
   display: flex;
@@ -27,10 +38,56 @@ const MessagesAndInput = styled.div`
   contain: content;
 `
 
+const MessageListContainer = styled.div`
+  position: relative;
+  flex-grow: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+`
+
 const StyledMessageList = styled(MessageList)`
   position: relative;
   flex-grow: 1;
 `
+
+const JumpToBottomButtonContainer = styled(m.div)`
+  position: absolute;
+  right: 16px;
+  bottom: 12px;
+  display: flex;
+`
+
+const JumpToBottomButton = styled(IconButton)`
+  width: 40px;
+  min-height: 40px;
+  border-radius: 50%;
+
+  background-color: var(--theme-container-highest);
+  color: var(--theme-on-surface);
+
+  ${elevationPlus2};
+`
+
+const jumpToBottomVariants: Variants = {
+  initial: {
+    opacity: 0,
+    y: 8,
+  },
+  visible: {
+    opacity: 1,
+    y: 0,
+  },
+  exit: {
+    opacity: 0,
+    y: 8,
+  },
+}
+
+const jumpToBottomTransition: Transition = {
+  type: 'tween',
+  duration: 0.12,
+}
 
 export interface ChatProps {
   className?: string
@@ -82,10 +139,13 @@ export function Chat({
   disallowMentionInteraction: disallowUserInteraction,
   onAtBottomChange,
 }: ChatProps) {
+  const { t } = useTranslation()
   const dispatch = useAppDispatch()
   const [isScrolledUp, setIsScrolledUp] = useState<boolean>(false)
+  const [showJumpToBottom, setShowJumpToBottom] = useState<boolean>(false)
   // Message lists mount pinned to the bottom, matching how `MessageList` initially scrolls.
   const wasAtBottomRef = useRef(true)
+  const scrollerRef = useRef<HTMLDivElement | null>(null)
 
   const onScrollUpdate = useCallback(
     (target: EventTarget) => {
@@ -99,9 +159,21 @@ export function Chat({
         wasAtBottomRef.current = newAtBottom
         onAtBottomChange?.(newAtBottom)
       }
+
+      const distanceFromBottom = scrollHeight - clientHeight - scrollTop
+      setShowJumpToBottom(distanceFromBottom > JUMP_TO_BOTTOM_THRESHOLD_PX)
+
+      scrollerRef.current = target as HTMLDivElement
     },
     [onAtBottomChange],
   )
+
+  const onJumpToBottomClick = () => {
+    const scroller = scrollerRef.current
+    if (scroller) {
+      scroller.scrollTop = scroller.scrollHeight
+    }
+  }
 
   const messageInputRef = useRef<MessageInputHandle>(null)
 
@@ -140,7 +212,27 @@ export function Chat({
         <MessagesAndInput className={className}>
           {header}
           {backgroundContent}
-          <StyledMessageList {...listProps} onScrollUpdate={onScrollUpdate} />
+          <MessageListContainer>
+            <StyledMessageList {...listProps} onScrollUpdate={onScrollUpdate} />
+            <AnimatePresence>
+              {showJumpToBottom ? (
+                <JumpToBottomButtonContainer
+                  key='jump-to-bottom'
+                  variants={jumpToBottomVariants}
+                  initial='initial'
+                  animate='visible'
+                  exit='exit'
+                  transition={jumpToBottomTransition}>
+                  <JumpToBottomButton
+                    icon={<MaterialIcon icon='arrow_downward' />}
+                    title={t('messaging.jumpToBottom', 'Jump to bottom')}
+                    ariaLabel={t('messaging.jumpToBottom', 'Jump to bottom')}
+                    onClick={onJumpToBottomClick}
+                  />
+                </JumpToBottomButtonContainer>
+              ) : null}
+            </AnimatePresence>
+          </MessageListContainer>
           <MessageInput
             {...inputProps}
             ref={messageInputRef}

--- a/client/messaging/chat.tsx
+++ b/client/messaging/chat.tsx
@@ -7,10 +7,9 @@ import styled from 'styled-components'
 import { Merge, Simplify } from 'type-fest'
 import { SbUserId } from '../../common/users/sb-user-id'
 import { MaterialIcon } from '../icons/material/material-icon'
-import { IconButton } from '../material/button'
+import { ElevatedButton } from '../material/button'
 import { MenuItem, MenuItemProps } from '../material/menu/item'
 import { MenuItemSymbol, MenuItemType } from '../material/menu/menu-item-symbol'
-import { elevationPlus2 } from '../material/shadows'
 import { MessageInput, MessageInputHandle, MessageInputProps } from '../messaging/message-input'
 import { MessageList, MessageListProps } from '../messaging/message-list'
 import { useAppDispatch } from '../redux-hooks'
@@ -24,10 +23,10 @@ import { ChatContext } from './chat-context'
 import { DefaultMessageMenu, MessageMenuComponent } from './message-context-menu'
 
 /**
- * How far above the bottom of the message list, in pixels, the user must scroll before the
- * jump-to-bottom button appears.
+ * How far above the bottom of the message list, in viewport heights, the user must scroll before
+ * the jump-to-bottom button appears.
  */
-const JUMP_TO_BOTTOM_THRESHOLD_PX = 160
+const JUMP_TO_BOTTOM_THRESHOLD_SCREENS = 1.5
 
 const MessagesAndInput = styled.div`
   position: relative;
@@ -53,20 +52,16 @@ const StyledMessageList = styled(MessageList)`
 
 const JumpToBottomButtonContainer = styled(m.div)`
   position: absolute;
-  right: 16px;
+  left: 0;
+  right: 0;
   bottom: 12px;
   display: flex;
+  justify-content: center;
+  pointer-events: none;
 `
 
-const JumpToBottomButton = styled(IconButton)`
-  width: 40px;
-  min-height: 40px;
-  border-radius: 50%;
-
-  background-color: var(--theme-container-highest);
-  color: var(--theme-on-surface);
-
-  ${elevationPlus2};
+const JumpToBottomButton = styled(ElevatedButton)`
+  pointer-events: auto;
 `
 
 const jumpToBottomVariants: Variants = {
@@ -161,7 +156,7 @@ export function Chat({
       }
 
       const distanceFromBottom = scrollHeight - clientHeight - scrollTop
-      setShowJumpToBottom(distanceFromBottom > JUMP_TO_BOTTOM_THRESHOLD_PX)
+      setShowJumpToBottom(distanceFromBottom > clientHeight * JUMP_TO_BOTTOM_THRESHOLD_SCREENS)
 
       scrollerRef.current = target as HTMLDivElement
     },
@@ -224,9 +219,8 @@ export function Chat({
                   exit='exit'
                   transition={jumpToBottomTransition}>
                   <JumpToBottomButton
-                    icon={<MaterialIcon icon='arrow_downward' />}
-                    title={t('messaging.jumpToBottom', 'Jump to bottom')}
-                    ariaLabel={t('messaging.jumpToBottom', 'Jump to bottom')}
+                    iconStart={<MaterialIcon icon='arrow_downward' size={20} />}
+                    label={t('messaging.jumpToBottom', 'Jump to bottom')}
                     onClick={onJumpToBottomClick}
                   />
                 </JumpToBottomButtonContainer>

--- a/server/public/locales/en/global.json
+++ b/server/public/locales/en/global.json
@@ -1469,6 +1469,7 @@
     "blockedMessage": "Blocked message",
     "copyLinkAddress": "Copy link address",
     "copyMessage": "Copy message",
+    "jumpToBottom": "Jump to bottom",
     "mention": "Mention",
     "messageTooLongContent": "Messages can be at most {{maxLength}} characters, and this one is {{length}}. Please shorten it before sending.",
     "messageTooLongTitle": "Message too long",


### PR DESCRIPTION
Shows a small floating button over the bottom-right of the message list in all chat surfaces (channels, whispers, lobbies, parties) once the user has scrolled more than a small distance (160px) above the bottom. Clicking it instantly jumps back to the newest messages. The button fades/slides in and out with a short animation.

Implementation notes:
- Lives in the shared `Chat` component, so every surface gets it for free. The existing scroll handler (which already drives the input divider) now also tracks distance-from-bottom and stashes the scroller element for the click handler.
- The message list is wrapped in a new relative container so the button can be positioned against the non-scrolling list area (rather than scrolling with content or colliding with the variable-height input). Net layout is unchanged.
- No unread-count badge or "jump to present" semantics yet — this is purely a scroll affordance; the message window is always attached today.

Verified live against the dev server: button appears only past the threshold (hidden at bottom and at <160px up), click jumps to bottom (including after infinite-scroll loaded more history above), button hides again, and geometry/layout are unchanged.