### PR TITLE
Move side panel meta above the hero and show win/loss in the roster

### DIFF
--- a/client/games/game-list-view.tsx
+++ b/client/games/game-list-view.tsx
@@ -461,6 +461,7 @@ export function GameListView({
           <GameRecordSidePanel
             game={selectedGame}
             forUserId={forUserId}
+            spoilerFree={spoilerFree}
             alignWithFirstRow={sortIsDateBased}
             onViewResults={gameId => navigateToGameResults(gameId)}
           />

--- a/client/games/game-players-display.tsx
+++ b/client/games/game-players-display.tsx
@@ -5,7 +5,7 @@ import { ReadonlyDeep } from 'type-fest'
 import { GameConfigPlayer } from '../../common/games/configuration'
 import { GameType } from '../../common/games/game-type'
 import { GameRecordJson } from '../../common/games/games'
-import { ReconciledPlayerResult } from '../../common/games/results'
+import { ReconciledPlayerResult, ReconciledResult } from '../../common/games/results'
 import { SbUser } from '../../common/users/sb-user'
 import { SbUserId } from '../../common/users/sb-user-id'
 import { useAppSelector } from '../redux-hooks'
@@ -146,16 +146,63 @@ export function getOrderedTeams(
   return [firstTeam, secondTeam]
 }
 
+/**
+ * Derives one reconciled result per displayed column, or `undefined` when the columns can't be
+ * honestly reduced to one result apiece. Outside `topVBottom`, a "column" from `getOrderedTeams`
+ * is an alphabetical split of all players rather than a real team, so a result is only shown for
+ * a column where every player is human, has a known (not `'unknown'`) result, and all of those
+ * results agree — a mixed FFA split, a computer player, or a missing result blanks every column
+ * rather than showing a lopsided subset.
+ */
+function getTeamResults(
+  orderedTeams: ReadonlyArray<ReadonlyArray<GameConfigPlayer>>,
+  resultsById: ReadonlyMap<SbUserId, ReconciledPlayerResult>,
+): ReadonlyArray<ReconciledResult> | undefined {
+  const teamResults: ReconciledResult[] = []
+
+  for (const team of orderedTeams) {
+    let teamResult: ReconciledResult | undefined
+
+    for (const player of team) {
+      if (player.isComputer) {
+        return undefined
+      }
+
+      const result = resultsById.get(player.id)?.result
+      if (!result || result === 'unknown') {
+        return undefined
+      }
+
+      if (teamResult === undefined) {
+        teamResult = result
+      } else if (teamResult !== result) {
+        return undefined
+      }
+    }
+
+    if (teamResult === undefined) {
+      return undefined
+    }
+
+    teamResults.push(teamResult)
+  }
+
+  return teamResults
+}
+
 export function GamePlayersDisplay({
   game,
   forUserId,
   showTeamLabels = true,
+  showTeamResults = false,
   interactiveNames = false,
   className,
 }: {
   game: ReadonlyDeep<GameRecordJson>
   forUserId?: SbUserId
   showTeamLabels?: boolean
+  /** When true, each displayed column's overline gains a win/loss result, colored accordingly. */
+  showTeamResults?: boolean
   /**
    * When true, human players' names render as store-connected, interactive usernames (clicking
    * opens the profile overlay, right-clicking opens the user context menu) instead of plain text.
@@ -199,5 +246,14 @@ export function GamePlayersDisplay({
       ? [t('game.teamName.top', 'Top'), t('game.teamName.bottom', 'Bottom')]
       : undefined
 
-  return <PlayerTeamsDisplay teams={teams} teamLabels={teamLabels} className={className} />
+  const teamResults = showTeamResults ? getTeamResults(orderedTeams, resultsById) : undefined
+
+  return (
+    <PlayerTeamsDisplay
+      teams={teams}
+      teamLabels={teamLabels}
+      teamResults={teamResults}
+      className={className}
+    />
+  )
 }

--- a/client/games/game-record-side-panel.tsx
+++ b/client/games/game-record-side-panel.tsx
@@ -3,7 +3,6 @@ import styled from 'styled-components'
 import { ReadonlyDeep } from 'type-fest'
 import { GameRecordJson, getGameTypeLabel } from '../../common/games/games'
 import { SbUserId } from '../../common/users/sb-user-id'
-import { longTimestamp } from '../i18n/date-formats'
 import { MaterialIcon } from '../icons/material/material-icon'
 import { FilledButton, IconButton } from '../material/button'
 import { Popover, usePopoverController, useRefAnchorPosition } from '../material/popover'
@@ -15,9 +14,8 @@ import {
   GameSidePanelActions,
   GameSidePanelChipsRow,
   GameSidePanelEmpty,
-  GameSidePanelHeader,
+  GameSidePanelRelativeTime,
   GameSidePanelSection,
-  GameSidePanelSubline,
   GameSidePanelTitle,
 } from './game-side-panel'
 import { SaveReplayMenuContent } from './save-replay-menu'
@@ -41,6 +39,8 @@ export interface GameRecordSidePanelProps {
   game?: ReadonlyDeep<GameRecordJson>
   /** When set, the roster shows win/loss coloring for this user's perspective. */
   forUserId?: SbUserId
+  /** When true, the roster's per-column win/loss result is hidden. */
+  spoilerFree?: boolean
   alignWithFirstRow?: boolean
   onViewResults: (gameId: string) => void
   className?: string
@@ -53,6 +53,7 @@ export interface GameRecordSidePanelProps {
 export function GameRecordSidePanel({
   game,
   forUserId,
+  spoilerFree = false,
   alignWithFirstRow = false,
   onViewResults,
   className,
@@ -71,6 +72,7 @@ export function GameRecordSidePanel({
     <GameRecordSidePanelContent
       game={game}
       forUserId={forUserId}
+      spoilerFree={spoilerFree}
       alignWithFirstRow={alignWithFirstRow}
       onViewResults={onViewResults}
       className={className}
@@ -81,6 +83,7 @@ export function GameRecordSidePanel({
 interface GameRecordSidePanelContentProps {
   game: ReadonlyDeep<GameRecordJson>
   forUserId?: SbUserId
+  spoilerFree: boolean
   alignWithFirstRow: boolean
   onViewResults: (gameId: string) => void
   className?: string
@@ -89,6 +92,7 @@ interface GameRecordSidePanelContentProps {
 function GameRecordSidePanelContent({
   game,
   forUserId,
+  spoilerFree,
   alignWithFirstRow,
   onViewResults,
   className,
@@ -106,21 +110,31 @@ function GameRecordSidePanelContent({
 
   const mapName = map?.name ?? t('game.mapName.unknown', 'Unknown map')
 
+  const headerMeta = (
+    <>
+      <GameSidePanelChipsRow>
+        <GameTypeChip>{getGameTypeLabel(game, t)}</GameTypeChip>
+      </GameSidePanelChipsRow>
+      <GameSidePanelRelativeTime timestampMs={game.startTime} />
+    </>
+  )
+
   return (
-    <GameSidePanel map={map} alignWithFirstRow={alignWithFirstRow} className={className}>
-      <GameSidePanelHeader>
-        <GameSidePanelChipsRow>
-          <GameTypeChip>{getGameTypeLabel(game, t)}</GameTypeChip>
-        </GameSidePanelChipsRow>
-        <GameSidePanelTitle>{mapName}</GameSidePanelTitle>
-        <GameSidePanelSubline>{longTimestamp.format(game.startTime)}</GameSidePanelSubline>
-      </GameSidePanelHeader>
+    <GameSidePanel
+      map={map}
+      headerMeta={headerMeta}
+      alignWithFirstRow={alignWithFirstRow}
+      className={className}>
+      {/* The map thumbnail carries its own name label; a title is only needed when there's no
+          thumbnail for it to live on. */}
+      {!map ? <GameSidePanelTitle>{mapName}</GameSidePanelTitle> : null}
 
       <GameSidePanelSection>
         <GamePlayersDisplay
           game={game}
           forUserId={forUserId}
           showTeamLabels={true}
+          showTeamResults={!spoilerFree}
           interactiveNames={true}
         />
       </GameSidePanelSection>

--- a/client/games/game-side-panel.tsx
+++ b/client/games/game-side-panel.tsx
@@ -7,7 +7,8 @@ import { MapInfoJson } from '../../common/maps'
 import { MapNoImage } from '../maps/map-image'
 import { ReduxMapThumbnail } from '../maps/map-thumbnail'
 import { ContainerLevel, containerStyles } from '../styles/colors'
-import { bodyMedium, titleLarge } from '../styles/typography'
+import { bodyMedium, bodySmall, singleLine, titleLarge } from '../styles/typography'
+import { GameRelativeTime } from './game-list-entry'
 
 // Mirrors `DayHeader`'s own box (see `client/games/day-header.tsx`): 16px top padding + 20px
 // `titleSmall` line-height + 8px bottom padding. Used to align the panel with the first replay
@@ -99,9 +100,16 @@ const GameSidePanelEmptyText = styled.div`
   text-align: center;
 `
 
-export const GameSidePanelHeader = styled.div`
+const HeaderAndHero = styled.div`
   display: flex;
   flex-direction: column;
+  gap: 12px;
+`
+
+const HeaderMetaRow = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
   gap: 8px;
 `
 
@@ -116,12 +124,10 @@ export const GameSidePanelTitle = styled.div`
   ${titleLarge};
 `
 
-export const GameSidePanelSubline = styled.div`
-  ${bodyMedium};
-
-  display: flex;
-  align-items: center;
-  gap: 4px;
+/** The panel's meta row's relative-time side, e.g. "18h ago"; hover reveals the absolute time. */
+export const GameSidePanelRelativeTime = styled(GameRelativeTime)`
+  ${bodySmall};
+  ${singleLine};
 
   color: var(--theme-on-surface-variant);
 `
@@ -146,6 +152,12 @@ export interface GameSidePanelProps {
    * placeholder — avoids flashing "not available" while the map is still being fetched.
    */
   isMapLoading?: boolean
+  /**
+   * A one-line row (chips + relative time) shown above the hero image, grouped tightly with it so
+   * the two read as one unit. Omitted entirely (rather than left blank) when there's nothing to
+   * show above the hero, e.g. a replay that failed to parse.
+   */
+  headerMeta?: React.ReactNode
   /** True when the adjacent list is day-grouped, so the panel's top aligns with the first row. */
   alignWithFirstRow?: boolean
   className?: string
@@ -155,6 +167,7 @@ export interface GameSidePanelProps {
 export function GameSidePanel({
   map,
   isMapLoading = false,
+  headerMeta,
   alignWithFirstRow = false,
   className,
   children,
@@ -181,7 +194,14 @@ export function GameSidePanel({
 
   return (
     <GameSidePanelRoot $alignWithFirstRow={alignWithFirstRow} className={className}>
-      {hero}
+      {headerMeta ? (
+        <HeaderAndHero>
+          <HeaderMetaRow>{headerMeta}</HeaderMetaRow>
+          {hero}
+        </HeaderAndHero>
+      ) : (
+        hero
+      )}
 
       {children}
     </GameSidePanelRoot>

--- a/client/games/player-teams-display.tsx
+++ b/client/games/player-teams-display.tsx
@@ -1,4 +1,6 @@
+import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
+import { getResultLabel, ReconciledResult } from '../../common/games/results'
 import { RaceChar } from '../../common/races'
 import { SbUserId } from '../../common/users/sb-user-id'
 import { RaceIcon } from '../lobbies/race-icon'
@@ -29,6 +31,18 @@ const PlayerTeamOverline = styled.div`
   ${singleLine};
 
   color: var(--theme-on-surface-variant);
+`
+
+const PlayerTeamOverlineResult = styled.span<{ $result: ReconciledResult }>`
+  color: ${props => {
+    if (props.$result === 'win') {
+      return 'var(--theme-positive)'
+    } else if (props.$result === 'loss') {
+      return 'var(--theme-negative)'
+    } else {
+      return 'inherit'
+    }
+  }};
 `
 
 const PlayerRowContainer = styled.div`
@@ -123,31 +137,51 @@ export interface PlayerTeamsDisplayPlayer {
 export function PlayerTeamsDisplay({
   teams,
   teamLabels,
+  teamResults,
   className,
 }: {
   teams: ReadonlyArray<ReadonlyArray<PlayerTeamsDisplayPlayer>>
   teamLabels?: ReadonlyArray<string>
+  /** One reconciled result per team, aligned by index with `teams`. */
+  teamResults?: ReadonlyArray<ReconciledResult>
   className?: string
 }) {
+  const { t } = useTranslation()
+
   return (
     <PlayerTeamsRoot className={className}>
-      {teams.map((team, teamIndex) => (
-        <PlayerTeamColumn key={`team-${teamIndex}`}>
-          {teamLabels?.[teamIndex] ? (
-            <PlayerTeamOverline>{teamLabels[teamIndex]}</PlayerTeamOverline>
-          ) : null}
-          {team.map((player, playerIndex) => (
-            <PlayerRowContainer key={`player-${playerIndex}`}>
-              <PlayerRace race={player.race} isRandom={player.isRandom} />
-              {player.userId !== undefined ? (
-                <PlayerRowConnectedName userId={player.userId} />
-              ) : (
-                <PlayerRowName $dimmed={player.nameColor === 'dimmed'}>{player.name}</PlayerRowName>
-              )}
-            </PlayerRowContainer>
-          ))}
-        </PlayerTeamColumn>
-      ))}
+      {teams.map((team, teamIndex) => {
+        const label = teamLabels?.[teamIndex]
+        const result = teamResults?.[teamIndex]
+
+        return (
+          <PlayerTeamColumn key={`team-${teamIndex}`}>
+            {label || result ? (
+              <PlayerTeamOverline>
+                {label}
+                {label && result ? ' · ' : null}
+                {result ? (
+                  <PlayerTeamOverlineResult $result={result}>
+                    {getResultLabel(result, t)}
+                  </PlayerTeamOverlineResult>
+                ) : null}
+              </PlayerTeamOverline>
+            ) : null}
+            {team.map((player, playerIndex) => (
+              <PlayerRowContainer key={`player-${playerIndex}`}>
+                <PlayerRace race={player.race} isRandom={player.isRandom} />
+                {player.userId !== undefined ? (
+                  <PlayerRowConnectedName userId={player.userId} />
+                ) : (
+                  <PlayerRowName $dimmed={player.nameColor === 'dimmed'}>
+                    {player.name}
+                  </PlayerRowName>
+                )}
+              </PlayerRowContainer>
+            ))}
+          </PlayerTeamColumn>
+        )
+      })}
     </PlayerTeamsRoot>
   )
 }

--- a/client/replays/replay-inspector.tsx
+++ b/client/replays/replay-inspector.tsx
@@ -16,13 +16,11 @@ import {
   GameSidePanelActions,
   GameSidePanelChipsRow,
   GameSidePanelEmpty,
-  GameSidePanelHeader,
+  GameSidePanelRelativeTime,
   GameSidePanelSection,
-  GameSidePanelSubline,
   GameSidePanelTitle,
 } from '../games/game-side-panel'
 import { PlayerTeamsDisplay } from '../games/player-teams-display'
-import { longTimestamp } from '../i18n/date-formats'
 import { MaterialIcon } from '../icons/material/material-icon'
 import Logo from '../logos/logo-no-bg.svg?react'
 import { FilledButton, IconButton } from '../material/button'
@@ -431,6 +429,15 @@ export function ReplayInspector({
     </GameSidePanelChipsRow>
   )
 
+  // An unreadable replay's source and timestamp are unknown (only path/fileName/fileSize are
+  // meaningful then), so it gets no meta row at all.
+  const headerMeta = entry.parseError ? undefined : (
+    <>
+      {chips}
+      <GameSidePanelRelativeTime timestampMs={entry.gameTime} />
+    </>
+  )
+
   const bookmarked = entry.bookmarkedAt !== undefined
   const playlistsForEntry =
     entryPlaylists && entryPlaylists.forId === entry.id ? entryPlaylists.list : []
@@ -507,35 +514,30 @@ export function ReplayInspector({
     <GameSidePanel
       map={map}
       isMapLoading={mapStatus === 'loading'}
+      headerMeta={headerMeta}
       alignWithFirstRow={alignWithFirstRow}>
       {entry.parseError ? (
         <>
-          <GameSidePanelHeader>
-            {/*
-              No source badge: an unreadable replay's source is genuinely unknown (we couldn't read
-              the embedded SB section), so the SB/B.NET distinction can't be made here.
-            */}
-            <GameSidePanelTitle>{entry.fileName}</GameSidePanelTitle>
-          </GameSidePanelHeader>
+          {/*
+            No source badge: an unreadable replay's source is genuinely unknown (we couldn't read
+            the embedded SB section), so the SB/B.NET distinction can't be made here.
+          */}
+          <GameSidePanelTitle>{entry.fileName}</GameSidePanelTitle>
           <ErrorNote>
             {t('replays.library.inspector.parseError', 'This replay could not be read.')}
           </ErrorNote>
         </>
       ) : (
         <>
-          <GameSidePanelHeader>
-            {chips}
-            {/*
-              The map thumbnail renders its own name label, so a title here would duplicate it once
-              loaded. Show the name as text only when there's genuinely no thumbnail coming (no
-              linked map) — not while it's still loading, which would otherwise shift the header's
-              height when the title is dropped on load.
-            */}
-            {mapStatus === 'unavailable' ? (
-              <GameSidePanelTitle>{filterColorCodes(entry.mapName)}</GameSidePanelTitle>
-            ) : null}
-            <GameSidePanelSubline>{longTimestamp.format(entry.gameTime)}</GameSidePanelSubline>
-          </GameSidePanelHeader>
+          {/*
+            The map thumbnail renders its own name label, so a title here would duplicate it once
+            loaded. Show the name as text only when there's genuinely no thumbnail coming (no
+            linked map) — not while it's still loading, which would otherwise shift the header's
+            height when the title is dropped on load.
+          */}
+          {mapStatus === 'unavailable' ? (
+            <GameSidePanelTitle>{filterColorCodes(entry.mapName)}</GameSidePanelTitle>
+          ) : null}
           <GameSidePanelSection>
             <PlayerTeamsDisplay
               teams={playersToDisplayTeams(layout!, computerLabel, linkedUserIds)}


### PR DESCRIPTION
### What

The game/replay side panel's header (chips + map-name title + absolute timestamp) becomes a single meta row **above** the hero image — chips on the left, a relative time ("18h ago", absolute on hover) on the right — grouped tightly with the artwork so the line reads as belonging to it. The map name now lives only on the hero thumbnail's own info layer; a plain title below the hero remains as a fallback when there's no thumbnail to carry it (unknown map for games, unlinked map for replays, unreadable replays).

On the games side (games list / match history), the roster's per-column overline gains a colored win/loss result — "Top · Win" / "Bottom · Loss", or the result alone for a 1v1's unlabeled columns. The existing **Spoiler-free** toggle hides these panel results the same way it already hides results and durations in list rows.

### How

- `GameSidePanel` gains a `headerMeta` slot rendered in a tight (12px) group with the hero; the `GameSidePanelHeader`/`GameSidePanelSubline` building blocks are deleted. A shared `GameSidePanelRelativeTime` wraps the list rows' `GameRelativeTime`.
- `PlayerTeamsDisplay` accepts optional per-team `teamResults`, rendered in (or as) the column overline.
- `GamePlayersDisplay` derives them honestly: outside topVBottom, displayed columns are an alphabetical split rather than real teams, so a column is only labeled when every player in it is a human whose reconciled result is known and all agree — a mixed FFA split, a computer player, or a missing/unknown result blanks **all** columns rather than showing a lopsided subset.
- The replay inspector keeps a plain roster — replay files carry no reconciled outcomes.

### Verification

Live-verified in the Electron app (dev stack, claude-1): games page panel shows the chip + relative-time meta row above the hero with no duplicated title; a 1v1 shows "Win"/"Loss" overlines, a ranked 2v2 shows "Top · Win"/"Bottom · Loss", and a game with unreported results shows no overlines; toggling Spoiler-free removes the panel results (and restores them when toggled back). Replay library inspector shows the SB badge + relative time meta row and an unchanged roster. Typecheck and lint pass; no translation catalog changes (labels reuse existing keys).
