### PR TITLE
Track per-user read positions for chat channels and whispers.

### DIFF
--- a/client/chat/action-creators.ts
+++ b/client/chat/action-creators.ts
@@ -13,6 +13,7 @@ import {
   JoinChannelResponse,
   ListChannelBansResponse,
   ListUserChannelEntriesResponse,
+  MarkChannelReadRequest,
   ModerateChannelUserServerRequest,
   SbChannelId,
   SearchChannelsResponse,
@@ -30,6 +31,7 @@ import { DialogType } from '../dialogs/dialog-type'
 import { ThunkAction } from '../dispatch-registry'
 import i18n from '../i18n/i18next'
 import logger from '../logging/logger'
+import { reportLastRead } from '../messaging/last-read'
 import { push, replace } from '../navigation/routing'
 import { RequestHandlingSpec, abortableThunk } from '../network/abortable-thunk'
 import { MicrotaskBatchRequester } from '../network/batch-requests'
@@ -53,6 +55,31 @@ export function getJoinedChannels(spec: RequestHandlingSpec<void>): ThunkAction 
       payload: joinedChannels,
     })
   })
+}
+
+/** The `reportLastRead`/`flushLastRead` coalescing key for a channel's read position. */
+export function getChannelLastReadKey(channelId: SbChannelId): string {
+  return `channel-${channelId}`
+}
+
+/**
+ * Reports the newest message time the current user has read in a channel, coalescing rapid-fire
+ * reports (see `reportLastRead`). Fire-and-forget: there's no `RequestHandlingSpec` since nothing
+ * needs to react to this request's outcome.
+ */
+export function markChannelRead(channelId: SbChannelId, lastReadTime: number): ThunkAction {
+  return () => {
+    reportLastRead(getChannelLastReadKey(channelId), lastReadTime, time => {
+      fetchJson<void>(apiUrl`chat/${channelId}/mark-read`, {
+        method: 'POST',
+        body: encodeBodyAsParams<MarkChannelReadRequest>({ lastReadTime: time }),
+      }).catch(err => {
+        logger.error(
+          `Error reporting read position for channel ${channelId}: ${getErrorStack(err)}`,
+        )
+      })
+    })
+  }
 }
 
 /**

--- a/client/chat/channel.tsx
+++ b/client/chat/channel.tsx
@@ -6,9 +6,11 @@ import {
   ClientChatMessageType,
   SbChannelId,
   ServerChatMessageType,
+  isServerChatMessage,
 } from '../../common/chat'
 import { SbUserId } from '../../common/users/sb-user-id'
 import { Chat } from '../messaging/chat'
+import { flushLastRead } from '../messaging/last-read'
 import { MAX_MENTIONED_USERS } from '../messaging/message-input'
 import { MessageComponentProps } from '../messaging/message-list'
 import { push } from '../navigation/routing'
@@ -24,8 +26,10 @@ import {
   correctChannelNameForChat,
   deactivateChannel,
   getChannelInfo,
+  getChannelLastReadKey,
   getMessageHistory,
   leaveChannelWithConfirmation,
+  markChannelRead,
   retrieveUserList,
   sendMessage,
   updateChannelAtBottom,
@@ -127,6 +131,8 @@ export function ConnectedChatChannel({
   const channelMessages = useAppSelector(s => s.chat.idToMessages.get(channelId))
   const selfPreferences = useAppSelector(s => s.chat.idToSelfPreferences.get(channelId))
   const isInChannel = useAppSelector(s => s.chat.joinedChannels.has(channelId))
+  const isActivated = useAppSelector(s => s.chat.activatedChannels.has(channelId))
+  const isAtBottom = useAppSelector(s => s.chat.atBottomChannels.has(channelId))
 
   // NOTE(2Pac): When user types the single @ character in chat, we show the ten most recent
   // chatters in the channel as an option to mention.
@@ -224,6 +230,30 @@ export function ConnectedChatChannel({
       dispatch(deactivateChannel(channelId))
     }
   }, [isInChannel, channelId, dispatch])
+
+  // The newest server-recorded message time: client-only messages (e.g. the self-join banner) are
+  // stamped with the local clock, so they can't be reported as a read position.
+  let newestMessageTime: number | undefined
+  if (channelMessages) {
+    for (let i = channelMessages.messages.length - 1; i >= 0; i--) {
+      const message = channelMessages.messages[i]
+      if (isServerChatMessage(message)) {
+        newestMessageTime = message.time
+        break
+      }
+    }
+  }
+
+  // Reports the read position whenever the channel is both open and scrolled to the bottom, so
+  // arriving at a channel already at the bottom (or scrolling back down to it) reports the newest
+  // message just as much as a message arriving while already there does.
+  useEffect(() => {
+    if (isActivated && isAtBottom && newestMessageTime !== undefined) {
+      dispatch(markChannelRead(channelId, newestMessageTime))
+    }
+  }, [isActivated, isAtBottom, newestMessageTime, channelId, dispatch])
+
+  useEffect(() => () => flushLastRead(getChannelLastReadKey(channelId)), [channelId])
 
   useEffect(() => {
     if (basicChannelInfo && channelNameFromRoute !== basicChannelInfo.name) {

--- a/client/chat/chat-reducer.ts
+++ b/client/chat/chat-reducer.ts
@@ -245,8 +245,14 @@ function initChannelUsers(state: ChatState, channelId: SbChannelId, activeUserId
 }
 
 function initChannel(state: ChatState, channelId: SbChannelId, data: InitialChannelData) {
-  const { channelInfo, detailedChannelInfo, joinedChannelInfo, selfPreferences, selfPermissions } =
-    data
+  const {
+    channelInfo,
+    detailedChannelInfo,
+    joinedChannelInfo,
+    selfPreferences,
+    selfPermissions,
+    hasUnread,
+  } = data
 
   const messagesState: MessagesState = {
     messages: [],
@@ -262,6 +268,14 @@ function initChannel(state: ChatState, channelId: SbChannelId, data: InitialChan
   state.idToUserProfiles.set(channelId, new Map())
   state.idToSelfPreferences.set(channelId, selfPreferences)
   state.idToSelfPermissions.set(channelId, selfPermissions)
+
+  // Seeds the unread badge from the server's recorded read position, so it survives a restart
+  // instead of resetting to "read" until the next message arrives. A channel the user is currently
+  // viewing is never marked unread, matching how a live message never marks an activated channel
+  // unread either.
+  if (hasUnread && !state.activatedChannels.has(channelId)) {
+    state.unreadChannels.add(channelId)
+  }
 
   updateMessages(state, channelId, false, m => {
     m.push({

--- a/client/messaging/last-read.test.ts
+++ b/client/messaging/last-read.test.ts
@@ -1,0 +1,179 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import {
+  LAST_READ_COALESCE_MS,
+  flushLastRead,
+  reportLastRead,
+  resetLastReadForTesting,
+} from './last-read'
+
+describe('messaging/last-read', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    resetLastReadForTesting()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  test('leading edge: first report for a key sends immediately', () => {
+    const send = vi.fn()
+
+    reportLastRead('key', 100, send)
+
+    expect(send).toHaveBeenCalledTimes(1)
+    expect(send).toHaveBeenCalledWith(100)
+  })
+
+  test('trailing fold fires once, at the shortened delay relative to the last actual send', () => {
+    const send = vi.fn()
+
+    reportLastRead('key', 100, send) // t=0, leading
+    expect(send).toHaveBeenCalledTimes(1)
+
+    vi.advanceTimersByTime(1000) // t=1000
+    reportLastRead('key', 150, send) // folded; timer scheduled for t=1000+4000=5000
+    expect(send).toHaveBeenCalledTimes(1)
+
+    vi.advanceTimersByTime(500) // t=1500
+    reportLastRead('key', 200, send) // another rapid report; still folded into the same timer
+    expect(send).toHaveBeenCalledTimes(1)
+
+    vi.advanceTimersByTime(3499) // t=4999, just short of the window
+    expect(send).toHaveBeenCalledTimes(1)
+
+    vi.advanceTimersByTime(1) // t=5000
+    expect(send).toHaveBeenCalledTimes(2)
+    expect(send).toHaveBeenLastCalledWith(200)
+  })
+
+  test('a report at or before the last sent value is dropped and never sent, immediately or later', () => {
+    const send = vi.fn()
+
+    reportLastRead('key', 100, send) // t=0, leading
+    expect(send).toHaveBeenCalledTimes(1)
+
+    reportLastRead('key', 100, send) // equal to lastValue -> dropped
+    reportLastRead('key', 50, send) // older than lastValue -> dropped
+    expect(send).toHaveBeenCalledTimes(1)
+
+    // Nothing was scheduled, so letting the window elapse must not produce a trailing send either.
+    vi.advanceTimersByTime(LAST_READ_COALESCE_MS + 1000)
+    expect(send).toHaveBeenCalledTimes(1)
+  })
+
+  test('a stale report while a trailing send is pending does not lower the scheduled value', () => {
+    const send = vi.fn()
+
+    reportLastRead('key', 100, send) // t=0, leading
+    vi.advanceTimersByTime(1000) // t=1000
+    reportLastRead('key', 300, send) // pending scheduled with lastValue=300, fires at t=5000
+    reportLastRead('key', 200, send) // stale relative to the pending value -> dropped
+    expect(send).toHaveBeenCalledTimes(1)
+
+    vi.advanceTimersByTime(4000) // t=5000
+    expect(send).toHaveBeenCalledTimes(2)
+    expect(send).toHaveBeenLastCalledWith(300)
+  })
+
+  test('newer reports while pending only raise the value: still one trailing send, with the newest value', () => {
+    const send = vi.fn()
+
+    reportLastRead('key', 100, send) // t=0, leading
+    vi.advanceTimersByTime(1000) // t=1000
+    reportLastRead('key', 200, send) // pending scheduled, fires at t=5000
+    vi.advanceTimersByTime(500) // t=1500
+    reportLastRead('key', 300, send) // still pending, just raises lastValue
+    vi.advanceTimersByTime(500) // t=2000
+    reportLastRead('key', 400, send) // still pending, just raises lastValue again
+    expect(send).toHaveBeenCalledTimes(1)
+
+    vi.advanceTimersByTime(3000) // t=5000, the original timer fires
+    expect(send).toHaveBeenCalledTimes(2)
+    expect(send).toHaveBeenLastCalledWith(400)
+  })
+
+  test('a report after the window has fully elapsed with nothing pending is leading-edge again', () => {
+    const send = vi.fn()
+
+    reportLastRead('key', 100, send) // t=0, leading
+    expect(send).toHaveBeenCalledTimes(1)
+
+    vi.advanceTimersByTime(LAST_READ_COALESCE_MS) // t=5000, exactly the window since the last send
+    reportLastRead('key', 200, send)
+
+    expect(send).toHaveBeenCalledTimes(2)
+    expect(send).toHaveBeenLastCalledWith(200)
+  })
+
+  test('flushLastRead fires a pending trailing send immediately, exactly once, with the newest value', () => {
+    const send = vi.fn()
+
+    reportLastRead('key', 100, send) // t=0, leading
+    vi.advanceTimersByTime(1000) // t=1000
+    reportLastRead('key', 200, send) // pending, would otherwise fire at t=5000
+
+    flushLastRead('key')
+
+    expect(send).toHaveBeenCalledTimes(2)
+    expect(send).toHaveBeenLastCalledWith(200)
+
+    // The timer must have been cancelled, so letting the original window elapse fires nothing more.
+    vi.advanceTimersByTime(LAST_READ_COALESCE_MS + 1000)
+    expect(send).toHaveBeenCalledTimes(2)
+  })
+
+  test('flushLastRead with nothing pending is a no-op', () => {
+    expect(() => flushLastRead('never-reported')).not.toThrow()
+
+    const send = vi.fn()
+    reportLastRead('key', 100, send) // leading send, nothing left pending
+
+    expect(() => flushLastRead('key')).not.toThrow()
+    expect(send).toHaveBeenCalledTimes(1)
+  })
+
+  test('flushLastRead after the trailing timer already fired is a no-op', () => {
+    const send = vi.fn()
+
+    reportLastRead('key', 100, send) // t=0, leading
+    vi.advanceTimersByTime(1000) // t=1000
+    reportLastRead('key', 200, send) // pending, fires at t=5000
+    vi.advanceTimersByTime(4000) // t=5000, trailing send fires on its own
+    expect(send).toHaveBeenCalledTimes(2)
+
+    expect(() => flushLastRead('key')).not.toThrow()
+    expect(send).toHaveBeenCalledTimes(2)
+  })
+
+  test('keys are independent: a pending window on one key does not delay a leading send on another', () => {
+    const sendA = vi.fn()
+    const sendB = vi.fn()
+
+    reportLastRead('a', 100, sendA) // t=0, leading for a
+    vi.advanceTimersByTime(1000) // t=1000
+    reportLastRead('a', 200, sendA) // pending for a, fires at t=5000
+
+    reportLastRead('b', 500, sendB) // b has no prior state, so this is leading-edge
+
+    expect(sendB).toHaveBeenCalledTimes(1)
+    expect(sendB).toHaveBeenCalledWith(500)
+    expect(sendA).toHaveBeenCalledTimes(1)
+  })
+
+  test('the trailing send uses the callback captured when the pending entry was created', () => {
+    const sendFirst = vi.fn()
+    const sendSecond = vi.fn()
+
+    reportLastRead('key', 100, sendFirst) // t=0, leading; calls sendFirst
+    vi.advanceTimersByTime(1000) // t=1000
+    reportLastRead('key', 200, sendFirst) // creates the pending entry, capturing sendFirst
+    reportLastRead('key', 300, sendSecond) // still pending; only raises lastValue, doesn't replace the captured send
+
+    vi.advanceTimersByTime(4000) // t=5000, trailing send fires
+
+    expect(sendFirst).toHaveBeenCalledTimes(2)
+    expect(sendFirst).toHaveBeenLastCalledWith(300)
+    expect(sendSecond).not.toHaveBeenCalled()
+  })
+})

--- a/client/messaging/last-read.ts
+++ b/client/messaging/last-read.ts
@@ -86,3 +86,13 @@ export function flushLastRead(key: string): void {
   state.lastSentAt = Date.now()
   send(state.lastValue)
 }
+
+/** Clears all coalescing state across every key, cancelling any pending timers. Only for use in tests. */
+export function resetLastReadForTesting(): void {
+  for (const state of keyStates.values()) {
+    if (state.pending) {
+      clearTimeout(state.pending.timer)
+    }
+  }
+  keyStates.clear()
+}

--- a/client/messaging/last-read.ts
+++ b/client/messaging/last-read.ts
@@ -1,0 +1,88 @@
+/**
+ * How long to wait, per conversation, before allowing another read-position report to reach the
+ * server. The first report for a conversation (or one that arrives after this much time has passed
+ * since the last one actually sent) goes out immediately — the leading edge, so the common case of
+ * reading a message and not reading another for a while incurs no added latency. Reports that keep
+ * arriving faster than this get folded into a single trailing send of the newest position once the
+ * window elapses, so scrolling through a burst of newly-arrived messages sends at most one request
+ * per window rather than one per message.
+ */
+export const LAST_READ_COALESCE_MS = 5000
+
+interface KeyState {
+  /** Wall-clock time (`Date.now()`) of the last report actually sent for this key. */
+  lastSentAt: number
+  /**
+   * The newest time value sent (or, while a trailing send is pending, scheduled to be sent) for
+   * this key. Reports at or before this value never advance the read position, so they're dropped.
+   */
+  lastValue: number
+  /** A trailing send already scheduled for this key, waiting for the coalescing window to elapse. */
+  pending?: {
+    send: (time: number) => void
+    timer: ReturnType<typeof setTimeout>
+  }
+}
+
+const keyStates = new Map<string, KeyState>()
+
+/**
+ * Reports that `key`'s read position has advanced to `time`, coalescing rapid-fire reports down to
+ * at most one outgoing send per `LAST_READ_COALESCE_MS` window. `send` is called with the position
+ * to report once this call's report actually goes out (immediately, or later as part of a trailing
+ * send); it's expected to be a fire-and-forget request, since nothing here awaits it.
+ */
+export function reportLastRead(key: string, time: number, send: (time: number) => void): void {
+  const state = keyStates.get(key)
+
+  if (state && time <= state.lastValue) {
+    return
+  }
+
+  if (state?.pending) {
+    state.lastValue = time
+    return
+  }
+
+  const elapsedSinceSend = state ? Date.now() - state.lastSentAt : Infinity
+  if (elapsedSinceSend >= LAST_READ_COALESCE_MS) {
+    keyStates.set(key, { lastSentAt: Date.now(), lastValue: time })
+    send(time)
+    return
+  }
+
+  state!.lastValue = time
+  state!.pending = {
+    send,
+    timer: setTimeout(() => {
+      const s = keyStates.get(key)
+      if (!s?.pending) {
+        return
+      }
+
+      const { send: sendPending } = s.pending
+      s.pending = undefined
+      s.lastSentAt = Date.now()
+      sendPending(s.lastValue)
+    }, LAST_READ_COALESCE_MS - elapsedSinceSend),
+  }
+}
+
+/**
+ * Immediately fires a trailing send scheduled for `key` by `reportLastRead`, if one is pending, and
+ * cancels its timer. Meant to be called when a conversation is torn down (e.g. on unmount), so a
+ * read position that arrived just before that doesn't sit unreported until the window elapses on
+ * its own.
+ */
+export function flushLastRead(key: string): void {
+  const state = keyStates.get(key)
+  if (!state?.pending) {
+    return
+  }
+
+  clearTimeout(state.pending.timer)
+  const { send } = state.pending
+  state.pending = undefined
+  state.lastSentAt = Date.now()
+  send(state.lastValue)
+}

--- a/client/whispers/action-creators.ts
+++ b/client/whispers/action-creators.ts
@@ -1,11 +1,15 @@
+import { getErrorStack } from '../../common/errors'
 import { apiUrl, urlPath } from '../../common/urls'
 import { SbUserId } from '../../common/users/sb-user-id'
 import {
   GetSessionHistoryResponse,
   GetWhisperSessionsResponse,
+  MarkWhisperReadRequest,
   SendWhisperMessageRequest,
 } from '../../common/whispers'
 import { ThunkAction } from '../dispatch-registry'
+import logger from '../logging/logger'
+import { reportLastRead } from '../messaging/last-read'
 import { push, replace } from '../navigation/routing'
 import { RequestHandlingSpec, abortableThunk } from '../network/abortable-thunk'
 import { encodeBodyAsParams, fetchJson } from '../network/fetch'
@@ -24,6 +28,30 @@ export function getWhisperSessions(spec: RequestHandlingSpec<void>): ThunkAction
     })
   })
 }
+
+/** The `reportLastRead`/`flushLastRead` coalescing key for a whisper conversation's read position. */
+export function getWhisperLastReadKey(targetId: SbUserId): string {
+  return `whisper-${targetId}`
+}
+
+/**
+ * Reports the newest message time the current user has read in a whisper conversation, coalescing
+ * rapid-fire reports (see `reportLastRead`). Fire-and-forget: there's no `RequestHandlingSpec` since
+ * nothing needs to react to this request's outcome.
+ */
+export function markWhisperRead(targetId: SbUserId, lastReadTime: number): ThunkAction {
+  return () => {
+    reportLastRead(getWhisperLastReadKey(targetId), lastReadTime, time => {
+      fetchJson<void>(apiUrl`whispers/${targetId}/mark-read`, {
+        method: 'POST',
+        body: encodeBodyAsParams<MarkWhisperReadRequest>({ lastReadTime: time }),
+      }).catch(err => {
+        logger.error(`Error reporting read position for whisper ${targetId}: ${getErrorStack(err)}`)
+      })
+    })
+  }
+}
+
 export function startWhisperSessionByName(
   target: string,
   spec: RequestHandlingSpec<{ userId: SbUserId }>,

--- a/client/whispers/whisper-reducer.ts
+++ b/client/whispers/whisper-reducer.ts
@@ -83,6 +83,17 @@ export default immerKeyedReducer(DEFAULT_STATE, {
 
       state.byId.set(session, defaultWhisperSession(session))
     }
+
+    // Seeds the unread badge from the server's recorded read position, so it survives a restart
+    // instead of resetting to "read" until the next message arrives. A session the user is
+    // currently viewing is never marked unread, matching how a live message never marks an
+    // activated session unread either.
+    for (const target of action.payload.unreadSessions ?? []) {
+      const session = state.byId.get(target)
+      if (session && !session.activated) {
+        session.hasUnread = true
+      }
+    }
   },
 
   ['@whispers/initSession'](state, action) {

--- a/client/whispers/whisper.tsx
+++ b/client/whispers/whisper.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components'
 import { SbUserId } from '../../common/users/sb-user-id'
 import { useSelfUser } from '../auth/auth-utils'
 import { Chat } from '../messaging/chat'
+import { flushLastRead } from '../messaging/last-read'
 import { push, replace } from '../navigation/routing'
 import LoadingIndicator from '../progress/dots'
 import { usePrevious, useStableCallback } from '../react/state-hooks'
@@ -17,6 +18,8 @@ import {
   correctUsernameForWhisper,
   deactivateWhisperSession,
   getMessageHistory,
+  getWhisperLastReadKey,
+  markWhisperRead,
   sendMessage,
   startWhisperSessionById,
   updateSessionAtBottom,
@@ -119,6 +122,21 @@ export function ConnectedWhisper({
       dispatch(deactivateWhisperSession(targetId))
     }
   }, [isSessionOpen, isClosingWhisper, targetId, dispatch, t, snackbarController])
+
+  const newestMessageTime = whisperSession?.messages.length
+    ? whisperSession.messages[whisperSession.messages.length - 1].time
+    : undefined
+
+  // Reports the read position whenever the session is both open and scrolled to the bottom, so
+  // arriving at a session already at the bottom (or scrolling back down to it) reports the newest
+  // message just as much as a message arriving while already there does.
+  useEffect(() => {
+    if (whisperSession?.activated && whisperSession.atBottom && newestMessageTime !== undefined) {
+      dispatch(markWhisperRead(targetId, newestMessageTime))
+    }
+  }, [whisperSession?.activated, whisperSession?.atBottom, newestMessageTime, targetId, dispatch])
+
+  useEffect(() => () => flushLastRead(getWhisperLastReadKey(targetId)), [targetId])
 
   const [isLoadingHistory, setIsLoadingHistory] = useState(false)
   const onLoadMoreMessages = useStableCallback(() => {

--- a/common/chat.ts
+++ b/common/chat.ts
@@ -65,6 +65,19 @@ export enum ClientChatMessageType {
 
 export type ChatMessageType = ServerChatMessageType | ClientChatMessageType
 
+const SERVER_CHAT_MESSAGE_TYPES: ReadonlySet<ChatMessageType> = new Set(
+  Object.values(ServerChatMessageType),
+)
+
+/**
+ * Returns whether a chat message originated on the server, i.e. it's stored in the database and its
+ * `time` is a server-recorded time. Client-only messages stamp `time` with the local clock, so they
+ * can't be used anywhere a durable server time is needed (e.g. read positions).
+ */
+export function isServerChatMessage(message: { type: ChatMessageType }): boolean {
+  return SERVER_CHAT_MESSAGE_TYPES.has(message.type)
+}
+
 export interface BaseChatMessage {
   id: string
   type: ChatMessageType
@@ -220,6 +233,11 @@ export interface InitialChannelData {
   selfPreferences: ChannelPreferences
   /** The channel permissions for the current user that is initializing the channel. */
   selfPermissions: ChannelPermissions
+  /**
+   * Whether the channel has messages newer than the user's last recorded read position. Absent or
+   * false means the channel should not be treated as unread.
+   */
+  hasUnread?: boolean
 }
 
 export interface ChatInitEvent extends InitialChannelData {
@@ -396,6 +414,14 @@ export interface EditChannelResponse {
 
 export interface SendChatMessageServerRequest {
   message: string
+}
+
+/**
+ * The body data of the API route for reporting a user's read position in a chat channel.
+ */
+export interface MarkChannelReadRequest {
+  /** Epoch ms of the newest message the user has seen in the channel. */
+  lastReadTime: number
 }
 
 /**

--- a/common/whispers.ts
+++ b/common/whispers.ts
@@ -58,6 +58,14 @@ export interface SendWhisperMessageRequest {
 }
 
 /**
+ * The body data of the API route for reporting a user's read position in a whisper conversation.
+ */
+export interface MarkWhisperReadRequest {
+  /** Epoch ms of the newest message the user has seen in the conversation. */
+  lastReadTime: number
+}
+
+/**
  * Payload returned for a request to retrieve the session history.
  */
 export interface GetSessionHistoryResponse {
@@ -121,4 +129,10 @@ export function whisperServiceErrorToString(
 export interface GetWhisperSessionsResponse {
   sessions: SbUserId[]
   users: SbUser[]
+  /**
+   * IDs of the target users whose conversations have messages newer than the user's last recorded
+   * read position. A session whose target ID is absent from this list should not be treated as
+   * unread. Additive over the base response so older clients ignore it.
+   */
+  unreadSessions?: SbUserId[]
 }

--- a/migrations/20260829120000_add_last_read_time.sql
+++ b/migrations/20260829120000_add_last_read_time.sql
@@ -1,0 +1,6 @@
+-- Per-user read position for chat channels and whisper conversations. NULL means no read position
+-- has ever been recorded, which the unread-detection queries treat as "everything is read" (a user
+-- who never marked anything read has nothing they've missed, until a message actually arrives after
+-- they join/start the conversation).
+ALTER TABLE channel_users ADD COLUMN last_read_time timestamptz;
+ALTER TABLE whisper_sessions ADD COLUMN last_read_time timestamptz;

--- a/server/lib/chat/chat-api.ts
+++ b/server/lib/chat/chat-api.ts
@@ -19,6 +19,7 @@ import {
   JoinChannelResponse,
   ListChannelBansResponse,
   ListUserChannelEntriesResponse,
+  MarkChannelReadRequest,
   ModerateChannelUserServerRequest,
   SEARCH_CHANNELS_LIMIT,
   SbChannelId,
@@ -128,6 +129,12 @@ const userChannelEntriesThrottle = createThrottle('chatuserchannelentries', {
 const userPreferencesThrottle = createThrottle('chatuserpreferences', {
   rate: 20,
   burst: 40,
+  window: 60000,
+})
+
+const markReadThrottle = createThrottle('chatmarkread', {
+  rate: 30,
+  burst: 60,
   window: 60000,
 })
 
@@ -404,6 +411,24 @@ export class ChatApi {
     })
 
     await this.chatService.updateUserPreferences(channelId, ctx.session!.user.id, body)
+
+    ctx.status = 204
+  }
+
+  @httpPost('/:channelId/mark-read')
+  @httpBefore(throttleMiddleware(markReadThrottle, throttleByUser))
+  async markChannelRead(ctx: RouterContext): Promise<void> {
+    const {
+      params: { channelId },
+      body: { lastReadTime },
+    } = validateRequest(ctx, {
+      params: channelIdParamsSchema(),
+      body: Joi.object<MarkChannelReadRequest>({
+        lastReadTime: Joi.number().integer().min(0).required(),
+      }),
+    })
+
+    await this.chatService.markRead(channelId, ctx.session!.user.id, new Date(lastReadTime))
 
     ctx.status = 204
   }

--- a/server/lib/chat/chat-models.ts
+++ b/server/lib/chat/chat-models.ts
@@ -673,6 +673,69 @@ export async function updateUserPermissions(
   }
 }
 
+/**
+ * Advances a user's read position in a channel to `lastReadTime`. The update is monotonic (never
+ * moves the stored position backward) so a stale report from one device can't clobber a newer
+ * position recorded by another, and clamped to `now()` so a client can't push the position into the
+ * future. A silent no-op if the user isn't (or is no longer) a member of the channel.
+ */
+export async function updateLastReadTime(
+  userId: SbUserId,
+  channelId: SbChannelId,
+  lastReadTime: Date,
+  withClient?: DbClient,
+): Promise<void> {
+  const { client, done } = await db(withClient)
+  try {
+    await client.query(sql`
+      UPDATE channel_users
+      SET last_read_time = GREATEST(
+        COALESCE(last_read_time, '-infinity'::timestamptz), LEAST(${lastReadTime}, now())
+      )
+      WHERE user_id = ${userId} AND channel_id = ${channelId};
+    `)
+  } finally {
+    done()
+  }
+}
+
+/**
+ * Returns the IDs of a user's joined channels that have a text message sent by someone else after
+ * their last recorded read position in that channel. A channel with no recorded read position
+ * never counts as unread here, since there's nothing to compare newly-arrived messages against;
+ * `markRead` establishes that baseline the first time a client reports one. Only text messages
+ * count, mirroring the client's own `makeUnread` flag: join/leave/moderation events never mark a
+ * channel unread. A single set-based query over all of the user's channels, rather than one query
+ * per channel. `sent` columns store naive UTC wall time (see the timestamp parser setup in
+ * `server/lib/db`), so the read position is converted to naive UTC for the comparison instead of
+ * being left to the connection's session time zone. The comparison works at millisecond
+ * granularity (`sent >= read + 1ms` rather than `sent > read`): read positions arrive as epoch
+ * milliseconds while `sent` keeps microseconds, so a full-precision strict comparison would leave
+ * the newest message permanently unread.
+ */
+export async function getUnreadChannels(userId: SbUserId): Promise<SbChannelId[]> {
+  const { client, done } = await db()
+  try {
+    const result = await client.query<{ channel_id: SbChannelId }>(sql`
+      SELECT cu.channel_id FROM channel_users cu
+      WHERE cu.user_id = ${userId}
+        AND EXISTS (
+          SELECT 1 FROM channel_messages m
+          WHERE m.channel_id = cu.channel_id
+            AND m.user_id != cu.user_id
+            AND m.sent >= COALESCE(
+              (cu.last_read_time AT TIME ZONE 'UTC') + interval '1 millisecond',
+              'infinity'::timestamp
+            )
+            AND m.data ->> 'type' = ${ServerChatMessageType.TextMessage}
+        )
+    `)
+    return result.rows.map(row => row.channel_id)
+  } finally {
+    done()
+  }
+}
+
 export async function countBannedIdentifiersForChannel(
   {
     channelId,

--- a/server/lib/chat/chat-service.test.ts
+++ b/server/lib/chat/chat-service.test.ts
@@ -54,6 +54,7 @@ import {
   getChannelInfos,
   getChannelsForUser,
   getMessagesForChannel,
+  getUnreadChannels,
   getUserChannelEntriesForChannel,
   getUserChannelEntriesForUser,
   getUserChannelEntryForUser,
@@ -127,6 +128,8 @@ vi.mock('./chat-models', async () => {
   const originalModule = await vi.importActual<typeof import('./chat-models')>('./chat-models')
   return {
     getChannelsForUser: vi.fn().mockResolvedValue([]),
+    getUnreadChannels: vi.fn().mockResolvedValue([]),
+    updateLastReadTime: vi.fn(),
     getUsersForChannel: vi.fn().mockResolvedValue([]),
     getUserChannelEntryForUser: vi.fn(),
     getUserChannelEntriesForUser: vi.fn().mockResolvedValue([]),
@@ -537,6 +540,7 @@ describe('chat/chat-service', () => {
           joinedChannelInfo: shieldBatteryJoinedInfo,
           selfPreferences: channelPreferences,
           selfPermissions: channelPermissions,
+          hasUnread: false,
         },
         {
           channelInfo: testBasicInfo,
@@ -544,6 +548,36 @@ describe('chat/chat-service', () => {
           joinedChannelInfo: testJoinedInfo,
           selfPreferences: channelPreferences,
           selfPermissions: channelPermissions,
+          hasUnread: false,
+        },
+      ])
+    })
+
+    test('marks a channel with unread messages', async () => {
+      await joinUserToChannel(
+        user1,
+        shieldBatteryChannel,
+        user1ShieldBatteryChannelEntry,
+        joinUser1ShieldBatteryChannelMessage,
+      )
+
+      asMockedFunction(getChannelsForUser).mockResolvedValue([user1ShieldBatteryChannelEntry])
+      asMockedFunction(getChannelInfos).mockResolvedValue([shieldBatteryChannel])
+      asMockedFunction(getUnreadChannels).mockResolvedValue([shieldBatteryChannel.id])
+
+      const result = await chatService.getJoinedChannels(user1.id)
+
+      asMockedFunction(getChannelsForUser).mockResolvedValue([])
+      asMockedFunction(getUnreadChannels).mockResolvedValue([])
+
+      expect(result).toEqual([
+        {
+          channelInfo: shieldBatteryBasicInfo,
+          detailedChannelInfo: shieldBatteryDetailedInfo,
+          joinedChannelInfo: shieldBatteryJoinedInfo,
+          selfPreferences: channelPreferences,
+          selfPermissions: channelPermissions,
+          hasUnread: true,
         },
       ])
     })

--- a/server/lib/chat/chat-service.ts
+++ b/server/lib/chat/chat-service.ts
@@ -78,6 +78,7 @@ import {
   getChannelInfos,
   getChannelsForUser,
   getMessagesForChannel,
+  getUnreadChannels,
   getUserChannelEntriesForChannel,
   getUserChannelEntriesForUser,
   getUserChannelEntryForUser,
@@ -92,6 +93,7 @@ import {
   transferChannelOwnership,
   unbanUserFromChannel,
   updateChannel,
+  updateLastReadTime,
   updateUserPermissions,
   updateUserPreferences,
 } from './chat-models'
@@ -150,10 +152,14 @@ export default class ChatService {
   }
 
   async getJoinedChannels(userId: SbUserId): Promise<InitialChannelData[]> {
-    const joinedChannels = await getChannelsForUser(userId)
+    const [joinedChannels, unreadChannels] = await Promise.all([
+      getChannelsForUser(userId),
+      getUnreadChannels(userId),
+    ])
     const channelInfos = await getChannelInfos(joinedChannels.map(c => c.channelId))
 
     const channelInfosMap = new global.Map(channelInfos.map(c => [c.id, c]))
+    const unreadChannelsSet = new global.Set(unreadChannels)
 
     return joinedChannels.map(c => {
       const channelInfo = channelInfosMap.get(c.channelId)!
@@ -164,6 +170,7 @@ export default class ChatService {
         joinedChannelInfo: toJoinedChannelInfo(channelInfo),
         selfPreferences: c.channelPreferences,
         selfPermissions: c.channelPermissions,
+        hasUnread: unreadChannelsSet.has(c.channelId),
       }
     })
   }
@@ -204,6 +211,8 @@ export default class ChatService {
       ])
 
       if (channelInfo && userChannelEntry) {
+        // `hasUnread` is omitted: a membership this fresh has no recorded read position yet, which
+        // `getUnreadChannels` always treats as fully read.
         this.publisher.publish(getChannelUserPath(channelId, userSockets.userId), {
           action: 'init3',
           channelInfo: toBasicChannelInfo(channelInfo),
@@ -1361,6 +1370,14 @@ export default class ChatService {
       action: 'preferencesChanged',
       selfPreferences: channelPreferences,
     })
+  }
+
+  /**
+   * Records the newest message time a user has seen in a channel. A no-op if they aren't a member
+   * of the channel (e.g. a stale report arriving after they left).
+   */
+  async markRead(channelId: SbChannelId, userId: SbUserId, lastReadTime: Date): Promise<void> {
+    await updateLastReadTime(userId, channelId, lastReadTime)
   }
 
   async updateUserPermissions(

--- a/server/lib/whispers/whisper-api.ts
+++ b/server/lib/whispers/whisper-api.ts
@@ -6,6 +6,7 @@ import { SbUserId } from '../../../common/users/sb-user-id'
 import {
   GetSessionHistoryResponse,
   GetWhisperSessionsResponse,
+  MarkWhisperReadRequest,
   SendWhisperMessageRequest,
   WhisperServiceErrorCode,
 } from '../../../common/whispers'
@@ -48,6 +49,12 @@ const sendThrottle = createThrottle('whispersend', {
 const retrievalThrottle = createThrottle('whisperretrieval', {
   rate: 30,
   burst: 120,
+  window: 60000,
+})
+
+const markReadThrottle = createThrottle('whispermarkread', {
+  rate: 30,
+  burst: 60,
   window: 60000,
 })
 
@@ -152,6 +159,26 @@ export class WhisperApi {
     })
 
     await this.whisperService.sendWhisperMessage(ctx.session!.user.id, targetId, message)
+
+    ctx.status = 204
+  }
+
+  @httpPost('/:targetId/mark-read')
+  @httpBefore(throttleMiddleware(markReadThrottle, throttleByUser))
+  async markWhisperRead(ctx: RouterContext): Promise<void> {
+    const {
+      params: { targetId },
+      body: { lastReadTime },
+    } = validateRequest(ctx, {
+      params: Joi.object<{ targetId: SbUserId }>({
+        targetId: joiUserId().required(),
+      }),
+      body: Joi.object<MarkWhisperReadRequest>({
+        lastReadTime: Joi.number().integer().min(0).required(),
+      }),
+    })
+
+    await this.whisperService.markRead(ctx.session!.user.id, targetId, new Date(lastReadTime))
 
     ctx.status = 204
   }

--- a/server/lib/whispers/whisper-models.ts
+++ b/server/lib/whispers/whisper-models.ts
@@ -63,6 +63,68 @@ export async function startWhisperSessionsBothDirections(
   }
 }
 
+/**
+ * Advances a user's read position in a whisper conversation to `lastReadTime`. The update is
+ * monotonic (never moves the stored position backward) so a stale report from one device can't
+ * clobber a newer position recorded by another, and clamped to `now()` so a client can't push the
+ * position into the future. A silent no-op if the session doesn't exist (e.g. it was closed).
+ */
+export async function updateLastReadTime(
+  userId: SbUserId,
+  targetId: SbUserId,
+  lastReadTime: Date,
+): Promise<void> {
+  const { client, done } = await db()
+  try {
+    await client.query(sql`
+      UPDATE whisper_sessions
+      SET last_read_time = GREATEST(
+        COALESCE(last_read_time, '-infinity'::timestamptz), LEAST(${lastReadTime}, now())
+      )
+      WHERE user_id = ${userId} AND target_user_id = ${targetId};
+    `)
+  } finally {
+    done()
+  }
+}
+
+/**
+ * Returns the IDs of the target users in a user's whisper sessions that have a message from that
+ * target after the user's last recorded read position for the session. A session with no recorded
+ * read position never counts as unread here, since there's nothing to compare newly-arrived
+ * messages against; `markRead` establishes that baseline the first time a client reports one.
+ * Every whisper message is a text message (`WhisperMessageData` has a single variant), so every
+ * message from the target counts. A single set-based query over all of the user's sessions, rather
+ * than one query per session. `sent` columns store naive UTC wall time (see the timestamp parser
+ * setup in `server/lib/db`), so the read position is converted to naive UTC for the comparison
+ * instead of being left to the connection's session time zone. The comparison works at millisecond
+ * granularity (`sent >= read + 1ms` rather than `sent > read`): read positions arrive as epoch
+ * milliseconds while `sent` keeps microseconds, so a full-precision strict comparison would leave
+ * the newest message permanently unread.
+ */
+export async function getUnreadWhisperTargets(userId: SbUserId): Promise<SbUserId[]> {
+  const { client, done } = await db()
+  try {
+    const result = await client.query<{ target_user_id: SbUserId }>(sql`
+      SELECT ws.target_user_id FROM whisper_sessions ws
+      WHERE ws.user_id = ${userId}
+        AND EXISTS (
+          SELECT 1 FROM whisper_messages m
+          WHERE m.user_low = LEAST(ws.user_id, ws.target_user_id)
+            AND m.user_high = GREATEST(ws.user_id, ws.target_user_id)
+            AND m.from_id = ws.target_user_id
+            AND m.sent >= COALESCE(
+              (ws.last_read_time AT TIME ZONE 'UTC') + interval '1 millisecond',
+              'infinity'::timestamp
+            )
+        )
+    `)
+    return result.rows.map(row => row.target_user_id)
+  } finally {
+    done()
+  }
+}
+
 export async function closeWhisperSession(userId: SbUserId, targetId: SbUserId): Promise<boolean> {
   const { client, done } = await db()
   try {

--- a/server/lib/whispers/whisper-service.ts
+++ b/server/lib/whispers/whisper-service.ts
@@ -30,7 +30,9 @@ import {
   startWhisperSession as dbStartWhisperSession,
   startWhisperSessionsBothDirections as dbStartWhisperSessionsBothDirections,
   getMessagesForWhisperSession,
+  getUnreadWhisperTargets,
   getWhisperSessionsForUser,
+  updateLastReadTime,
 } from './whisper-models'
 
 export class WhisperServiceError extends Error {
@@ -73,12 +75,24 @@ export default class WhisperService {
   }
 
   async getWhisperSessions(userId: SbUserId): Promise<GetWhisperSessionsResponse> {
-    const sessions = await getWhisperSessionsForUser(userId)
+    const [sessions, unreadSessions] = await Promise.all([
+      getWhisperSessionsForUser(userId),
+      getUnreadWhisperTargets(userId),
+    ])
     const users = await findUsersById(sessions)
     return {
       sessions,
       users,
+      unreadSessions,
     }
+  }
+
+  /**
+   * Records the newest message time a user has seen in a whisper conversation. A no-op if the
+   * session doesn't exist (e.g. it was closed, or never opened).
+   */
+  async markRead(userId: SbUserId, targetId: SbUserId, lastReadTime: Date): Promise<void> {
+    await updateLastReadTime(userId, targetId, lastReadTime)
   }
 
   async startWhisperSession(userId: SbUserId, targetUser: SbUserId) {


### PR DESCRIPTION
Adds server-side tracking of per-user read positions for chat channels and whispers, so unread state survives restarts and syncs across devices (previously it lived only in client memory and reset on every launch).

## What this does

- New nullable `last_read_time` column on `channel_users` and `whisper_sessions`.
- New mark-read endpoints that advance the stored position monotonically, clamped to `now()`.
- Initial payloads now compute `hasUnread` per channel / `unreadSessions` per whisper target set-based against messages newer than the stored position, so badges are correct immediately on login.
- The client reports the newest loaded server message's `sent` time whenever a conversation is open and scrolled to the bottom — coalesced leading-edge (5s) per conversation, with a flush on unmount.

## Why a timestamp marker (and what else was considered)

**Last-read message ID (the Discord model).** Discord stores a per-channel `last_message_id`, but its snowflake IDs embed a millisecond timestamp, so that *is* a time marker with total order. Our `sb_uuid()` IDs are UUIDv7, so `WHERE id > marker` would genuinely work here too. Rejected because:

- Message lists are ordered by `sent`, not by `id`, and the v7 timestamp comes from `clock_timestamp()` at insert, which can disagree with `sent` by a hair. Using ID order for the unread comparison while the user sees `sent` order invites off-by-one phantom-unread bugs at exactly the boundary that matters. (Discord avoids this because the snowflake is both the ID and the sole sort key.)
- A stored ID can dangle after a staff message deletion; a timestamp never does.
- The client already holds the newest message's `sent` time, so reporting it costs nothing.

Slack's `conversations.mark` takes a `ts` — this PR is that model. The one wart of the time approach is precision: Postgres stores microseconds, JS has milliseconds, and two messages can share a millisecond — hence the unread comparison treats anything at `last_read_time + 1ms` or later as unread, applied consistently by the endpoints and the seeding queries.

**A stored "fully read" flag.** Derivable state — a marker at or past the newest message's time means fully read. Storing it would mean flipping a flag for every channel member on every send (or accepting staleness), so it was left out.

**Ack transport/frequency.** Alternatives to the throttled HTTP ack: sending it over the existing WebSocket (saves per-request overhead but not frequency, and mutations-over-HTTP is this codebase's pattern), acking only on conversation-leave/blur (fewer requests, but other devices keep their badge until you navigate away, and a crash loses the ack), or a trailing debounce (delays cross-device badge clearing). Leading-edge throttling acks eagerly so other devices clear immediately, and worst case is one request per 5s per user per actively-read busy conversation. Moving to the socket is a cheap follow-up if it ever shows up in metrics.

## Testing

- Unit tests for the unread seeding logic in `chat-service.test.ts`.
- Live-verified with two Electron clients: badge on message to an unfocused channel, badge survives client restart, reading (scrolled to bottom) clears it durably, scrolled-up history leaves it unread; same for whispers.
