### PR TITLE
Recover from AudioContext device/renderer errors

### DIFF
--- a/client/audio/audio-manager.ts
+++ b/client/audio/audio-manager.ts
@@ -1,4 +1,5 @@
 import { urlPath } from '../../common/urls'
+import logger from '../logging/logger'
 import { fetchRaw } from '../network/fetch'
 
 export enum AvailableSound {
@@ -38,14 +39,147 @@ export class AudioManager {
   // NOTE(tec27): If we end up with a lot of different sounds (or potentially larger sounds) we
   // probably don't want to keep all these in memory forever :)
   private loadedSounds = new Map<AvailableSound, AudioBuffer>()
-  private context = new AudioContext()
-  private nodes = {
-    destination: this.context.destination,
-    masterGain: this.context.createGain(),
+
+  // Assigned by createContext(), which the constructor calls immediately and which
+  // recreateContext() calls again to swap in a fresh context after the renderer kills one.
+  private context!: AudioContext
+  private nodes!: {
+    destination: AudioDestinationNode
+    masterGain: GainNode
   }
+  // Lets a context being replaced have its listeners detached before it's closed, so the close()
+  // doesn't itself trigger a spurious statechange/error through a stale handler.
+  private listenerAbort!: AbortController
+
+  // Backoff state for context recreation. The counter only resets to 0 once the context has
+  // stayed 'running' for 30s straight, so a device that keeps flapping keeps escalating the
+  // delay instead of resetting on every brief recovery.
+  private recreateAttempts = 0
+  private healthyResetTimer: ReturnType<typeof setTimeout> | undefined
+  private recreateTimer: ReturnType<typeof setTimeout> | undefined
 
   constructor() {
-    this.nodes.masterGain.connect(this.nodes.destination)
+    this.createContext()
+  }
+
+  /**
+   * Creates the AudioContext and master gain node, and wires up the diagnostics/recovery
+   * listeners. Called once from the constructor, and again from recreateContext() to replace a
+   * context the renderer has killed.
+   */
+  private createContext() {
+    const context = new AudioContext()
+    const masterGain = context.createGain()
+    masterGain.connect(context.destination)
+
+    this.context = context
+    this.nodes = {
+      destination: context.destination,
+      masterGain,
+    }
+
+    if (!IS_ELECTRON) {
+      // The web build never plays sounds and its context starts (and stays) suspended under
+      // autoplay policy, so watching it here would just be log noise.
+      return
+    }
+
+    this.listenerAbort = new AbortController()
+    const { signal } = this.listenerAbort
+
+    context.addEventListener(
+      'statechange',
+      () => {
+        logger.verbose(`AudioContext state changed to: ${context.state}`)
+        clearTimeout(this.healthyResetTimer)
+
+        if (context.state === 'running') {
+          this.healthyResetTimer = setTimeout(() => {
+            this.recreateAttempts = 0
+          }, 30_000)
+        } else if (context.state === 'suspended') {
+          // Nothing in this class calls suspend() itself, so landing here means the OS/renderer
+          // suspended the context out from under us (e.g. an audio device change).
+          logger.warning('AudioContext was unexpectedly suspended, attempting to resume')
+          context.resume().catch(err => {
+            logger.error(`Failed to resume suspended AudioContext: ${err}`)
+          })
+        } else if (context.state === 'closed') {
+          // Nothing in this class closes a context that still has listeners attached (they're
+          // detached before our own close() during recreation), so landing here means the
+          // renderer/device killed the context without firing an error event.
+          logger.warning('AudioContext was closed unexpectedly')
+          this.scheduleRecreate()
+        }
+      },
+      { signal },
+    )
+
+    context.addEventListener(
+      'error',
+      event => {
+        const message = event instanceof ErrorEvent ? event.message : undefined
+        logger.error(`AudioContext error (state: ${context.state})${message ? `: ${message}` : ''}`)
+        clearTimeout(this.healthyResetTimer)
+
+        // Fire-and-forget diagnostics: helps correlate context errors with device changes in
+        // prod logs (output devices can be swapped/removed without an explicit device-change
+        // signal reaching this class).
+        navigator.mediaDevices
+          .enumerateDevices()
+          .then(devices => {
+            const outputs = devices.filter(d => d.kind === 'audiooutput')
+            logger.verbose(
+              `Audio output devices (${outputs.length}): [${outputs.map(d => d.label).join(', ')}]`,
+            )
+          })
+          .catch(err => {
+            logger.error(`Failed to enumerate audio devices: ${err}`)
+          })
+
+        this.scheduleRecreate()
+      },
+      { signal },
+    )
+  }
+
+  /**
+   * Schedules a context recreation with exponential backoff (capped at 30s). No-op if a
+   * recreation is already pending.
+   */
+  private scheduleRecreate() {
+    if (this.recreateTimer !== undefined) {
+      return
+    }
+
+    const delay = Math.min(1000 * 2 ** this.recreateAttempts, 30_000)
+    this.recreateAttempts++
+    this.recreateTimer = setTimeout(() => {
+      this.recreateTimer = undefined
+      this.recreateContext()
+    }, delay)
+  }
+
+  /**
+   * Swaps in a fresh AudioContext after the current one has been killed by the renderer/device.
+   * Decoded AudioBuffers aren't tied to a particular context, so `loadedSounds` keeps working
+   * against the new context unchanged; anything mid-playback on the old context is simply lost.
+   */
+  private recreateContext() {
+    const previousGain = this.nodes.masterGain.gain.value
+    const oldContext = this.context
+
+    this.listenerAbort.abort()
+    oldContext.close().catch(() => {
+      // May already be closed by the renderer that killed it.
+    })
+
+    this.createContext()
+    this.nodes.masterGain.gain.value = previousGain
+
+    logger.warning(
+      `AudioContext recreated after an audio device/renderer error (new state: ${this.context.state})`,
+    )
   }
 
   async initialize() {


### PR DESCRIPTION
## Problem

Leaving the app running for a while can produce `The AudioContext encountered an error from the audio device or the WebAudio renderer`, after which all in-app sounds are dead until restart. Chromium kills the context when the platform audio stream fails (output device removed/changed — e.g. a Bluetooth speaker powering off — sleep/resume, driver reset, audio service crash) and never resurrects it, and `AudioManager` created one context for the app's lifetime with nothing watching it.

## Fix

- Listen for `error` and `statechange` on the context (Electron only — the web build never plays sounds and its context idles suspended under autoplay policy).
- On error (or an unexpected `closed` state): log the failure plus the current audio output devices to the app log for root-cause correlation, then rebuild the context with exponential backoff (1s doubling, capped at 30s). The backoff counter only resets after the context stays `running` for 30s, so a flapping device keeps escalating instead of hammering.
- On unexpected `suspended`: log and attempt `resume()`.
- Rebuild detaches the old context's listeners (per-context `AbortController`), closes it, creates a fresh context + master gain, and reapplies the previous volume. Decoded `AudioBuffer`s aren't tied to a context, so loaded sounds survive without re-fetching; anything mid-playback is simply lost.

## Verification

eslint / tsc / prettier clean. Live-tested in the dev Electron app over CDP by dispatching a synthetic `ErrorEvent('error')` on the running app's live context: a fresh context was swapped in ~1s later (old `closed`, new `running`), master volume was preserved (a fresh gain node would default to 1), sounds decoded by the old context played through the new one, the backoff counter incremented and reset after 30s healthy, and the app log captured the full trail (error + device dump + recreation warning).