### PR TITLE
Add win/loss and relative time to game/replay list rows

### DIFF
--- a/client/games/game-list-entry.tsx
+++ b/client/games/game-list-entry.tsx
@@ -5,7 +5,7 @@ import { ReadonlyDeep } from 'type-fest'
 import { GameRecordJson, getGameDurationString, getGameTypeLabel } from '../../common/games/games'
 import { getResultLabel, ReconciledResult } from '../../common/games/results'
 import { SbUserId } from '../../common/users/sb-user-id'
-import { longTimestamp, shortRelativeTime } from '../i18n/date-formats'
+import { longTimestamp, narrowDuration } from '../i18n/date-formats'
 import { ButtonStateStyleProps, useButtonState } from '../material/button'
 import { Ripple } from '../material/ripple'
 import { Tooltip } from '../material/tooltip'
@@ -252,7 +252,7 @@ export interface GameRelativeTimeProps {
 }
 
 /**
- * A game/replay row's relative-time cell content: a short label (e.g. "23 hr. ago") that refreshes
+ * A game/replay row's relative-time cell content: a narrow label (e.g. "18h ago") that refreshes
  * as real time crosses each minute boundary, backed by the shared minute clock rather than a timer
  * of its own. Hovering reveals the absolute date and time.
  */
@@ -265,7 +265,7 @@ export function GameRelativeTime({ timestampMs, className }: GameRelativeTimePro
   const label =
     currentMinuteMs - timestampMs < 60_000
       ? t('game.time.justNow', 'Just now')
-      : shortRelativeTime.format(timestampMs, currentMinuteMs)
+      : narrowDuration.format(timestampMs, currentMinuteMs)
 
   return (
     <Tooltip text={longTimestamp.format(timestampMs)} className={className}>

--- a/client/games/game-list-entry.tsx
+++ b/client/games/game-list-entry.tsx
@@ -5,11 +5,24 @@ import { ReadonlyDeep } from 'type-fest'
 import { GameRecordJson, getGameDurationString, getGameTypeLabel } from '../../common/games/games'
 import { getResultLabel, ReconciledResult } from '../../common/games/results'
 import { SbUserId } from '../../common/users/sb-user-id'
+import { longTimestamp, shortRelativeTime } from '../i18n/date-formats'
 import { ButtonStateStyleProps, useButtonState } from '../material/button'
 import { Ripple } from '../material/ripple'
+import { Tooltip } from '../material/tooltip'
+import { useCurrentMinuteMs } from '../react/date-hooks'
 import { useAppSelector } from '../redux-hooks'
 import { bodyMedium, singleLine, titleMedium, titleSmall } from '../styles/typography'
-import { GamePlayersDisplay } from './game-players-display'
+import { GamePlayersDisplay, getOrderedTeams, useGamePlayerNames } from './game-players-display'
+
+// The row's cells respond to the `game-list-rows` container established around the scrolling list
+// in `GameListView` and the replay library (its inline size tracks the actual row width, unlike
+// the page width, which also has to fit the side detail panel). Thresholds come from the cells'
+// widths (players' 328px basis, duration's fixed 96px, map's 196px, this file's own 100px time
+// column, the 96px leading cell when present, gaps, and row padding).
+/** Row width below which the relative-time cell is dropped first. */
+const HIDE_RELATIVE_TIME_BELOW_PX = 880
+/** Row width below which the map + game type cell is also dropped, to stop clipping. */
+const HIDE_MAP_AND_GAME_TYPE_BELOW_PX = 640
 
 const GameListEntryRoot = styled.div<{ $hasLeadingAction?: boolean }>`
   width: 100%;
@@ -75,6 +88,24 @@ const PlayersCell = styled(BaseCell)`
   }
 `
 
+const RelativeTimeCell = styled(BaseCell)`
+  ${bodyMedium};
+  ${singleLine};
+  width: 100px;
+  flex-shrink: 0;
+
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  text-align: right;
+
+  color: var(--theme-on-surface-variant);
+
+  @container game-list-rows (width < ${HIDE_RELATIVE_TIME_BELOW_PX}px) {
+    display: none;
+  }
+`
+
 const GameLengthCell = styled(BaseCell)`
   ${titleMedium};
   font-variant-numeric: tabular-nums;
@@ -97,6 +128,10 @@ const MapAndGameTypeCell = styled(BaseCell)`
   align-items: center;
   justify-content: flex-end;
   gap: 8px;
+
+  @container game-list-rows (width < ${HIDE_MAP_AND_GAME_TYPE_BELOW_PX}px) {
+    display: none;
+  }
 `
 
 const GameListEntryResult = styled.div<{ $result: ReconciledResult }>`
@@ -153,6 +188,12 @@ export interface GameListEntryLayoutProps {
   leading?: React.ReactNode
   /** Content of the players cell (a players/teams display). */
   players: React.ReactNode
+  /**
+   * Content of the relative-time cell (e.g. a `GameRelativeTime`), shown between the players and
+   * duration cells. Pass an empty node rather than omitting it to keep the column's width reserved
+   * for a row with nothing to show (e.g. an unparseable replay).
+   */
+  relativeTime?: React.ReactNode
   /** Preformatted game duration text (e.g. `12:34`, or `—` when unknown). */
   duration: string
   /** Map name text (already color-code-stripped). */
@@ -173,6 +214,7 @@ export function GameListEntryLayout({
   bookmark,
   leading,
   players,
+  relativeTime,
   duration,
   mapName,
   gameTypeLabel,
@@ -187,6 +229,8 @@ export function GameListEntryLayout({
 
       <PlayersCell>{players}</PlayersCell>
 
+      {relativeTime !== undefined ? <RelativeTimeCell>{relativeTime}</RelativeTimeCell> : null}
+
       <GameLengthCell>{duration}</GameLengthCell>
 
       <MapAndGameTypeCell>
@@ -198,6 +242,35 @@ export function GameListEntryLayout({
 
       {children}
     </GameListEntryRoot>
+  )
+}
+
+export interface GameRelativeTimeProps {
+  /** Unix ms when the game/replay started. */
+  timestampMs: number
+  className?: string
+}
+
+/**
+ * A game/replay row's relative-time cell content: a short label (e.g. "23 hr. ago") that refreshes
+ * as real time crosses each minute boundary, backed by the shared minute clock rather than a timer
+ * of its own. Hovering reveals the absolute date and time.
+ */
+export function GameRelativeTime({ timestampMs, className }: GameRelativeTimeProps) {
+  const { t } = useTranslation()
+  const currentMinuteMs = useCurrentMinuteMs()
+
+  // Intl's relative-time units bottom out at seconds, which reads as false precision when the
+  // display itself only ever refreshes once a minute.
+  const label =
+    currentMinuteMs - timestampMs < 60_000
+      ? t('game.time.justNow', 'Just now')
+      : shortRelativeTime.format(timestampMs, currentMinuteMs)
+
+  return (
+    <Tooltip text={longTimestamp.format(timestampMs)} className={className}>
+      {label}
+    </Tooltip>
   )
 }
 
@@ -254,6 +327,7 @@ export function GameListEntry({
 }: GameListEntryProps) {
   const { t } = useTranslation()
   const map = useAppSelector(s => s.maps.byId.get(game.mapId))
+  const nameById = useGamePlayerNames(game)
 
   const [buttonProps, rippleRef] = useButtonState({
     onClick: onClick ? () => onClick(game.id) : undefined,
@@ -262,14 +336,41 @@ export function GameListEntry({
 
   const { results } = game
 
+  // The side the result label refers to: `forUserId`'s side when one was given, otherwise
+  // whichever side `GamePlayersDisplay` lists first for this row — sharing its ordering logic
+  // keeps the label and the rendered player order from ever disagreeing. Outside of topVBottom,
+  // the two displayed columns are an alphabetical split of all players rather than real teams, so
+  // only the single first-listed player can honestly be labeled with one result. Left empty
+  // (rather than computed) when the result isn't even shown.
+  const orderedTeams = showResult
+    ? getOrderedTeams(game.config.teams, game.config.gameType, nameById, forUserId)
+    : []
+  const firstSide =
+    game.config.gameType === 'topVBottom'
+      ? (orderedTeams[0] ?? [])
+      : (orderedTeams[0]?.slice(0, 1) ?? [])
+
   // NOTE(2Pac): No need to memoize this under react-compiler; it re-derives only when its inputs
   // change.
   let result: ReconciledResult = 'unknown'
-  if (results && forUserId) {
-    for (const [userId, r] of results) {
-      if (userId === forUserId) {
-        result = r.result
-        break
+  if (results) {
+    if (forUserId) {
+      for (const [userId, r] of results) {
+        if (userId === forUserId) {
+          result = r.result
+          break
+        }
+      }
+    } else {
+      // Team members' results agree in practice, so the first member with a reported entry is
+      // enough. A no-op loop over an empty `firstSide` when the result isn't shown.
+      for (const player of firstSide) {
+        if (player.isComputer) continue
+        const entry = results.find(([userId]) => userId === player.id)
+        if (entry) {
+          result = entry[1].result
+          break
+        }
       }
     }
   }
@@ -277,14 +378,28 @@ export function GameListEntry({
   const gameType = getGameTypeLabel(game, t)
   const mapName = map?.name ?? t('game.mapName.unknown', 'Unknown map')
 
+  const resultForNames = firstSide
+    .map(player =>
+      player.isComputer
+        ? t('game.playerName.computer', 'Computer')
+        : (nameById.get(player.id) ?? t('game.playerName.unknown', 'Unknown player')),
+    )
+    .join(', ')
+
   const layoutProps: GameListEntryLayoutProps = {
-    leading:
-      showResult && forUserId ? (
+    leading: showResult ? (
+      <Tooltip
+        text={t('games.list.resultTooltip', {
+          defaultValue: 'Result for {{names}}',
+          names: resultForNames,
+        })}>
         <GameListEntryResult $result={spoilerFree ? 'unknown' : result}>
           {spoilerFree ? '—' : getResultLabel(result, t, true)}
         </GameListEntryResult>
-      ) : undefined,
+      </Tooltip>
+    ) : undefined,
     players: <GamePlayersDisplay game={game} forUserId={forUserId} showTeamLabels={false} />,
+    relativeTime: <GameRelativeTime timestampMs={game.startTime} />,
     duration: spoilerFree || !game.gameLength ? '—' : getGameDurationString(game.gameLength),
     mapName,
     gameTypeLabel: gameType,

--- a/client/games/game-list-view.tsx
+++ b/client/games/game-list-view.tsx
@@ -54,6 +54,13 @@ const BodyRow = styled.div`
 const ListColumn = styled.div`
   flex-grow: 1;
   min-width: 0;
+
+  /*
+    Named container so row cells (see game-list-entry.tsx) can adapt to the actual width rows get —
+    which depends on the window size *and* whether the side detail panel is showing — rather than
+    the viewport or the whole BodyRow (which also includes the panel's width).
+  */
+  container: game-list-rows / inline-size;
 `
 
 const SELECTION_MEMORY_MAX_AGE_MS = 30 * 60 * 1000
@@ -95,7 +102,10 @@ export interface GameListViewProps {
   showRankedCustom?: boolean
   /** Shows the game source (All/Ranked/Custom) filter chip and reads its URL param (games page only). */
   showSourceFilter?: boolean
-  /** Shows each row's win/loss result, from `forUserId`'s perspective (match history only). */
+  /**
+   * Shows each row's win/loss result. From `forUserId`'s perspective when given (match history);
+   * otherwise from whichever side of the matchup is listed first (games page, league games).
+   */
   showResult?: boolean
   /** Whose perspective results and the side panel roster are shown from (match history only). */
   forUserId?: SbUserId

--- a/client/games/game-list.tsx
+++ b/client/games/game-list.tsx
@@ -115,6 +115,7 @@ export function GameList() {
         <GameListView
           loadPage={loadPage}
           showSourceFilter={true}
+          showResult={true}
           noResultsText={t('games.list.noMatchingGames', 'No matching games.')}
           errorText={t('games.list.retrievingError', 'There was an error retrieving the games.')}
         />

--- a/client/games/game-players-display.tsx
+++ b/client/games/game-players-display.tsx
@@ -3,6 +3,7 @@ import { useCallback, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { ReadonlyDeep } from 'type-fest'
 import { GameConfigPlayer } from '../../common/games/configuration'
+import { GameType } from '../../common/games/game-type'
 import { GameRecordJson } from '../../common/games/games'
 import { ReconciledPlayerResult } from '../../common/games/results'
 import { SbUser } from '../../common/users/sb-user'
@@ -41,6 +42,110 @@ function areUsersEqual(a: ReadonlyArray<SbUser>, b: ReadonlyArray<SbUser>): bool
   return true
 }
 
+/**
+ * Resolves the display names (from the users store) of every human player in a game, keyed by
+ * their user ID. Computer players are never present in the result.
+ */
+export function useGamePlayerNames(
+  game: ReadonlyDeep<GameRecordJson>,
+): ReadonlyMap<SbUserId, string> {
+  const players = useAppSelector(usePlayersSelector(game), areUsersEqual)
+  return new Map(players.map(p => [p.id, p.name]))
+}
+
+// TODO(2Pac): Handle game types which can have more than two teams
+/**
+ * Orders a game's teams the same way they're shown in `GamePlayersDisplay`, so a row's rendered
+ * player order and anything derived from "the first-listed side" (e.g. a result label) can never
+ * diverge.
+ *
+ * For `topVBottom`, the two teams are ordered with `forUserId`'s team first (falling back to
+ * alphabetical by first player name when absent or when there's no `forUserId`), then each team's
+ * own members are sorted alphabetically. Otherwise, every player is flattened into one alphabetical
+ * ordering (`forUserId` first) and split into two roughly-even sides by alternating players into
+ * them — the "first side" here is the even-indexed half of that single sorted list, not a real team.
+ *
+ * Players with no resolved name (absent from `nameById`, e.g. computer players) sort last within
+ * whatever grouping they fall into.
+ */
+export function getOrderedTeams(
+  teams: ReadonlyArray<ReadonlyArray<GameConfigPlayer>>,
+  gameType: GameType,
+  nameById: ReadonlyMap<SbUserId, string>,
+  forUserId?: SbUserId,
+): ReadonlyArray<ReadonlyArray<GameConfigPlayer>> {
+  if (gameType === GameType.TopVsBottom) {
+    // Sort the teams so that the team with the user whose profile this is being displayed on comes
+    // first and keeps the teams in consistent order. This is mostly helpful when there are a lot of
+    // games with the same teams one after another.
+    const sortedTeams = teams.toSorted((a, b) => {
+      if (forUserId) {
+        if (a.some(p => p.id === forUserId)) {
+          return -1
+        } else if (b.some(p => p.id === forUserId)) {
+          return 1
+        }
+      }
+
+      // When no forUserId (e.g. public games page), sort teams by first player name for consistency
+      const aFirstName = a[0] ? (nameById.get(a[0].id) ?? '') : ''
+      const bFirstName = b[0] ? (nameById.get(b[0].id) ?? '') : ''
+      return aFirstName.localeCompare(bFirstName)
+    })
+    const [teamTop, teamBottom] = sortedTeams
+
+    const sortTeam = (team: ReadonlyArray<GameConfigPlayer>) =>
+      team.toSorted((a, b) => {
+        const aName = nameById.get(a.id)
+        const bName = nameById.get(b.id)
+
+        if (!aName) {
+          return 1
+        } else if (!bName) {
+          return -1
+        }
+
+        return aName.localeCompare(bName)
+      })
+
+    return [sortTeam(teamTop), sortTeam(teamBottom)]
+  }
+
+  const sortedPlayers = teams.flat().toSorted((a, b) => {
+    // Sort the players so that the player whose profile this is being displayed on comes first
+    // and all the rest are alphabetically sorted.
+    if (a.id === forUserId) {
+      return -1
+    } else if (b.id === forUserId) {
+      return 1
+    }
+
+    const aName = nameById.get(a.id)
+    const bName = nameById.get(b.id)
+
+    if (!aName) {
+      return 1
+    } else if (!bName) {
+      return -1
+    }
+
+    return aName.localeCompare(bName)
+  })
+
+  const firstTeam: GameConfigPlayer[] = []
+  const secondTeam: GameConfigPlayer[] = []
+
+  for (const player of sortedPlayers) {
+    if (firstTeam.length === secondTeam.length) {
+      firstTeam.push(player)
+    } else {
+      secondTeam.push(player)
+    }
+  }
+
+  return [firstTeam, secondTeam]
+}
+
 export function GamePlayersDisplay({
   game,
   forUserId,
@@ -62,10 +167,7 @@ export function GamePlayersDisplay({
   const { t } = useTranslation()
 
   const players = useAppSelector(usePlayersSelector(game), areUsersEqual)
-  const playersMapping = useMemo(
-    () => new Map<SbUserId, SbUser>(players.map(p => [p.id, p])),
-    [players],
-  )
+  const nameById = new Map<SbUserId, string>(players.map(p => [p.id, p.name]))
 
   const results = game?.results
   const resultsById = useMemo(() => {
@@ -83,96 +185,19 @@ export function GamePlayersDisplay({
       isRandom: player.race === 'r',
       name: player.isComputer
         ? t('game.playerName.computer', 'Computer')
-        : (playersMapping.get(player.id)?.name ?? t('game.playerName.unknown', 'Unknown player')),
+        : (nameById.get(player.id) ?? t('game.playerName.unknown', 'Unknown player')),
       userId: interactiveNames && !player.isComputer ? player.id : undefined,
     }
   }
 
-  // TODO(2Pac): Handle game types which can have more than two teams
-  let teams: ReadonlyArray<ReadonlyArray<PlayerTeamsDisplayPlayer>>
-  let teamLabels: ReadonlyArray<string> | undefined
+  const orderedTeams = getOrderedTeams(game.config.teams, game.config.gameType, nameById, forUserId)
+  const teams = orderedTeams.map(team => team.map(toDisplayPlayer))
 
-  if (game.config.gameType === 'topVBottom') {
-    // Sort the teams so that the team with the user whose profile this is being displayed on comes
-    // first and keeps the teams in consistent order. This is mostly helpful when there are a lot of
-    // games with the same teams one after another.
-    const sortedTeams = game.config.teams.toSorted((a, b) => {
-      if (forUserId) {
-        if (a.some(p => p.id === forUserId)) {
-          return -1
-        } else if (b.some(p => p.id === forUserId)) {
-          return 1
-        }
-      }
-
-      // When no forUserId (e.g. public games page), sort teams by first player name for consistency
-      const aFirstName = a[0] ? (playersMapping.get(a[0].id)?.name ?? '') : ''
-      const bFirstName = b[0] ? (playersMapping.get(b[0].id)?.name ?? '') : ''
-      return aFirstName.localeCompare(bFirstName)
-    })
-    const [teamTop, teamBottom] = sortedTeams
-
-    const mapTeam = (team: ReadonlyArray<GameConfigPlayer>) => {
-      return team
-        .toSorted((a, b) => {
-          const aName = playersMapping.get(a.id)?.name
-          const bName = playersMapping.get(b.id)?.name
-
-          if (!aName) {
-            return 1
-          } else if (!bName) {
-            return -1
-          }
-
-          return aName.localeCompare(bName)
-        })
-        .map(toDisplayPlayer)
-    }
-
-    teams = [mapTeam(teamTop), mapTeam(teamBottom)]
-
-    if (showTeamLabels) {
-      teamLabels = [t('game.teamName.top', 'Top'), t('game.teamName.bottom', 'Bottom')]
-    }
-  } else {
-    // TODO(tec27): Handle UMS game types with 2 teams? Always add team labels for 1v1?
-
-    const sortedPlayers = game.config.teams.flat().toSorted((a, b) => {
-      // Sort the players so that the player whose profile this is being displayed on comes first
-      // and all the rest are alphabetically sorted.
-      if (a.id === forUserId) {
-        return -1
-      } else if (b.id === forUserId) {
-        return 1
-      }
-
-      const aName = playersMapping.get(a.id)?.name
-      const bName = playersMapping.get(b.id)?.name
-
-      if (!aName) {
-        return 1
-      } else if (!bName) {
-        return -1
-      }
-
-      return aName.localeCompare(bName)
-    })
-
-    const firstTeam: PlayerTeamsDisplayPlayer[] = []
-    const secondTeam: PlayerTeamsDisplayPlayer[] = []
-
-    for (const player of sortedPlayers) {
-      const displayPlayer = toDisplayPlayer(player)
-
-      if (firstTeam.length === secondTeam.length) {
-        firstTeam.push(displayPlayer)
-      } else {
-        secondTeam.push(displayPlayer)
-      }
-    }
-
-    teams = [firstTeam, secondTeam]
-  }
+  // TODO(tec27): Handle UMS game types with 2 teams? Always add team labels for 1v1?
+  const teamLabels: ReadonlyArray<string> | undefined =
+    game.config.gameType === GameType.TopVsBottom && showTeamLabels
+      ? [t('game.teamName.top', 'Top'), t('game.teamName.bottom', 'Bottom')]
+      : undefined
 
   return <PlayerTeamsDisplay teams={teams} teamLabels={teamLabels} className={className} />
 }

--- a/client/i18n/date-formats.tsx
+++ b/client/i18n/date-formats.tsx
@@ -49,16 +49,6 @@ export const narrowDuration = new RelativeTimeFormatter(navigator.language, {
   numeric: 'always',
 })
 
-/**
- * A formatter for timestamps that show a relative time since something occurred using
- * spelled-out (but abbreviated) units, e.g. "5 min. ago", "23 hr. ago". Wider than
- * `narrowDuration`'s output, but more readable at a glance.
- */
-export const shortRelativeTime = new RelativeTimeFormatter(navigator.language, {
-  style: 'short',
-  numeric: 'always',
-})
-
 export interface NarrowDurationProps {
   to: Date | number
   from?: Date | number

--- a/client/i18n/date-formats.tsx
+++ b/client/i18n/date-formats.tsx
@@ -49,6 +49,16 @@ export const narrowDuration = new RelativeTimeFormatter(navigator.language, {
   numeric: 'always',
 })
 
+/**
+ * A formatter for timestamps that show a relative time since something occurred using
+ * spelled-out (but abbreviated) units, e.g. "5 min. ago", "23 hr. ago". Wider than
+ * `narrowDuration`'s output, but more readable at a glance.
+ */
+export const shortRelativeTime = new RelativeTimeFormatter(navigator.language, {
+  style: 'short',
+  numeric: 'always',
+})
+
 export interface NarrowDurationProps {
   to: Date | number
   from?: Date | number

--- a/client/leagues/league-games.tsx
+++ b/client/leagues/league-games.tsx
@@ -50,6 +50,7 @@ export function LeagueGames({ leagueId }: { leagueId: LeagueId }) {
     <LeagueGamesContainer>
       <GameListView
         loadPage={loadPage}
+        showResult={true}
         noResultsText={t('leagues.leagueGames.noMatchingGames', 'No matching games.')}
         errorText={t(
           'leagues.leagueGames.retrievingError',

--- a/client/react/date-hooks.ts
+++ b/client/react/date-hooks.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useSyncExternalStore } from 'react'
 
 /**
  * Returns `Date.now()`, updated every `updateIntervalMs` milliseconds. Defaults to updating every
@@ -18,4 +18,59 @@ export function useNow(updateIntervalMs = 1000) {
   }, [updateIntervalMs])
 
   return now
+}
+
+const MINUTE_MS = 60 * 1000
+// Frequent enough that the shared minute value can't drift more than this far past an actual
+// minute boundary, without running a timer per subscriber.
+const MINUTE_CLOCK_POLL_MS = 15 * 1000
+
+function roundDownToMinute(ms: number): number {
+  return ms - (ms % MINUTE_MS)
+}
+
+let currentMinuteMs = roundDownToMinute(Date.now())
+let intervalId: ReturnType<typeof setInterval> | undefined
+const minuteClockListeners = new Set<() => void>()
+
+function tickMinuteClock() {
+  const nextMinuteMs = roundDownToMinute(Date.now())
+  if (nextMinuteMs !== currentMinuteMs) {
+    currentMinuteMs = nextMinuteMs
+    for (const listener of minuteClockListeners) {
+      listener()
+    }
+  }
+}
+
+function subscribeToMinuteClock(listener: () => void): () => void {
+  minuteClockListeners.add(listener)
+  if (intervalId === undefined) {
+    // The stored minute can be arbitrarily stale from a period with no subscribers (and thus no
+    // running timer), so sync it before the first snapshot read instead of waiting out a poll.
+    tickMinuteClock()
+    intervalId = setInterval(tickMinuteClock, MINUTE_CLOCK_POLL_MS)
+  }
+
+  return () => {
+    minuteClockListeners.delete(listener)
+    if (minuteClockListeners.size === 0 && intervalId !== undefined) {
+      clearInterval(intervalId)
+      intervalId = undefined
+    }
+  }
+}
+
+function getMinuteClockSnapshot(): number {
+  return currentMinuteMs
+}
+
+/**
+ * Returns the current time rounded down to the start of the minute (unix ms), updated as real
+ * time crosses each minute boundary. Backed by a single interval shared across every subscriber
+ * (started lazily on the first one, stopped once the last unsubscribes) rather than a timer per
+ * caller, so a long list of rows showing relative times can all refresh together cheaply.
+ */
+export function useCurrentMinuteMs(): number {
+  return useSyncExternalStore(subscribeToMinuteClock, getMinuteClockSnapshot)
 }

--- a/client/replays/replay-library.tsx
+++ b/client/replays/replay-library.tsx
@@ -36,7 +36,11 @@ import {
 } from '../games/day-header'
 import { GameFilterBar } from '../games/game-filter-bar'
 import { parseMatchup } from '../games/game-filter-url'
-import { GameListEntryLayout, SelectableRowContainer } from '../games/game-list-entry'
+import {
+  GameListEntryLayout,
+  GameRelativeTime,
+  SelectableRowContainer,
+} from '../games/game-list-entry'
 import { PlayerTeamsDisplay } from '../games/player-teams-display'
 import { MaterialIcon } from '../icons/material/material-icon'
 import { useKeyListener } from '../keyboard/key-listener'
@@ -215,6 +219,13 @@ const BodyRow = styled.div`
 const ListColumn = styled.div`
   flex-grow: 1;
   min-width: 0;
+
+  /*
+    Named container so row cells (see game-list-entry.tsx) can adapt to the actual width rows get,
+    which is narrower than the replay-library-body container above once the rail's own width is
+    subtracted — rather than reacting to a width that still includes the rail.
+  */
+  container: game-list-rows / inline-size;
 `
 
 // ---- Empty / loading states ------------------------------------------------------------------
@@ -376,6 +387,11 @@ function ReplayListEntry({
       <GameListEntryLayout
         bookmark={bookmark}
         players={players}
+        relativeTime={
+          // A parse-error row's `gameTime` isn't a real timestamp (see `ReplayLibraryEntry`), so
+          // there's nothing meaningful to show — but the empty node still reserves the column.
+          entry.parseError ? <></> : <GameRelativeTime timestampMs={entry.gameTime} />
+        }
         duration={
           entry.parseError || spoilerFree
             ? '—'

--- a/server/public/locales/en/global.json
+++ b/server/public/locales/en/global.json
@@ -623,6 +623,9 @@
       "bottom": "Bottom",
       "number": "Team {{teamNumber}}",
       "top": "Top"
+    },
+    "time": {
+      "justNow": "Just now"
     }
   },
   "gameDetails": {
@@ -765,6 +768,7 @@
     },
     "list": {
       "noMatchingGames": "No matching games.",
+      "resultTooltip": "Result for {{names}}",
       "retrievingError": "There was an error retrieving the games."
     },
     "liveGames": {

--- a/server/public/locales/es/global.json
+++ b/server/public/locales/es/global.json
@@ -626,6 +626,9 @@
       "bottom": "Abajo",
       "number": "Equipo {{teamNumber}}",
       "top": "Arriba"
+    },
+    "time": {
+      "justNow": "Ahora mismo"
     }
   },
   "gameDetails": {
@@ -755,6 +758,7 @@
     },
     "list": {
       "noMatchingGames": "No hay partidas que coincidan.",
+      "resultTooltip": "Resultado de {{names}}",
       "retrievingError": "Hubo un error al obtener las partidas."
     },
     "liveGames": {

--- a/server/public/locales/ko/global.json
+++ b/server/public/locales/ko/global.json
@@ -620,6 +620,9 @@
       "bottom": "원정팀",
       "number": "{{teamNumber}} 팀",
       "top": "홈팀"
+    },
+    "time": {
+      "justNow": "방금 전"
     }
   },
   "gameDetails": {
@@ -749,6 +752,7 @@
     },
     "list": {
       "noMatchingGames": "일치하는 게임이 없습니다.",
+      "resultTooltip": "{{names}}의 결과",
       "retrievingError": "게임을 불러오는 중 오류가 발생했습니다."
     },
     "liveGames": {

--- a/server/public/locales/ru/global.json
+++ b/server/public/locales/ru/global.json
@@ -629,6 +629,9 @@
       "bottom": "Низ",
       "number": "Команда {{teamNumber}}",
       "top": "Верх"
+    },
+    "time": {
+      "justNow": "Только что"
     }
   },
   "gameDetails": {
@@ -758,6 +761,7 @@
     },
     "list": {
       "noMatchingGames": "Нет подходящих игр.",
+      "resultTooltip": "Результат: {{names}}",
       "retrievingError": "Произошла ошибка при получении игр."
     },
     "liveGames": {

--- a/server/public/locales/zh-Hans/global.json
+++ b/server/public/locales/zh-Hans/global.json
@@ -620,6 +620,9 @@
       "bottom": "客队",
       "number": "{{teamNumber}}队",
       "top": "主队"
+    },
+    "time": {
+      "justNow": "刚刚"
     }
   },
   "gameDetails": {
@@ -749,6 +752,7 @@
     },
     "list": {
       "noMatchingGames": "没有匹配的游戏。",
+      "resultTooltip": "{{names}}的结果",
       "retrievingError": "获取游戏时出错。"
     },
     "liveGames": {


### PR DESCRIPTION
Part 1 of the games-list improvements discussed with Claude (win/loss + relative time + responsive columns; the sub-2-minute filter and filter persistence follow as separate PRs).

## What's here

**Win/loss on the games page and league games tab.** The leading result cell match history already had now renders on the viewer-less surfaces too, referring to the first-listed player/team in the row — the same convention match history already follows (it sorts the profile user's side first). The ordering logic is extracted from `GamePlayersDisplay` into a shared `getOrderedTeams` helper so the label and the rendered order can never diverge, and the label carries a tooltip ("Result for X") naming whose result it is. For non-topVBottom games the displayed columns are an alphabetical split rather than real teams, so only the single first-listed player is labeled. No icons, no name coloring; spoiler-free blanks it exactly as on match history.

**Relative-time column on all four surfaces** (games page, match history, league tab, replay library), placed between the players and the duration: short style ("23 hr. ago"), "Just now" under a minute, absolute timestamp tooltip. Rows share one lazily-started minute clock (`useCurrentMinuteMs`, `useSyncExternalStore`-based) instead of a timer per row. Visible in spoiler-free mode — when a game was played isn't a spoiler, unlike how long it ran. Parse-error replay rows reserve the column with an empty cell.

**Responsive column collapse via container queries** on the list column (so an open side panel narrows rows the same as a small window): below 880px the time cell drops; below 640px the map + game type cell drops too, which also fixes the clipping very narrow windows could already produce. Thresholds are named constants for easy tuning.

The two new strings are translated for es/ko/ru/zh-Hans (the pre-existing 11-key backlog per language is untouched).

## Verification

- typecheck, lint, and the client vitest suite (288/288) pass.
- Live-verified in the Electron app: games page rows show Win/first-listed convention + "Result for claude-1" tooltip + relative time with absolute-timestamp tooltip; spoiler-free blanks result and duration while the time stays; both container tiers fire at the expected widths (probed by forcing the container width); match history keeps its existing behavior with the time column appearing when its container is wide enough; replay library rows show the time column.