### PR TITLE
Fix manual game resolution matchup and last-played dates

### DIFF
--- a/server/lib/games/game-models.ts
+++ b/server/lib/games/game-models.ts
@@ -186,14 +186,18 @@ export async function lockGameForManualResolution(
  * that applies the result-derived side effects.
  *
  * `dispute_requested` is left alone: it's the historical record of whether players actually asked
- * for a review. `game_length` and `assigned_matchup` are left alone too — manual resolution only
- * decides outcomes, and a disputed game's stored races can include a fabricated one for a player
- * who appeared in no report, which must never be baked into a matchup.
+ * for a review. `game_length` is left alone too — manual resolution only decides outcomes.
+ *
+ * `assigned_matchup` is written as given, `null` included: a disputed game's stored races can
+ * include a fabricated one for a player who appeared in no report, which must never be baked into a
+ * matchup, so callers pass a matchup only when every player's race is known from a trustworthy
+ * source. The column is already NULL for a disputed game, so writing NULL is a no-op in practice.
  */
 export async function setManuallyResolvedResult(
   client: DbClient,
   gameId: string,
   results: Map<SbUserId, ReconciledPlayerResult>,
+  assignedMatchup: MatchupString | null,
   resolvedBy: SbUserId,
   resolvedAt: Date,
 ): Promise<void> {
@@ -203,6 +207,7 @@ export async function setManuallyResolvedResult(
       results = ${JSON.stringify(Array.from(results.entries()))},
       disputable = false,
       dispute_reviewed = true,
+      assigned_matchup = ${assignedMatchup},
       manually_resolved_by = ${resolvedBy},
       manually_resolved_at = ${resolvedAt}
     WHERE id = ${gameId}

--- a/server/lib/games/game-result-service.test.ts
+++ b/server/lib/games/game-result-service.test.ts
@@ -7,6 +7,7 @@ import {
 } from '../../../common/games/configuration'
 import { GameType } from '../../../common/games/game-type'
 import { GameRecord } from '../../../common/games/games'
+import { makeMatchupString } from '../../../common/games/matchups'
 import {
   GameClientResult,
   GameResultErrorCode,
@@ -14,6 +15,7 @@ import {
 } from '../../../common/games/results'
 import { makeSbMapId } from '../../../common/maps'
 import { MatchmakingSeason, MatchmakingType, makeSeasonId } from '../../../common/matchmaking'
+import { AssignedRaceChar } from '../../../common/races'
 import { asMockedFunction } from '../../../common/testing/mocks'
 import { SbUserId, makeSbUserId } from '../../../common/users/sb-user-id'
 import { updateRankings } from '../ladder/rankings'
@@ -804,6 +806,33 @@ describe('games/game-result-service/GameResultService#resolveGameManually', () =
     [p4, { result: 'unknown', race: 't', apm: 90 }],
   ]
 
+  /** A 1v1 where p1 picked random, so only the reports can say what they actually played. */
+  const RANDOM_PICK_TEAMS: GameConfigPlayer[][] = [
+    [{ id: p1, race: 'r', isComputer: false }],
+    [{ id: p2, race: 'z', isComputer: false }],
+  ]
+
+  /** A stored (already digested) report claiming each listed player played the given race. */
+  function reportWithRaces(
+    reporter: SbUserId,
+    races: Array<[SbUserId, AssignedRaceChar]>,
+  ): StoredResultReport {
+    return {
+      kind: 'legacy',
+      reporter,
+      time: 60_000,
+      playerResults: races.map(([id, race]) => [
+        id,
+        { result: GameClientResult.Playing, race, apm: 100 },
+      ]),
+    }
+  }
+
+  /** The matchup argument `setManuallyResolvedResult` was called with. */
+  function resolvedMatchup() {
+    return asMockedFunction(setManuallyResolvedResult).mock.calls[0][3]
+  }
+
   let clock: FakeClock
   let service: GameResultService
   let getSeasonForDate: ReturnType<typeof vi.fn>
@@ -827,12 +856,16 @@ describe('games/game-result-service/GameResultService#resolveGameManually', () =
     }
   }
 
-  function makeMmr(userId: SbUserId): MatchmakingRating {
+  function makeMmr(
+    userId: SbUserId,
+    overrides: Partial<MatchmakingRating> = {},
+  ): MatchmakingRating {
     return {
       ...DEFAULT_MATCHMAKING_RATING,
       userId,
       matchmakingType: MatchmakingType.Match1v1,
       seasonId: SEASON.id,
+      ...overrides,
     }
   }
 
@@ -867,6 +900,7 @@ describe('games/game-result-service/GameResultService#resolveGameManually', () =
       results: DISPUTED_1V1_RESULTS,
     })
     asMockedFunction(setManuallyResolvedResult).mockResolvedValue(undefined)
+    asMockedFunction(getCurrentReportedResults).mockResolvedValue([])
     asMockedFunction(setUserReconciledResult).mockResolvedValue(undefined as any)
     asMockedFunction(incrementUserStatsCount).mockResolvedValue(undefined as any)
     asMockedFunction(getActiveLeaguesForUsers).mockResolvedValue(new Map())
@@ -903,7 +937,7 @@ describe('games/game-result-service/GameResultService#resolveGameManually', () =
     })
 
     // The games row is rewritten by the manual-resolution write, not the reconcile one — so the
-    // game keeps its length and assigned matchup.
+    // game keeps its length.
     expect(setReconciledResult).not.toHaveBeenCalled()
     expect(setManuallyResolvedResult).toHaveBeenCalledWith(
       expect.anything(),
@@ -912,6 +946,7 @@ describe('games/game-result-service/GameResultService#resolveGameManually', () =
         [p1, { result: 'win', race: 't', apm: 120 }],
         [p2, { result: 'loss', race: 'z', apm: 80 }],
       ]),
+      makeMatchupString('t-z'),
       ADMIN_ID,
       new Date(clock.now()),
     )
@@ -930,6 +965,99 @@ describe('games/game-result-service/GameResultService#resolveGameManually', () =
     expect(result.ratingsApplied).toBe(false)
     expect(result.game).toEqual(resolved)
     expect(publishReconciledGame).toHaveBeenCalledWith(GAME_ID)
+  })
+
+  test('assigns the matchup from the config when no player picked random', async () => {
+    asMockedFunction(getGameRecord).mockResolvedValue(
+      makeDisputedGame({
+        config: lobbyConfig({ teams: TEAM_TEAMS, lockedAlliances: true }),
+        results: DISPUTED_2V2_RESULTS,
+      }),
+    )
+    asMockedFunction(lockGameForManualResolution).mockResolvedValue({
+      disputable: true,
+      results: DISPUTED_2V2_RESULTS,
+    })
+
+    await resolve([
+      { userId: p1, result: 'win' },
+      { userId: p2, result: 'win' },
+      { userId: p3, result: 'loss' },
+      { userId: p4, result: 'loss' },
+    ])
+
+    expect(resolvedMatchup()).toBe(makeMatchupString('pt-tz'))
+    // A picked race is what the player got, so no report needs consulting for it.
+    expect(getCurrentReportedResults).not.toHaveBeenCalled()
+  })
+
+  test('assigns the matchup using a random player race that every report agrees on', async () => {
+    asMockedFunction(getGameRecord).mockResolvedValue(
+      makeDisputedGame({
+        config: lobbyConfig({ teams: RANDOM_PICK_TEAMS, lockedAlliances: true }),
+      }),
+    )
+    asMockedFunction(getCurrentReportedResults).mockResolvedValue([
+      reportWithRaces(p1, [
+        [p1, 'p'],
+        [p2, 'z'],
+      ]),
+      reportWithRaces(p2, [
+        [p1, 'p'],
+        [p2, 'z'],
+      ]),
+    ])
+
+    await resolve([
+      { userId: p1, result: 'win' },
+      { userId: p2, result: 'loss' },
+    ])
+
+    expect(resolvedMatchup()).toBe(makeMatchupString('p-z'))
+  })
+
+  test('leaves the matchup unassigned when a random player is in no report at all', async () => {
+    asMockedFunction(getGameRecord).mockResolvedValue(
+      makeDisputedGame({
+        config: lobbyConfig({ teams: RANDOM_PICK_TEAMS, lockedAlliances: true }),
+      }),
+    )
+    asMockedFunction(getCurrentReportedResults).mockResolvedValue([
+      reportWithRaces(p2, [[p2, 'z']]),
+      null,
+    ])
+
+    await resolve([
+      { userId: p1, result: 'win' },
+      { userId: p2, result: 'loss' },
+    ])
+
+    expect(resolvedMatchup()).toBeNull()
+  })
+
+  test('leaves the matchup unassigned when reports disagree on a random player race', async () => {
+    asMockedFunction(getGameRecord).mockResolvedValue(
+      makeDisputedGame({
+        config: lobbyConfig({ teams: RANDOM_PICK_TEAMS, lockedAlliances: true }),
+      }),
+    )
+    asMockedFunction(getCurrentReportedResults).mockResolvedValue([
+      reportWithRaces(p1, [
+        [p1, 'p'],
+        [p2, 'z'],
+      ]),
+      reportWithRaces(p2, [
+        [p1, 't'],
+        [p2, 'z'],
+      ]),
+    ])
+
+    await resolve([
+      { userId: p1, result: 'win' },
+      { userId: p2, result: 'loss' },
+    ])
+
+    expect(resolvedMatchup()).toBeNull()
   })
 
   test('applies rating, points and ranking changes for a 1v1 matchmaking game', async () => {
@@ -974,6 +1102,62 @@ describe('games/game-result-service/GameResultService#resolveGameManually', () =
 
     expect(updateRankings).toHaveBeenCalledWith(expect.anything(), [winner, loser])
     expect(result.ratingsApplied).toBe(true)
+  })
+
+  test('dates the rating activity from the end of the game, not the resolution', async () => {
+    asMockedFunction(getGameRecord).mockResolvedValue(
+      makeDisputedGame({
+        config: matchmakingConfig(DEFAULT_TEAMS),
+        startTime: new Date(500_000),
+        gameLength: 60_000,
+      }),
+    )
+    asMockedFunction(getMatchmakingRatingsWithLock).mockResolvedValue([makeMmr(p1), makeMmr(p2)])
+
+    await resolve([
+      { userId: p1, result: 'win' },
+      { userId: p2, result: 'loss' },
+    ])
+
+    const updatedRatings = asMockedFunction(updateMatchmakingRating).mock.calls.map(
+      ([, mmr]) => mmr,
+    )
+    expect(updatedRatings).toHaveLength(2)
+    for (const mmr of updatedRatings) {
+      expect(mmr.lastPlayedDate).toEqual(new Date(560_000))
+    }
+
+    // The rating itself genuinely changes when the game is resolved, so the change stays dated
+    // from the resolution.
+    expect(insertMatchmakingRatingChange).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ userId: p1, changeDate: new Date(clock.now()) }),
+    )
+  })
+
+  test('keeps a rating activity date that is already newer than the resolved game', async () => {
+    asMockedFunction(getGameRecord).mockResolvedValue(
+      makeDisputedGame({
+        config: matchmakingConfig(DEFAULT_TEAMS),
+        startTime: new Date(500_000),
+        gameLength: 60_000,
+      }),
+    )
+    asMockedFunction(getMatchmakingRatingsWithLock).mockResolvedValue([
+      makeMmr(p1, { lastPlayedDate: new Date(900_000) }),
+      makeMmr(p2),
+    ])
+
+    await resolve([
+      { userId: p1, result: 'win' },
+      { userId: p2, result: 'loss' },
+    ])
+
+    const updatedRatings = asMockedFunction(updateMatchmakingRating).mock.calls.map(
+      ([, mmr]) => mmr,
+    )
+    expect(updatedRatings.find(mmr => mmr.userId === p1)!.lastPlayedDate).toEqual(new Date(900_000))
+    expect(updatedRatings.find(mmr => mmr.userId === p2)!.lastPlayedDate).toEqual(new Date(560_000))
   })
 
   test('records the resolution without rating changes once the season is finalized', async () => {

--- a/server/lib/games/game-result-service.ts
+++ b/server/lib/games/game-result-service.ts
@@ -11,7 +11,11 @@ import {
   MatchmakingResultsEvent,
   toGameRecordJson,
 } from '../../../common/games/games'
-import { computeMatchupString, getTeamsFromConfig } from '../../../common/games/matchups'
+import {
+  MatchupString,
+  computeMatchupString,
+  getTeamsFromConfig,
+} from '../../../common/games/matchups'
 import {
   ALL_GAME_CLIENT_ALLIANCE_STATES,
   ALL_GAME_CLIENT_LOSE_TYPES,
@@ -78,6 +82,7 @@ import {
 import { calculateChangedRatings } from '../matchmaking/rating'
 import { getDesyncEventsForGame } from '../models/game-desync-events'
 import {
+  StoredResultReport,
   areAllHumansAccountedFor,
   getCurrentReportedResults,
   getDepartureTimesForGame,
@@ -197,6 +202,96 @@ function validateMatchmakingResolution(
       'exactly one full team must win a matchmaking game',
     )
   }
+}
+
+/**
+ * Digests a game's stored reports into the uniform `ResultSubmission` shape a legacy report already
+ * has, so everything downstream (reconcile, desync policy, departure tiebreak, persistence, matchup
+ * derivation) is agnostic to which form a client submitted. The returned array stays aligned with
+ * the input, `null` for a player who never reported.
+ *
+ * `isUms` comes from our own config, never the client. The raw-report veto (Rule A in
+ * `deriveResultSubmission`) needs cross-report evidence: the set of users whose OWN report claims a
+ * self-Victory is computed once over every stored report and fed to each derivation, so a leaver's
+ * uncorroborated quit-victory in someone else's capture can be stripped while a genuine
+ * winner-who-quit's victory is preserved.
+ */
+function digestStoredReports(
+  config: GameConfig,
+  storedResults: ReadonlyArray<StoredResultReport | null>,
+): Array<ResultSubmission | null> {
+  const isUms = config.gameType === GameType.UseMapSettings
+  const corroboratedVictors = computeCorroboratedVictors(storedResults)
+  return storedResults.map(stored => {
+    if (!stored) {
+      return null
+    }
+    if (stored.kind === 'raw') {
+      return deriveResultSubmission(stored.raw, stored.reporter, { isUms, corroboratedVictors })
+    }
+    return { reporter: stored.reporter, time: stored.time, playerResults: stored.playerResults }
+  })
+}
+
+/**
+ * Determines the assigned matchup for a game being resolved by hand, or `null` when any player's
+ * assigned race can't be established from a trustworthy source.
+ *
+ * A player who picked a specific race in the config settles their own race: the game can't have
+ * given them a different one, so no report is consulted for them. A player who picked random only
+ * has the reports to go on, and a game that ended in a dispute can have reports that disagree about
+ * a race or omit a player entirely, so a random player's race counts as known only when they appear
+ * in at least one report and every appearance agrees. Anything short of that leaves the whole
+ * matchup unknown rather than baking in a guess — the same standard reconciliation applies when it
+ * refuses to assign a matchup to a disputed game.
+ *
+ * Games with computer players never get a matchup: they're exempt from results entirely.
+ */
+async function computeManualResolutionMatchup(
+  gameRecord: GameRecord,
+): Promise<MatchupString | null> {
+  if (gameRecord.config.teams.some(team => team.some(p => p.isComputer))) {
+    return null
+  }
+
+  const teams = getTeamsFromConfig(gameRecord.config)
+  if (!teams) {
+    return null
+  }
+
+  const players = teams.flat()
+  const assignedRaces = new Map<SbUserId, RaceChar>(
+    players.filter(p => p.race !== 'r').map(p => [p.id, p.race]),
+  )
+
+  const randomPlayers = players.filter(p => p.race === 'r')
+  if (randomPlayers.length) {
+    const submissions = digestStoredReports(
+      gameRecord.config,
+      await getCurrentReportedResults(gameRecord.id),
+    )
+
+    for (const player of randomPlayers) {
+      const reportedRaces = new Set<RaceChar>()
+      for (const submission of submissions) {
+        for (const [id, result] of submission?.playerResults ?? []) {
+          if (id === player.id) {
+            reportedRaces.add(result.race)
+          }
+        }
+      }
+
+      if (reportedRaces.size === 1) {
+        assignedRaces.set(player.id, reportedRaces.values().next().value!)
+      }
+    }
+  }
+
+  if (players.some(p => !assignedRaces.has(p.id))) {
+    return null
+  }
+
+  return computeMatchupString(teams.map(team => team.map(p => assignedRaces.get(p.id)!)))
 }
 
 /**
@@ -766,24 +861,7 @@ export default class GameResultService {
 
     const gameId = gameRecord.id
     const storedResults = await getCurrentReportedResults(gameId)
-    // Raw reports are digested into the same `ResultSubmission` shape a legacy report already has,
-    // so everything downstream (reconcile, desync policy, departure tiebreak, persistence) is
-    // agnostic to which form a client submitted. `isUms` comes from our own config, never the client.
-    const isUms = gameRecord.config.gameType === GameType.UseMapSettings
-    // Cross-report evidence for the raw-report veto (Rule A in `deriveResultSubmission`): the set of
-    // users whose OWN report claims a self-Victory, computed once over every stored report and fed to
-    // each derivation so a leaver's uncorroborated quit-victory in someone else's capture can be
-    // stripped while a genuine winner-who-quit's victory is preserved.
-    const corroboratedVictors = computeCorroboratedVictors(storedResults)
-    const currentResults: Array<ResultSubmission | null> = storedResults.map(stored => {
-      if (!stored) {
-        return null
-      }
-      if (stored.kind === 'raw') {
-        return deriveResultSubmission(stored.raw, stored.reporter, { isUms, corroboratedVictors })
-      }
-      return { reporter: stored.reporter, time: stored.time, playerResults: stored.playerResults }
-    })
+    const currentResults = digestStoredReports(gameRecord.config, storedResults)
     const humans = gameRecord.config.teams.flatMap(t => t.filter(p => !p.isComputer).map(p => p.id))
     const desyncEvents = await getDesyncEventsForGame(gameId)
 
@@ -971,6 +1049,11 @@ export default class GameResultService {
         .flat(),
     )
 
+    // Activity dates describe when a game was *played*, which can be long before its results are
+    // applied: a periodic sweep or an admin resolving a dispute can land days later. A missing game
+    // length degrades to the start time, which is still far closer than the application time.
+    const gameEndDate = new Date(Number(gameRecord.startTime) + reconciled.time)
+
     const [season, seasonEnd] = await this.matchmakingSeasonsService.getSeasonForDate(
       gameRecord.startTime,
     )
@@ -1069,7 +1152,8 @@ export default class GameResultService {
             bonusUsed: matchmakingChange.bonusUsed,
             numGamesPlayed: mmr.numGamesPlayed + 1,
             lifetimeGames: matchmakingChange.lifetimeGames,
-            lastPlayedDate: reconcileDate,
+            // Never rewind past a newer game that has already been applied.
+            lastPlayedDate: new Date(Math.max(Number(mmr.lastPlayedDate), Number(gameEndDate))),
             wins: mmr.wins + winCount,
             losses: mmr.losses + lossCount,
 
@@ -1113,7 +1197,10 @@ export default class GameResultService {
             leagueId: oldLeagueUser.leagueId,
             userId: oldLeagueUser.userId,
             isBanned: oldLeagueUser.isBanned,
-            lastPlayedDate: reconcileDate,
+            // Never rewind past a newer game that has already been applied.
+            lastPlayedDate: new Date(
+              Math.max(Number(oldLeagueUser.lastPlayedDate ?? 0), Number(gameEndDate)),
+            ),
             points: leagueChange.points,
             pointsConverged: leagueChange.pointsConverged,
             wins: oldLeagueUser.wins + winCount,
@@ -1212,8 +1299,10 @@ export default class GameResultService {
    * rating, points and league changes for a ranked game. A disputed game never had any of those
    * applied, so this only ever adds effects, never reverses them.
    *
-   * Only the outcomes change. Each player's stored race and APM, the game's length, and its
-   * assigned matchup are all left exactly as reconciliation left them.
+   * Only the outcomes change: each player's stored race and APM, and the game's length, are left
+   * exactly as reconciliation left them. The assigned matchup is filled in here, since a disputed
+   * game is never given one, but only when every player's race can be established from a
+   * trustworthy source (see `computeManualResolutionMatchup`).
    *
    * @returns the updated game record, and whether matchmaking rating changes were actually applied
    *   (see `applyReconciledResultEffects`)
@@ -1233,6 +1322,11 @@ export default class GameResultService {
     }
 
     const resolvedAt = new Date(this.clock.now())
+    // Derived from the config and the stored reports, both immutable once a game has reconciled to
+    // a dispute — so this can run before the transaction rather than acquiring a second pool
+    // connection while holding the games row lock.
+    const assignedMatchup = await computeManualResolutionMatchup(gameRecord)
+
     const { ratingsApplied } = await transact(async client => {
       // Everything this decides on has to be read under the games row lock: two admins can submit a
       // resolution for the same game at once, and the second one must see the first's committed
@@ -1284,7 +1378,14 @@ export default class GameResultService {
         results: newResults,
       }
 
-      await setManuallyResolvedResult(client, gameId, newResults, resolvedBy, resolvedAt)
+      await setManuallyResolvedResult(
+        client,
+        gameId,
+        newResults,
+        assignedMatchup,
+        resolvedBy,
+        resolvedAt,
+      )
 
       const { ratingsApplied } = await this.applyReconciledResultEffects(
         client,

--- a/tools/backfills/2026-08-09-backfill-matchups.sql
+++ b/tools/backfills/2026-08-09-backfill-matchups.sql
@@ -1,6 +1,7 @@
 -- Backfills games.selected_matchup / games.assigned_matchup from the historical config/results
--- JSONB. Run this AFTER the 20260212000000_add_matchup_columns migration has been applied and the
--- new application code has been deployed.
+-- JSONB. Run this AFTER the 20260212000000_add_matchup_columns and
+-- 20260825120000_add_manual_game_resolution migrations have been applied and the new application
+-- code has been deployed.
 --
 -- Why this isn't part of the migration: backfilling (potentially) rewrites every row in `games`,
 -- and we don't want to hold a lock on that table for the whole duration. This processes the table
@@ -11,6 +12,15 @@
 -- differs from what's stored. Running it again after the deploy has settled therefore doubles as a
 -- cheap catch-up pass for any games that were created or reconciled by old code during the deploy
 -- window (which would otherwise keep NULL matchups forever).
+--
+-- Games an admin resolved by hand get their assigned matchup from their config plus their players'
+-- stored reports, never from their stored results. Hand-resolving clears `disputable` without
+-- touching the races the disputed reconciliation left behind, and those races can be inventions: a
+-- player who appeared in no report at all is stored as 'p'. A player who picked a specific race
+-- settles their own race, a random player's race is known only when the reports mention them and
+-- agree, and a game where any player's race is unknown gets no assigned matchup at all. Those are
+-- the same rules the resolution itself applies, so a re-run recomputes what is already stored
+-- rather than replacing it.
 --
 -- Usage (psql, and NOT wrapped in an explicit transaction, so the per-batch COMMITs can take
 -- effect):
@@ -42,6 +52,7 @@ DECLARE
   team jsonb;
   player jsonb;
   result_pair jsonb;
+  agreed_races jsonb;
   processed bigint := 0;
   changed bigint := 0;
 BEGIN
@@ -49,7 +60,8 @@ BEGIN
     batch_last_id := NULL;
 
     FOR r IN
-      SELECT id, config, results, disputable, selected_matchup, assigned_matchup
+      SELECT id, config, results, disputable, manually_resolved_at, selected_matchup,
+             assigned_matchup
       FROM games
       WHERE id > last_id
       ORDER BY id
@@ -121,47 +133,156 @@ BEGIN
         SELECT array_agg(s ORDER BY s) INTO all_team_strings FROM unnest(all_team_strings) AS s;
         selected := array_to_string(all_team_strings, '-');
 
-        -- assigned_matchup: from each player's assigned (result) race, only when results exist and
-        -- there are no computer players (computers aren't included in our results). Some legacy rows
-        -- store results as a non-array (e.g. an empty `{}` object), which we treat as "no results".
-        -- Disputed games are skipped too: their results (and thus assigned races) are unreliable,
-        -- and a player missing from the reports gets a fabricated 'p' race baked into the stored
-        -- results. This matches the live reconciliation path, which leaves assigned_matchup NULL for
-        -- disputed games.
-        IF jsonb_typeof(r.results) = 'array' AND NOT has_computers AND NOT r.disputable THEN
-          all_team_strings := ARRAY[]::text[];
-          FOREACH team IN ARRAY teams_for_matchup LOOP
-            team_races := ARRAY[]::text[];
-            FOR j IN 0..(jsonb_array_length(team) - 1) LOOP
-              player := team->j;
-              player_id := (player->>'id')::int;
-              player_race := NULL;
-              FOR result_pair IN SELECT jsonb_array_elements(r.results) LOOP
-                IF (result_pair->>0)::int = player_id THEN
-                  player_race := result_pair->1->>'race';
+        -- assigned_matchup: the race each player was actually given. Games with computer players
+        -- never get one, since computers aren't included in our results at all.
+        IF NOT has_computers THEN
+          IF r.manually_resolved_at IS NOT NULL THEN
+            -- Hand-resolving a game clears `disputable` but leaves the races the disputed
+            -- reconciliation stored exactly where they were, and those races can be inventions: a
+            -- player no report mentioned is stored as 'p', reports that disagree keep whichever
+            -- race the first one claimed, and a voided game with no reports at all stores 'p' for
+            -- everyone. The stored results are therefore no evidence here, and the assigned races
+            -- are rebuilt from the two sources that stand on their own.
+            --
+            -- A player who picked a specific race settles their own race: the game had no way to
+            -- hand them a different one, so no report is consulted for them. A random player has
+            -- only the reports to go on, and their race counts as known when at least one stored
+            -- report mentions them and every mention agrees on one of 'p'/'t'/'z'. Anything short
+            -- of that leaves the game without an assigned matchup rather than fabricating a race
+            -- for one slot.
+            BEGIN
+              -- The race the reports agree on for each user, dropped where they disagree. A row's
+              -- `reported_results` is either a raw (v2) report, listing one entry per BW player
+              -- (`userId` null for computers), or a legacy digested one, whose `playerResults`
+              -- pairs a user id with that user's verdict; the presence of `version` tells the two
+              -- apart. A user can be named more than once within a single report, so every mention
+              -- is aggregated rather than picked from.
+              --
+              -- `reported_results` is schemaless jsonb on a long-lived table, so each array is
+              -- forced through a CASE yielding [] for a row of the wrong shape:
+              -- jsonb_array_elements raises on a non-array, and it expands rows before the WHERE
+              -- clause gets to filter them out.
+              SELECT coalesce(jsonb_object_agg(user_id, races[1]), '{}'::jsonb)
+                INTO agreed_races
+              FROM (
+                SELECT user_id, array_agg(DISTINCT race) AS races
+                FROM (
+                  SELECT (p->>'userId')::int AS user_id, p->>'race' AS race
+                  FROM games_users gu,
+                       jsonb_array_elements(
+                         CASE WHEN jsonb_typeof(gu.reported_results->'players') = 'array'
+                           THEN gu.reported_results->'players'
+                           ELSE '[]'::jsonb
+                         END
+                       ) AS p
+                  WHERE gu.game_id = r.id
+                    AND gu.reported_results IS NOT NULL
+                    AND jsonb_exists(gu.reported_results, 'version')
+                    AND jsonb_typeof(p) = 'object'
+                    AND jsonb_typeof(p->'userId') = 'number'
+                    AND p->>'race' IN ('p', 't', 'z')
+                  UNION ALL
+                  SELECT (pair->>0)::int AS user_id, pair->1->>'race' AS race
+                  FROM games_users gu,
+                       jsonb_array_elements(
+                         CASE WHEN jsonb_typeof(gu.reported_results->'playerResults') = 'array'
+                           THEN gu.reported_results->'playerResults'
+                           ELSE '[]'::jsonb
+                         END
+                       ) AS pair
+                  WHERE gu.game_id = r.id
+                    AND gu.reported_results IS NOT NULL
+                    AND NOT jsonb_exists(gu.reported_results, 'version')
+                    AND jsonb_typeof(pair) = 'array'
+                    AND jsonb_typeof(pair->0) = 'number'
+                    AND pair->1->>'race' IN ('p', 't', 'z')
+                ) AS mentions
+                GROUP BY user_id
+              ) AS per_user
+              WHERE array_length(races, 1) = 1;
+
+              all_team_strings := ARRAY[]::text[];
+              FOREACH team IN ARRAY teams_for_matchup LOOP
+                team_races := ARRAY[]::text[];
+                FOR j IN 0..(jsonb_array_length(team) - 1) LOOP
+                  player := team->j;
+                  player_race := player->>'race';
+                  IF player_race = 'r' THEN
+                    player_race := agreed_races->>(player->>'id');
+                  ELSIF player_race NOT IN ('p', 't', 'z') THEN
+                    -- A config race that isn't a race settles nothing
+                    player_race := NULL;
+                  END IF;
+
+                  IF player_race IS NULL THEN
+                    -- This player's race can't be established, so the game gets no matchup
+                    team_races := NULL;
+                    EXIT;
+                  END IF;
+                  team_races := array_append(team_races, player_race);
+                END LOOP;
+
+                IF team_races IS NULL THEN
+                  all_team_strings := NULL;
                   EXIT;
                 END IF;
+
+                SELECT array_agg(s ORDER BY s) INTO team_races FROM unnest(team_races) AS s;
+                all_team_strings := array_append(all_team_strings, array_to_string(team_races, ''));
               END LOOP;
-              IF player_race IS NULL THEN
-                -- Player missing from results, can't compute an assigned matchup for this game
-                team_races := NULL;
+
+              IF all_team_strings IS NOT NULL THEN
+                SELECT array_agg(s ORDER BY s) INTO all_team_strings
+                FROM unnest(all_team_strings) AS s;
+                assigned := array_to_string(all_team_strings, '-');
+              END IF;
+            EXCEPTION WHEN OTHERS THEN
+              -- A report or config shape we can't read must not abort the whole run, and it says
+              -- nothing about whether the stored matchup is right. Keep what's there and move on.
+              assigned := r.assigned_matchup;
+            END;
+          ELSIF jsonb_typeof(r.results) = 'array' AND NOT r.disputable THEN
+            -- A game that reconciled takes its assigned races from the stored results. Some legacy
+            -- rows store results as a non-array (e.g. an empty `{}` object), which we treat as "no
+            -- results". Games still sitting in a dispute are skipped: their results (and thus
+            -- assigned races) are unreliable, and a player missing from the reports gets a
+            -- fabricated 'p' race baked into the stored results. This matches the live
+            -- reconciliation path, which leaves assigned_matchup NULL for disputed games.
+            all_team_strings := ARRAY[]::text[];
+            FOREACH team IN ARRAY teams_for_matchup LOOP
+              team_races := ARRAY[]::text[];
+              FOR j IN 0..(jsonb_array_length(team) - 1) LOOP
+                player := team->j;
+                player_id := (player->>'id')::int;
+                player_race := NULL;
+                FOR result_pair IN SELECT jsonb_array_elements(r.results) LOOP
+                  IF (result_pair->>0)::int = player_id THEN
+                    player_race := result_pair->1->>'race';
+                    EXIT;
+                  END IF;
+                END LOOP;
+                IF player_race IS NULL THEN
+                  -- Player missing from results, can't compute an assigned matchup for this game
+                  team_races := NULL;
+                  EXIT;
+                END IF;
+                team_races := array_append(team_races, player_race);
+              END LOOP;
+
+              IF team_races IS NULL THEN
+                all_team_strings := NULL;
                 EXIT;
               END IF;
-              team_races := array_append(team_races, player_race);
+
+              SELECT array_agg(s ORDER BY s) INTO team_races FROM unnest(team_races) AS s;
+              all_team_strings := array_append(all_team_strings, array_to_string(team_races, ''));
             END LOOP;
 
-            IF team_races IS NULL THEN
-              all_team_strings := NULL;
-              EXIT;
+            IF all_team_strings IS NOT NULL THEN
+              SELECT array_agg(s ORDER BY s) INTO all_team_strings
+              FROM unnest(all_team_strings) AS s;
+              assigned := array_to_string(all_team_strings, '-');
             END IF;
-
-            SELECT array_agg(s ORDER BY s) INTO team_races FROM unnest(team_races) AS s;
-            all_team_strings := array_append(all_team_strings, array_to_string(team_races, ''));
-          END LOOP;
-
-          IF all_team_strings IS NOT NULL THEN
-            SELECT array_agg(s ORDER BY s) INTO all_team_strings FROM unnest(all_team_strings) AS s;
-            assigned := array_to_string(all_team_strings, '-');
           END IF;
         END IF;
       END IF;


### PR DESCRIPTION
Two follow-up fixes to manual game resolution (#1422):

**Assigned matchup.** Manually resolved games left `assigned_matchup` NULL (the reconcile path skips it for disputed games because of the fabricated-race hazard), so they never matched matchup-filtered game lists. Resolution now computes the matchup when every player's race is trustworthy:
- A picked (non-random) race comes straight from the config — the game can't have assigned anything else, so reports aren't consulted.
- A random player's race counts only when they appear in ≥1 stored report and every report agrees; the reports are digested through the same raw/legacy path reconciliation uses (extracted as `digestStoredReports` so the two can't drift).
- Anything short of that (including games with computers) leaves the matchup NULL rather than baking in a guess.

**Last played.** `applyReconciledResultEffects` stamped `last_played_date` (matchmaking rating + league user) with the effect-application time, so a game resolved days later showed the resolve date as "Last played" on the ladder — the periodic-sweep reconcile path had the same latent problem. It's now dated from the game's end (start time + length), max-guarded so a late resolve can't rewind past a newer game the player already had applied. `change_date` on rating changes intentionally stays at effect-application time: the change genuinely happens then, and the rating history's ordering/season bucketing relies on it.

**Backfill.** `tools/backfills/2026-08-09-backfill-matchups.sql` learned the same trust rules: its stored-results path was gated on `NOT disputable`, which manual resolution turned into a false signal — a re-run would have baked fabricated races into manually resolved games (and overwritten matchups the resolution derives). Manually resolved games now get their assigned matchup from config + `games_users.reported_results` under the rules above, so re-running it doubles as the catch-up pass for games resolved before this PR. Verified on the dev DB: dry-run and real run agree (3/105 rows), the one manual game with an agreeing report gained `p-t`, the zero-report/empty-report ones stayed NULL (one fabricated `p-p` cleared), and an immediate re-run changes 0 rows.

Covered by 6 new unit tests (matchup from config, random-agreeing, random-absent, random-disagreeing, end-of-game dating, max-guard).