### PR TITLE
Add manual resolution of disputed game results.

### DIFF
--- a/client/matchmaking/devonly/post-match-dialog-test.tsx
+++ b/client/matchmaking/devonly/post-match-dialog-test.tsx
@@ -75,6 +75,7 @@ const GAME: GameRecordJson = {
   ],
   selectedMatchup: makeMatchupString('p-z'),
   assignedMatchup: makeMatchupString('p-z'),
+  manuallyResolved: false,
 }
 
 const SEASON: MatchmakingSeasonJson = {

--- a/common/games/games.ts
+++ b/common/games/games.ts
@@ -45,6 +45,11 @@ export interface GameRecord {
   results: [SbUserId, ReconciledPlayerResult][] | null
   selectedMatchup: MatchupString | null
   assignedMatchup: MatchupString | null
+  /**
+   * Whether an admin hand-assigned this game's outcomes instead of them coming purely from
+   * reconciled player reports. Who did it and when is kept server-side only.
+   */
+  manuallyResolved: boolean
 }
 
 export type GameRecordJson = Jsonify<GameRecord>
@@ -108,6 +113,7 @@ export function toGameRecordJson(game: GameRecord): GameRecordJson {
     results: game.results,
     selectedMatchup: game.selectedMatchup,
     assignedMatchup: game.assignedMatchup,
+    manuallyResolved: game.manuallyResolved,
   }
 }
 
@@ -209,6 +215,26 @@ export interface NullifyGamePointsResponse {
    * breakdown lives in the `game_points_refunds` audit row.
    */
   refundedUsers: SbUserId[]
+}
+
+/**
+ * Request to hand-assign the outcomes of a disputed game (an admin action). Every player with a
+ * stored result must be given an outcome; the submitted outcomes replace the disputed ones and the
+ * side effects the disputed reconciliation skipped (win/loss counters, and ratings/points for
+ * matchmaking games) are applied.
+ */
+export interface ManuallyResolveGameRequest {
+  results: Array<{ userId: SbUserId; result: 'win' | 'loss' | 'draw' }>
+}
+
+export interface ManuallyResolveGameResponse {
+  game: GameRecordJson
+  /**
+   * Whether matchmaking rating/points changes were applied. This is false for custom games (which
+   * have no ratings) and for matchmaking games whose season is already finalized — the resolution
+   * is still recorded in those cases.
+   */
+  ratingsApplied: boolean
 }
 
 export function getGameDurationString(durationMs: number): string {

--- a/common/games/results.ts
+++ b/common/games/results.ts
@@ -83,6 +83,13 @@ export enum GameResultErrorCode {
   InvalidClient = 'InvalidClient',
   /** The game has not been marked as loaded yet, so results cannot be submitted. */
   NotLoaded = 'NotLoaded',
+  /**
+   * The game is not awaiting manual resolution: its reconciled results were never disputed, or an
+   * admin has already resolved it.
+   */
+  NotDisputable = 'NotDisputable',
+  /** The submitted outcomes aren't a valid result for this game (e.g. a draw in matchmaking). */
+  InvalidResults = 'InvalidResults',
 }
 
 /** The payload format for submitting game results to the server. */

--- a/migrations/20260825120000_add_manual_game_resolution.sql
+++ b/migrations/20260825120000_add_manual_game_resolution.sql
@@ -1,0 +1,6 @@
+-- Records that an admin hand-assigned a game's outcomes after automatic reconciliation ended in a
+-- dispute. NULL in both columns means the game was never manually resolved; the pair is always set
+-- together.
+ALTER TABLE games
+  ADD COLUMN manually_resolved_by INTEGER REFERENCES users (id),
+  ADD COLUMN manually_resolved_at TIMESTAMPTZ;

--- a/server/lib/games/game-api.ts
+++ b/server/lib/games/game-api.ts
@@ -14,6 +14,8 @@ import {
   GET_GAMES_LIMIT,
   GetGameResponse,
   GetGamesResponse,
+  ManuallyResolveGameRequest,
+  ManuallyResolveGameResponse,
   NullifyGamePointsRequest,
   NullifyGamePointsResponse,
   toGameDebugInfoJson,
@@ -68,7 +70,10 @@ import {
   GamePointsRefundService,
   GamePointsRefundServiceError,
 } from './game-points-refund-service'
-import GameResultService, { GameResultServiceError } from './game-result-service'
+import GameResultService, {
+  ALL_MANUAL_GAME_RESULTS,
+  GameResultServiceError,
+} from './game-result-service'
 import { deriveResultSubmission } from './raw-results'
 
 /** Maximum size of a replay file that we allow to be uploaded. */
@@ -179,6 +184,10 @@ function convertGameResultServiceErrors(err: unknown) {
       throw asHttpError(400, err)
     case GameResultErrorCode.NotLoaded:
       throw asHttpError(409, err)
+    case GameResultErrorCode.NotDisputable:
+      throw asHttpError(409, err)
+    case GameResultErrorCode.InvalidResults:
+      throw asHttpError(400, err)
     default:
       assertUnreachable(err.code)
   }
@@ -248,6 +257,40 @@ export class GameApi {
       punishedUserIds,
       refundedBy: ctx.session!.user.id,
     })
+  }
+
+  @httpPost('/:gameId/manual-resolution')
+  @httpBefore(ensureLoggedIn, checkAllPermissions('manageGameReports'))
+  async manuallyResolveGame(ctx: RouterContext): Promise<ManuallyResolveGameResponse> {
+    const {
+      params: { gameId },
+      body: { results },
+    } = validateRequest(ctx, {
+      params: GAME_ID_PARAM,
+      body: Joi.object<ManuallyResolveGameRequest>({
+        // 8 is the most human players a game can have.
+        results: Joi.array()
+          .items(
+            Joi.object({
+              userId: joiUserId().required(),
+              result: Joi.string()
+                .valid(...ALL_MANUAL_GAME_RESULTS)
+                .required(),
+            }),
+          )
+          .min(1)
+          .max(8)
+          .required(),
+      }),
+    })
+
+    const { game, ratingsApplied } = await this.gameResultService.resolveGameManually({
+      gameId,
+      results,
+      resolvedBy: ctx.session!.user.id,
+    })
+
+    return { game: toGameRecordJson(game), ratingsApplied }
   }
 
   @httpGet('/list')

--- a/server/lib/games/game-models.ts
+++ b/server/lib/games/game-models.ts
@@ -10,7 +10,7 @@ import {
 import { GameRecord } from '../../../common/games/games'
 import { expandMatchupFilter, MatchupString } from '../../../common/games/matchups'
 import { NetcodeV2RelayEvent } from '../../../common/games/netcode-v2'
-import { ReconciledResults } from '../../../common/games/results'
+import { ReconciledPlayerResult, ReconciledResults } from '../../../common/games/results'
 import { LeagueId } from '../../../common/leagues/leagues'
 import { LobbyVisibility } from '../../../common/lobbies/lobby-visibility'
 import { SbUserId } from '../../../common/users/sb-user-id'
@@ -19,6 +19,11 @@ import { escapeSearchString } from '../db/escape-search-string'
 import { sql, sqlConcat, sqlRaw, SqlTemplate } from '../db/sql'
 import { Dbify } from '../db/types'
 
+/**
+ * A row shape for the `games` table. `manually_resolved` has no physical column behind it — it's
+ * derived from `manually_resolved_at`, so every query producing these rows must select
+ * `manually_resolved_at IS NOT NULL AS manually_resolved` alongside the real columns.
+ */
 type DbGameRecord = Dbify<GameRecord>
 
 export type CreateGameRecordData = Pick<
@@ -42,6 +47,7 @@ function convertFromDb(row: DbGameRecord): GameRecord {
     results: Array.isArray(row.results) ? row.results : null,
     selectedMatchup: row.selected_matchup,
     assignedMatchup: row.assigned_matchup,
+    manuallyResolved: row.manually_resolved,
   }
 }
 
@@ -76,7 +82,8 @@ export async function getGameRecord(gameId: string): Promise<GameRecord | undefi
   try {
     const result = await client.query<DbGameRecord>(sql`
       SELECT id, start_time, map_id, config, disputable, dispute_requested, dispute_reviewed,
-        game_length, results, selected_matchup, assigned_matchup
+        game_length, results, selected_matchup, assigned_matchup,
+        manually_resolved_at IS NOT NULL AS manually_resolved
       FROM games
       WHERE id = ${gameId}`)
     return result.rowCount ? convertFromDb(result.rows[0]) : undefined
@@ -136,6 +143,67 @@ export async function setReconciledResult(
       dispute_requested = false,
       dispute_reviewed = false,
       assigned_matchup = ${assignedMatchup}
+    WHERE id = ${gameId}
+  `)
+}
+
+/**
+ * Locks a game's row for the remainder of the current transaction and returns the dispute state a
+ * manual resolution has to decide against, or `undefined` if the game row no longer exists. Reading
+ * this under the lock is what makes two admins resolving the same game concurrently safe: the first
+ * to commit clears `disputable`, so the second sees a game that can no longer be resolved instead
+ * of applying the additive side effects (win/loss counters, rating changes) a second time.
+ */
+export async function lockGameForManualResolution(
+  client: DbClient,
+  gameId: string,
+): Promise<
+  { disputable: boolean; results: [SbUserId, ReconciledPlayerResult][] | null } | undefined
+> {
+  const result = await client.query<{
+    disputable: boolean
+    results: [SbUserId, ReconciledPlayerResult][] | null
+  }>(sql`
+    SELECT disputable, results FROM games WHERE id = ${gameId} FOR UPDATE
+  `)
+  if (result.rows.length === 0) {
+    return undefined
+  }
+
+  const row = result.rows[0]
+  return {
+    disputable: row.disputable,
+    // Some legacy rows store `results` as an empty object `{}` rather than an array (or null);
+    // normalize those to null so the runtime value matches the declared type.
+    results: Array.isArray(row.results) ? row.results : null,
+  }
+}
+
+/**
+ * Overwrites a game's results with outcomes an admin assigned by hand, clearing its disputable
+ * state and recording who resolved it and when. Intended to be executed in the same transaction
+ * that applies the result-derived side effects.
+ *
+ * `dispute_requested` is left alone: it's the historical record of whether players actually asked
+ * for a review. `game_length` and `assigned_matchup` are left alone too — manual resolution only
+ * decides outcomes, and a disputed game's stored races can include a fabricated one for a player
+ * who appeared in no report, which must never be baked into a matchup.
+ */
+export async function setManuallyResolvedResult(
+  client: DbClient,
+  gameId: string,
+  results: Map<SbUserId, ReconciledPlayerResult>,
+  resolvedBy: SbUserId,
+  resolvedAt: Date,
+): Promise<void> {
+  await client.query(sql`
+    UPDATE games
+    SET
+      results = ${JSON.stringify(Array.from(results.entries()))},
+      disputable = false,
+      dispute_reviewed = true,
+      manually_resolved_by = ${resolvedBy},
+      manually_resolved_at = ${resolvedAt}
     WHERE id = ${gameId}
   `)
 }
@@ -282,7 +350,7 @@ export async function getRecentGamesForUser(
   const { client, done } = await db()
   try {
     const result = await client.query<DbGameRecord>(sql`
-      SELECT g.*
+      SELECT g.*, g.manually_resolved_at IS NOT NULL AS manually_resolved
       FROM games_users u JOIN games g ON u.game_id = g.id
       WHERE u.user_id = ${userId}
       AND (g.config->>'resultsExempt')::boolean IS NOT TRUE
@@ -469,7 +537,7 @@ export async function getGames(
     }
 
     let query = sql`
-      SELECT g.*
+      SELECT g.*, g.manually_resolved_at IS NOT NULL AS manually_resolved
       FROM games g
     `
 
@@ -636,7 +704,7 @@ export async function getGamesForUser(
     }
 
     let query = sql`
-      SELECT g.*
+      SELECT g.*, g.manually_resolved_at IS NOT NULL AS manually_resolved
       FROM games_users gu
       INNER JOIN games g ON gu.game_id = g.id
     `

--- a/server/lib/games/game-page-meta.test.ts
+++ b/server/lib/games/game-page-meta.test.ts
@@ -74,6 +74,7 @@ const BASE_GAME: GameRecord = {
   results: null,
   selectedMatchup: null,
   assignedMatchup: null,
+  manuallyResolved: false,
 }
 
 describe('games/game-page-meta', () => {

--- a/server/lib/games/game-result-service.test.ts
+++ b/server/lib/games/game-result-service.test.ts
@@ -7,11 +7,25 @@ import {
 } from '../../../common/games/configuration'
 import { GameType } from '../../../common/games/game-type'
 import { GameRecord } from '../../../common/games/games'
-import { GameClientResult } from '../../../common/games/results'
+import {
+  GameClientResult,
+  GameResultErrorCode,
+  ReconciledPlayerResult,
+} from '../../../common/games/results'
 import { makeSbMapId } from '../../../common/maps'
-import { MatchmakingType } from '../../../common/matchmaking'
+import { MatchmakingSeason, MatchmakingType, makeSeasonId } from '../../../common/matchmaking'
 import { asMockedFunction } from '../../../common/testing/mocks'
 import { SbUserId, makeSbUserId } from '../../../common/users/sb-user-id'
+import { updateRankings } from '../ladder/rankings'
+import { updateLeaderboards } from '../leagues/leaderboard'
+import { getActiveLeaguesForUsers } from '../leagues/league-models'
+import {
+  DEFAULT_MATCHMAKING_RATING,
+  MatchmakingRating,
+  getMatchmakingRatingsWithLock,
+  insertMatchmakingRatingChange,
+  updateMatchmakingRating,
+} from '../matchmaking/models'
 import { getDesyncEventsForGame } from '../models/game-desync-events'
 import {
   StoredResultReport,
@@ -21,7 +35,7 @@ import {
 } from '../models/games-users'
 import { checkSessionsAlive, loadConfigFromEnv } from '../netcode-v2/netcode-v2-service'
 import { FakeClock } from '../time/testing/fake-clock'
-import { incrementUserStatsCount } from '../users/user-stats-model'
+import { incrementUserStatsCount, makeCountKeys } from '../users/user-stats-model'
 import {
   findFullyReportedUnreconciledGames,
   findKnownCompleteUnreconciledGames,
@@ -29,6 +43,8 @@ import {
   findUnreconciledV2GamesForProbe,
   getGameRecord,
   lockGameAndCheckReconciled,
+  lockGameForManualResolution,
+  setManuallyResolvedResult,
   setReconciledResult,
 } from './game-models'
 import GameResultService, {
@@ -49,7 +65,50 @@ vi.mock('./game-models', async () => {
     findKnownCompleteUnreconciledGames: vi.fn(),
     findUnreconciledV2GamesForProbe: vi.fn(),
     lockGameAndCheckReconciled: vi.fn(),
+    lockGameForManualResolution: vi.fn(),
+    setManuallyResolvedResult: vi.fn(),
     setReconciledResult: vi.fn(),
+  }
+})
+
+vi.mock('../matchmaking/models', async () => {
+  const actual =
+    await vi.importActual<typeof import('../matchmaking/models')>('../matchmaking/models')
+  return {
+    ...actual,
+    getMatchmakingRatingsWithLock: vi.fn(),
+    insertMatchmakingRatingChange: vi.fn(),
+    updateMatchmakingRating: vi.fn(),
+  }
+})
+
+vi.mock('../leagues/league-models', async () => {
+  const actual = await vi.importActual<typeof import('../leagues/league-models')>(
+    '../leagues/league-models',
+  )
+  return {
+    ...actual,
+    getActiveLeaguesForUsers: vi.fn(),
+    insertLeagueUserChange: vi.fn(),
+    updateLeagueUser: vi.fn(),
+  }
+})
+
+vi.mock('../ladder/rankings', async () => {
+  const actual = await vi.importActual<typeof import('../ladder/rankings')>('../ladder/rankings')
+  return {
+    ...actual,
+    doFullRankingsUpdate: vi.fn(),
+    updateRankings: vi.fn(),
+  }
+})
+
+vi.mock('../leagues/leaderboard', async () => {
+  const actual =
+    await vi.importActual<typeof import('../leagues/leaderboard')>('../leagues/leaderboard')
+  return {
+    ...actual,
+    updateLeaderboards: vi.fn(),
   }
 })
 
@@ -281,6 +340,7 @@ describe('games/game-result-service/GameResultService#maybeScheduleKnownComplete
       results: null,
       selectedMatchup: null,
       assignedMatchup: null,
+      manuallyResolved: false,
       ...overrides,
     }
   }
@@ -415,6 +475,7 @@ describe('games/game-result-service/GameResultService#forceReconcileGame', () =>
       results: null,
       selectedMatchup: null,
       assignedMatchup: null,
+      manuallyResolved: false,
       ...overrides,
     }
   }
@@ -642,6 +703,7 @@ describe('games/game-result-service/GameResultService#maybeReconcileResults', ()
       results: null,
       selectedMatchup: null,
       assignedMatchup: null,
+      manuallyResolved: false,
     }
   }
 
@@ -703,5 +765,364 @@ describe('games/game-result-service/GameResultService#maybeReconcileResults', ()
     const second = await (service as any).maybeReconcileResults(staleRecord)
     expect(second).toBe(false)
     expect(asMockedFunction(incrementUserStatsCount).mock.calls.length).toBe(statsCallsAfterFirst)
+  })
+})
+
+describe('games/game-result-service/GameResultService#resolveGameManually', () => {
+  const GAME_ID = 'game-manual-1'
+  const ADMIN_ID = makeSbUserId(99)
+  const p4 = makeSbUserId(4)
+
+  const SEASON: MatchmakingSeason = {
+    id: makeSeasonId(1),
+    name: 'Season 1',
+    startDate: new Date(0),
+    resetMmr: true,
+  }
+
+  /** The stored results a disputed 1v1 leaves behind: races and APM known, outcomes not. */
+  const DISPUTED_1V1_RESULTS: Array<[SbUserId, ReconciledPlayerResult]> = [
+    [p1, { result: 'unknown', race: 't', apm: 120 }],
+    [p2, { result: 'unknown', race: 'z', apm: 80 }],
+  ]
+
+  const TEAM_TEAMS: GameConfigPlayer[][] = [
+    [
+      { id: p1, race: 't', isComputer: false },
+      { id: p2, race: 'z', isComputer: false },
+    ],
+    [
+      { id: p3, race: 'p', isComputer: false },
+      { id: p4, race: 't', isComputer: false },
+    ],
+  ]
+
+  const DISPUTED_2V2_RESULTS: Array<[SbUserId, ReconciledPlayerResult]> = [
+    [p1, { result: 'unknown', race: 't', apm: 120 }],
+    [p2, { result: 'unknown', race: 'z', apm: 80 }],
+    [p3, { result: 'unknown', race: 'p', apm: 200 }],
+    [p4, { result: 'unknown', race: 't', apm: 90 }],
+  ]
+
+  let clock: FakeClock
+  let service: GameResultService
+  let getSeasonForDate: ReturnType<typeof vi.fn>
+  let publishReconciledGame: ReturnType<typeof vi.spyOn>
+
+  function makeDisputedGame(overrides: Partial<GameRecord> = {}): GameRecord {
+    return {
+      id: GAME_ID,
+      startTime: new Date(0),
+      mapId: makeSbMapId('1'),
+      config: lobbyConfig({ lockedAlliances: true }),
+      disputable: true,
+      disputeRequested: false,
+      disputeReviewed: false,
+      gameLength: 60_000,
+      results: DISPUTED_1V1_RESULTS,
+      selectedMatchup: null,
+      assignedMatchup: null,
+      manuallyResolved: false,
+      ...overrides,
+    }
+  }
+
+  function makeMmr(userId: SbUserId): MatchmakingRating {
+    return {
+      ...DEFAULT_MATCHMAKING_RATING,
+      userId,
+      matchmakingType: MatchmakingType.Match1v1,
+      seasonId: SEASON.id,
+    }
+  }
+
+  const resolve = (results: Array<{ userId: SbUserId; result: 'win' | 'loss' | 'draw' }>) =>
+    service.resolveGameManually({ gameId: GAME_ID, results, resolvedBy: ADMIN_ID })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    clock = new FakeClock()
+    clock.setCurrentTime(1_000_000)
+
+    getSeasonForDate = vi.fn().mockResolvedValue([SEASON, undefined])
+    service = new GameResultService(
+      { on: vi.fn() } as any,
+      { publish: vi.fn() } as any,
+      { publish: vi.fn() } as any,
+      { scheduleJob: vi.fn(), unscheduleJob: vi.fn() } as any,
+      { getSeasonForDate } as any,
+      clock,
+      {} as any,
+    )
+    // Publishing is covered by the reconcile path's own callers; here we only care that a committed
+    // resolution triggers it.
+    publishReconciledGame = vi
+      .spyOn(service as any, 'publishReconciledGame')
+      .mockResolvedValue(undefined)
+
+    asMockedFunction(getGameRecord).mockResolvedValue(makeDisputedGame())
+    asMockedFunction(lockGameForManualResolution).mockResolvedValue({
+      disputable: true,
+      results: DISPUTED_1V1_RESULTS,
+    })
+    asMockedFunction(setManuallyResolvedResult).mockResolvedValue(undefined)
+    asMockedFunction(setUserReconciledResult).mockResolvedValue(undefined as any)
+    asMockedFunction(incrementUserStatsCount).mockResolvedValue(undefined as any)
+    asMockedFunction(getActiveLeaguesForUsers).mockResolvedValue(new Map())
+    asMockedFunction(insertMatchmakingRatingChange).mockResolvedValue(undefined as any)
+    asMockedFunction(updateMatchmakingRating).mockResolvedValue(undefined as any)
+    asMockedFunction(updateRankings).mockResolvedValue(undefined)
+    asMockedFunction(updateLeaderboards).mockResolvedValue(undefined)
+  })
+
+  test('rewrites a custom game outcome, keeping each player race and apm', async () => {
+    const resolved = makeDisputedGame({
+      disputable: false,
+      disputeReviewed: true,
+      manuallyResolved: true,
+    })
+    asMockedFunction(getGameRecord)
+      .mockResolvedValueOnce(makeDisputedGame())
+      .mockResolvedValueOnce(resolved)
+
+    const result = await resolve([
+      { userId: p1, result: 'win' },
+      { userId: p2, result: 'loss' },
+    ])
+
+    expect(setUserReconciledResult).toHaveBeenCalledWith(expect.anything(), p1, GAME_ID, {
+      result: 'win',
+      race: 't',
+      apm: 120,
+    })
+    expect(setUserReconciledResult).toHaveBeenCalledWith(expect.anything(), p2, GAME_ID, {
+      result: 'loss',
+      race: 'z',
+      apm: 80,
+    })
+
+    // The games row is rewritten by the manual-resolution write, not the reconcile one — so the
+    // game keeps its length and assigned matchup.
+    expect(setReconciledResult).not.toHaveBeenCalled()
+    expect(setManuallyResolvedResult).toHaveBeenCalledWith(
+      expect.anything(),
+      GAME_ID,
+      new Map([
+        [p1, { result: 'win', race: 't', apm: 120 }],
+        [p2, { result: 'loss', race: 'z', apm: 80 }],
+      ]),
+      ADMIN_ID,
+      new Date(clock.now()),
+    )
+
+    // A custom game has no ratings at stake, but its win/loss counters (skipped while disputed) do
+    // get applied now.
+    for (const key of makeCountKeys('t', 't', 'win')) {
+      expect(incrementUserStatsCount).toHaveBeenCalledWith(expect.anything(), p1, key)
+    }
+    for (const key of makeCountKeys('z', 'z', 'loss')) {
+      expect(incrementUserStatsCount).toHaveBeenCalledWith(expect.anything(), p2, key)
+    }
+    expect(getMatchmakingRatingsWithLock).not.toHaveBeenCalled()
+    expect(updateRankings).not.toHaveBeenCalled()
+
+    expect(result.ratingsApplied).toBe(false)
+    expect(result.game).toEqual(resolved)
+    expect(publishReconciledGame).toHaveBeenCalledWith(GAME_ID)
+  })
+
+  test('applies rating, points and ranking changes for a 1v1 matchmaking game', async () => {
+    asMockedFunction(getGameRecord).mockResolvedValue(
+      makeDisputedGame({ config: matchmakingConfig(DEFAULT_TEAMS) }),
+    )
+    asMockedFunction(getMatchmakingRatingsWithLock).mockResolvedValue([makeMmr(p1), makeMmr(p2)])
+
+    const result = await resolve([
+      { userId: p1, result: 'win' },
+      { userId: p2, result: 'loss' },
+    ])
+
+    expect(getMatchmakingRatingsWithLock).toHaveBeenCalledWith(
+      expect.anything(),
+      [p1, p2],
+      MatchmakingType.Match1v1,
+      SEASON.id,
+    )
+
+    expect(insertMatchmakingRatingChange).toHaveBeenCalledTimes(2)
+    expect(insertMatchmakingRatingChange).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ userId: p1, gameId: GAME_ID, outcome: 'win' }),
+    )
+    expect(insertMatchmakingRatingChange).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ userId: p2, gameId: GAME_ID, outcome: 'loss' }),
+    )
+
+    const updatedRatings = asMockedFunction(updateMatchmakingRating).mock.calls.map(
+      ([, mmr]) => mmr,
+    )
+    const winner = updatedRatings.find(mmr => mmr.userId === p1)!
+    const loser = updatedRatings.find(mmr => mmr.userId === p2)!
+    expect(winner.rating).toBeGreaterThan(DEFAULT_MATCHMAKING_RATING.rating)
+    expect(winner.wins).toBe(1)
+    expect(winner.tWins).toBe(1)
+    expect(loser.rating).toBeLessThan(DEFAULT_MATCHMAKING_RATING.rating)
+    expect(loser.losses).toBe(1)
+    expect(loser.zLosses).toBe(1)
+
+    expect(updateRankings).toHaveBeenCalledWith(expect.anything(), [winner, loser])
+    expect(result.ratingsApplied).toBe(true)
+  })
+
+  test('records the resolution without rating changes once the season is finalized', async () => {
+    clock.setCurrentTime(100_000_000)
+    getSeasonForDate.mockResolvedValue([SEASON, new Date(0)])
+    asMockedFunction(getGameRecord).mockResolvedValue(
+      makeDisputedGame({ config: matchmakingConfig(DEFAULT_TEAMS) }),
+    )
+
+    const result = await resolve([
+      { userId: p1, result: 'win' },
+      { userId: p2, result: 'loss' },
+    ])
+
+    expect(getMatchmakingRatingsWithLock).not.toHaveBeenCalled()
+    expect(updateRankings).not.toHaveBeenCalled()
+    expect(setManuallyResolvedResult).toHaveBeenCalled()
+    expect(result.ratingsApplied).toBe(false)
+  })
+
+  test('throws NotFound when the game does not exist', async () => {
+    asMockedFunction(getGameRecord).mockResolvedValue(undefined)
+
+    await expect(
+      resolve([
+        { userId: p1, result: 'win' },
+        { userId: p2, result: 'loss' },
+      ]),
+    ).rejects.toMatchObject({ code: GameResultErrorCode.NotFound })
+    expect(lockGameForManualResolution).not.toHaveBeenCalled()
+  })
+
+  test('throws NotDisputable for a game that was never disputed or is already resolved', async () => {
+    asMockedFunction(lockGameForManualResolution).mockResolvedValue({
+      disputable: false,
+      results: DISPUTED_1V1_RESULTS,
+    })
+
+    await expect(
+      resolve([
+        { userId: p1, result: 'win' },
+        { userId: p2, result: 'loss' },
+      ]),
+    ).rejects.toMatchObject({ code: GameResultErrorCode.NotDisputable })
+    expect(setManuallyResolvedResult).not.toHaveBeenCalled()
+    expect(setUserReconciledResult).not.toHaveBeenCalled()
+  })
+
+  test('throws NotDisputable for a game with no reconciled results at all', async () => {
+    asMockedFunction(lockGameForManualResolution).mockResolvedValue({
+      disputable: true,
+      results: null,
+    })
+
+    await expect(
+      resolve([
+        { userId: p1, result: 'win' },
+        { userId: p2, result: 'loss' },
+      ]),
+    ).rejects.toMatchObject({ code: GameResultErrorCode.NotDisputable })
+  })
+
+  test('throws NotDisputable when the game row is gone', async () => {
+    asMockedFunction(lockGameForManualResolution).mockResolvedValue(undefined)
+
+    await expect(
+      resolve([
+        { userId: p1, result: 'win' },
+        { userId: p2, result: 'loss' },
+      ]),
+    ).rejects.toMatchObject({ code: GameResultErrorCode.NotDisputable })
+  })
+
+  test('throws InvalidPlayers when the submitted players do not match the stored ones', async () => {
+    await expect(resolve([{ userId: p1, result: 'win' }])).rejects.toMatchObject({
+      code: GameResultErrorCode.InvalidPlayers,
+    })
+
+    await expect(
+      resolve([
+        { userId: p1, result: 'win' },
+        { userId: p3, result: 'loss' },
+      ]),
+    ).rejects.toMatchObject({ code: GameResultErrorCode.InvalidPlayers })
+
+    expect(setManuallyResolvedResult).not.toHaveBeenCalled()
+  })
+
+  test('throws InvalidResults for an outcome that is not a win, loss or draw', async () => {
+    await expect(
+      resolve([
+        { userId: p1, result: 'unknown' as any },
+        { userId: p2, result: 'loss' },
+      ]),
+    ).rejects.toMatchObject({ code: GameResultErrorCode.InvalidResults })
+    expect(setManuallyResolvedResult).not.toHaveBeenCalled()
+  })
+
+  test('throws InvalidResults for a draw in a matchmaking game', async () => {
+    asMockedFunction(getGameRecord).mockResolvedValue(
+      makeDisputedGame({ config: matchmakingConfig(DEFAULT_TEAMS) }),
+    )
+
+    await expect(
+      resolve([
+        { userId: p1, result: 'draw' },
+        { userId: p2, result: 'draw' },
+      ]),
+    ).rejects.toMatchObject({ code: GameResultErrorCode.InvalidResults })
+    expect(setManuallyResolvedResult).not.toHaveBeenCalled()
+  })
+
+  test('throws InvalidResults when a matchmaking game has more than one winner in 1v1', async () => {
+    asMockedFunction(getGameRecord).mockResolvedValue(
+      makeDisputedGame({ config: matchmakingConfig(DEFAULT_TEAMS) }),
+    )
+
+    await expect(
+      resolve([
+        { userId: p1, result: 'win' },
+        { userId: p2, result: 'win' },
+      ]),
+    ).rejects.toMatchObject({ code: GameResultErrorCode.InvalidResults })
+  })
+
+  test('throws InvalidResults when matchmaking winners span two teams', async () => {
+    asMockedFunction(getGameRecord).mockResolvedValue(
+      makeDisputedGame({
+        config: matchmakingConfig(TEAM_TEAMS, {
+          gameSourceExtra: { type: MatchmakingType.Match2v2, parties: [] },
+          gameType: GameType.TopVsBottom,
+          gameSubType: 2,
+        }),
+        results: DISPUTED_2V2_RESULTS,
+      }),
+    )
+    asMockedFunction(lockGameForManualResolution).mockResolvedValue({
+      disputable: true,
+      results: DISPUTED_2V2_RESULTS,
+    })
+
+    await expect(
+      resolve([
+        { userId: p1, result: 'win' },
+        { userId: p2, result: 'loss' },
+        { userId: p3, result: 'win' },
+        { userId: p4, result: 'loss' },
+      ]),
+    ).rejects.toMatchObject({ code: GameResultErrorCode.InvalidResults })
+    expect(setManuallyResolvedResult).not.toHaveBeenCalled()
   })
 })

--- a/server/lib/games/game-result-service.ts
+++ b/server/lib/games/game-result-service.ts
@@ -2,7 +2,7 @@ import Joi from 'joi'
 import { Logger } from 'pino'
 import { singleton } from 'tsyringe'
 import { assertUnreachable } from '../../../common/assert-unreachable'
-import { GameConfig, GameSource } from '../../../common/games/configuration'
+import { GameConfig, GameSource, MatchmakingGameConfig } from '../../../common/games/configuration'
 import { GameType } from '../../../common/games/game-type'
 import {
   GameRecord,
@@ -18,6 +18,9 @@ import {
   ALL_GAME_CLIENT_RESULTS,
   GameResultErrorCode,
   RawGameResultsReport,
+  ReconciledPlayerResult,
+  ReconciledResult,
+  ReconciledResults,
   StoredGameResults,
   SubmitGameResultsRequest,
 } from '../../../common/games/results'
@@ -31,6 +34,7 @@ import {
 import { RaceChar } from '../../../common/races'
 import { urlPath } from '../../../common/urls'
 import { SbUserId } from '../../../common/users/sb-user-id'
+import { DbClient } from '../db'
 import { UNIQUE_VIOLATION } from '../db/pg-error-codes'
 import transact from '../db/transaction'
 import { CodedError } from '../errors/coded-error'
@@ -40,6 +44,8 @@ import {
   findUnreconciledGames,
   findUnreconciledV2GamesForProbe,
   lockGameAndCheckReconciled,
+  lockGameForManualResolution,
+  setManuallyResolvedResult,
   setReconciledResult,
 } from '../games/game-models'
 import {
@@ -118,6 +124,79 @@ export function getValidationTeams(
   }
 
   return getTeamsFromConfig(config)?.map(team => team.map(p => p.id)) ?? humans.map(id => [id])
+}
+
+/** An outcome an admin can hand-assign to a player when manually resolving a disputed game. */
+export type ManualGameResult = Exclude<ReconciledResult, 'unknown'>
+
+export const ALL_MANUAL_GAME_RESULTS: ReadonlyArray<ManualGameResult> = ['win', 'loss', 'draw']
+
+/**
+ * The team groupings a matchmaking game's hand-assigned outcomes must line up with: exactly one of
+ * these teams wins and every other player loses. Partitioned the way rating calculation partitions
+ * players — a 1v1 pits its participants against each other individually, every team mode takes the
+ * teams from the config.
+ */
+function getMatchmakingResolutionTeams(
+  config: MatchmakingGameConfig,
+  userIds: ReadonlyArray<SbUserId>,
+): SbUserId[][] {
+  const { gameSourceExtra } = config
+  switch (gameSourceExtra.type) {
+    case MatchmakingType.Match1v1:
+    case MatchmakingType.Match1v1Fastest:
+      return userIds.map(id => [id])
+    case MatchmakingType.Match2v2:
+    case MatchmakingType.Match2v2Bgh:
+    case MatchmakingType.Match2v2Hunters:
+    case MatchmakingType.Match2v2Fastest:
+    case MatchmakingType.Match3v3Bgh:
+    case MatchmakingType.Match3v3Hunters:
+    case MatchmakingType.Match3v3Fastest:
+      // Records created while the observer team was serialized alongside the player teams carry it
+      // as an empty array, which would otherwise read as a team that trivially "wins".
+      return config.teams.map(team => team.map(p => p.id)).filter(team => team.length > 0)
+    default:
+      return assertUnreachable(gameSourceExtra)
+  }
+}
+
+/**
+ * Checks that hand-assigned outcomes describe a result a matchmaking game could actually have had:
+ * matchmaking has no draws, and exactly one full team wins while everyone else loses.
+ */
+function validateMatchmakingResolution(
+  config: MatchmakingGameConfig,
+  results: ReadonlyMap<SbUserId, ManualGameResult>,
+): void {
+  for (const result of results.values()) {
+    if (result === 'draw') {
+      throw new GameResultServiceError(
+        GameResultErrorCode.InvalidResults,
+        'matchmaking games cannot be resolved as a draw',
+      )
+    }
+  }
+
+  const teams = getMatchmakingResolutionTeams(config, Array.from(results.keys()))
+  const teamPlayers = teams.flat()
+  if (teamPlayers.length !== results.size || teamPlayers.some(id => !results.has(id))) {
+    throw new GameResultServiceError(
+      GameResultErrorCode.InvalidResults,
+      "the game's teams don't cover exactly the players being resolved",
+    )
+  }
+
+  const winners = new Set(
+    Array.from(results.entries()).flatMap(([id, result]) => (result === 'win' ? [id] : [])),
+  )
+  const winningTeam = teams.find(team => team.every(id => winners.has(id)))
+  if (!winningTeam || winningTeam.length !== winners.size) {
+    throw new GameResultServiceError(
+      GameResultErrorCode.InvalidResults,
+      'exactly one full team must win a matchmaking game',
+    )
+  }
 }
 
 /**
@@ -828,228 +907,6 @@ export default class GameResultService {
         return false
       }
 
-      // TODO(tec27): in some cases, we'll be re-reconciling results, and we may need to go back
-      // and "fixup" rank changes and win/loss counters
-      const resultEntries = Array.from(reconciled.results.entries())
-
-      const idToSelectedRace = new Map(
-        gameRecord.config.teams
-          .map(team =>
-            team
-              .filter(p => !p.isComputer)
-              .map<[id: SbUserId, race: RaceChar]>(p => [p.id, p.race]),
-          )
-          .flat(),
-      )
-
-      const [season, seasonEnd] = await this.matchmakingSeasonsService.getSeasonForDate(
-        gameRecord.startTime,
-      )
-
-      const matchmakingRankingChanges: MatchmakingRating[] = []
-      const leagueLeaderboardChanges: LeagueUser[] = []
-      if (
-        gameRecord.config.gameSource === GameSource.Matchmaking &&
-        !reconciled.disputed &&
-        // Only update matchmaking ratings if we're not past the point that the season is finalized
-        (seasonEnd === undefined ||
-          Number(seasonEnd) + MATCHMAKING_SEASON_FINALIZED_TIME_MS > Number(reconcileDate))
-      ) {
-        // Calculate and update the matchmaking ranks
-
-        // NOTE(tec27): We sort these so we always lock them in the same order and avoid
-        // deadlocks
-        const userIds = Array.from(reconciled.results.keys()).sort()
-
-        const mmrs = await getMatchmakingRatingsWithLock(
-          client,
-          userIds,
-          gameRecord.config.gameSourceExtra.type,
-          season.id,
-        )
-        const activeLeagues = await getActiveLeaguesForUsers(
-          userIds,
-          gameRecord.config.gameSourceExtra.type,
-          gameRecord.startTime,
-          client,
-        )
-        if (mmrs.length !== userIds.length) {
-          throw new Error('missing MMR for some users')
-        }
-
-        const {
-          config: { gameSourceExtra },
-        } = gameRecord
-
-        let teams: [teamA: SbUserId[], teamB: SbUserId[]]
-        if (
-          gameSourceExtra.type === MatchmakingType.Match1v1 ||
-          gameSourceExtra.type === MatchmakingType.Match1v1Fastest
-        ) {
-          teams = [[userIds[0]], [userIds[1]]]
-        } else if (
-          gameSourceExtra.type === MatchmakingType.Match2v2 ||
-          gameSourceExtra.type === MatchmakingType.Match2v2Bgh ||
-          gameSourceExtra.type === MatchmakingType.Match2v2Hunters ||
-          gameSourceExtra.type === MatchmakingType.Match2v2Fastest ||
-          gameSourceExtra.type === MatchmakingType.Match3v3Bgh ||
-          gameSourceExtra.type === MatchmakingType.Match3v3Hunters ||
-          gameSourceExtra.type === MatchmakingType.Match3v3Fastest
-        ) {
-          // TODO(tec27): Pass gameSourceExtra.parties info to rating change calculation
-          teams = gameRecord.config.teams.map(t => t.map(p => p.id)) as [
-            teamA: SbUserId[],
-            teamB: SbUserId[],
-          ]
-        } else {
-          teams = assertUnreachable(gameSourceExtra)
-        }
-
-        const ratingChanges = calculateChangedRatings({
-          season,
-          gameId,
-          gameDate: reconcileDate,
-          results: reconciled.results,
-          mmrs,
-          teams,
-          activeLeagues,
-        })
-
-        for (const mmr of mmrs) {
-          const { matchmaking: matchmakingChange, leagues: leagueChanges } = ratingChanges.get(
-            mmr.userId,
-          )!
-          await insertMatchmakingRatingChange(client, matchmakingChange)
-
-          const selectedRace = idToSelectedRace.get(mmr.userId)!
-          const assignedRace = reconciled.results.get(mmr.userId)!.race
-
-          {
-            const winCount = matchmakingChange.outcome === 'win' ? 1 : 0
-            const lossCount = matchmakingChange.outcome === 'win' ? 0 : 1
-
-            const updatedMmr: MatchmakingRating = {
-              userId: mmr.userId,
-              matchmakingType: mmr.matchmakingType,
-              seasonId: mmr.seasonId,
-              rating: matchmakingChange.rating,
-              uncertainty: matchmakingChange.uncertainty,
-              volatility: matchmakingChange.volatility,
-              points: matchmakingChange.points,
-              pointsConverged: matchmakingChange.pointsConverged,
-              bonusUsed: matchmakingChange.bonusUsed,
-              numGamesPlayed: mmr.numGamesPlayed + 1,
-              lifetimeGames: matchmakingChange.lifetimeGames,
-              lastPlayedDate: reconcileDate,
-              wins: mmr.wins + winCount,
-              losses: mmr.losses + lossCount,
-
-              pWins: mmr.pWins + (selectedRace === 'p' ? winCount : 0),
-              pLosses: mmr.pLosses + (selectedRace === 'p' ? lossCount : 0),
-              tWins: mmr.tWins + (selectedRace === 't' ? winCount : 0),
-              tLosses: mmr.tLosses + (selectedRace === 't' ? lossCount : 0),
-              zWins: mmr.zWins + (selectedRace === 'z' ? winCount : 0),
-              zLosses: mmr.zLosses + (selectedRace === 'z' ? lossCount : 0),
-              rWins: mmr.rWins + (selectedRace === 'r' ? winCount : 0),
-              rLosses: mmr.rLosses + (selectedRace === 'r' ? lossCount : 0),
-
-              rPWins: mmr.rPWins + (selectedRace === 'r' && assignedRace === 'p' ? winCount : 0),
-              rPLosses:
-                mmr.rPLosses + (selectedRace === 'r' && assignedRace === 'p' ? lossCount : 0),
-              rTWins: mmr.rTWins + (selectedRace === 'r' && assignedRace === 't' ? winCount : 0),
-              rTLosses:
-                mmr.rTLosses + (selectedRace === 'r' && assignedRace === 't' ? lossCount : 0),
-              rZWins: mmr.rZWins + (selectedRace === 'r' && assignedRace === 'z' ? winCount : 0),
-              rZLosses:
-                mmr.rZLosses + (selectedRace === 'r' && assignedRace === 'z' ? lossCount : 0),
-            }
-
-            await updateMatchmakingRating(client, updatedMmr)
-            matchmakingRankingChanges.push(updatedMmr)
-          }
-
-          for (const leagueChange of leagueChanges) {
-            const oldLeagueUser = activeLeagues
-              .get(leagueChange.userId)!
-              .find(l => l.leagueId === leagueChange.leagueId)!
-
-            if (oldLeagueUser.isBanned) {
-              // Don't process league changes for banned users
-              continue
-            }
-
-            await insertLeagueUserChange(leagueChange, client)
-
-            const winCount = leagueChange.outcome === 'win' ? 1 : 0
-            const lossCount = leagueChange.outcome === 'win' ? 0 : 1
-
-            const updatedLeagueUser: LeagueUser = {
-              leagueId: oldLeagueUser.leagueId,
-              userId: oldLeagueUser.userId,
-              isBanned: oldLeagueUser.isBanned,
-              lastPlayedDate: reconcileDate,
-              points: leagueChange.points,
-              pointsConverged: leagueChange.pointsConverged,
-              wins: oldLeagueUser.wins + winCount,
-              losses: oldLeagueUser.losses + lossCount,
-
-              pWins: oldLeagueUser.pWins + (selectedRace === 'p' ? winCount : 0),
-              pLosses: oldLeagueUser.pLosses + (selectedRace === 'p' ? lossCount : 0),
-              tWins: oldLeagueUser.tWins + (selectedRace === 't' ? winCount : 0),
-              tLosses: oldLeagueUser.tLosses + (selectedRace === 't' ? lossCount : 0),
-              zWins: oldLeagueUser.zWins + (selectedRace === 'z' ? winCount : 0),
-              zLosses: oldLeagueUser.zLosses + (selectedRace === 'z' ? lossCount : 0),
-              rWins: oldLeagueUser.rWins + (selectedRace === 'r' ? winCount : 0),
-              rLosses: oldLeagueUser.rLosses + (selectedRace === 'r' ? lossCount : 0),
-
-              rPWins:
-                oldLeagueUser.rPWins +
-                (selectedRace === 'r' && assignedRace === 'p' ? winCount : 0),
-              rPLosses:
-                oldLeagueUser.rPLosses +
-                (selectedRace === 'r' && assignedRace === 'p' ? lossCount : 0),
-              rTWins:
-                oldLeagueUser.rTWins +
-                (selectedRace === 'r' && assignedRace === 't' ? winCount : 0),
-              rTLosses:
-                oldLeagueUser.rTLosses +
-                (selectedRace === 'r' && assignedRace === 't' ? lossCount : 0),
-              rZWins:
-                oldLeagueUser.rZWins +
-                (selectedRace === 'r' && assignedRace === 'z' ? winCount : 0),
-              rZLosses:
-                oldLeagueUser.rZLosses +
-                (selectedRace === 'r' && assignedRace === 'z' ? lossCount : 0),
-            }
-
-            await updateLeagueUser(updatedLeagueUser, client)
-            leagueLeaderboardChanges.push(updatedLeagueUser)
-          }
-        }
-      }
-      for (const [userId, result] of resultEntries) {
-        await setUserReconciledResult(client, userId, gameId, result)
-      }
-
-      // TODO(tec27): Perhaps we should auto-trigger a dispute request in particular cases, such
-      // as when a user has an unknown result?
-
-      if (gameRecord.config.gameType !== GameType.UseMapSettings && !reconciled.disputed) {
-        for (const [userId, result] of reconciled.results.entries()) {
-          if (result.result !== 'win' && result.result !== 'loss') {
-            continue
-          }
-
-          const selectedRace = idToSelectedRace.get(userId)!
-          const assignedRace = result.race
-          const countKeys = makeCountKeys(selectedRace, assignedRace, result.result)
-
-          for (const key of countKeys) {
-            await incrementUserStatsCount(client, userId, key)
-          }
-        }
-      }
-
       // Only compute an assigned matchup when we actually know every player's assigned race: skip
       // games with computers (which are excluded from results) and disputed games. A disputed game
       // can have a player who's missing from every report, in which case reconcileResults falls back
@@ -1065,40 +922,385 @@ export default class GameResultService {
 
       await setReconciledResult(client, gameId, reconciled, assignedMatchup)
 
-      if (matchmakingRankingChanges.length) {
-        // NOTE(tec27): This is a best-effort thing, as these leaderboards are basically just a
-        // cache and can be regenerated from the data at any time. We don't want to update them
-        // unless the DB queries succeed, but the DB queries succeeding and this failing is "okay"
-        // as far as accepting the game results
-        updateRankings(this.redis, matchmakingRankingChanges).catch(err => {
-          logger.error({ err }, 'Error updating rankings, triggering full update')
-          // TODO(tec27): Should probably debounce this update in some way in case we get a ton of
-          // errors in a row for some reason
-          doFullRankingsUpdate(
-            this.redis,
-            matchmakingRankingChanges[0].matchmakingType,
-            season.id,
-          ).catch(err => {
-            logger.error({ err }, 'Error doing full rankings update')
-          })
-        })
-      }
-      if (leagueLeaderboardChanges.length) {
-        // NOTE(tec27): This is a best-effort thing, as these leaderboards are basically just a
-        // cache and can be regenerated from the data at any time. We don't want to update them
-        // unless the DB queries succeed, but the DB queries succeeding and this failing is "okay"
-        // as far as accepting the game results
-        updateLeaderboards(this.redis, leagueLeaderboardChanges).catch(err => {
-          logger.error({ err }, 'Error updating league leaderboards')
-          // TODO(tec27): If this fails, the leaderboards should be queued for regeneration at some
-          // point in the (near) future
-        })
-      }
+      await this.applyReconciledResultEffects(client, gameRecord, reconciled, reconcileDate)
 
       return true
     })
 
     return committed
+  }
+
+  /**
+   * Applies every side effect a set of reconciled results implies, within the caller's transaction:
+   * the matchmaking rating and league point changes, each player's `games_users` result row, and
+   * the lifetime win/loss stat counters. Disputed results get only the `games_users` rows — the
+   * rating changes and stat counters wait until an outcome is actually known.
+   *
+   * Locking the games row and writing the games row itself are the caller's responsibility, and
+   * the write must happen before calling this: the method ends by kicking off best-effort Redis
+   * ranking-cache refreshes, which need to be the transaction's last statements so that a DB
+   * failure after them can't roll back changes the caches already show.
+   *
+   * @returns whether matchmaking rating changes were applied, which is false whenever there were
+   *   none to apply: a game with no ratings at stake (a custom game), a still-disputed result, or a
+   *   season that's already finalized.
+   */
+  private async applyReconciledResultEffects(
+    client: DbClient,
+    gameRecord: GameRecord,
+    reconciled: ReconciledResults,
+    reconcileDate: Date,
+  ): Promise<{ ratingsApplied: boolean }> {
+    const gameId = gameRecord.id
+
+    // TODO(tec27): in some cases, we'll be re-reconciling results, and we may need to go back
+    // and "fixup" rank changes and win/loss counters
+    const resultEntries = Array.from(reconciled.results.entries())
+
+    const idToSelectedRace = new Map(
+      gameRecord.config.teams
+        .map(team =>
+          team.filter(p => !p.isComputer).map<[id: SbUserId, race: RaceChar]>(p => [p.id, p.race]),
+        )
+        .flat(),
+    )
+
+    const [season, seasonEnd] = await this.matchmakingSeasonsService.getSeasonForDate(
+      gameRecord.startTime,
+    )
+
+    const matchmakingRankingChanges: MatchmakingRating[] = []
+    const leagueLeaderboardChanges: LeagueUser[] = []
+    if (
+      gameRecord.config.gameSource === GameSource.Matchmaking &&
+      !reconciled.disputed &&
+      // Only update matchmaking ratings if we're not past the point that the season is finalized
+      (seasonEnd === undefined ||
+        Number(seasonEnd) + MATCHMAKING_SEASON_FINALIZED_TIME_MS > Number(reconcileDate))
+    ) {
+      // Calculate and update the matchmaking ranks
+
+      // NOTE(tec27): We sort these so we always lock them in the same order and avoid
+      // deadlocks
+      const userIds = Array.from(reconciled.results.keys()).sort()
+
+      const mmrs = await getMatchmakingRatingsWithLock(
+        client,
+        userIds,
+        gameRecord.config.gameSourceExtra.type,
+        season.id,
+      )
+      const activeLeagues = await getActiveLeaguesForUsers(
+        userIds,
+        gameRecord.config.gameSourceExtra.type,
+        gameRecord.startTime,
+        client,
+      )
+      if (mmrs.length !== userIds.length) {
+        throw new Error('missing MMR for some users')
+      }
+
+      const {
+        config: { gameSourceExtra },
+      } = gameRecord
+
+      let teams: [teamA: SbUserId[], teamB: SbUserId[]]
+      if (
+        gameSourceExtra.type === MatchmakingType.Match1v1 ||
+        gameSourceExtra.type === MatchmakingType.Match1v1Fastest
+      ) {
+        teams = [[userIds[0]], [userIds[1]]]
+      } else if (
+        gameSourceExtra.type === MatchmakingType.Match2v2 ||
+        gameSourceExtra.type === MatchmakingType.Match2v2Bgh ||
+        gameSourceExtra.type === MatchmakingType.Match2v2Hunters ||
+        gameSourceExtra.type === MatchmakingType.Match2v2Fastest ||
+        gameSourceExtra.type === MatchmakingType.Match3v3Bgh ||
+        gameSourceExtra.type === MatchmakingType.Match3v3Hunters ||
+        gameSourceExtra.type === MatchmakingType.Match3v3Fastest
+      ) {
+        // TODO(tec27): Pass gameSourceExtra.parties info to rating change calculation
+        teams = gameRecord.config.teams.map(t => t.map(p => p.id)) as [
+          teamA: SbUserId[],
+          teamB: SbUserId[],
+        ]
+      } else {
+        teams = assertUnreachable(gameSourceExtra)
+      }
+
+      const ratingChanges = calculateChangedRatings({
+        season,
+        gameId,
+        gameDate: reconcileDate,
+        results: reconciled.results,
+        mmrs,
+        teams,
+        activeLeagues,
+      })
+
+      for (const mmr of mmrs) {
+        const { matchmaking: matchmakingChange, leagues: leagueChanges } = ratingChanges.get(
+          mmr.userId,
+        )!
+        await insertMatchmakingRatingChange(client, matchmakingChange)
+
+        const selectedRace = idToSelectedRace.get(mmr.userId)!
+        const assignedRace = reconciled.results.get(mmr.userId)!.race
+
+        {
+          const winCount = matchmakingChange.outcome === 'win' ? 1 : 0
+          const lossCount = matchmakingChange.outcome === 'win' ? 0 : 1
+
+          const updatedMmr: MatchmakingRating = {
+            userId: mmr.userId,
+            matchmakingType: mmr.matchmakingType,
+            seasonId: mmr.seasonId,
+            rating: matchmakingChange.rating,
+            uncertainty: matchmakingChange.uncertainty,
+            volatility: matchmakingChange.volatility,
+            points: matchmakingChange.points,
+            pointsConverged: matchmakingChange.pointsConverged,
+            bonusUsed: matchmakingChange.bonusUsed,
+            numGamesPlayed: mmr.numGamesPlayed + 1,
+            lifetimeGames: matchmakingChange.lifetimeGames,
+            lastPlayedDate: reconcileDate,
+            wins: mmr.wins + winCount,
+            losses: mmr.losses + lossCount,
+
+            pWins: mmr.pWins + (selectedRace === 'p' ? winCount : 0),
+            pLosses: mmr.pLosses + (selectedRace === 'p' ? lossCount : 0),
+            tWins: mmr.tWins + (selectedRace === 't' ? winCount : 0),
+            tLosses: mmr.tLosses + (selectedRace === 't' ? lossCount : 0),
+            zWins: mmr.zWins + (selectedRace === 'z' ? winCount : 0),
+            zLosses: mmr.zLosses + (selectedRace === 'z' ? lossCount : 0),
+            rWins: mmr.rWins + (selectedRace === 'r' ? winCount : 0),
+            rLosses: mmr.rLosses + (selectedRace === 'r' ? lossCount : 0),
+
+            rPWins: mmr.rPWins + (selectedRace === 'r' && assignedRace === 'p' ? winCount : 0),
+            rPLosses: mmr.rPLosses + (selectedRace === 'r' && assignedRace === 'p' ? lossCount : 0),
+            rTWins: mmr.rTWins + (selectedRace === 'r' && assignedRace === 't' ? winCount : 0),
+            rTLosses: mmr.rTLosses + (selectedRace === 'r' && assignedRace === 't' ? lossCount : 0),
+            rZWins: mmr.rZWins + (selectedRace === 'r' && assignedRace === 'z' ? winCount : 0),
+            rZLosses: mmr.rZLosses + (selectedRace === 'r' && assignedRace === 'z' ? lossCount : 0),
+          }
+
+          await updateMatchmakingRating(client, updatedMmr)
+          matchmakingRankingChanges.push(updatedMmr)
+        }
+
+        for (const leagueChange of leagueChanges) {
+          const oldLeagueUser = activeLeagues
+            .get(leagueChange.userId)!
+            .find(l => l.leagueId === leagueChange.leagueId)!
+
+          if (oldLeagueUser.isBanned) {
+            // Don't process league changes for banned users
+            continue
+          }
+
+          await insertLeagueUserChange(leagueChange, client)
+
+          const winCount = leagueChange.outcome === 'win' ? 1 : 0
+          const lossCount = leagueChange.outcome === 'win' ? 0 : 1
+
+          const updatedLeagueUser: LeagueUser = {
+            leagueId: oldLeagueUser.leagueId,
+            userId: oldLeagueUser.userId,
+            isBanned: oldLeagueUser.isBanned,
+            lastPlayedDate: reconcileDate,
+            points: leagueChange.points,
+            pointsConverged: leagueChange.pointsConverged,
+            wins: oldLeagueUser.wins + winCount,
+            losses: oldLeagueUser.losses + lossCount,
+
+            pWins: oldLeagueUser.pWins + (selectedRace === 'p' ? winCount : 0),
+            pLosses: oldLeagueUser.pLosses + (selectedRace === 'p' ? lossCount : 0),
+            tWins: oldLeagueUser.tWins + (selectedRace === 't' ? winCount : 0),
+            tLosses: oldLeagueUser.tLosses + (selectedRace === 't' ? lossCount : 0),
+            zWins: oldLeagueUser.zWins + (selectedRace === 'z' ? winCount : 0),
+            zLosses: oldLeagueUser.zLosses + (selectedRace === 'z' ? lossCount : 0),
+            rWins: oldLeagueUser.rWins + (selectedRace === 'r' ? winCount : 0),
+            rLosses: oldLeagueUser.rLosses + (selectedRace === 'r' ? lossCount : 0),
+
+            rPWins:
+              oldLeagueUser.rPWins + (selectedRace === 'r' && assignedRace === 'p' ? winCount : 0),
+            rPLosses:
+              oldLeagueUser.rPLosses +
+              (selectedRace === 'r' && assignedRace === 'p' ? lossCount : 0),
+            rTWins:
+              oldLeagueUser.rTWins + (selectedRace === 'r' && assignedRace === 't' ? winCount : 0),
+            rTLosses:
+              oldLeagueUser.rTLosses +
+              (selectedRace === 'r' && assignedRace === 't' ? lossCount : 0),
+            rZWins:
+              oldLeagueUser.rZWins + (selectedRace === 'r' && assignedRace === 'z' ? winCount : 0),
+            rZLosses:
+              oldLeagueUser.rZLosses +
+              (selectedRace === 'r' && assignedRace === 'z' ? lossCount : 0),
+          }
+
+          await updateLeagueUser(updatedLeagueUser, client)
+          leagueLeaderboardChanges.push(updatedLeagueUser)
+        }
+      }
+    }
+    for (const [userId, result] of resultEntries) {
+      await setUserReconciledResult(client, userId, gameId, result)
+    }
+
+    // TODO(tec27): Perhaps we should auto-trigger a dispute request in particular cases, such
+    // as when a user has an unknown result?
+
+    if (gameRecord.config.gameType !== GameType.UseMapSettings && !reconciled.disputed) {
+      for (const [userId, result] of reconciled.results.entries()) {
+        if (result.result !== 'win' && result.result !== 'loss') {
+          continue
+        }
+
+        const selectedRace = idToSelectedRace.get(userId)!
+        const assignedRace = result.race
+        const countKeys = makeCountKeys(selectedRace, assignedRace, result.result)
+
+        for (const key of countKeys) {
+          await incrementUserStatsCount(client, userId, key)
+        }
+      }
+    }
+
+    if (matchmakingRankingChanges.length) {
+      // NOTE(tec27): This is a best-effort thing, as these leaderboards are basically just a
+      // cache and can be regenerated from the data at any time. We don't want to update them
+      // unless the DB queries succeed, but the DB queries succeeding and this failing is "okay"
+      // as far as accepting the game results
+      updateRankings(this.redis, matchmakingRankingChanges).catch(err => {
+        logger.error({ err }, 'Error updating rankings, triggering full update')
+        // TODO(tec27): Should probably debounce this update in some way in case we get a ton of
+        // errors in a row for some reason
+        doFullRankingsUpdate(
+          this.redis,
+          matchmakingRankingChanges[0].matchmakingType,
+          season.id,
+        ).catch(err => {
+          logger.error({ err }, 'Error doing full rankings update')
+        })
+      })
+    }
+    if (leagueLeaderboardChanges.length) {
+      // NOTE(tec27): This is a best-effort thing, as these leaderboards are basically just a
+      // cache and can be regenerated from the data at any time. We don't want to update them
+      // unless the DB queries succeed, but the DB queries succeeding and this failing is "okay"
+      // as far as accepting the game results
+      updateLeaderboards(this.redis, leagueLeaderboardChanges).catch(err => {
+        logger.error({ err }, 'Error updating league leaderboards')
+        // TODO(tec27): If this fails, the leaderboards should be queued for regeneration at some
+        // point in the (near) future
+      })
+    }
+
+    return { ratingsApplied: matchmakingRankingChanges.length > 0 }
+  }
+
+  /**
+   * Hand-assigns the outcomes of a game whose automatic reconciliation ended in a dispute, and
+   * applies the side effects that dispute skipped: the win/loss stat counters, plus the matchmaking
+   * rating, points and league changes for a ranked game. A disputed game never had any of those
+   * applied, so this only ever adds effects, never reverses them.
+   *
+   * Only the outcomes change. Each player's stored race and APM, the game's length, and its
+   * assigned matchup are all left exactly as reconciliation left them.
+   *
+   * @returns the updated game record, and whether matchmaking rating changes were actually applied
+   *   (see `applyReconciledResultEffects`)
+   */
+  async resolveGameManually({
+    gameId,
+    results,
+    resolvedBy,
+  }: {
+    gameId: string
+    results: ReadonlyArray<{ userId: SbUserId; result: ManualGameResult }>
+    resolvedBy: SbUserId
+  }): Promise<{ game: GameRecord; ratingsApplied: boolean }> {
+    const gameRecord = await getGameRecord(gameId)
+    if (!gameRecord) {
+      throw new GameResultServiceError(GameResultErrorCode.NotFound, 'no matching game found')
+    }
+
+    const resolvedAt = new Date(this.clock.now())
+    const { ratingsApplied } = await transact(async client => {
+      // Everything this decides on has to be read under the games row lock: two admins can submit a
+      // resolution for the same game at once, and the second one must see the first's committed
+      // state (no longer disputable) rather than re-applying the additive side effects.
+      const locked = await lockGameForManualResolution(client, gameId)
+      if (!locked || !locked.disputable || !locked.results) {
+        throw new GameResultServiceError(
+          GameResultErrorCode.NotDisputable,
+          'game is not awaiting manual resolution',
+        )
+      }
+
+      const storedResults = new Map(locked.results)
+      const submitted = new Map(results.map(r => [r.userId, r.result]))
+      if (
+        submitted.size !== results.length ||
+        submitted.size !== storedResults.size ||
+        Array.from(submitted.keys()).some(id => !storedResults.has(id))
+      ) {
+        throw new GameResultServiceError(
+          GameResultErrorCode.InvalidPlayers,
+          "submitted results must cover exactly the game's players, once each",
+        )
+      }
+      for (const { result } of results) {
+        if (!ALL_MANUAL_GAME_RESULTS.includes(result)) {
+          throw new GameResultServiceError(
+            GameResultErrorCode.InvalidResults,
+            `'${result}' is not an outcome a game can be resolved to`,
+          )
+        }
+      }
+
+      if (gameRecord.config.gameSource === GameSource.Matchmaking) {
+        validateMatchmakingResolution(gameRecord.config, submitted)
+      }
+
+      const newResults = new Map<SbUserId, ReconciledPlayerResult>(
+        Array.from(storedResults, ([userId, stored]) => [
+          userId,
+          { ...stored, result: submitted.get(userId)! },
+        ]),
+      )
+      const reconciled: ReconciledResults = {
+        disputed: false,
+        // The game's length isn't in dispute and isn't rewritten, so the reconciled results carry
+        // the length already on record.
+        time: gameRecord.gameLength ?? 0,
+        results: newResults,
+      }
+
+      await setManuallyResolvedResult(client, gameId, newResults, resolvedBy, resolvedAt)
+
+      const { ratingsApplied } = await this.applyReconciledResultEffects(
+        client,
+        gameRecord,
+        reconciled,
+        resolvedAt,
+      )
+
+      return { ratingsApplied }
+    })
+
+    // Subscribers see the resolved game (and any points that moved with it). The client only opens
+    // a post-match dialog for the viewing user's own most recent game, where showing the newly
+    // applied points is the point. The resolution is already committed, so a publish failure is
+    // logged rather than failing the request.
+    try {
+      await this.publishReconciledGame(gameId)
+    } catch (err) {
+      logger.error({ err }, `failed to publish manually resolved game ${gameId}`)
+    }
+
+    return { game: await this.retrieveGame(gameId), ratingsApplied }
   }
 
   /**

--- a/server/lib/replays/replay-access.test.ts
+++ b/server/lib/replays/replay-access.test.ts
@@ -25,6 +25,7 @@ function makeGameRecord(config: GameConfig): GameRecord {
     results: null,
     selectedMatchup: null,
     assignedMatchup: null,
+    manuallyResolved: false,
   }
 }
 


### PR DESCRIPTION
Admins with `manageGameReports` can hand-assign win/loss/draw outcomes for a game whose automatic reconciliation ended in a dispute, via `POST /games/:gameId/manual-resolution`. Resolving applies the side effects the disputed reconciliation skipped — win/loss stat counters and, for matchmaking games, rating/points/league changes — through the same machinery as normal reconciliation, now extracted into `applyReconciledResultEffects`. The `games` row records who resolved it and when, and game records expose a public `manuallyResolved` flag.

The admin UI for this is in a follow-up PR stacked on this one.