### PR TITLE
Remember games/replays filter preferences across visits

### DIFF
--- a/client/games/game-list-view.tsx
+++ b/client/games/game-list-view.tsx
@@ -32,6 +32,7 @@ import {
 import { GameListEntry } from './game-list-entry'
 import { GameRecordSidePanel } from './game-record-side-panel'
 import { GameListSearchPage, useGameListSearch } from './use-game-list-search'
+import { FilterMemorySurface, useRememberedFilters } from './use-remembered-filters'
 
 const NoResults = styled.div`
   ${bodyLarge};
@@ -100,6 +101,11 @@ export interface GameListViewProps {
     offset: number,
     signal: AbortSignal,
   ) => Promise<GameListSearchPage>
+  /**
+   * Which surface this is, naming the saved set its mode-like filter preferences (sort, duration,
+   * short games, and whichever mode filters it shows) are remembered in across visits.
+   */
+  surface: Exclude<FilterMemorySurface, 'replays'>
   /** Shows the Ranked/Custom source toggles and reads their URL params (match history only). */
   showRankedCustom?: boolean
   /** Shows the game source (All/Ranked/Custom) filter chip and reads its URL param (games page only). */
@@ -122,13 +128,14 @@ export interface GameListViewProps {
  * panel and per-row context menu, backed by `useGameListSearch`. The games page, match history, and
  * a league's games tab are all thin wrappers that supply a `loadPage` and their own outer layout.
  *
- * Owns the filter state (mirrored to URL search params), the list selection, and the keyboard
- * navigation; callers differ only in where they fetch from and a few presentation flags. Renders as
- * a fragment (filter bar, then the list/panel row) so each surface controls its own container and
- * spacing.
+ * Owns the filter state (mirrored to URL search params, with the mode-like ones remembered per
+ * surface across visits), the list selection, and the keyboard navigation; callers differ only in
+ * where they fetch from and a few presentation flags. Renders as a fragment (filter bar, then the
+ * list/panel row) so each surface controls its own container and spacing.
  */
 export function GameListView({
   loadPage,
+  surface,
   showRankedCustom = false,
   showSourceFilter = false,
   showResult = false,
@@ -151,18 +158,37 @@ export function GameListView({
   const [endDateParam, setEndDateParam] = useLocationSearchParam('endDate')
   const [includeShortParam, setIncludeShortParam] = useLocationSearchParam('includeShort')
 
+  // Only the params a surface actually shows are remembered for it, which also keeps a hand-edited
+  // param that surface ignores from counting as "the URL specifies the filters".
+  const rememberedUrlValues: Record<string, string> = {
+    sort: sortParam,
+    duration: durationParam,
+    includeShort: includeShortParam,
+  }
+  if (showSourceFilter) {
+    rememberedUrlValues.source = sourceParam
+  }
+  if (showRankedCustom) {
+    rememberedUrlValues.ranked = rankedParam
+    rememberedUrlValues.custom = customParam
+  }
+  const { values: filterValues, save: saveFilterPrefs } = useRememberedFilters(
+    surface,
+    rememberedUrlValues,
+  )
+
   // Ranked/custom only exist on the match-history surface; elsewhere we neither read nor send them,
   // so a hand-edited `?ranked=true` on another surface can't leak into the request.
-  const ranked = showRankedCustom && rankedParam === 'true'
-  const custom = showRankedCustom && customParam === 'true'
+  const ranked = showRankedCustom && filterValues.ranked === 'true'
+  const custom = showRankedCustom && filterValues.custom === 'true'
   // The source filter only exists on the games page; elsewhere we neither read nor send it, so a
   // hand-edited `?source=custom` on another surface can't leak into the request.
-  const source = showSourceFilter ? parseSource(sourceParam) : GameSourceFilter.All
-  const duration = parseDuration(durationParam)
-  const sort = parseSort(sortParam)
+  const source = showSourceFilter ? parseSource(filterValues.source) : GameSourceFilter.All
+  const duration = parseDuration(filterValues.duration)
+  const sort = parseSort(filterValues.sort)
   const format = parseFormat(formatParam)
   const matchup = parseMatchup(matchupParam, format)
-  const includeShort = includeShortParam === 'true'
+  const includeShort = filterValues.includeShort === 'true'
 
   const entryKey = useHistoryEntryKey()
   // Read once per mount: a lazy initializer runs at most once, so this never re-reads the store on
@@ -295,27 +321,32 @@ export function GameListView({
       ranked={ranked}
       setRanked={v => {
         setRankedParam(v ? 'true' : '')
+        saveFilterPrefs()
         reset()
       }}
       custom={custom}
       setCustom={v => {
         setCustomParam(v ? 'true' : '')
+        saveFilterPrefs()
         reset()
       }}
       showSourceFilter={showSourceFilter}
       source={source}
       setSource={v => {
         setSourceParam(v === GameSourceFilter.All ? '' : v)
+        saveFilterPrefs()
         reset()
       }}
       duration={duration}
       setDuration={v => {
         setDurationParam(v === GameDurationFilter.All ? '' : v)
+        saveFilterPrefs()
         reset()
       }}
       sort={sort}
       setSort={v => {
         setSortParam(v === GameSortOption.LatestFirst ? '' : v)
+        saveFilterPrefs()
         reset()
       }}
       mapName={mapName}
@@ -344,6 +375,7 @@ export function GameListView({
       includeShort={includeShort}
       setIncludeShort={v => {
         setIncludeShortParam(v ? 'true' : '')
+        saveFilterPrefs()
         reset()
       }}
       spoilerFree={spoilerFree}

--- a/client/games/game-list.tsx
+++ b/client/games/game-list.tsx
@@ -114,6 +114,7 @@ export function GameList() {
 
         <GameListView
           loadPage={loadPage}
+          surface='games'
           showSourceFilter={true}
           showResult={true}
           noResultsText={t('games.list.noMatchingGames', 'No matching games.')}

--- a/client/games/use-remembered-filters.test.ts
+++ b/client/games/use-remembered-filters.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'vitest'
 import {
+  mergeSavedFilters,
   readFilterParams,
   urlHasRememberedFilters,
   withFilterParams,
@@ -34,6 +35,37 @@ describe('readFilterParams', () => {
 
   test('an empty search reads as nothing saved', () => {
     expect(readFilterParams('', ['sort', 'duration'])).toEqual({})
+  })
+})
+
+describe('mergeSavedFilters', () => {
+  test('the named params take their current URL values', () => {
+    expect(
+      mergeSavedFilters({ sort: 'oldest', duration: 'under10' }, ['sort', 'duration'], {
+        sort: 'longest',
+        duration: 'over30',
+      }),
+    ).toEqual({ sort: 'longest', duration: 'over30' })
+  })
+
+  test('a named param unset in the URL drops out of the saved set', () => {
+    expect(
+      mergeSavedFilters({ sort: 'oldest', duration: 'under10' }, ['sort', 'duration'], {
+        sort: 'oldest',
+      }),
+    ).toEqual({ sort: 'oldest' })
+  })
+
+  test('saved entries outside the named params survive a save made without them', () => {
+    expect(
+      mergeSavedFilters({ sort: 'oldest', includeShort: 'true' }, ['duration', 'gameType'], {
+        duration: 'under10',
+      }),
+    ).toEqual({ sort: 'oldest', includeShort: 'true', duration: 'under10' })
+  })
+
+  test('nothing left to save reads as unset rather than an empty set', () => {
+    expect(mergeSavedFilters({ sort: 'oldest' }, ['sort'], {})).toBeUndefined()
   })
 })
 

--- a/client/games/use-remembered-filters.test.ts
+++ b/client/games/use-remembered-filters.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from 'vitest'
+import {
+  readFilterParams,
+  urlHasRememberedFilters,
+  withFilterParams,
+} from './use-remembered-filters'
+
+describe('urlHasRememberedFilters', () => {
+  test('a URL carrying none of the surface params seeds from the saved set', () => {
+    expect(urlHasRememberedFilters({ sort: '', duration: '', includeShort: '' })).toBe(false)
+  })
+
+  test('a URL carrying any one of them is authoritative for all of them', () => {
+    expect(urlHasRememberedFilters({ sort: '', duration: 'under10', includeShort: '' })).toBe(true)
+  })
+
+  test('no surface params at all seeds from the saved set', () => {
+    expect(urlHasRememberedFilters({})).toBe(false)
+  })
+})
+
+describe('readFilterParams', () => {
+  test('reads the named params, omitting unset ones', () => {
+    expect(
+      readFilterParams('?sort=oldest&duration=', ['sort', 'duration', 'includeShort']),
+    ).toEqual({ sort: 'oldest' })
+  })
+
+  test('ignores params the surface does not remember', () => {
+    expect(readFilterParams('?sort=oldest&mapName=lost+temple', ['sort', 'duration'])).toEqual({
+      sort: 'oldest',
+    })
+  })
+
+  test('an empty search reads as nothing saved', () => {
+    expect(readFilterParams('', ['sort', 'duration'])).toEqual({})
+  })
+})
+
+describe('withFilterParams', () => {
+  test('writes the seeded values into the search string', () => {
+    const search = withFilterParams('', { duration: 'under10', sort: 'oldest' })
+
+    expect(new URLSearchParams(search).get('duration')).toBe('under10')
+    expect(new URLSearchParams(search).get('sort')).toBe('oldest')
+  })
+
+  test('preserves params the surface does not remember', () => {
+    const search = withFilterParams('?mapName=lost+temple', { duration: 'under10' })
+
+    expect(new URLSearchParams(search).get('mapName')).toBe('lost temple')
+    expect(new URLSearchParams(search).get('duration')).toBe('under10')
+  })
+
+  test('overwrites an existing value rather than appending a second copy', () => {
+    const search = withFilterParams('?duration=over30', { duration: 'under10' })
+
+    expect(new URLSearchParams(search).getAll('duration')).toEqual(['under10'])
+  })
+
+  test('produces a leading ? only when something is left', () => {
+    expect(withFilterParams('', { duration: 'under10' }).startsWith('?')).toBe(true)
+    expect(withFilterParams('', {})).toBe('')
+  })
+})

--- a/client/games/use-remembered-filters.ts
+++ b/client/games/use-remembered-filters.ts
@@ -1,0 +1,170 @@
+import { useLayoutEffect, useState } from 'react'
+import { replace } from '../navigation/routing'
+import { useUserLocalStorageValue } from '../react/state-hooks'
+
+/**
+ * A filter surface that remembers its mode-like preferences (sort, duration bucket, and whichever
+ * mode filters it shows) across visits. Each surface gets its own saved set, stored per user — so
+ * match history's set belongs to the *viewing* user and is shared across every profile they look
+ * at.
+ *
+ * Search-like filters (map/player name, format, matchup, date range) are deliberately never
+ * remembered: silently re-applying a search on a later visit produces a mysteriously empty list.
+ */
+export type FilterMemorySurface = 'games' | 'matchHistory' | 'league' | 'replays'
+
+/**
+ * Raw URL-param values for a surface's remembered filters, keyed by param name. Values are exactly
+ * what the URL carries, so an unset filter is `''` (or absent) and callers apply the same parse
+ * functions they would apply to a raw param.
+ */
+export type FilterParamValues = Readonly<Record<string, string>>
+
+const NO_VALUES: FilterParamValues = Object.freeze({})
+
+/**
+ * Whether the URL carries any of a surface's remembered params. The check is all-or-nothing across
+ * the surface: a URL that pins even one of them is a deliberate destination (a shared link, or a
+ * history entry being traversed back to) and describes the whole filter set on its own.
+ */
+export function urlHasRememberedFilters(urlValues: FilterParamValues): boolean {
+  return Object.values(urlValues).some(value => !!value)
+}
+
+/** Reads the values of `keys` out of a search string, omitting the ones that are unset. */
+export function readFilterParams(
+  search: string,
+  keys: ReadonlyArray<string>,
+): Record<string, string> {
+  const searchParams = new URLSearchParams(search)
+  const result: Record<string, string> = {}
+  for (const key of keys) {
+    const value = searchParams.get(key)
+    if (value) {
+      result[key] = value
+    }
+  }
+  return result
+}
+
+/**
+ * Writes `values` into a search string and returns it in `?a=b` form (empty string when nothing is
+ * left). Params not named in `values` are preserved as they were.
+ */
+export function withFilterParams(search: string, values: FilterParamValues): string {
+  const searchParams = new URLSearchParams(search)
+  for (const [key, value] of Object.entries(values)) {
+    searchParams.set(key, value)
+  }
+  const searchString = searchParams.toString()
+  return searchString ? `?${searchString}` : ''
+}
+
+/** Narrows `values` to `keys`, dropping unset entries and any key the surface doesn't use. */
+function pickNonEmpty(values: FilterParamValues, keys: ReadonlyArray<string>): FilterParamValues {
+  const result: Record<string, string> = {}
+  for (const key of keys) {
+    const value = values[key]
+    if (value) {
+      result[key] = value
+    }
+  }
+  return result
+}
+
+/**
+ * localStorage holds whatever an older version of the app wrote (or a user hand-edited), so
+ * anything that isn't a plain object of non-empty strings is treated as unset. The strings
+ * themselves aren't checked: they're the same raw values a URL can carry, and each surface's parse
+ * functions already fall back to their defaults for garbage.
+ */
+function validateStoredValues(value: unknown): FilterParamValues | undefined {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return undefined
+  }
+
+  const result: Record<string, string> = {}
+  for (const [key, entry] of Object.entries(value)) {
+    if (typeof entry === 'string' && entry) {
+      result[key] = entry
+    }
+  }
+  return result
+}
+
+export interface RememberedFilters {
+  /**
+   * The values to render and fetch with: whatever the URL carries, except on a visit that arrived
+   * without any of this surface's remembered params, where the saved preferences fill in.
+   */
+  values: FilterParamValues
+  /**
+   * Stores this surface's params as they currently stand in the URL. Call it from a filter setter,
+   * after that setter has written its param, so that only explicit user changes are remembered and
+   * the whole set is captured (including a filter just returned to its default, which drops out).
+   */
+  save: () => void
+}
+
+/**
+ * Remembers a filter surface's mode-like preferences across visits and app restarts, per user.
+ *
+ * `urlValues` names the surface's remembered params and supplies their current URL values; the
+ * returned `values` are the ones to actually use. On a visit whose URL carries none of them, the
+ * saved preferences are applied from the very first render — so the first fetch already uses them,
+ * with no fetch-with-defaults-then-refetch — and a single history replace then writes them into the
+ * URL, which keeps the address bar, sharing, and back/forward truthful without changing anything
+ * the list is showing.
+ *
+ * Nothing is saved from URL-derived state: opening someone else's filtered link never overwrites
+ * saved preferences. Saving happens only where a setter calls {@link RememberedFilters.save}, which
+ * keeps the saved set equal to the URL's params from the user's first change onward. That equality
+ * is why `values` reads through to the live saved set for the keys that seeded at mount: once the
+ * user sets the last remembered filter back to its default, both the URL and the saved set are
+ * empty, so nothing is re-applied behind them. Keys that did NOT seed at mount are never overlaid —
+ * the storage is cross-tab reactive, and a preference saved in another tab must not refilter a list
+ * sitting on a bare URL here (the loaded pages wouldn't be refetched, so old-filter and new-filter
+ * pages would mix).
+ */
+export function useRememberedFilters(
+  surface: FilterMemorySurface,
+  urlValues: FilterParamValues,
+): RememberedFilters {
+  const [saved, setSaved] = useUserLocalStorageValue<FilterParamValues>(
+    `gameListFilters:${surface}`,
+    NO_VALUES,
+    validateStoredValues,
+  )
+
+  const keys = Object.keys(urlValues)
+  const savedForSurface = pickNonEmpty(saved, keys)
+
+  // Decided once, at mount: `undefined` marks a visit whose URL was authoritative, anything else is
+  // the set to seed. A lazy initializer runs at most once, so this never re-decides on a re-render.
+  const [mountSeed] = useState<FilterParamValues | undefined>(() =>
+    urlHasRememberedFilters(urlValues) ? undefined : savedForSurface,
+  )
+
+  useLayoutEffect(() => {
+    if (!mountSeed || !urlHasRememberedFilters(mountSeed)) {
+      return
+    }
+
+    // One replace for the whole set, pre-paint, preserving any params this surface doesn't
+    // remember. The seeded values are what's being rendered already, so no filter appears to
+    // change and nothing reloads.
+    replace(window.location.pathname + withFilterParams(window.location.search, mountSeed))
+  }, [mountSeed])
+
+  const values =
+    mountSeed && !urlHasRememberedFilters(urlValues)
+      ? { ...urlValues, ...pickNonEmpty(saved, Object.keys(mountSeed)) }
+      : urlValues
+
+  const save = () => {
+    const current = readFilterParams(window.location.search, keys)
+    setSaved(Object.keys(current).length > 0 ? current : undefined)
+  }
+
+  return { values, save }
+}

--- a/client/games/use-remembered-filters.ts
+++ b/client/games/use-remembered-filters.ts
@@ -60,6 +60,28 @@ export function withFilterParams(search: string, values: FilterParamValues): str
   return searchString ? `?${searchString}` : ''
 }
 
+/**
+ * Merges a save's freshly-read URL params into the previously saved set: `current` wins for the
+ * named `keys` (so a named param unset in the URL drops out), while saved entries outside them
+ * belong to another view of the same surface (e.g. a playlist view never names `sort`, whose
+ * absence means manual order there) and ride along untouched. Returns `undefined` when nothing is
+ * left to save.
+ */
+export function mergeSavedFilters(
+  saved: FilterParamValues,
+  keys: ReadonlyArray<string>,
+  current: FilterParamValues,
+): FilterParamValues | undefined {
+  const merged: Record<string, string> = {}
+  for (const [key, value] of Object.entries(saved)) {
+    if (!keys.includes(key)) {
+      merged[key] = value
+    }
+  }
+  Object.assign(merged, current)
+  return Object.keys(merged).length > 0 ? merged : undefined
+}
+
 /** Narrows `values` to `keys`, dropping unset entries and any key the surface doesn't use. */
 function pickNonEmpty(values: FilterParamValues, keys: ReadonlyArray<string>): FilterParamValues {
   const result: Record<string, string> = {}
@@ -99,9 +121,10 @@ export interface RememberedFilters {
    */
   values: FilterParamValues
   /**
-   * Stores this surface's params as they currently stand in the URL. Call it from a filter setter,
+   * Stores the named params as they currently stand in the URL. Call it from a filter setter,
    * after that setter has written its param, so that only explicit user changes are remembered and
-   * the whole set is captured (including a filter just returned to its default, which drops out).
+   * the whole named set is captured (including a filter just returned to its default, which drops
+   * out). Saved entries outside the named params are preserved as they were.
    */
   save: () => void
 }
@@ -109,22 +132,24 @@ export interface RememberedFilters {
 /**
  * Remembers a filter surface's mode-like preferences across visits and app restarts, per user.
  *
- * `urlValues` names the surface's remembered params and supplies their current URL values; the
- * returned `values` are the ones to actually use. On a visit whose URL carries none of them, the
- * saved preferences are applied from the very first render — so the first fetch already uses them,
- * with no fetch-with-defaults-then-refetch — and a single history replace then writes them into the
- * URL, which keeps the address bar, sharing, and back/forward truthful without changing anything
- * the list is showing.
+ * `urlValues` names the remembered params this caller uses and supplies their current URL values;
+ * the returned `values` are the ones to actually use. Callers sharing a surface may name different
+ * subsets (the replay library's views do): a param left unnamed is neither seeded, counted in the
+ * URL-authoritative check, nor touched by {@link RememberedFilters.save}. On a visit whose URL
+ * carries none of the named params, the saved preferences are applied from the very first render —
+ * so the first fetch already uses them, with no fetch-with-defaults-then-refetch — and a single
+ * history replace then writes them into the URL, which keeps the address bar, sharing, and
+ * back/forward truthful without changing anything the list is showing.
  *
  * Nothing is saved from URL-derived state: opening someone else's filtered link never overwrites
  * saved preferences. Saving happens only where a setter calls {@link RememberedFilters.save}, which
- * keeps the saved set equal to the URL's params from the user's first change onward. That equality
- * is why `values` reads through to the live saved set for the keys that seeded at mount: once the
- * user sets the last remembered filter back to its default, both the URL and the saved set are
- * empty, so nothing is re-applied behind them. Keys that did NOT seed at mount are never overlaid —
- * the storage is cross-tab reactive, and a preference saved in another tab must not refilter a list
- * sitting on a bare URL here (the loaded pages wouldn't be refetched, so old-filter and new-filter
- * pages would mix).
+ * keeps the saved set equal to the URL's values for the named params from the user's first change
+ * onward. That equality is why `values` reads through to the live saved set for the keys that
+ * seeded at mount: once the user sets the last remembered filter back to its default, both the URL
+ * and the saved set are empty, so nothing is re-applied behind them. Keys that did NOT seed at
+ * mount are never overlaid — the storage is cross-tab reactive, and a preference saved in another
+ * tab must not refilter a list sitting on a bare URL here (the loaded pages wouldn't be refetched,
+ * so old-filter and new-filter pages would mix).
  */
 export function useRememberedFilters(
   surface: FilterMemorySurface,
@@ -162,8 +187,7 @@ export function useRememberedFilters(
       : urlValues
 
   const save = () => {
-    const current = readFilterParams(window.location.search, keys)
-    setSaved(Object.keys(current).length > 0 ? current : undefined)
+    setSaved(mergeSavedFilters(saved, keys, readFilterParams(window.location.search, keys)))
   }
 
   return { values, save }

--- a/client/leagues/league-games.tsx
+++ b/client/leagues/league-games.tsx
@@ -50,6 +50,7 @@ export function LeagueGames({ leagueId }: { leagueId: LeagueId }) {
     <LeagueGamesContainer>
       <GameListView
         loadPage={loadPage}
+        surface='league'
         showResult={true}
         noResultsText={t('leagues.leagueGames.noMatchingGames', 'No matching games.')}
         errorText={t(

--- a/client/replays/replay-library-helpers.ts
+++ b/client/replays/replay-library-helpers.ts
@@ -52,12 +52,12 @@ export function encodeViewPathname(view: LibraryView): string {
 }
 
 /**
- * True when `view` is a playlist and the user hasn't chosen an explicit sort (`sortParam` is the
- * raw, possibly-empty `sort` URL param). In that case results come back in the playlist's manual
- * order, which shouldn't be day-grouped like the date sorts are.
+ * True when `view` is a playlist and the user hasn't chosen an explicit sort (`rawSort` is the sort
+ * in the raw, possibly-empty form a `sort` URL param carries). In that case results come back in
+ * the playlist's manual order, which shouldn't be day-grouped like the date sorts are.
  */
-export function isManualPlaylistOrder(view: LibraryView, sortParam: string): boolean {
-  return view.kind === 'playlist' && !sortParam
+export function isManualPlaylistOrder(view: LibraryView, rawSort: string): boolean {
+  return view.kind === 'playlist' && !rawSort
 }
 
 /**

--- a/client/replays/replay-library.tsx
+++ b/client/replays/replay-library.tsx
@@ -42,6 +42,7 @@ import {
   SelectableRowContainer,
 } from '../games/game-list-entry'
 import { PlayerTeamsDisplay } from '../games/player-teams-display'
+import { useRememberedFilters } from '../games/use-remembered-filters'
 import { MaterialIcon } from '../icons/material/material-icon'
 import { useKeyListener } from '../keyboard/key-listener'
 import InfiniteScrollList from '../lists/infinite-scroll-list'
@@ -489,15 +490,26 @@ export function ReplayLibrary({ view }: ReplayLibraryProps) {
   const [endDate, setEndDateParam] = useLocationSearchParam('endDate')
   const [includeShortParam, setIncludeShortParam] = useLocationSearchParam('includeShort')
 
-  const duration = parseDuration(durationParam)
-  const sort = parseSort(sortParam)
+  // The library's mode-like filters are remembered per user across visits, with every view (the
+  // whole library, bookmarks, each playlist) sharing one saved set.
+  const { values: filterValues, save: saveFilterPrefs } = useRememberedFilters('replays', {
+    sort: sortParam,
+    duration: durationParam,
+    includeShort: includeShortParam,
+    gameType: gameTypeParam,
+  })
+
+  const duration = parseDuration(filterValues.duration)
+  const sort = parseSort(filterValues.sort)
   const format = parseFormat(formatParam)
   const matchup = parseMatchup(matchupParam, format)
-  const gameType = parseModeFilter(gameTypeParam)
+  const gameType = parseModeFilter(filterValues.gameType)
   // The minimum-length floor never applies to curation views (bookmarked/playlist) — see
   // `buildReplaySqlQuery` — so `includeShort` is meaningless there: it isn't read (a hand-edited
   // URL param must not disable reordering via `hasActiveFilters`) and the checkbox isn't offered.
-  const includeShort = view.kind === 'all' && includeShortParam === 'true'
+  // It stays in the shared remembered set even so, since `save` rewrites the whole set — dropping
+  // it on curation views would forget the library view's preference on any save made from one.
+  const includeShort = view.kind === 'all' && filterValues.includeShort === 'true'
 
   const computerLabel = t('game.playerName.computer', 'Computer')
   const bookmarkTitle = t('replays.library.bookmark', 'Bookmark')
@@ -522,7 +534,7 @@ export function ReplayLibrary({ view }: ReplayLibraryProps) {
 
   const isDurationSort =
     sort === GameSortOption.ShortestFirst || sort === GameSortOption.LongestFirst
-  const manualOrder = isManualPlaylistOrder(view, sortParam)
+  const manualOrder = isManualPlaylistOrder(view, filterValues.sort)
   // A playlist's manual order has no meaningful day boundaries, so it renders flat like the
   // duration sorts do.
   const useFlatList = isDurationSort || manualOrder
@@ -820,8 +832,10 @@ export function ReplayLibrary({ view }: ReplayLibraryProps) {
     setStartDateParam('')
     setEndDateParam('')
     setIncludeShortParam('')
+    saveFilterPrefs()
     reset()
-    // `sort` is a view option (not a filter), so it's intentionally left untouched.
+    // `sort` is a view option (not a filter), so it's intentionally left untouched — including in
+    // the remembered set, which `saveFilterPrefs` rewrites from the params that remain.
   }
 
   useKeyListener({
@@ -1050,6 +1064,7 @@ export function ReplayLibrary({ view }: ReplayLibraryProps) {
           duration={duration}
           setDuration={v => {
             setDurationParam(v === GameDurationFilter.All ? '' : v)
+            saveFilterPrefs()
             reset()
           }}
           sort={sort}
@@ -1057,6 +1072,7 @@ export function ReplayLibrary({ view }: ReplayLibraryProps) {
             // Inside a playlist even `latest` stays explicit in the URL, since an absent sort
             // means the playlist's manual order there.
             setSortParam(v === GameSortOption.LatestFirst && view.kind !== 'playlist' ? '' : v)
+            saveFilterPrefs()
             reset()
           }}
           mapName={mapName}
@@ -1085,6 +1101,7 @@ export function ReplayLibrary({ view }: ReplayLibraryProps) {
           includeShort={includeShort}
           setIncludeShort={v => {
             setIncludeShortParam(v ? 'true' : '')
+            saveFilterPrefs()
             reset()
           }}
           showIncludeShort={view.kind === 'all'}
@@ -1092,6 +1109,7 @@ export function ReplayLibrary({ view }: ReplayLibraryProps) {
           gameType={gameType}
           setGameType={v => {
             setGameTypeParam(v === undefined ? '' : String(v))
+            saveFilterPrefs()
             reset()
           }}
           spoilerFree={spoilerFree}

--- a/client/replays/replay-library.tsx
+++ b/client/replays/replay-library.tsx
@@ -491,24 +491,41 @@ export function ReplayLibrary({ view }: ReplayLibraryProps) {
   const [includeShortParam, setIncludeShortParam] = useLocationSearchParam('includeShort')
 
   // The library's mode-like filters are remembered per user across visits, with every view (the
-  // whole library, bookmarks, each playlist) sharing one saved set.
-  const { values: filterValues, save: saveFilterPrefs } = useRememberedFilters('replays', {
-    sort: sortParam,
+  // whole library, bookmarks, each playlist) sharing one saved set. Each view names only the
+  // params it actually uses, so a preference a view can't express is neither seeded into its URL
+  // nor counted as "the URL specifies the filters" there (saved entries outside a view's params
+  // survive its saves untouched).
+  const rememberedUrlValues: Record<string, string> = {
     duration: durationParam,
-    includeShort: includeShortParam,
     gameType: gameTypeParam,
-  })
+  }
+  if (view.kind !== 'playlist') {
+    // Inside a playlist an absent sort means the playlist's manual order, and nothing there ever
+    // writes an absent sort back (every menu choice is explicit, and Clear leaves sort alone) — so
+    // seeding a remembered sort would make drag-to-reorder permanently unreachable.
+    rememberedUrlValues.sort = sortParam
+  }
+  if (view.kind === 'all') {
+    rememberedUrlValues.includeShort = includeShortParam
+  }
+  const { values: filterValues, save: saveFilterPrefs } = useRememberedFilters(
+    'replays',
+    rememberedUrlValues,
+  )
+
+  // A playlist reads sort straight from the URL: absent means its manual order, never a
+  // remembered fill-in.
+  const sortValue = view.kind === 'playlist' ? sortParam : filterValues.sort
 
   const duration = parseDuration(filterValues.duration)
-  const sort = parseSort(filterValues.sort)
+  const sort = parseSort(sortValue)
   const format = parseFormat(formatParam)
   const matchup = parseMatchup(matchupParam, format)
   const gameType = parseModeFilter(filterValues.gameType)
   // The minimum-length floor never applies to curation views (bookmarked/playlist) — see
   // `buildReplaySqlQuery` — so `includeShort` is meaningless there: it isn't read (a hand-edited
-  // URL param must not disable reordering via `hasActiveFilters`) and the checkbox isn't offered.
-  // It stays in the shared remembered set even so, since `save` rewrites the whole set — dropping
-  // it on curation views would forget the library view's preference on any save made from one.
+  // URL param must not disable reordering via `hasActiveFilters`), seeded, or saved, and the
+  // checkbox isn't offered.
   const includeShort = view.kind === 'all' && filterValues.includeShort === 'true'
 
   const computerLabel = t('game.playerName.computer', 'Computer')
@@ -534,7 +551,7 @@ export function ReplayLibrary({ view }: ReplayLibraryProps) {
 
   const isDurationSort =
     sort === GameSortOption.ShortestFirst || sort === GameSortOption.LongestFirst
-  const manualOrder = isManualPlaylistOrder(view, filterValues.sort)
+  const manualOrder = isManualPlaylistOrder(view, sortValue)
   // A playlist's manual order has no meaningful day boundaries, so it renders flat like the
   // duration sorts do.
   const useFlatList = isDurationSort || manualOrder

--- a/client/users/match-history.tsx
+++ b/client/users/match-history.tsx
@@ -45,6 +45,7 @@ export function ConnectedMatchHistory({ userId }: { userId: SbUserId }) {
     <MatchHistoryContainer>
       <GameListView
         loadPage={loadPage}
+        surface='matchHistory'
         showRankedCustom={true}
         showResult={true}
         forUserId={userId}


### PR DESCRIPTION
Part 3 of the games-list improvements, stacked on #1426 (it persists the new include-short preference; retarget to master once #1426 merges). Part 1: #1425.

## What's here

The mode-like filter preferences now survive navigation and app restarts, per user and per surface:

| surface | remembered |
|---|---|
| games page | sort, duration, include-short, source |
| match history | sort, duration, include-short, ranked, custom |
| league games tab | sort, duration, include-short |
| replay library | sort, duration, include-short, game type |

Search-like filters (map/player name, format, matchup, date range) are **deliberately never remembered** — silently re-applying a stale search would produce a mysteriously empty list. Because nothing surprising is remembered, this is always-on: no settings toggle, no expiry. Storage is the same per-user localStorage mechanism `gamesSpoilerFree` already uses (`gameListFilters:<surface>` JSON blobs of raw param values).

Core mechanism (`useRememberedFilters` in `client/games/use-remembered-filters.ts`):

- **URL wins.** A visit carrying any of the surface's remembered params (shared link, back/forward) renders as-is and never overwrites the saved set — saving happens only inside the filter setters.
- **Bare mounts seed from the first render.** The initial fetch already uses the saved values (verified: exactly one `/games/list` request with the seeded params — no defaults-then-refetch), then a single pre-paint history replace writes them into the URL so the address bar and sharing stay truthful.
- The overlay applies only the keys that seeded at mount: the storage is cross-tab reactive, and another tab saving a preference must not silently refilter a list whose already-loaded pages wouldn't be refetched.
- **Clear** resets the saved set along with the params — except sort, which Clear already deliberately leaves alone (so the saved sort survives, matching existing behavior).

## Verification

- typecheck, lint, client vitest suite (298 tests incl. new unit tests for the seed/no-seed and URL merge helpers) all pass.
- Live in the Electron app: set duration+sort on the games page → navigate away and back → URL seeds `?sort=oldest&duration=under10` with chips restored and a single seeded fetch; a `?duration=over30` deep link renders over30 and does not overwrite the saved prefs (they return on the next bare visit); Clear + revisit leaves only `?sort=oldest`; the replay library seeds independently, and localStorage shows cleanly separated per-surface blobs.