### PR TITLE
Add keyboard shortcuts to the news markdown editor

### DIFF
--- a/client/admin/admin-news.test.ts
+++ b/client/admin/admin-news.test.ts
@@ -7,13 +7,15 @@ import {
   insertInlineImage,
   NewsEditorModel,
   NewsPostEdit,
+  publishedAtUpdate,
+  toDateTimeLocalString,
+} from './admin-news'
+import {
   PUBLISH_MODE_DRAFT,
   PUBLISH_MODE_NOW,
   PUBLISH_MODE_PUBLISHED,
   PUBLISH_MODE_SCHEDULE,
-  publishedAtUpdate,
-  toDateTimeLocalString,
-} from './admin-news'
+} from './news-post-settings-dialog'
 
 describe('getPostStatus', () => {
   test('returns draft for a null publishedAt', () => {

--- a/client/admin/admin-news.test.ts
+++ b/client/admin/admin-news.test.ts
@@ -9,6 +9,7 @@ import {
   NewsPostEdit,
   PUBLISH_MODE_DRAFT,
   PUBLISH_MODE_NOW,
+  PUBLISH_MODE_PUBLISHED,
   PUBLISH_MODE_SCHEDULE,
   publishedAtUpdate,
   toDateTimeLocalString,
@@ -101,6 +102,13 @@ describe('createPublishedAt', () => {
     expect(result).toBeDefined()
     expect(new Date(result!).toISOString()).toBe(result)
   })
+
+  test('returns a parseable ISO string for published mode', () => {
+    const result = createPublishedAt({ ...baseModel, publishMode: PUBLISH_MODE_PUBLISHED })
+
+    expect(result).toBeDefined()
+    expect(new Date(result!).toISOString()).toBe(result)
+  })
 })
 
 describe('publishedAtUpdate', () => {
@@ -134,6 +142,13 @@ describe('publishedAtUpdate', () => {
     expect(result).toBeDefined()
     expect(result!.value).not.toBeNull()
     expect(new Date(result!.value!).toISOString()).toBe(result!.value)
+  })
+
+  test('published mode makes no change to an originally published post', () => {
+    const model: NewsEditorModel = { ...baseModel, publishMode: PUBLISH_MODE_PUBLISHED }
+    const original = new Date(2026, 0, 1).toISOString()
+
+    expect(publishedAtUpdate(model, original)).toBeUndefined()
   })
 
   test('schedule mode makes no change when the target minute matches the original', () => {

--- a/client/admin/admin-news.tsx
+++ b/client/admin/admin-news.tsx
@@ -1233,6 +1233,27 @@ function NewsEditor({ post }: { post: EditablePost | undefined }) {
     }
   }
 
+  // The save button doubles as a summary of the publish state chosen in the post settings
+  // dialog, so what saving will do is visible without opening it.
+  const publishModeValue = getInputValue('publishMode')
+  let saveLabel: string
+  switch (publishModeValue) {
+    case PUBLISH_MODE_DRAFT:
+      saveLabel = t('admin.news.saveDraft', 'Save draft')
+      break
+    case PUBLISH_MODE_NOW:
+      saveLabel = t('admin.news.publishNow', 'Publish now')
+      break
+    case PUBLISH_MODE_SCHEDULE:
+      saveLabel = t('admin.news.schedulePost', 'Schedule post')
+      break
+    case PUBLISH_MODE_PUBLISHED:
+      saveLabel = t('admin.news.saveChanges', 'Save changes')
+      break
+    default:
+      saveLabel = publishModeValue satisfies never
+  }
+
   return (
     <CenteredContentContainer $fullWidth={true} data-content-fullbleed=''>
       <EditorRoot>
@@ -1260,11 +1281,7 @@ function NewsEditor({ post }: { post: EditablePost | undefined }) {
               onClick={openSettings}
             />
             <FilledButton
-              label={
-                post
-                  ? t('admin.news.saveChanges', 'Save changes')
-                  : t('admin.news.createPost', 'Create post')
-              }
+              label={saveLabel}
               onClick={onSaveClick}
               disabled={fetching || imageUploading || videoUploading}
             />

--- a/client/admin/admin-news.tsx
+++ b/client/admin/admin-news.tsx
@@ -749,9 +749,28 @@ export interface NewsEditorModel {
   scheduledAt: string
 }
 
+// The public news post page renders markdown at a 720px max width (see `news-post-page.tsx`);
+// this is that width plus the preview pane's 24px of horizontal padding on each side. The editor
+// column is capped at the same width so both sides of the split view keep a readable line length.
+const EDITOR_COLUMN_MAX_WIDTH = 768
+const editorColumnWidth = `minmax(0, ${EDITOR_COLUMN_MAX_WIDTH}px)`
+
+const EditorRoot = styled.div`
+  height: 100%;
+  padding-block: 24px;
+
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+`
+
 const FormArea = styled.div`
+  flex: 1 1 0;
+  min-height: 0;
+
   display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  grid-template-columns: ${editorColumnWidth} ${editorColumnWidth};
+  grid-template-rows: auto minmax(0, 1fr);
   grid-template-areas:
     'toolbar .'
     'editor preview';
@@ -762,10 +781,11 @@ const FormArea = styled.div`
 const EditorColumn = styled.div`
   grid-area: editor;
   min-width: 0;
+  overflow-y: auto;
 
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 16px;
 `
 
 const EditorToolbar = styled(MarkdownToolbar)`
@@ -780,11 +800,6 @@ const PreviewContainer = styled.div`
   grid-area: preview;
   min-width: 0;
   position: relative;
-  /**
-    Mirrors the 20px strip TextField reserves below the field box for a validation error, so the
-    preview's bottom edge stays level with the field box rather than the error strip.
-  */
-  margin-bottom: 20px;
 `
 
 const MarkdownPreview = styled(Markdown)`
@@ -798,9 +813,20 @@ const MarkdownPreview = styled(Markdown)`
 `
 
 const Form = styled.form`
+  flex: 1 1 0;
+  min-height: 0;
+  width: 100%;
+  max-width: ${2 * EDITOR_COLUMN_MAX_WIDTH + 24}px;
+  margin-inline: auto;
+
   display: flex;
   flex-direction: column;
   gap: 16px;
+`
+
+const NarrowTextField = styled(TextField)`
+  width: 100%;
+  max-width: ${EDITOR_COLUMN_MAX_WIDTH}px;
 `
 
 const PublishControl = styled.div`
@@ -1290,7 +1316,7 @@ function NewsEditor({ post }: { post: EditablePost | undefined }) {
 
   return (
     <CenteredContentContainer $fullWidth={true} data-content-fullbleed=''>
-      <Root>
+      <EditorRoot>
         <HeaderRow>
           <Title>
             {post
@@ -1313,8 +1339,8 @@ function NewsEditor({ post }: { post: EditablePost | undefined }) {
         </HeaderRow>
         {error ? <ErrorText>{error.message}</ErrorText> : null}
         <Form onSubmit={submit}>
-          <TextField {...bindInput('title')} label={t('admin.news.form.title', 'Title')} />
-          <TextField
+          <NarrowTextField {...bindInput('title')} label={t('admin.news.form.title', 'Title')} />
+          <NarrowTextField
             {...bindInput('summary')}
             label={t('admin.news.form.summary', 'Summary')}
             multiline={true}
@@ -1375,112 +1401,114 @@ function NewsEditor({ post }: { post: EditablePost | undefined }) {
                 label={t('admin.news.form.content', 'Content (Markdown)')}
                 multiline={true}
                 rows={18}
-                maxRows={40}
               />
               {imageError ? <ErrorText>{imageError}</ErrorText> : null}
               {videoError ? <ErrorText>{videoError}</ErrorText> : null}
+              <CoverSection>
+                <CoverLabel>{t('admin.news.form.cover', 'Cover image')}</CoverLabel>
+                <CoverPreview>
+                  {coverImageUrl ? (
+                    <CoverImage src={coverImageUrl} alt='' draggable={false} />
+                  ) : (
+                    <CoverPlaceholder>
+                      {t(
+                        'admin.news.form.coverNone',
+                        'No cover image (a stock image will be used)',
+                      )}
+                    </CoverPlaceholder>
+                  )}
+                </CoverPreview>
+                <HiddenFileInput
+                  ref={coverFileInputRef}
+                  type='file'
+                  accept='image/*'
+                  onChange={onCoverFileSelected}
+                  data-testid='news-cover-file-input'
+                />
+                <CoverActions>
+                  <OutlinedButton
+                    label={
+                      coverImageUrl
+                        ? t('admin.news.form.coverChange', 'Change cover')
+                        : t('admin.news.form.coverUpload', 'Upload cover')
+                    }
+                    iconStart={<MaterialIcon icon='image' />}
+                    onClick={() => coverFileInputRef.current?.click()}
+                    disabled={coverUploading}
+                  />
+                  {coverImageUrl ? (
+                    <TextButton
+                      label={t('admin.news.form.coverRemove', 'Remove cover')}
+                      onClick={onRemoveCover}
+                      disabled={coverUploading}
+                    />
+                  ) : null}
+                </CoverActions>
+                {coverUploading ? (
+                  <CoverHint>{t('admin.news.form.coverUploading', 'Uploading…')}</CoverHint>
+                ) : null}
+                {coverError ? <ErrorText>{coverError}</ErrorText> : null}
+              </CoverSection>
+              <PublishControl>
+                <RadioGroup
+                  {...bindInput('publishMode')}
+                  label={t('admin.news.form.publish', 'Publish')}
+                  dense={true}>
+                  {initialStatus.kind === 'published' ? (
+                    <RadioButton
+                      value={PUBLISH_MODE_PUBLISHED}
+                      label={t('admin.news.form.publishPublished', 'Published ({{date}})', {
+                        date: longTimestamp.format(initialStatus.date),
+                      })}
+                    />
+                  ) : null}
+                  <RadioButton
+                    value={PUBLISH_MODE_DRAFT}
+                    label={t('admin.news.form.publishDraft', 'Draft (not published)')}
+                  />
+                  <RadioButton
+                    value={PUBLISH_MODE_NOW}
+                    label={t('admin.news.form.publishNow', 'Publish now')}
+                  />
+                  <RadioButton
+                    value={PUBLISH_MODE_SCHEDULE}
+                    label={t('admin.news.form.publishSchedule', 'Schedule')}
+                  />
+                </RadioGroup>
+                {currentPublishMode === PUBLISH_MODE_SCHEDULE ? (
+                  <>
+                    <ScheduleField
+                      {...bindInput('scheduledAt')}
+                      label={t('admin.news.form.scheduleDate', 'Publish date and time')}
+                      floatingLabel={true}
+                    />
+                    <ScheduleHint>
+                      {t(
+                        'admin.news.form.scheduleHint',
+                        'A future date/time schedules the post; a past date/time publishes it immediately.',
+                      )}
+                    </ScheduleHint>
+                  </>
+                ) : null}
+              </PublishControl>
+              <SaveRow>
+                <FilledButton
+                  label={
+                    post
+                      ? t('admin.news.saveChanges', 'Save changes')
+                      : t('admin.news.createPost', 'Create post')
+                  }
+                  onClick={submit}
+                  disabled={fetching || coverUploading || imageUploading || videoUploading}
+                />
+              </SaveRow>
             </EditorColumn>
             <PreviewContainer>
               <MarkdownPreview source={getInputValue('content')} allowMedia={true} />
             </PreviewContainer>
           </FormArea>
-          <CoverSection>
-            <CoverLabel>{t('admin.news.form.cover', 'Cover image')}</CoverLabel>
-            <CoverPreview>
-              {coverImageUrl ? (
-                <CoverImage src={coverImageUrl} alt='' draggable={false} />
-              ) : (
-                <CoverPlaceholder>
-                  {t('admin.news.form.coverNone', 'No cover image (a stock image will be used)')}
-                </CoverPlaceholder>
-              )}
-            </CoverPreview>
-            <HiddenFileInput
-              ref={coverFileInputRef}
-              type='file'
-              accept='image/*'
-              onChange={onCoverFileSelected}
-              data-testid='news-cover-file-input'
-            />
-            <CoverActions>
-              <OutlinedButton
-                label={
-                  coverImageUrl
-                    ? t('admin.news.form.coverChange', 'Change cover')
-                    : t('admin.news.form.coverUpload', 'Upload cover')
-                }
-                iconStart={<MaterialIcon icon='image' />}
-                onClick={() => coverFileInputRef.current?.click()}
-                disabled={coverUploading}
-              />
-              {coverImageUrl ? (
-                <TextButton
-                  label={t('admin.news.form.coverRemove', 'Remove cover')}
-                  onClick={onRemoveCover}
-                  disabled={coverUploading}
-                />
-              ) : null}
-            </CoverActions>
-            {coverUploading ? (
-              <CoverHint>{t('admin.news.form.coverUploading', 'Uploading…')}</CoverHint>
-            ) : null}
-            {coverError ? <ErrorText>{coverError}</ErrorText> : null}
-          </CoverSection>
-          <PublishControl>
-            <RadioGroup
-              {...bindInput('publishMode')}
-              label={t('admin.news.form.publish', 'Publish')}
-              dense={true}>
-              {initialStatus.kind === 'published' ? (
-                <RadioButton
-                  value={PUBLISH_MODE_PUBLISHED}
-                  label={t('admin.news.form.publishPublished', 'Published ({{date}})', {
-                    date: longTimestamp.format(initialStatus.date),
-                  })}
-                />
-              ) : null}
-              <RadioButton
-                value={PUBLISH_MODE_DRAFT}
-                label={t('admin.news.form.publishDraft', 'Draft (not published)')}
-              />
-              <RadioButton
-                value={PUBLISH_MODE_NOW}
-                label={t('admin.news.form.publishNow', 'Publish now')}
-              />
-              <RadioButton
-                value={PUBLISH_MODE_SCHEDULE}
-                label={t('admin.news.form.publishSchedule', 'Schedule')}
-              />
-            </RadioGroup>
-            {currentPublishMode === PUBLISH_MODE_SCHEDULE ? (
-              <>
-                <ScheduleField
-                  {...bindInput('scheduledAt')}
-                  label={t('admin.news.form.scheduleDate', 'Publish date and time')}
-                  floatingLabel={true}
-                />
-                <ScheduleHint>
-                  {t(
-                    'admin.news.form.scheduleHint',
-                    'A future date/time schedules the post; a past date/time publishes it immediately.',
-                  )}
-                </ScheduleHint>
-              </>
-            ) : null}
-          </PublishControl>
-          <SaveRow>
-            <FilledButton
-              label={
-                post
-                  ? t('admin.news.saveChanges', 'Save changes')
-                  : t('admin.news.createPost', 'Create post')
-              }
-              onClick={submit}
-              disabled={fetching || coverUploading || imageUploading || videoUploading}
-            />
-          </SaveRow>
         </Form>
-      </Root>
+      </EditorRoot>
     </CenteredContentContainer>
   )
 }

--- a/client/admin/admin-news.tsx
+++ b/client/admin/admin-news.tsx
@@ -24,6 +24,7 @@ import logger from '../logging/logger'
 import { Markdown } from '../markdown/markdown'
 import {
   applyMarkdownFormat,
+  markdownFormatForKeyEvent,
   MarkdownFormatKind,
   MarkdownToolbar,
   ToolbarButton,
@@ -1331,6 +1332,13 @@ function NewsEditor({ post }: { post: EditablePost | undefined }) {
                 ref={contentInputRef}
                 onFocus={() => {
                   contentEverFocusedRef.current = true
+                }}
+                onKeyDown={event => {
+                  const kind = markdownFormatForKeyEvent(event)
+                  if (kind) {
+                    event.preventDefault()
+                    onFormat(kind)
+                  }
                 }}
                 label={t('admin.news.form.content', 'Content (Markdown)')}
                 multiline={true}

--- a/client/admin/admin-news.tsx
+++ b/client/admin/admin-news.tsx
@@ -1112,7 +1112,11 @@ function NewsEditor({ post }: { post: EditablePost | undefined }) {
 
   const validations: ValidatorMap<NewsEditorModel> = {
     title: required(t('admin.news.form.titleRequired', 'Title is required')),
-    summary: required(t('admin.news.form.summaryRequired', 'Summary is required')),
+    // Whitespace-only summaries must fail validation, since the save flow only opens the settings
+    // dialog (where the summary error can actually be seen) for summaries that are blank after
+    // trimming.
+    summary: value =>
+      value.trim() ? undefined : t('admin.news.form.summaryRequired', 'Summary is required'),
     content: required(t('admin.news.form.contentRequired', 'Content is required')),
     scheduledAt: (value, model) => {
       if (model.publishMode !== PUBLISH_MODE_SCHEDULE) {
@@ -1267,7 +1271,14 @@ function NewsEditor({ post }: { post: EditablePost | undefined }) {
           </HeaderActions>
         </HeaderRow>
         {error ? <ErrorText>{error.message}</ErrorText> : null}
-        <Form onSubmit={submit}>
+        <Form
+          onSubmit={event => {
+            // Implicit submission (e.g. Enter in the title field) needs the same
+            // missing-summary/schedule handling as the save button, since submitting directly
+            // would fail validation against inputs that only render in the settings dialog.
+            event.preventDefault()
+            onSaveClick()
+          }}>
           <FormArea>
             <TitleField {...bindInput('title')} label={t('admin.news.form.title', 'Title')} />
             <EditorToolbar onFormat={onFormat}>

--- a/client/admin/admin-news.tsx
+++ b/client/admin/admin-news.tsx
@@ -14,6 +14,8 @@ import {
 } from '../../common/news'
 import { apiUrl, urlPath } from '../../common/urls'
 import { useSelfUser } from '../auth/auth-utils'
+import { openDialog } from '../dialogs/action-creators'
+import { DialogType } from '../dialogs/dialog-type'
 import { useForm, useFormCallbacks, ValidatorMap } from '../forms/form-hook'
 import { required } from '../forms/validators'
 import { graphql } from '../gql'
@@ -30,17 +32,16 @@ import {
   ToolbarButton,
 } from '../markdown/markdown-toolbar'
 import { FilledButton, IconButton, OutlinedButton, TextButton } from '../material/button'
-import { DateTimeTextField } from '../material/datetime-text-field'
 import { DestructiveMenuItem, MenuItem } from '../material/menu/item'
 import { MenuList } from '../material/menu/menu'
 import { Popover, usePopoverController, useRefAnchorPosition } from '../material/popover'
-import { RadioButton, RadioGroup } from '../material/radio'
 import { TextField } from '../material/text-field'
 import { push } from '../navigation/routing'
 import { fetchJson } from '../network/fetch'
 import { urlForNewsPost } from '../news/news-url'
 import { LoadingDotsArea } from '../progress/dots'
 import { useNow } from '../react/date-hooks'
+import { useAppDispatch } from '../redux-hooks'
 import { useSnackbarController } from '../snackbars/snackbar-overlay'
 import { CenteredContentContainer } from '../styles/centered-container'
 import { ContainerLevel, containerStyles } from '../styles/colors'
@@ -53,6 +54,15 @@ import {
   titleMedium,
 } from '../styles/typography'
 import { ConnectedUsername } from '../users/connected-username'
+import {
+  NewsPostSettings,
+  PostStatus,
+  PUBLISH_MODE_DRAFT,
+  PUBLISH_MODE_NOW,
+  PUBLISH_MODE_PUBLISHED,
+  PUBLISH_MODE_SCHEDULE,
+  PublishMode,
+} from './news-post-settings-dialog'
 
 const AdminNewsListQuery = graphql(/* GraphQL */ `
   query AdminNewsList($first: Int, $after: String) {
@@ -148,19 +158,6 @@ const NewsDeletePostMutation = graphql(/* GraphQL */ `
 `)
 
 const PAGE_SIZE = 20
-
-export const PUBLISH_MODE_DRAFT = 'draft'
-export const PUBLISH_MODE_NOW = 'now'
-export const PUBLISH_MODE_SCHEDULE = 'schedule'
-export const PUBLISH_MODE_PUBLISHED = 'published'
-type PublishMode =
-  | typeof PUBLISH_MODE_DRAFT
-  | typeof PUBLISH_MODE_NOW
-  | typeof PUBLISH_MODE_SCHEDULE
-  | typeof PUBLISH_MODE_PUBLISHED
-
-type PostStatus =
-  { kind: 'draft' } | { kind: 'scheduled'; date: Date } | { kind: 'published'; date: Date }
 
 /** Classifies a post's publish state given the current time (`now`, in millis). */
 export function getPostStatus(publishedAt: string | null | undefined, now: number): PostStatus {
@@ -770,9 +767,10 @@ const FormArea = styled.div`
 
   display: grid;
   grid-template-columns: ${editorColumnWidth} ${editorColumnWidth};
-  grid-template-rows: auto minmax(0, 1fr);
+  grid-template-rows: auto auto minmax(0, 1fr);
   grid-template-areas:
-    'toolbar .'
+    'title preview'
+    'toolbar preview'
     'editor preview';
   column-gap: 24px;
   row-gap: 8px;
@@ -824,92 +822,18 @@ const Form = styled.form`
   gap: 16px;
 `
 
-const NarrowTextField = styled(TextField)`
+const TitleField = styled(TextField)`
+  grid-area: title;
   width: 100%;
-  max-width: ${EDITOR_COLUMN_MAX_WIDTH}px;
-`
-
-const PublishControl = styled.div`
-  ${containerStyles(ContainerLevel.Low)};
-
-  padding: 16px;
-
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-
-  border-radius: 4px;
-`
-
-const ScheduleField = styled(DateTimeTextField)`
-  max-width: 320px;
-`
-
-const ScheduleHint = styled.div`
-  ${bodyMedium};
-  color: var(--theme-on-surface-variant);
-`
-
-const SaveRow = styled.div`
-  display: flex;
-  gap: 8px;
-`
-
-const CoverSection = styled.div`
-  ${containerStyles(ContainerLevel.Low)};
-
-  padding: 16px;
-
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-
-  border-radius: 4px;
-`
-
-const CoverLabel = styled.div`
-  ${labelMedium};
-  color: var(--theme-on-surface-variant);
-`
-
-const CoverPreview = styled.div`
-  width: 100%;
-  max-width: 480px;
-  aspect-ratio: 2 / 1;
-
-  display: flex;
-  align-items: center;
-  justify-content: center;
-
-  border: 1px solid var(--theme-outline-variant);
-  border-radius: 4px;
-  overflow: hidden;
-`
-
-const CoverImage = styled.img`
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-`
-
-const CoverPlaceholder = styled.div`
-  ${bodyMedium};
-  color: var(--theme-on-surface-variant);
-`
-
-const CoverActions = styled.div`
-  display: flex;
-  align-items: center;
-  gap: 8px;
-`
-
-const CoverHint = styled.div`
-  ${bodyMedium};
-  color: var(--theme-on-surface-variant);
 `
 
 const HiddenFileInput = styled.input`
   display: none;
+`
+
+const UploadHint = styled.div`
+  ${bodyMedium};
+  color: var(--theme-on-surface-variant);
 `
 
 /**
@@ -1008,6 +932,7 @@ export function publishedAtUpdate(
 
 function NewsEditor({ post }: { post: EditablePost | undefined }) {
   const { t } = useTranslation()
+  const dispatch = useAppDispatch()
   const selfUser = useSelfUser()
   const snackbarController = useSnackbarController()
   const [{ fetching: creating, error: createError }, createPost] =
@@ -1017,11 +942,8 @@ function NewsEditor({ post }: { post: EditablePost | undefined }) {
   const fetching = creating || updating
   const error = createError ?? updateError
 
-  const coverFileInputRef = useRef<HTMLInputElement>(null)
   const [coverImagePath, setCoverImagePath] = useState<string | null>(post?.coverImagePath ?? null)
   const [coverImageUrl, setCoverImageUrl] = useState<string | null>(post?.coverImageUrl ?? null)
-  const [coverUploading, setCoverUploading] = useState(false)
-  const [coverError, setCoverError] = useState<string | undefined>(undefined)
 
   const imageFileInputRef = useRef<HTMLInputElement>(null)
   const contentInputRef = useRef<HTMLInputElement | HTMLTextAreaElement>(null)
@@ -1035,50 +957,6 @@ function NewsEditor({ post }: { post: EditablePost | undefined }) {
   const videoFileInputRef = useRef<HTMLInputElement>(null)
   const [videoUploading, setVideoUploading] = useState(false)
   const [videoError, setVideoError] = useState<string | undefined>(undefined)
-
-  const onCoverFileSelected = (event: ChangeEvent<HTMLInputElement>) => {
-    const file = event.target.files?.[0]
-    // Reset the input so selecting the same file again still fires a change event.
-    event.target.value = ''
-    if (!file) {
-      return
-    }
-    if (!file.type.startsWith('image/')) {
-      setCoverError(t('admin.news.form.coverInvalidType', 'Please choose an image file.'))
-      return
-    }
-    if (file.size > MAX_IMAGE_SIZE_BYTES) {
-      setCoverError(t('admin.news.form.coverTooLarge', 'That image is too large (max 5 MB).'))
-      return
-    }
-
-    setCoverError(undefined)
-    setCoverUploading(true)
-    const formData = new FormData()
-    formData.append('image', file)
-    fetchJson<NewsImageUploadResponse>(apiUrl`news/images`, {
-      method: 'POST',
-      body: formData,
-    })
-      .then(result => {
-        setCoverUploading(false)
-        setCoverImagePath(result.path)
-        setCoverImageUrl(result.url)
-      })
-      .catch(err => {
-        setCoverUploading(false)
-        setCoverError(
-          t('admin.news.form.coverUploadError', 'Something went wrong uploading the cover image.'),
-        )
-        logger.error(`Error uploading news cover image: ${getErrorStack(err)}`)
-      })
-  }
-
-  const onRemoveCover = () => {
-    setCoverError(undefined)
-    setCoverImagePath(null)
-    setCoverImageUrl(null)
-  }
 
   // Splices the uploaded file's URL into the content textarea as inline markdown, at the current
   // cursor position. Shared by the image and video upload handlers: the inserted markdown syntax
@@ -1312,7 +1190,44 @@ function NewsEditor({ post }: { post: EditablePost | undefined }) {
     },
   })
 
-  const currentPublishMode = getInputValue('publishMode')
+  const openSettings = () => {
+    dispatch(
+      openDialog({
+        type: DialogType.NewsPostSettings,
+        initData: {
+          savedStatus: initialStatus,
+          settings: {
+            summary: getInputValue('summary'),
+            publishMode: getInputValue('publishMode'),
+            scheduledAt: getInputValue('scheduledAt'),
+            coverImagePath,
+            coverImageUrl,
+          },
+          onApply: (s: NewsPostSettings) => {
+            setInputValue('summary', s.summary)
+            setInputValue('publishMode', s.publishMode)
+            setInputValue('scheduledAt', s.scheduledAt)
+            setCoverImagePath(s.coverImagePath)
+            setCoverImageUrl(s.coverImageUrl)
+          },
+        },
+      }),
+    )
+  }
+
+  const onSaveClick = () => {
+    // The summary and schedule fields are edited in the post settings dialog now, so a validation
+    // failure on either needs to open that dialog rather than failing silently against inputs that
+    // no longer appear on this page.
+    const scheduleInvalid =
+      getInputValue('publishMode') === PUBLISH_MODE_SCHEDULE &&
+      Number.isNaN(new Date(getInputValue('scheduledAt')).getTime())
+    if (!getInputValue('summary').trim() || scheduleInvalid) {
+      openSettings()
+    } else {
+      submit()
+    }
+  }
 
   return (
     <CenteredContentContainer $fullWidth={true} data-content-fullbleed=''>
@@ -1335,19 +1250,26 @@ function NewsEditor({ post }: { post: EditablePost | undefined }) {
               label={t('admin.news.backToList', 'Back to list')}
               onClick={() => push('/admin/news')}
             />
+            <OutlinedButton
+              label={t('admin.news.form.postSettings', 'Post settings')}
+              iconStart={<MaterialIcon icon='settings' />}
+              onClick={openSettings}
+            />
+            <FilledButton
+              label={
+                post
+                  ? t('admin.news.saveChanges', 'Save changes')
+                  : t('admin.news.createPost', 'Create post')
+              }
+              onClick={onSaveClick}
+              disabled={fetching || imageUploading || videoUploading}
+            />
           </HeaderActions>
         </HeaderRow>
         {error ? <ErrorText>{error.message}</ErrorText> : null}
         <Form onSubmit={submit}>
-          <NarrowTextField {...bindInput('title')} label={t('admin.news.form.title', 'Title')} />
-          <NarrowTextField
-            {...bindInput('summary')}
-            label={t('admin.news.form.summary', 'Summary')}
-            multiline={true}
-            rows={2}
-            maxRows={4}
-          />
           <FormArea>
+            <TitleField {...bindInput('title')} label={t('admin.news.form.title', 'Title')} />
             <EditorToolbar onFormat={onFormat}>
               <HiddenFileInput
                 ref={imageFileInputRef}
@@ -1364,7 +1286,7 @@ function NewsEditor({ post }: { post: EditablePost | undefined }) {
                 onClick={() => imageFileInputRef.current?.click()}
               />
               {imageUploading ? (
-                <CoverHint>{t('admin.news.form.imageUploading', 'Uploading…')}</CoverHint>
+                <UploadHint>{t('admin.news.form.imageUploading', 'Uploading…')}</UploadHint>
               ) : null}
               <HiddenFileInput
                 ref={videoFileInputRef}
@@ -1381,7 +1303,7 @@ function NewsEditor({ post }: { post: EditablePost | undefined }) {
                 onClick={() => videoFileInputRef.current?.click()}
               />
               {videoUploading ? (
-                <CoverHint>{t('admin.news.form.videoUploading', 'Uploading…')}</CoverHint>
+                <UploadHint>{t('admin.news.form.videoUploading', 'Uploading…')}</UploadHint>
               ) : null}
             </EditorToolbar>
             <EditorColumn>
@@ -1404,104 +1326,6 @@ function NewsEditor({ post }: { post: EditablePost | undefined }) {
               />
               {imageError ? <ErrorText>{imageError}</ErrorText> : null}
               {videoError ? <ErrorText>{videoError}</ErrorText> : null}
-              <CoverSection>
-                <CoverLabel>{t('admin.news.form.cover', 'Cover image')}</CoverLabel>
-                <CoverPreview>
-                  {coverImageUrl ? (
-                    <CoverImage src={coverImageUrl} alt='' draggable={false} />
-                  ) : (
-                    <CoverPlaceholder>
-                      {t(
-                        'admin.news.form.coverNone',
-                        'No cover image (a stock image will be used)',
-                      )}
-                    </CoverPlaceholder>
-                  )}
-                </CoverPreview>
-                <HiddenFileInput
-                  ref={coverFileInputRef}
-                  type='file'
-                  accept='image/*'
-                  onChange={onCoverFileSelected}
-                  data-testid='news-cover-file-input'
-                />
-                <CoverActions>
-                  <OutlinedButton
-                    label={
-                      coverImageUrl
-                        ? t('admin.news.form.coverChange', 'Change cover')
-                        : t('admin.news.form.coverUpload', 'Upload cover')
-                    }
-                    iconStart={<MaterialIcon icon='image' />}
-                    onClick={() => coverFileInputRef.current?.click()}
-                    disabled={coverUploading}
-                  />
-                  {coverImageUrl ? (
-                    <TextButton
-                      label={t('admin.news.form.coverRemove', 'Remove cover')}
-                      onClick={onRemoveCover}
-                      disabled={coverUploading}
-                    />
-                  ) : null}
-                </CoverActions>
-                {coverUploading ? (
-                  <CoverHint>{t('admin.news.form.coverUploading', 'Uploading…')}</CoverHint>
-                ) : null}
-                {coverError ? <ErrorText>{coverError}</ErrorText> : null}
-              </CoverSection>
-              <PublishControl>
-                <RadioGroup
-                  {...bindInput('publishMode')}
-                  label={t('admin.news.form.publish', 'Publish')}
-                  dense={true}>
-                  {initialStatus.kind === 'published' ? (
-                    <RadioButton
-                      value={PUBLISH_MODE_PUBLISHED}
-                      label={t('admin.news.form.publishPublished', 'Published ({{date}})', {
-                        date: longTimestamp.format(initialStatus.date),
-                      })}
-                    />
-                  ) : null}
-                  <RadioButton
-                    value={PUBLISH_MODE_DRAFT}
-                    label={t('admin.news.form.publishDraft', 'Draft (not published)')}
-                  />
-                  <RadioButton
-                    value={PUBLISH_MODE_NOW}
-                    label={t('admin.news.form.publishNow', 'Publish now')}
-                  />
-                  <RadioButton
-                    value={PUBLISH_MODE_SCHEDULE}
-                    label={t('admin.news.form.publishSchedule', 'Schedule')}
-                  />
-                </RadioGroup>
-                {currentPublishMode === PUBLISH_MODE_SCHEDULE ? (
-                  <>
-                    <ScheduleField
-                      {...bindInput('scheduledAt')}
-                      label={t('admin.news.form.scheduleDate', 'Publish date and time')}
-                      floatingLabel={true}
-                    />
-                    <ScheduleHint>
-                      {t(
-                        'admin.news.form.scheduleHint',
-                        'A future date/time schedules the post; a past date/time publishes it immediately.',
-                      )}
-                    </ScheduleHint>
-                  </>
-                ) : null}
-              </PublishControl>
-              <SaveRow>
-                <FilledButton
-                  label={
-                    post
-                      ? t('admin.news.saveChanges', 'Save changes')
-                      : t('admin.news.createPost', 'Create post')
-                  }
-                  onClick={submit}
-                  disabled={fetching || coverUploading || imageUploading || videoUploading}
-                />
-              </SaveRow>
             </EditorColumn>
             <PreviewContainer>
               <MarkdownPreview source={getInputValue('content')} allowMedia={true} />

--- a/client/admin/admin-news.tsx
+++ b/client/admin/admin-news.tsx
@@ -152,8 +152,12 @@ const PAGE_SIZE = 20
 export const PUBLISH_MODE_DRAFT = 'draft'
 export const PUBLISH_MODE_NOW = 'now'
 export const PUBLISH_MODE_SCHEDULE = 'schedule'
+export const PUBLISH_MODE_PUBLISHED = 'published'
 type PublishMode =
-  typeof PUBLISH_MODE_DRAFT | typeof PUBLISH_MODE_NOW | typeof PUBLISH_MODE_SCHEDULE
+  | typeof PUBLISH_MODE_DRAFT
+  | typeof PUBLISH_MODE_NOW
+  | typeof PUBLISH_MODE_SCHEDULE
+  | typeof PUBLISH_MODE_PUBLISHED
 
 type PostStatus =
   { kind: 'draft' } | { kind: 'scheduled'; date: Date } | { kind: 'published'; date: Date }
@@ -934,6 +938,7 @@ export function createPublishedAt(model: NewsEditorModel): string | undefined {
     case PUBLISH_MODE_DRAFT:
       return undefined
     case PUBLISH_MODE_NOW:
+    case PUBLISH_MODE_PUBLISHED:
       return new Date().toISOString()
     case PUBLISH_MODE_SCHEDULE:
       return new Date(model.scheduledAt).toISOString()
@@ -950,6 +955,10 @@ export function publishedAtUpdate(
   model: NewsEditorModel,
   originalPublishedAt: string | null,
 ): { value: string | null } | undefined {
+  if (model.publishMode === PUBLISH_MODE_PUBLISHED) {
+    // The post keeps its existing publish time; there's nothing to send.
+    return undefined
+  }
   if (model.publishMode === PUBLISH_MODE_DRAFT) {
     return originalPublishedAt === null ? undefined : { value: null }
   }
@@ -1172,13 +1181,21 @@ function NewsEditor({ post }: { post: EditablePost | undefined }) {
     })
   }
 
+  // The post's saved status at mount, fixed for the lifetime of the editor: a draft starts on the
+  // draft mode, a post scheduled for the future starts on the schedule mode showing that time, and
+  // an already-published post starts on its own published mode rather than presenting as
+  // scheduled. Both the scheduled and published cases prefill scheduledAt from the current publish
+  // time, so switching to the schedule mode starts from where the post already is.
+  const [initialStatus] = useState(() => getPostStatus(post?.publishedAt, Date.now()))
+
   let publishMode: PublishMode = PUBLISH_MODE_DRAFT
   let scheduledAt = toDateTimeLocalString(new Date())
-  if (post?.publishedAt) {
-    // Both scheduled (future) and already-published (past) posts start here with their current
-    // publish time prefilled; leaving it untouched preserves it on save.
+  if (initialStatus.kind === 'scheduled') {
     publishMode = PUBLISH_MODE_SCHEDULE
-    scheduledAt = toDateTimeLocalString(new Date(post.publishedAt))
+    scheduledAt = toDateTimeLocalString(initialStatus.date)
+  } else if (initialStatus.kind === 'published') {
+    publishMode = PUBLISH_MODE_PUBLISHED
+    scheduledAt = toDateTimeLocalString(initialStatus.date)
   }
 
   const defaults: NewsEditorModel = {
@@ -1414,6 +1431,14 @@ function NewsEditor({ post }: { post: EditablePost | undefined }) {
               {...bindInput('publishMode')}
               label={t('admin.news.form.publish', 'Publish')}
               dense={true}>
+              {initialStatus.kind === 'published' ? (
+                <RadioButton
+                  value={PUBLISH_MODE_PUBLISHED}
+                  label={t('admin.news.form.publishPublished', 'Published ({{date}})', {
+                    date: longTimestamp.format(initialStatus.date),
+                  })}
+                />
+              ) : null}
               <RadioButton
                 value={PUBLISH_MODE_DRAFT}
                 label={t('admin.news.form.publishDraft', 'Draft (not published)')}

--- a/client/admin/admin-news.tsx
+++ b/client/admin/admin-news.tsx
@@ -746,13 +746,17 @@ export interface NewsEditorModel {
 }
 
 const FormArea = styled.div`
-  display: flex;
-  gap: 24px;
-  align-items: stretch;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  grid-template-areas:
+    'toolbar .'
+    'editor preview';
+  column-gap: 24px;
+  row-gap: 8px;
 `
 
 const EditorColumn = styled.div`
-  flex: 1 1 50%;
+  grid-area: editor;
   min-width: 0;
 
   display: flex;
@@ -760,14 +764,28 @@ const EditorColumn = styled.div`
   gap: 8px;
 `
 
+const EditorToolbar = styled(MarkdownToolbar)`
+  grid-area: toolbar;
+`
+
 const ContentField = styled(TextField)`
   width: 100%;
 `
 
-const MarkdownPreview = styled(Markdown)`
-  flex: 1 1 50%;
+const PreviewContainer = styled.div`
+  grid-area: preview;
   min-width: 0;
-  min-height: 480px;
+  position: relative;
+  /**
+    Mirrors the 20px strip TextField reserves below the field box for a validation error, so the
+    preview's bottom edge stays level with the field box rather than the error strip.
+  */
+  margin-bottom: 20px;
+`
+
+const MarkdownPreview = styled(Markdown)`
+  position: absolute;
+  inset: 0;
   padding: 16px 24px;
 
   border: 1px solid var(--theme-outline-variant);
@@ -1254,7 +1272,7 @@ function NewsEditor({ post }: { post: EditablePost | undefined }) {
   const currentPublishMode = getInputValue('publishMode')
 
   return (
-    <CenteredContentContainer>
+    <CenteredContentContainer $fullWidth={true} data-content-fullbleed=''>
       <Root>
         <HeaderRow>
           <Title>
@@ -1287,46 +1305,43 @@ function NewsEditor({ post }: { post: EditablePost | undefined }) {
             maxRows={4}
           />
           <FormArea>
+            <EditorToolbar onFormat={onFormat}>
+              <HiddenFileInput
+                ref={imageFileInputRef}
+                type='file'
+                accept='image/*'
+                onChange={onImageFileSelected}
+                data-testid='news-inline-image-file-input'
+              />
+              <ToolbarButton
+                icon={<MaterialIcon icon='add_photo_alternate' />}
+                label={t('admin.news.form.insertImage', 'Insert image')}
+                tooltipText={t('admin.news.form.insertImageTooltip', 'Insert image (up to 5 MB)')}
+                disabled={imageUploading}
+                onClick={() => imageFileInputRef.current?.click()}
+              />
+              {imageUploading ? (
+                <CoverHint>{t('admin.news.form.imageUploading', 'Uploading…')}</CoverHint>
+              ) : null}
+              <HiddenFileInput
+                ref={videoFileInputRef}
+                type='file'
+                accept='video/mp4,video/webm'
+                onChange={onVideoFileSelected}
+                data-testid='news-inline-video-file-input'
+              />
+              <ToolbarButton
+                icon={<MaterialIcon icon='videocam' />}
+                label={t('admin.news.form.insertVideo', 'Insert video')}
+                tooltipText={t('admin.news.form.insertVideoTooltip', 'Insert video (up to 30 MB)')}
+                disabled={videoUploading}
+                onClick={() => videoFileInputRef.current?.click()}
+              />
+              {videoUploading ? (
+                <CoverHint>{t('admin.news.form.videoUploading', 'Uploading…')}</CoverHint>
+              ) : null}
+            </EditorToolbar>
             <EditorColumn>
-              <MarkdownToolbar onFormat={onFormat}>
-                <HiddenFileInput
-                  ref={imageFileInputRef}
-                  type='file'
-                  accept='image/*'
-                  onChange={onImageFileSelected}
-                  data-testid='news-inline-image-file-input'
-                />
-                <ToolbarButton
-                  icon={<MaterialIcon icon='add_photo_alternate' />}
-                  label={t('admin.news.form.insertImage', 'Insert image')}
-                  tooltipText={t('admin.news.form.insertImageTooltip', 'Insert image (up to 5 MB)')}
-                  disabled={imageUploading}
-                  onClick={() => imageFileInputRef.current?.click()}
-                />
-                {imageUploading ? (
-                  <CoverHint>{t('admin.news.form.imageUploading', 'Uploading…')}</CoverHint>
-                ) : null}
-                <HiddenFileInput
-                  ref={videoFileInputRef}
-                  type='file'
-                  accept='video/mp4,video/webm'
-                  onChange={onVideoFileSelected}
-                  data-testid='news-inline-video-file-input'
-                />
-                <ToolbarButton
-                  icon={<MaterialIcon icon='videocam' />}
-                  label={t('admin.news.form.insertVideo', 'Insert video')}
-                  tooltipText={t(
-                    'admin.news.form.insertVideoTooltip',
-                    'Insert video (up to 30 MB)',
-                  )}
-                  disabled={videoUploading}
-                  onClick={() => videoFileInputRef.current?.click()}
-                />
-                {videoUploading ? (
-                  <CoverHint>{t('admin.news.form.videoUploading', 'Uploading…')}</CoverHint>
-                ) : null}
-              </MarkdownToolbar>
               <ContentField
                 {...bindInput('content')}
                 ref={contentInputRef}
@@ -1348,7 +1363,9 @@ function NewsEditor({ post }: { post: EditablePost | undefined }) {
               {imageError ? <ErrorText>{imageError}</ErrorText> : null}
               {videoError ? <ErrorText>{videoError}</ErrorText> : null}
             </EditorColumn>
-            <MarkdownPreview source={getInputValue('content')} allowMedia={true} />
+            <PreviewContainer>
+              <MarkdownPreview source={getInputValue('content')} allowMedia={true} />
+            </PreviewContainer>
           </FormArea>
           <CoverSection>
             <CoverLabel>{t('admin.news.form.cover', 'Cover image')}</CoverLabel>

--- a/client/admin/news-post-settings-dialog.tsx
+++ b/client/admin/news-post-settings-dialog.tsx
@@ -7,7 +7,6 @@ import { NewsImageUploadResponse } from '../../common/news'
 import { apiUrl } from '../../common/urls'
 import { CommonDialogProps } from '../dialogs/common-dialog-props'
 import { useForm, useFormCallbacks, ValidatorMap } from '../forms/form-hook'
-import { required } from '../forms/validators'
 import { longTimestamp } from '../i18n/date-formats'
 import { MaterialIcon } from '../icons/material/material-icon'
 import logger from '../logging/logger'
@@ -215,7 +214,11 @@ export function NewsPostSettingsDialog({
   }
 
   const validations: ValidatorMap<PostSettingsFormModel> = {
-    summary: required(t('admin.news.form.summaryRequired', 'Summary is required')),
+    // Whitespace-only summaries must fail here: the editor's save flow treats them as missing and
+    // opens this dialog, so accepting them would let Done close the dialog with no visible error
+    // only for save to immediately reopen it.
+    summary: value =>
+      value.trim() ? undefined : t('admin.news.form.summaryRequired', 'Summary is required'),
     scheduledAt: (value, model) => {
       if (model.publishMode !== PUBLISH_MODE_SCHEDULE) {
         return undefined

--- a/client/admin/news-post-settings-dialog.tsx
+++ b/client/admin/news-post-settings-dialog.tsx
@@ -1,0 +1,354 @@
+import { ChangeEvent, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import styled from 'styled-components'
+import { getErrorStack } from '../../common/errors'
+import { MAX_IMAGE_SIZE_BYTES } from '../../common/images'
+import { NewsImageUploadResponse } from '../../common/news'
+import { apiUrl } from '../../common/urls'
+import { CommonDialogProps } from '../dialogs/common-dialog-props'
+import { useForm, useFormCallbacks, ValidatorMap } from '../forms/form-hook'
+import { required } from '../forms/validators'
+import { longTimestamp } from '../i18n/date-formats'
+import { MaterialIcon } from '../icons/material/material-icon'
+import logger from '../logging/logger'
+import { OutlinedButton, TextButton } from '../material/button'
+import { DateTimeTextField } from '../material/datetime-text-field'
+import { Dialog } from '../material/dialog'
+import { RadioButton, RadioGroup } from '../material/radio'
+import { TextField } from '../material/text-field'
+import { fetchJson } from '../network/fetch'
+import { ContainerLevel, containerStyles } from '../styles/colors'
+import { bodyLarge, bodyMedium, labelMedium } from '../styles/typography'
+
+export const PUBLISH_MODE_DRAFT = 'draft'
+export const PUBLISH_MODE_NOW = 'now'
+export const PUBLISH_MODE_SCHEDULE = 'schedule'
+export const PUBLISH_MODE_PUBLISHED = 'published'
+export type PublishMode =
+  | typeof PUBLISH_MODE_DRAFT
+  | typeof PUBLISH_MODE_NOW
+  | typeof PUBLISH_MODE_SCHEDULE
+  | typeof PUBLISH_MODE_PUBLISHED
+
+export type PostStatus =
+  { kind: 'draft' } | { kind: 'scheduled'; date: Date } | { kind: 'published'; date: Date }
+
+/** The subset of a news post's editable fields that live in the post settings dialog. */
+export interface NewsPostSettings {
+  summary: string
+  publishMode: PublishMode
+  scheduledAt: string
+  coverImagePath: string | null
+  coverImageUrl: string | null
+}
+
+interface PostSettingsFormModel {
+  summary: string
+  publishMode: PublishMode
+  scheduledAt: string
+}
+
+const ErrorText = styled.div`
+  ${bodyLarge};
+  color: var(--theme-error);
+`
+
+const Form = styled.form`
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+`
+
+const SummaryField = styled(TextField)`
+  width: 100%;
+`
+
+const CoverSection = styled.div`
+  ${containerStyles(ContainerLevel.Low)};
+
+  padding: 16px;
+
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+
+  border-radius: 4px;
+`
+
+const CoverLabel = styled.div`
+  ${labelMedium};
+  color: var(--theme-on-surface-variant);
+`
+
+const CoverPreview = styled.div`
+  width: 100%;
+  max-width: 480px;
+  aspect-ratio: 2 / 1;
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  border: 1px solid var(--theme-outline-variant);
+  border-radius: 4px;
+  overflow: hidden;
+`
+
+const CoverImage = styled.img`
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+`
+
+const CoverPlaceholder = styled.div`
+  ${bodyMedium};
+  color: var(--theme-on-surface-variant);
+`
+
+const CoverActions = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+`
+
+const CoverHint = styled.div`
+  ${bodyMedium};
+  color: var(--theme-on-surface-variant);
+`
+
+const HiddenFileInput = styled.input`
+  display: none;
+`
+
+const PublishControl = styled.div`
+  ${containerStyles(ContainerLevel.Low)};
+
+  padding: 16px;
+
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+
+  border-radius: 4px;
+`
+
+const ScheduleField = styled(DateTimeTextField)`
+  max-width: 320px;
+`
+
+const ScheduleHint = styled.div`
+  ${bodyMedium};
+  color: var(--theme-on-surface-variant);
+`
+
+export interface NewsPostSettingsDialogProps extends CommonDialogProps {
+  /** The post's status as of when the editor was opened, fixed for the dialog's lifetime. */
+  savedStatus: PostStatus
+  settings: NewsPostSettings
+  /** Called with the edited settings once the dialog is submitted. */
+  onApply: (settings: NewsPostSettings) => void
+}
+
+export function NewsPostSettingsDialog({
+  savedStatus,
+  settings,
+  onApply,
+  onCancel,
+  close,
+}: NewsPostSettingsDialogProps) {
+  const { t } = useTranslation()
+
+  const coverFileInputRef = useRef<HTMLInputElement>(null)
+  const [coverImagePath, setCoverImagePath] = useState<string | null>(settings.coverImagePath)
+  const [coverImageUrl, setCoverImageUrl] = useState<string | null>(settings.coverImageUrl)
+  const [coverUploading, setCoverUploading] = useState(false)
+  const [coverError, setCoverError] = useState<string | undefined>(undefined)
+
+  const onCoverFileSelected = (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0]
+    // Reset the input so selecting the same file again still fires a change event.
+    event.target.value = ''
+    if (!file) {
+      return
+    }
+    if (!file.type.startsWith('image/')) {
+      setCoverError(t('admin.news.form.coverInvalidType', 'Please choose an image file.'))
+      return
+    }
+    if (file.size > MAX_IMAGE_SIZE_BYTES) {
+      setCoverError(t('admin.news.form.coverTooLarge', 'That image is too large (max 5 MB).'))
+      return
+    }
+
+    setCoverError(undefined)
+    setCoverUploading(true)
+    const formData = new FormData()
+    formData.append('image', file)
+    fetchJson<NewsImageUploadResponse>(apiUrl`news/images`, {
+      method: 'POST',
+      body: formData,
+    })
+      .then(result => {
+        setCoverUploading(false)
+        setCoverImagePath(result.path)
+        setCoverImageUrl(result.url)
+      })
+      .catch(err => {
+        setCoverUploading(false)
+        setCoverError(
+          t('admin.news.form.coverUploadError', 'Something went wrong uploading the cover image.'),
+        )
+        logger.error(`Error uploading news cover image: ${getErrorStack(err)}`)
+      })
+  }
+
+  const onRemoveCover = () => {
+    setCoverError(undefined)
+    setCoverImagePath(null)
+    setCoverImageUrl(null)
+  }
+
+  const defaults: PostSettingsFormModel = {
+    summary: settings.summary,
+    publishMode: settings.publishMode,
+    scheduledAt: settings.scheduledAt,
+  }
+
+  const validations: ValidatorMap<PostSettingsFormModel> = {
+    summary: required(t('admin.news.form.summaryRequired', 'Summary is required')),
+    scheduledAt: (value, model) => {
+      if (model.publishMode !== PUBLISH_MODE_SCHEDULE) {
+        return undefined
+      }
+      if (!value || Number.isNaN(new Date(value).getTime())) {
+        return t('admin.news.form.scheduleRequired', 'Choose a valid date and time')
+      }
+      return undefined
+    },
+  }
+
+  const { submit, bindInput, form, getInputValue } = useForm<PostSettingsFormModel>(
+    defaults,
+    validations,
+  )
+
+  useFormCallbacks(form, {
+    onSubmit: model => {
+      onApply({ ...model, coverImagePath, coverImageUrl })
+      close()
+    },
+  })
+
+  const currentPublishMode = getInputValue('publishMode')
+
+  const buttons = [
+    <TextButton label={t('common.actions.cancel', 'Cancel')} key='cancel' onClick={onCancel} />,
+    <TextButton
+      label={t('common.actions.done', 'Done')}
+      key='done'
+      onClick={() => submit()}
+      disabled={coverUploading}
+    />,
+  ]
+
+  return (
+    <Dialog
+      title={t('admin.news.settings.title', 'Post settings')}
+      buttons={buttons}
+      onCancel={onCancel}>
+      <Form noValidate={true} onSubmit={submit}>
+        <SummaryField
+          {...bindInput('summary')}
+          label={t('admin.news.form.summary', 'Summary')}
+          multiline={true}
+          rows={2}
+          maxRows={4}
+        />
+        <CoverSection>
+          <CoverLabel>{t('admin.news.form.cover', 'Cover image')}</CoverLabel>
+          <CoverPreview>
+            {coverImageUrl ? (
+              <CoverImage src={coverImageUrl} alt='' draggable={false} />
+            ) : (
+              <CoverPlaceholder>
+                {t('admin.news.form.coverNone', 'No cover image (a stock image will be used)')}
+              </CoverPlaceholder>
+            )}
+          </CoverPreview>
+          <HiddenFileInput
+            ref={coverFileInputRef}
+            type='file'
+            accept='image/*'
+            onChange={onCoverFileSelected}
+            data-testid='news-cover-file-input'
+          />
+          <CoverActions>
+            <OutlinedButton
+              label={
+                coverImageUrl
+                  ? t('admin.news.form.coverChange', 'Change cover')
+                  : t('admin.news.form.coverUpload', 'Upload cover')
+              }
+              iconStart={<MaterialIcon icon='image' />}
+              onClick={() => coverFileInputRef.current?.click()}
+              disabled={coverUploading}
+            />
+            {coverImageUrl ? (
+              <TextButton
+                label={t('admin.news.form.coverRemove', 'Remove cover')}
+                onClick={onRemoveCover}
+                disabled={coverUploading}
+              />
+            ) : null}
+          </CoverActions>
+          {coverUploading ? (
+            <CoverHint>{t('admin.news.form.coverUploading', 'Uploading…')}</CoverHint>
+          ) : null}
+          {coverError ? <ErrorText>{coverError}</ErrorText> : null}
+        </CoverSection>
+        <PublishControl>
+          <RadioGroup
+            {...bindInput('publishMode')}
+            label={t('admin.news.form.publish', 'Publish')}
+            dense={true}>
+            {savedStatus.kind === 'published' ? (
+              <RadioButton
+                value={PUBLISH_MODE_PUBLISHED}
+                label={t('admin.news.form.publishPublished', 'Published ({{date}})', {
+                  date: longTimestamp.format(savedStatus.date),
+                })}
+              />
+            ) : null}
+            <RadioButton
+              value={PUBLISH_MODE_DRAFT}
+              label={t('admin.news.form.publishDraft', 'Draft (not published)')}
+            />
+            <RadioButton
+              value={PUBLISH_MODE_NOW}
+              label={t('admin.news.form.publishNow', 'Publish now')}
+            />
+            <RadioButton
+              value={PUBLISH_MODE_SCHEDULE}
+              label={t('admin.news.form.publishSchedule', 'Schedule')}
+            />
+          </RadioGroup>
+          {currentPublishMode === PUBLISH_MODE_SCHEDULE ? (
+            <>
+              <ScheduleField
+                {...bindInput('scheduledAt')}
+                label={t('admin.news.form.scheduleDate', 'Publish date and time')}
+                floatingLabel={true}
+              />
+              <ScheduleHint>
+                {t(
+                  'admin.news.form.scheduleHint',
+                  'A future date/time schedules the post; a past date/time publishes it immediately.',
+                )}
+              </ScheduleHint>
+            </>
+          ) : null}
+        </PublishControl>
+      </Form>
+    </Dialog>
+  )
+}

--- a/client/dialogs/connected-dialog-overlay.tsx
+++ b/client/dialogs/connected-dialog-overlay.tsx
@@ -86,6 +86,9 @@ const FailedToAcceptMatchDialog = React.lazy(async () => ({
 const MatchmakingBannedDialog = React.lazy(async () => ({
   default: (await import('../matchmaking/matchmaking-banned-dialog')).MatchmakingBannedDialog,
 }))
+const NewsPostSettingsDialog = React.lazy(async () => ({
+  default: (await import('../admin/news-post-settings-dialog')).NewsPostSettingsDialog,
+}))
 const PostMatchDialog = React.lazy(async () => ({
   default: (await import('../matchmaking/post-match-dialog')).PostMatchDialog,
 }))
@@ -221,6 +224,8 @@ function getDialog(dialogType: DialogType): {
       return { component: MarkdownDialog }
     case DialogType.MatchmakingBanned:
       return { component: MatchmakingBannedDialog }
+    case DialogType.NewsPostSettings:
+      return { component: NewsPostSettingsDialog }
     case DialogType.PostMatch:
       return { component: PostMatchDialog }
     case DialogType.PrivacyPolicy:

--- a/client/dialogs/dialog-type.ts
+++ b/client/dialogs/dialog-type.ts
@@ -37,6 +37,7 @@ export enum DialogType {
   MapPreview = 'mapPreview',
   Markdown = 'markdown',
   MatchmakingBanned = 'matchmakingBanned',
+  NewsPostSettings = 'newsPostSettings',
   PostMatch = 'postMatch',
   PrivacyPolicy = 'privacyPolicy',
   RemoveUserAvatar = 'removeUserAvatar',
@@ -224,6 +225,27 @@ type MarkdownDialogPayload = BaseDialogPayload<
   }
 >
 type MatchmakingBannedDialogPayload = BaseDialogPayload<typeof DialogType.MatchmakingBanned>
+// Kept as an inline shape (rather than importing from the dialog's own file) so this file stays
+// free of dependencies on dialog implementations, which would otherwise cycle back here through
+// the dialog's use of form/state hooks that ultimately import the dialog reducer.
+type NewsPostStatus =
+  { kind: 'draft' } | { kind: 'scheduled'; date: Date } | { kind: 'published'; date: Date }
+type NewsPostSettingsValues = {
+  summary: string
+  publishMode: 'draft' | 'now' | 'schedule' | 'published'
+  scheduledAt: string
+  coverImagePath: string | null
+  coverImageUrl: string | null
+}
+type NewsPostSettingsDialogPayload = BaseDialogPayload<
+  typeof DialogType.NewsPostSettings,
+  {
+    savedStatus: NewsPostStatus
+    settings: NewsPostSettingsValues
+    /** Called with the edited settings once the dialog is submitted. */
+    onApply: (settings: NewsPostSettingsValues) => void
+  }
+>
 export type PostMatchDialogPayload = BaseDialogPayload<
   typeof DialogType.PostMatch,
   {
@@ -317,6 +339,7 @@ export type DialogPayload =
   | MapPreviewDialogPayload
   | MarkdownDialogPayload
   | MatchmakingBannedDialogPayload
+  | NewsPostSettingsDialogPayload
   | PostMatchDialogPayload
   | PrivacyPolicyDialogPayload
   | RemoveUserAvatarDialogPayload

--- a/client/markdown/markdown-toolbar.test.ts
+++ b/client/markdown/markdown-toolbar.test.ts
@@ -477,6 +477,20 @@ describe('markdownFormatForKeyEvent', () => {
     )
   })
 
+  test('Dvorak-style Ctrl+X (cut) is not hijacked by the physical-code fallback', () => {
+    // On a Dvorak layout the physical B key types 'x', so Ctrl+X reports code: 'KeyB'.
+    expect(
+      markdownFormatForKeyEvent(keyEvent({ key: 'x', code: 'KeyB', ctrlKey: true })),
+    ).toBeUndefined()
+  })
+
+  test('Dvorak-style Ctrl+C (copy) is not hijacked by the physical-code fallback', () => {
+    // On a Dvorak layout the physical I key types 'c', so Ctrl+C reports code: 'KeyI'.
+    expect(
+      markdownFormatForKeyEvent(keyEvent({ key: 'c', code: 'KeyI', ctrlKey: true })),
+    ).toBeUndefined()
+  })
+
   test('altKey blocks Ctrl+B, as with AltGr reporting ctrl+alt', () => {
     expect(
       markdownFormatForKeyEvent(keyEvent({ key: 'b', ctrlKey: true, altKey: true })),

--- a/client/markdown/markdown-toolbar.test.ts
+++ b/client/markdown/markdown-toolbar.test.ts
@@ -1,5 +1,26 @@
 import { describe, expect, test } from 'vitest'
-import { applyMarkdownFormat } from './markdown-toolbar'
+import { applyMarkdownFormat, markdownFormatForKeyEvent } from './markdown-toolbar'
+
+function keyEvent(
+  overrides: Partial<{
+    key: string
+    code: string
+    ctrlKey: boolean
+    metaKey: boolean
+    altKey: boolean
+    shiftKey: boolean
+  }>,
+) {
+  return {
+    key: '',
+    code: '',
+    ctrlKey: false,
+    metaKey: false,
+    altKey: false,
+    shiftKey: false,
+    ...overrides,
+  }
+}
 
 describe('applyMarkdownFormat', () => {
   describe('bold', () => {
@@ -405,5 +426,84 @@ describe('applyMarkdownFormat', () => {
     expect(result.content).toBe('Hello****')
     expect(result.selectionStart).toBe(7)
     expect(result.selectionEnd).toBe(7)
+  })
+})
+
+describe('markdownFormatForKeyEvent', () => {
+  test('Ctrl+B maps to bold', () => {
+    expect(markdownFormatForKeyEvent(keyEvent({ key: 'b', ctrlKey: true }))).toBe('bold')
+  })
+
+  test('Cmd+B (metaKey) maps to bold', () => {
+    expect(markdownFormatForKeyEvent(keyEvent({ key: 'b', metaKey: true }))).toBe('bold')
+  })
+
+  test('Ctrl+I maps to italic', () => {
+    expect(markdownFormatForKeyEvent(keyEvent({ key: 'i', ctrlKey: true }))).toBe('italic')
+  })
+
+  test('Ctrl+K maps to link', () => {
+    expect(markdownFormatForKeyEvent(keyEvent({ key: 'k', ctrlKey: true }))).toBe('link')
+  })
+
+  test('Ctrl+Shift+7 (Digit7) maps to orderedList', () => {
+    expect(
+      markdownFormatForKeyEvent(
+        keyEvent({ code: 'Digit7', key: '7', ctrlKey: true, shiftKey: true }),
+      ),
+    ).toBe('orderedList')
+  })
+
+  test('Ctrl+Shift+8 (Digit8) maps to unorderedList', () => {
+    expect(
+      markdownFormatForKeyEvent(
+        keyEvent({ code: 'Digit8', key: '8', ctrlKey: true, shiftKey: true }),
+      ),
+    ).toBe('unorderedList')
+  })
+
+  test('Ctrl+Shift+. (Period) maps to quote', () => {
+    expect(
+      markdownFormatForKeyEvent(
+        keyEvent({ code: 'Period', key: '.', ctrlKey: true, shiftKey: true }),
+      ),
+    ).toBe('quote')
+  })
+
+  test('letter shortcuts fall back to the physical code on non-Latin layouts', () => {
+    // On a Cyrillic layout Ctrl+B reports the Cyrillic letter as the key.
+    expect(markdownFormatForKeyEvent(keyEvent({ key: 'и', code: 'KeyB', ctrlKey: true }))).toBe(
+      'bold',
+    )
+  })
+
+  test('altKey blocks Ctrl+B, as with AltGr reporting ctrl+alt', () => {
+    expect(
+      markdownFormatForKeyEvent(keyEvent({ key: 'b', ctrlKey: true, altKey: true })),
+    ).toBeUndefined()
+  })
+
+  test('plain "b" without a ctrl/cmd modifier returns undefined', () => {
+    expect(markdownFormatForKeyEvent(keyEvent({ key: 'b' }))).toBeUndefined()
+  })
+
+  test('Ctrl+Shift+B returns undefined', () => {
+    expect(
+      markdownFormatForKeyEvent(keyEvent({ key: 'b', ctrlKey: true, shiftKey: true })),
+    ).toBeUndefined()
+  })
+
+  test('matches the list/quote shortcuts by physical code, independent of the layout-dependent key', () => {
+    // On some layouts Shift+7 produces a different character than '&' or '7' (e.g. '/' on a
+    // Croatian layout); the physical key position still identifies the shortcut.
+    expect(
+      markdownFormatForKeyEvent(
+        keyEvent({ code: 'Digit7', key: '/', ctrlKey: true, shiftKey: true }),
+      ),
+    ).toBe('orderedList')
+  })
+
+  test('an unmapped shortcut (Ctrl+Q) returns undefined', () => {
+    expect(markdownFormatForKeyEvent(keyEvent({ key: 'q', ctrlKey: true }))).toBeUndefined()
   })
 })

--- a/client/markdown/markdown-toolbar.tsx
+++ b/client/markdown/markdown-toolbar.tsx
@@ -151,10 +151,12 @@ function toggleLinePrefix(
  * report AltGr as ctrl+alt and that combination must not trigger a shortcut. The single-letter
  * shortcuts (B/I/K) match on `event.key` with an `event.code` fallback: the letter matches the
  * shortcut as users think of it, while the physical-key fallback keeps it working on non-Latin
- * layouts (e.g. Cyrillic, where Ctrl+B reports `key: 'и'` but `code: 'KeyB'`). The list/quote
- * shortcuts match on `event.code` only, because `event.key` for a shifted digit or punctuation
- * key is layout-dependent (e.g. Shift+7 produces `/` rather than `&` on some layouts) while the
- * physical key position is not.
+ * layouts (e.g. Cyrillic, where Ctrl+B reports `key: 'и'` but `code: 'KeyB'`). The fallback only
+ * runs when `event.key` is not a Latin letter: when the layout produced a different Latin letter
+ * (e.g. Dvorak, where Ctrl+X reports `key: 'x'`, `code: 'KeyB'`), the letter the user typed wins
+ * so cut/copy/paste are not hijacked. The list/quote shortcuts match on `event.code` only,
+ * because `event.key` for a shifted digit or punctuation key is layout-dependent (e.g. Shift+7
+ * produces `/` rather than `&` on some layouts) while the physical key position is not.
  */
 export function markdownFormatForKeyEvent(event: {
   key: string
@@ -169,13 +171,17 @@ export function markdownFormatForKeyEvent(event: {
   }
 
   if (!event.shiftKey) {
-    switch (event.key.toLowerCase()) {
+    const key = event.key.toLowerCase()
+    switch (key) {
       case 'b':
         return 'bold'
       case 'i':
         return 'italic'
       case 'k':
         return 'link'
+    }
+    if (/^[a-z]$/.test(key)) {
+      return undefined
     }
     switch (event.code) {
       case 'KeyB':

--- a/client/markdown/markdown-toolbar.tsx
+++ b/client/markdown/markdown-toolbar.tsx
@@ -141,6 +141,66 @@ function toggleLinePrefix(
   }
 }
 
+/**
+ * Maps a keyboard event to the markdown format it should trigger, following the GitHub-style
+ * shortcut set: Ctrl/Cmd+B (bold), Ctrl+I (italic), Ctrl+K (link), Ctrl+Shift+7 (ordered list),
+ * Ctrl+Shift+8 (unordered list), and Ctrl+Shift+. (quote). Returns `undefined` for any other
+ * event.
+ *
+ * All shortcuts require the ctrl/cmd modifier and reject `altKey`, since some keyboard layouts
+ * report AltGr as ctrl+alt and that combination must not trigger a shortcut. The single-letter
+ * shortcuts (B/I/K) match on `event.key` with an `event.code` fallback: the letter matches the
+ * shortcut as users think of it, while the physical-key fallback keeps it working on non-Latin
+ * layouts (e.g. Cyrillic, where Ctrl+B reports `key: 'и'` but `code: 'KeyB'`). The list/quote
+ * shortcuts match on `event.code` only, because `event.key` for a shifted digit or punctuation
+ * key is layout-dependent (e.g. Shift+7 produces `/` rather than `&` on some layouts) while the
+ * physical key position is not.
+ */
+export function markdownFormatForKeyEvent(event: {
+  key: string
+  code: string
+  ctrlKey: boolean
+  metaKey: boolean
+  altKey: boolean
+  shiftKey: boolean
+}): MarkdownFormatKind | undefined {
+  if (!(event.ctrlKey || event.metaKey) || event.altKey) {
+    return undefined
+  }
+
+  if (!event.shiftKey) {
+    switch (event.key.toLowerCase()) {
+      case 'b':
+        return 'bold'
+      case 'i':
+        return 'italic'
+      case 'k':
+        return 'link'
+    }
+    switch (event.code) {
+      case 'KeyB':
+        return 'bold'
+      case 'KeyI':
+        return 'italic'
+      case 'KeyK':
+        return 'link'
+      default:
+        return undefined
+    }
+  }
+
+  switch (event.code) {
+    case 'Digit7':
+      return 'orderedList'
+    case 'Digit8':
+      return 'unorderedList'
+    case 'Period':
+      return 'quote'
+    default:
+      return undefined
+  }
+}
+
 const HEADING_H2_PREFIX = '## '
 const HEADING_H3_PREFIX = '### '
 const HEADING_PATTERN = /^#{1,6} /
@@ -380,12 +440,14 @@ export function MarkdownToolbar({
       <ToolbarButton
         icon={<MaterialIcon icon='format_bold' />}
         label={t('markdown.toolbar.bold', 'Bold')}
+        tooltipText={t('markdown.toolbar.boldTooltip', 'Bold (Ctrl+B)')}
         disabled={disabled}
         onClick={() => onFormat('bold')}
       />
       <ToolbarButton
         icon={<MaterialIcon icon='format_italic' />}
         label={t('markdown.toolbar.italic', 'Italic')}
+        tooltipText={t('markdown.toolbar.italicTooltip', 'Italic (Ctrl+I)')}
         disabled={disabled}
         onClick={() => onFormat('italic')}
       />
@@ -393,18 +455,21 @@ export function MarkdownToolbar({
       <ToolbarButton
         icon={<MaterialIcon icon='format_quote' />}
         label={t('markdown.toolbar.quote', 'Quote')}
+        tooltipText={t('markdown.toolbar.quoteTooltip', 'Quote (Ctrl+Shift+.)')}
         disabled={disabled}
         onClick={() => onFormat('quote')}
       />
       <ToolbarButton
         icon={<MaterialIcon icon='format_list_bulleted' />}
         label={t('markdown.toolbar.unorderedList', 'Bulleted list')}
+        tooltipText={t('markdown.toolbar.unorderedListTooltip', 'Bulleted list (Ctrl+Shift+8)')}
         disabled={disabled}
         onClick={() => onFormat('unorderedList')}
       />
       <ToolbarButton
         icon={<MaterialIcon icon='format_list_numbered' />}
         label={t('markdown.toolbar.orderedList', 'Numbered list')}
+        tooltipText={t('markdown.toolbar.orderedListTooltip', 'Numbered list (Ctrl+Shift+7)')}
         disabled={disabled}
         onClick={() => onFormat('orderedList')}
       />
@@ -418,6 +483,7 @@ export function MarkdownToolbar({
       <ToolbarButton
         icon={<MaterialIcon icon='link' />}
         label={t('markdown.toolbar.link', 'Link')}
+        tooltipText={t('markdown.toolbar.linkTooltip', 'Link (Ctrl+K)')}
         disabled={disabled}
         onClick={() => onFormat('link')}
       />

--- a/server/public/locales/en/global.json
+++ b/server/public/locales/en/global.json
@@ -18,7 +18,6 @@
       },
       "confirmDelete": "Delete \"{{title}}\"? This cannot be undone.",
       "created": "News post created",
-      "createPost": "Create post",
       "createTitle": "Create news post",
       "deleteError": "Error deleting post:",
       "editPost": "Edit post",
@@ -84,9 +83,12 @@
       "loadMore": "Load more",
       "newPost": "New post",
       "notFound": "No news post found with this ID.",
+      "publishNow": "Publish now",
       "refresh": "Refresh",
       "saveChanges": "Save changes",
       "saved": "News post saved",
+      "saveDraft": "Save draft",
+      "schedulePost": "Schedule post",
       "settings": {
         "title": "Post settings"
       },

--- a/server/public/locales/en/global.json
+++ b/server/public/locales/en/global.json
@@ -53,6 +53,7 @@
         "publish": "Publish",
         "publishDraft": "Draft (not published)",
         "publishNow": "Publish now",
+        "publishPublished": "Published ({{date}})",
         "publishSchedule": "Schedule",
         "scheduleDate": "Publish date and time",
         "scheduleHint": "A future date/time schedules the post; a past date/time publishes it immediately.",

--- a/server/public/locales/en/global.json
+++ b/server/public/locales/en/global.json
@@ -1280,13 +1280,19 @@
   "markdown": {
     "toolbar": {
       "bold": "Bold",
+      "boldTooltip": "Bold (Ctrl+B)",
       "heading": "Heading",
       "horizontalRule": "Divider",
       "italic": "Italic",
+      "italicTooltip": "Italic (Ctrl+I)",
       "link": "Link",
+      "linkTooltip": "Link (Ctrl+K)",
       "orderedList": "Numbered list",
+      "orderedListTooltip": "Numbered list (Ctrl+Shift+7)",
       "quote": "Quote",
-      "unorderedList": "Bulleted list"
+      "quoteTooltip": "Quote (Ctrl+Shift+.)",
+      "unorderedList": "Bulleted list",
+      "unorderedListTooltip": "Bulleted list (Ctrl+Shift+8)"
     }
   },
   "matchmaking": {

--- a/server/public/locales/en/global.json
+++ b/server/public/locales/en/global.json
@@ -50,6 +50,7 @@
         "insertImageTooltip": "Insert image (up to 5 MB)",
         "insertVideo": "Insert video",
         "insertVideoTooltip": "Insert video (up to 30 MB)",
+        "postSettings": "Post settings",
         "publish": "Publish",
         "publishDraft": "Draft (not published)",
         "publishNow": "Publish now",
@@ -86,6 +87,9 @@
       "refresh": "Refresh",
       "saveChanges": "Save changes",
       "saved": "News post saved",
+      "settings": {
+        "title": "Post settings"
+      },
       "status": {
         "draft": "Draft",
         "published": "Published",


### PR DESCRIPTION
Adds standard formatting hotkeys to the admin news editor's content field (active while it's focused), following GitHub's shortcut set:

| Shortcut | Action |
|---|---|
| Ctrl+B (or Cmd) | Bold |
| Ctrl+I | Italic |
| Ctrl+K | Link |
| Ctrl+Shift+7 | Numbered list |
| Ctrl+Shift+8 | Bulleted list |
| Ctrl+Shift+. | Quote |

- Reuses the existing `onFormat` path, so toggle behavior and selection preservation are identical to the toolbar buttons.
- Toolbar tooltips now show the shortcut hints (e.g. "Bold (Ctrl+B)").
- Layout-robust matching: the shifted shortcuts match physical key codes (`Digit7`/`Digit8`/`Period`) since `event.key` for shifted digits is layout-dependent; the letter shortcuts match the letter with a physical-key fallback so they also work on non-Latin (e.g. Cyrillic) layouts. AltGr combos (reported as ctrl+alt) are rejected.
- Heading and divider have no widely-standard shortcut and stay toolbar-only.
- 13 new unit tests for the key-event mapping.