### PR TITLE
Make the accept-match dialog dismissable

### DIFF
--- a/client/dialogs/connected-dialog-overlay.tsx
+++ b/client/dialogs/connected-dialog-overlay.tsx
@@ -165,7 +165,7 @@ function getDialog(dialogType: DialogType): {
 } {
   switch (dialogType) {
     case DialogType.AcceptMatch:
-      return { component: AcceptMatchDialog, modal: true }
+      return { component: AcceptMatchDialog }
     case DialogType.AcceptableUse:
       return { component: AcceptableUseDialog }
     case DialogType.AdminDeleteChatMessage:

--- a/client/gameplay-activity/gameplay-activity-widget.tsx
+++ b/client/gameplay-activity/gameplay-activity-widget.tsx
@@ -11,16 +11,19 @@ import { urlForLobby } from '../../common/lobbies/lobby-url'
 import { useObservedDimensions } from '../dom/dimension-hooks'
 import { MaterialIcon } from '../icons/material/material-icon'
 import { isInLobby } from '../lobbies/lobby-reducer'
-import { cancelFindMatch } from '../matchmaking/action-creators'
+import { cancelFindMatch, openAcceptMatchDialog } from '../matchmaking/action-creators'
 import { isInDraftAtom } from '../matchmaking/draft-atoms'
 import { ElapsedTime } from '../matchmaking/elapsed-time'
 import {
   currentSearchInfoAtom,
   foundMatchAtom,
+  hasAcceptedAtom,
   isMatchmakingAtom,
   matchLaunchingAtom,
 } from '../matchmaking/matchmaking-atoms'
-import { OutlinedButton } from '../material/button'
+import { useAcceptMatch } from '../matchmaking/use-accept-match'
+import { FilledButton, OutlinedButton } from '../material/button'
+import { buttonReset } from '../material/button-reset'
 import { Portal } from '../material/portal'
 import { elevationPlus2 } from '../material/shadows'
 import { zIndexDialogScrim } from '../material/zindex'
@@ -203,15 +206,44 @@ const WidgetChildren = styled(m.div)`
 
 const DragHandle = styledWithAttrs(MaterialIcon, { icon: 'drag_indicator' })``
 
+const TitleActionButton = styled.button`
+  ${buttonReset};
+
+  flex-shrink: 0;
+  margin-left: auto;
+  width: 20px;
+  height: 20px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+
+  border-radius: 4px;
+  color: var(--theme-on-surface-variant);
+
+  &:hover {
+    color: var(--theme-on-surface);
+  }
+`
+
 interface WidgetProps {
   ref: React.Ref<HTMLDivElement>
   title: string
   hasTitlePip?: boolean
+  /** An optional icon button rendered at the end of the title bar (e.g. to reopen a dialog). */
+  titleAction?: React.ReactNode
   onDragStart: (e: React.MouseEvent) => void
   children: React.ReactNode
 }
 
-function Widget({ ref, title, hasTitlePip = false, onDragStart, children, ...rest }: WidgetProps) {
+function Widget({
+  ref,
+  title,
+  hasTitlePip = false,
+  titleAction,
+  onDragStart,
+  children,
+  ...rest
+}: WidgetProps) {
   const [sizeRef, contentRect] = useObservedDimensions<HTMLDivElement>()
   const composedRef = useMultiplexRef(ref, sizeRef)
 
@@ -258,6 +290,7 @@ function Widget({ ref, title, hasTitlePip = false, onDragStart, children, ...res
         $hasPip={hasTitlePip}>
         <DragHandle />
         <WidgetTitle>{title}</WidgetTitle>
+        {titleAction}
       </WidgetTitleArea>
       <WidgetChildren layout='size'>{children}</WidgetChildren>
       <InitialWash
@@ -318,13 +351,106 @@ const StyledElapsedTime = styled(ElapsedTime)`
   text-align: center;
 `
 
+/**
+ * How often the widget's accept countdown re-renders. Unlike the accept-match dialog's animated
+ * countdown, the widget only displays whole seconds, so a coarser tick is enough to keep it
+ * accurate.
+ */
+const WIDGET_COUNTDOWN_TICK_MS = 1000
+/** Seconds remaining at which the countdown switches to the "low time" treatment. */
+const LOW_TIME_SECONDS = 5
+
+const CountdownText = styled.span<{ $low: boolean }>`
+  ${titleLarge};
+
+  margin-top: 4px;
+
+  display: block;
+  font-feature-settings: 'tnum' on;
+  text-align: center;
+  color: ${props => (props.$low ? 'var(--theme-error)' : 'inherit')};
+`
+
+const AcceptProgressText = styled(BodyMedium)`
+  text-align: center;
+  color: var(--theme-on-surface-variant);
+`
+
 export function MatchmakingWidget(props: WidgetContainerProps) {
   const { t } = useTranslation()
   const dispatch = useAppDispatch()
-  const isMatched = !!useAtomValue(foundMatchAtom)
+  const foundMatch = useAtomValue(foundMatchAtom)
+  const isMatched = !!foundMatch
+  const hasAccepted = useAtomValue(hasAcceptedAtom)
   const startTime = useAtomValue(currentSearchInfoAtom)?.startTime
 
   const [isCancelling, setIsCancelling] = useState(false)
+  const { acceptInProgress, triggerAccept } = useAcceptMatch()
+
+  const [now, setNow] = useState(() => window.performance.now())
+  useEffect(() => {
+    if (!isMatched) {
+      return () => {}
+    }
+
+    const interval = setInterval(() => setNow(window.performance.now()), WIDGET_COUNTDOWN_TICK_MS)
+    return () => clearInterval(interval)
+  }, [isMatched])
+
+  let bodyContent: React.ReactNode
+  if (foundMatch) {
+    // `now` only advances while the countdown interval is running, so on the first render after a
+    // match is found it can lag behind `acceptStart`; clamp so that render shows the full accept
+    // window instead of a bogus value.
+    const remainingMillis = Math.min(
+      foundMatch.acceptTimeTotalMillis,
+      Math.max(0, foundMatch.acceptTimeTotalMillis - (now - foundMatch.acceptStart)),
+    )
+    const secondsLeft = Math.ceil(remainingMillis / 1000)
+    const lowTime = secondsLeft <= LOW_TIME_SECONDS
+
+    let readyAction: React.ReactNode
+    if (!hasAccepted) {
+      readyAction = (
+        <FilledButton
+          label={t('matchmaking.acceptMatch.readyUp', 'Ready up')}
+          disabled={acceptInProgress}
+          onClick={() => triggerAccept()}
+        />
+      )
+    } else {
+      readyAction = (
+        <BodyMedium>
+          {t('gameplayActivity.matchmaking.waitingForPlayers', 'Waiting for other players…')}
+        </BodyMedium>
+      )
+    }
+
+    bodyContent = (
+      <>
+        <CountdownText $low={lowTime}>
+          {Math.floor(secondsLeft / 60)}:{String(secondsLeft % 60).padStart(2, '0')}
+        </CountdownText>
+        <AcceptProgressText>
+          {t('gameplayActivity.matchmaking.acceptedCount', {
+            defaultValue: '{{accepted}} / {{total}} ready',
+            accepted: foundMatch.acceptedPlayers,
+            total: foundMatch.numPlayers,
+          })}
+        </AcceptProgressText>
+        {readyAction}
+      </>
+    )
+  } else if (startTime === undefined) {
+    bodyContent = <BodyLarge>…</BodyLarge>
+  } else {
+    bodyContent = <StyledElapsedTime startTimeMs={startTime} />
+  }
+
+  const reopenDialogLabel = t(
+    'gameplayActivity.matchmaking.reopenAcceptDialog',
+    'Reopen match dialog',
+  )
 
   return (
     <Widget
@@ -333,12 +459,19 @@ export function MatchmakingWidget(props: WidgetContainerProps) {
         isMatched
           ? t('gameplayActivity.matchmaking.matchFound', 'Match found!')
           : t('gameplayActivity.matchmaking.searching', 'Searching for a match…')
+      }
+      titleAction={
+        isMatched ? (
+          <TitleActionButton
+            onMouseDown={event => event.stopPropagation()}
+            onClick={() => dispatch(openAcceptMatchDialog())}
+            title={reopenDialogLabel}
+            aria-label={reopenDialogLabel}>
+            <MaterialIcon icon='open_in_new' size={16} />
+          </TitleActionButton>
+        ) : undefined
       }>
-      {isMatched || startTime === undefined ? (
-        <BodyLarge>…</BodyLarge>
-      ) : (
-        <StyledElapsedTime startTimeMs={startTime} />
-      )}
+      {bodyContent}
       {!isMatched ? (
         <OutlinedButton
           iconStart={<MaterialIcon icon='close' size={20} />}

--- a/client/gameplay-activity/gameplay-activity-widget.tsx
+++ b/client/gameplay-activity/gameplay-activity-widget.tsx
@@ -22,8 +22,7 @@ import {
   matchLaunchingAtom,
 } from '../matchmaking/matchmaking-atoms'
 import { useAcceptMatch } from '../matchmaking/use-accept-match'
-import { FilledButton, OutlinedButton } from '../material/button'
-import { buttonReset } from '../material/button-reset'
+import { FilledButton, IconButton, OutlinedButton } from '../material/button'
 import { Portal } from '../material/portal'
 import { elevationPlus2 } from '../material/shadows'
 import { zIndexDialogScrim } from '../material/zindex'
@@ -206,23 +205,11 @@ const WidgetChildren = styled(m.div)`
 
 const DragHandle = styledWithAttrs(MaterialIcon, { icon: 'drag_indicator' })``
 
-const TitleActionButton = styled.button`
-  ${buttonReset};
-
+const TitleActionButton = styled(IconButton)`
   flex-shrink: 0;
   margin-left: auto;
-  width: 20px;
-  height: 20px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-
-  border-radius: 4px;
-  color: var(--theme-on-surface-variant);
-
-  &:hover {
-    color: var(--theme-on-surface);
-  }
+  width: 24px;
+  min-height: 24px;
 `
 
 interface WidgetProps {
@@ -463,12 +450,12 @@ export function MatchmakingWidget(props: WidgetContainerProps) {
       titleAction={
         isMatched ? (
           <TitleActionButton
+            icon={<MaterialIcon icon='open_in_new' size={16} />}
             onMouseDown={event => event.stopPropagation()}
             onClick={() => dispatch(openAcceptMatchDialog())}
             title={reopenDialogLabel}
-            aria-label={reopenDialogLabel}>
-            <MaterialIcon icon='open_in_new' size={16} />
-          </TitleActionButton>
+            ariaLabel={reopenDialogLabel}
+          />
         ) : undefined
       }>
       {bodyContent}

--- a/client/matchmaking/accept-match-dialog.tsx
+++ b/client/matchmaking/accept-match-dialog.tsx
@@ -1,34 +1,21 @@
-import { useAtomValue, useStore } from 'jotai'
+import { useAtomValue } from 'jotai'
 import * as m from 'motion/react-m'
 import { useEffect, useRef, useState } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 import styled, { css, keyframes } from 'styled-components'
-import { getErrorStack } from '../../common/errors'
 import { TypedIpcRenderer } from '../../common/ipc'
-import {
-  MATCHMAKING_ACCEPT_MATCH_TIME_MS,
-  MatchmakingServiceErrorCode,
-  matchmakingTypeToLabel,
-} from '../../common/matchmaking'
+import { MATCHMAKING_ACCEPT_MATCH_TIME_MS, matchmakingTypeToLabel } from '../../common/matchmaking'
 import { range } from '../../common/range'
 import { audioManager, AvailableSound, FadeableSound } from '../audio/audio-manager'
 import { playRandomTickSound } from '../audio/tick-sounds'
 import { CommonDialogProps } from '../dialogs/common-dialog-props'
 import { useKeyListener } from '../keyboard/key-listener'
-import logger from '../logging/logger'
 import { FilledButton, TextButton } from '../material/button'
 import { decelerateEasing, standardEasing } from '../material/curve-constants'
 import { Dialog, Title } from '../material/dialog'
-import { isFetchError } from '../network/fetch-errors'
-import { useAppDispatch } from '../redux-hooks'
 import { BodyMedium, sofiaSansCondensed } from '../styles/typography'
-import { acceptMatch } from './action-creators'
-import {
-  clearMatchmakingState,
-  currentSearchInfoAtom,
-  foundMatchAtom,
-  hasAcceptedAtom,
-} from './matchmaking-atoms'
+import { currentSearchInfoAtom, foundMatchAtom, hasAcceptedAtom } from './matchmaking-atoms'
+import { useAcceptMatch } from './use-accept-match'
 
 const ipcRenderer = new TypedIpcRenderer()
 
@@ -209,7 +196,6 @@ const fadeUpTransition = { duration: 0.3, ease: [0, 0, 0, 1] as [number, number,
 
 export function AcceptMatchDialog({ onCancel, close }: CommonDialogProps) {
   const { t } = useTranslation()
-  const dispatch = useAppDispatch()
 
   const currentSearchInfo = useAtomValue(currentSearchInfoAtom)
   const foundMatch = useAtomValue(foundMatchAtom)
@@ -228,7 +214,7 @@ export function AcceptMatchDialog({ onCancel, close }: CommonDialogProps) {
     }
 
     return () => {}
-  }, [dispatch, currentSearchInfo, foundMatch, close])
+  }, [currentSearchInfo, foundMatch, close])
 
   let contents: React.ReactNode | undefined
   if (currentSearchInfo && !foundMatch) {
@@ -259,7 +245,7 @@ export function AcceptMatchDialog({ onCancel, close }: CommonDialogProps) {
       title={t('matchmaking.acceptMatch.matchFound', 'Match found')}
       overline={foundMatch ? matchmakingTypeToLabel(foundMatch.matchmakingType, t) : undefined}
       onCancel={onCancel}
-      showCloseButton={false}>
+      showCloseButton={true}>
       {contents}
     </StyledDialog>
   )
@@ -267,8 +253,6 @@ export function AcceptMatchDialog({ onCancel, close }: CommonDialogProps) {
 
 function AcceptingStateView({ close }: { close: () => void }) {
   const { t } = useTranslation()
-  const dispatch = useAppDispatch()
-  const store = useStore()
   const hasAccepted = useAtomValue(hasAcceptedAtom)
   const foundMatch = useAtomValue(foundMatchAtom)
 
@@ -291,8 +275,7 @@ function AcceptingStateView({ close }: { close: () => void }) {
   const parity = secondsLeft % 2 === 1
 
   const acceptButtonRef = useRef<HTMLButtonElement>(null)
-  const retries = useRef(0)
-  const [acceptInProgress, setAcceptInProgress] = useState(false)
+  const { acceptInProgress, triggerAccept } = useAcceptMatch(close)
 
   // A value that never goes below 4 because the countdown sound covers all 5 ticks below that
   const soundTimeLeft = Math.max(4, secondsLeft)
@@ -386,40 +369,7 @@ function AcceptingStateView({ close }: { close: () => void }) {
         <AcceptMatchButton
           ref={acceptButtonRef}
           label={t('matchmaking.acceptMatch.readyUp', 'Ready up')}
-          onClick={event => {
-            logger.debug(`Accept match button clicked, programmatic: ${!event.isTrusted}`)
-            setAcceptInProgress(true)
-            dispatch(
-              acceptMatch({
-                signal: AbortSignal.timeout(3000),
-                callbackOnAbort: true,
-                onSuccess: () => {
-                  logger.debug(`Accepted match successfully`)
-                  setAcceptInProgress(false)
-                },
-                onError: err => {
-                  if (isFetchError(err) && err.code === MatchmakingServiceErrorCode.NoActiveMatch) {
-                    logger.error('Accepting match failed, no active match: ' + getErrorStack(err))
-                    clearMatchmakingState(store)
-                    close()
-                  } else {
-                    logger.error(`Accepting match failed: ${getErrorStack(err)}`)
-                    setAcceptInProgress(false)
-                    setTimeout(() => {
-                      if (retries.current < 10) {
-                        retries.current++
-                        // Retry the accept after we let the button un-disable, since the user
-                        // almost certainly wants to and may not have much time to react to an
-                        // error
-                        logger.debug(`Retrying accept match...`)
-                        acceptButtonRef.current?.click()
-                      }
-                    }, 400)
-                  }
-                },
-              }),
-            )
-          }}
+          onClick={() => triggerAccept()}
           disabled={acceptInProgress}
         />
         <TimerCellRow>

--- a/client/matchmaking/socket-handlers.ts
+++ b/client/matchmaking/socket-handlers.ts
@@ -17,6 +17,7 @@ import i18n from '../i18n/i18next'
 import { jotaiStore } from '../jotai-store'
 import logger from '../logging/logger'
 import { externalShowSnackbar } from '../snackbars/snackbar-controller-registry'
+import { DURATION_LONG } from '../snackbars/snackbar-durations'
 import { closeAcceptMatchDialog, getCurrentMapPool, openAcceptMatchDialog } from './action-creators'
 import {
   addDraftChatMessage,
@@ -169,11 +170,25 @@ const eventToAction: EventToActionMap = {
     })
   },
 
-  requeue: (matchmakingType, event) => {
+  requeue: (matchmakingType, event) => (_dispatch, getState) => {
     logger.debug(`Re-entered matchmaking queue`)
     audioManager.playSound(AvailableSound.EnteredQueue)
 
     jotaiStore.set(foundMatchAtom, undefined)
+
+    // If the accept-match dialog was dismissed, it won't be around to show its own "returning to
+    // queue" message, so show a snackbar with the same information instead.
+    const dialogOpen = getState().dialog.history.some(d => d.type === DialogType.AcceptMatch)
+    if (!dialogOpen) {
+      externalShowSnackbar(
+        i18n.t(
+          'matchmaking.acceptMatch.returningToQueue',
+          "Some players didn't ready up in time or failed to load. Returning to the matchmaking " +
+            'queue…',
+        ),
+        DURATION_LONG,
+      )
+    }
   },
 
   matchReady: (matchmakingType, event) => (dispatch, getState) => {

--- a/client/matchmaking/use-accept-match.ts
+++ b/client/matchmaking/use-accept-match.ts
@@ -1,0 +1,78 @@
+import { useStore } from 'jotai'
+import { useRef, useState } from 'react'
+import { getErrorStack } from '../../common/errors'
+import { MatchmakingServiceErrorCode } from '../../common/matchmaking'
+import logger from '../logging/logger'
+import { isFetchError } from '../network/fetch-errors'
+import { useAppDispatch } from '../redux-hooks'
+import { acceptMatch } from './action-creators'
+import { clearMatchmakingState, foundMatchAtom } from './matchmaking-atoms'
+
+/** How many times to retry an accept request that fails for a transient reason. */
+const MAX_ACCEPT_RETRIES = 10
+/**
+ * How long to wait before retrying a failed accept request. Gives the button time to visibly
+ * re-enable, since the user almost certainly wants to retry and may not have much time to react to
+ * an error before the accept window closes.
+ */
+const ACCEPT_RETRY_DELAY_MS = 400
+
+export interface UseAcceptMatchResult {
+  /** Whether an accept request is currently in flight (including its retry backoff window). */
+  acceptInProgress: boolean
+  /** Sends the accept request, automatically retrying on transient failures. */
+  triggerAccept: () => void
+}
+
+/**
+ * Shared "Ready up" behavior for accepting a found match: sends the accept request, retrying
+ * transient failures up to `MAX_ACCEPT_RETRIES` times. Used by both the accept-match dialog and
+ * the matchmaking widget, so a match can be accepted regardless of whether the dialog has been
+ * dismissed.
+ *
+ * If the server reports there's no longer an active match to accept, matchmaking state is cleared
+ * and `onNoActiveMatch` is called (e.g. so the dialog can close itself).
+ */
+export function useAcceptMatch(onNoActiveMatch?: () => void): UseAcceptMatchResult {
+  const dispatch = useAppDispatch()
+  const store = useStore()
+  const retries = useRef(0)
+  const [acceptInProgress, setAcceptInProgress] = useState(false)
+
+  const triggerAccept = () => {
+    logger.debug('Accepting match...')
+    setAcceptInProgress(true)
+    dispatch(
+      acceptMatch({
+        signal: AbortSignal.timeout(3000),
+        callbackOnAbort: true,
+        onSuccess: () => {
+          logger.debug(`Accepted match successfully`)
+          setAcceptInProgress(false)
+        },
+        onError: err => {
+          if (isFetchError(err) && err.code === MatchmakingServiceErrorCode.NoActiveMatch) {
+            logger.error('Accepting match failed, no active match: ' + getErrorStack(err))
+            clearMatchmakingState(store)
+            onNoActiveMatch?.()
+          } else {
+            logger.error(`Accepting match failed: ${getErrorStack(err)}`)
+            setAcceptInProgress(false)
+            setTimeout(() => {
+              // The match can dissolve (e.g. a requeue) while this retry is pending; accepting
+              // then would get a NoActiveMatch response and wrongly clear the re-entered queue
+              // state, so only retry while the match is still active.
+              if (retries.current < MAX_ACCEPT_RETRIES && store.get(foundMatchAtom)) {
+                retries.current++
+                logger.debug(`Retrying accept match...`)
+                triggerAccept()
+              }
+            }, ACCEPT_RETRY_DELAY_MS)
+          }
+        },
+      }),
+    )
+  }
+
+  return { acceptInProgress, triggerAccept }
+}

--- a/client/matchmaking/use-accept-match.ts
+++ b/client/matchmaking/use-accept-match.ts
@@ -39,7 +39,7 @@ export function useAcceptMatch(onNoActiveMatch?: () => void): UseAcceptMatchResu
   const retries = useRef(0)
   const [acceptInProgress, setAcceptInProgress] = useState(false)
 
-  const triggerAccept = () => {
+  const sendAccept = () => {
     logger.debug('Accepting match...')
     setAcceptInProgress(true)
     dispatch(
@@ -53,7 +53,15 @@ export function useAcceptMatch(onNoActiveMatch?: () => void): UseAcceptMatchResu
         onError: err => {
           if (isFetchError(err) && err.code === MatchmakingServiceErrorCode.NoActiveMatch) {
             logger.error('Accepting match failed, no active match: ' + getErrorStack(err))
-            clearMatchmakingState(store)
+            setAcceptInProgress(false)
+            // The match can dissolve while this request is in flight (e.g. another player left
+            // during the accept window). If the server requeued this player, the requeue event
+            // clears `foundMatchAtom` but keeps the search state, so wiping everything here would
+            // drop the UI out of a queue the server still has this player in. Only clear when no
+            // newer event has already updated the match state.
+            if (store.get(foundMatchAtom)) {
+              clearMatchmakingState(store)
+            }
             onNoActiveMatch?.()
           } else {
             logger.error(`Accepting match failed: ${getErrorStack(err)}`)
@@ -65,13 +73,20 @@ export function useAcceptMatch(onNoActiveMatch?: () => void): UseAcceptMatchResu
               if (retries.current < MAX_ACCEPT_RETRIES && store.get(foundMatchAtom)) {
                 retries.current++
                 logger.debug(`Retrying accept match...`)
-                triggerAccept()
+                sendAccept()
               }
             }, ACCEPT_RETRY_DELAY_MS)
           }
         },
       }),
     )
+  }
+
+  const triggerAccept = () => {
+    // This hook can outlive a single match (the matchmaking widget stays mounted across a requeue),
+    // so the retry budget applies per user-initiated accept rather than per hook lifetime.
+    retries.current = 0
+    sendAccept()
   }
 
   return { acceptInProgress, triggerAccept }

--- a/server/public/locales/en/global.json
+++ b/server/public/locales/en/global.json
@@ -757,8 +757,11 @@
       "viewLobby": "View lobby"
     },
     "matchmaking": {
+      "acceptedCount": "{{accepted}} / {{total}} ready",
       "matchFound": "Match found!",
-      "searching": "Searching for a match…"
+      "reopenAcceptDialog": "Reopen match dialog",
+      "searching": "Searching for a match…",
+      "waitingForPlayers": "Waiting for other players…"
     }
   },
   "gameReport": {


### PR DESCRIPTION
Makes the accept-match dialog dismissable so you can keep using the app while readying up, with the floating gameplay activity widget covering everything the dialog did:

- The dialog is no longer modal and shows a close button.
- While a match is found, the widget shows the accept countdown (with a low-time treatment under 5s), a "N / M ready" count, and a **Ready up** button (or "Waiting for other players…" once accepted), plus a title-bar icon button to reopen the dialog.
- The accept logic (including its transient-failure retry loop) is extracted into a shared `useAcceptMatch` hook used by both the dialog and the widget. The retry loop now also bails if the match dissolves while a retry is pending, so a late accept can't wrongly clear re-entered queue state.
- If a requeue happens while the dialog is dismissed, a snackbar shows the "returning to queue" message the dialog would have shown.

Live-verified with two clients: dismissing, accepting from the widget, reopening the dialog, and the requeue snackbar path.
