### PR TITLE
Show an unread-messages divider and jump-to-first-unread banner in chat

### DIFF
--- a/client/chat/action-creators.ts
+++ b/client/chat/action-creators.ts
@@ -68,7 +68,14 @@ export function getChannelLastReadKey(channelId: SbChannelId): string {
  * needs to react to this request's outcome.
  */
 export function markChannelRead(channelId: SbChannelId, lastReadTime: number): ThunkAction {
-  return () => {
+  return dispatch => {
+    // Advances the local read position immediately; the reducer's monotonic guard keeps this
+    // correct even for reports the coalescer below ends up dropping.
+    dispatch({
+      type: '@chat/updateLastReadTime',
+      payload: { channelId, lastReadTime },
+    })
+
     reportLastRead(getChannelLastReadKey(channelId), lastReadTime, time => {
       fetchJson<void>(apiUrl`chat/${channelId}/mark-read`, {
         method: 'POST',

--- a/client/chat/actions.ts
+++ b/client/chat/actions.ts
@@ -50,6 +50,7 @@ export type ChatActions =
   | ActivateChannel
   | DeactivateChannel
   | UpdateChannelAtBottom
+  | UpdateLastReadTime
   | InitChannel
   | InitActiveUsers
   | UpdateJoin
@@ -279,6 +280,19 @@ export interface UpdateChannelAtBottom {
   payload: {
     channelId: SbChannelId
     atBottom: boolean
+  }
+}
+
+/**
+ * The client's read position for a chat channel has advanced. Dispatched optimistically when the
+ * client reports a mark-read, shaped so a future cross-session update published by the server can
+ * dispatch it as well.
+ */
+export interface UpdateLastReadTime {
+  type: '@chat/updateLastReadTime'
+  payload: {
+    channelId: SbChannelId
+    lastReadTime: number
   }
 }
 

--- a/client/chat/channel.tsx
+++ b/client/chat/channel.tsx
@@ -133,6 +133,7 @@ export function ConnectedChatChannel({
   const isInChannel = useAppSelector(s => s.chat.joinedChannels.has(channelId))
   const isActivated = useAppSelector(s => s.chat.activatedChannels.has(channelId))
   const isAtBottom = useAppSelector(s => s.chat.atBottomChannels.has(channelId))
+  const unreadLineTime = useAppSelector(s => s.chat.idToUnreadLineTime.get(channelId))
 
   // NOTE(2Pac): When user types the single @ character in chat, we show the ten most recent
   // chatters in the channel as an option to mention.
@@ -289,6 +290,7 @@ export function ConnectedChatChannel({
               refreshToken: channelId,
               MessageComponent: ChannelMessage,
               onLoadMoreMessages,
+              unreadLineTime,
             }}
             inputProps={{
               onSendChatMessage,

--- a/client/chat/chat-reducer.ts
+++ b/client/chat/chat-reducer.ts
@@ -62,6 +62,19 @@ export interface ChatState {
   unreadChannels: Set<SbChannelId>
   /** A set of channel IDs saved in various chat messages that no longer exist. */
   deletedChannels: Set<SbChannelId>
+  /**
+   * A map of channel ID -> the client's view of the server-recorded read position (epoch ms).
+   * Seeded from the server at init, and advanced optimistically whenever the client reports a
+   * mark-read for the channel.
+   */
+  idToLastReadTime: Map<SbChannelId, number>
+  /**
+   * A map of channel ID -> the frozen position of the unread divider for the current activation.
+   * Captured when an unread channel activates, or when a message arrives while the channel is
+   * activated and scrolled up, and held until deactivation so the divider doesn't chase
+   * `idToLastReadTime` as it keeps advancing underneath it.
+   */
+  idToUnreadLineTime: Map<SbChannelId, number>
 }
 
 const DEFAULT_CHAT_STATE: Immutable<ChatState> = {
@@ -78,6 +91,8 @@ const DEFAULT_CHAT_STATE: Immutable<ChatState> = {
   atBottomChannels: new Set(),
   unreadChannels: new Set(),
   deletedChannels: new Set(),
+  idToLastReadTime: new Map(),
+  idToUnreadLineTime: new Map(),
 }
 
 function removeUserFromChannel(
@@ -158,6 +173,8 @@ function removeSelfFromChannel(state: ChatState, channelId: SbChannelId) {
   state.activatedChannels.delete(channelId)
   state.atBottomChannels.delete(channelId)
   state.unreadChannels.delete(channelId)
+  state.idToLastReadTime.delete(channelId)
+  state.idToUnreadLineTime.delete(channelId)
 }
 
 /**
@@ -198,6 +215,21 @@ function updateMessages(
 
   if (makeUnread && !isChannelUnread && !isChannelActivated) {
     state.unreadChannels.add(channelId)
+  }
+
+  // The channel is being actively viewed but scrolled up, so a new message won't be seen right
+  // away. Freeze the unread divider at the read position so it marks where the user left off
+  // instead of chasing the read position as the eager mark-read keeps advancing it.
+  if (
+    makeUnread &&
+    isChannelActivated &&
+    !state.atBottomChannels.has(channelId) &&
+    !state.idToUnreadLineTime.has(channelId)
+  ) {
+    const lastReadTime = state.idToLastReadTime.get(channelId)
+    if (lastReadTime !== undefined) {
+      state.idToUnreadLineTime.set(channelId, lastReadTime)
+    }
   }
 
   channelMessages.hasHistory = channelMessages.hasHistory || sliced
@@ -252,6 +284,7 @@ function initChannel(state: ChatState, channelId: SbChannelId, data: InitialChan
     selfPreferences,
     selfPermissions,
     hasUnread,
+    lastReadTime,
   } = data
 
   const messagesState: MessagesState = {
@@ -268,6 +301,10 @@ function initChannel(state: ChatState, channelId: SbChannelId, data: InitialChan
   state.idToUserProfiles.set(channelId, new Map())
   state.idToSelfPreferences.set(channelId, selfPreferences)
   state.idToSelfPermissions.set(channelId, selfPermissions)
+
+  if (lastReadTime !== undefined) {
+    state.idToLastReadTime.set(channelId, lastReadTime)
+  }
 
   // Seeds the unread badge from the server's recorded read position, so it survives a restart
   // instead of resetting to "read" until the next message arrives. A channel the user is currently
@@ -546,6 +583,17 @@ export default immerKeyedReducer(DEFAULT_CHAT_STATE, {
   ['@chat/activateChannel'](state, action) {
     const { channelId } = action.payload
 
+    // Freeze the unread divider at the read position before clearing the unread flag, so the
+    // divider marks where the user left off instead of where the read position ends up after the
+    // eager mark-read this activation triggers.
+    if (
+      state.unreadChannels.has(channelId) &&
+      !state.idToUnreadLineTime.has(channelId) &&
+      state.idToLastReadTime.has(channelId)
+    ) {
+      state.idToUnreadLineTime.set(channelId, state.idToLastReadTime.get(channelId)!)
+    }
+
     state.unreadChannels.delete(channelId)
     state.activatedChannels.add(channelId)
     // Message lists mount pinned to the bottom.
@@ -554,6 +602,20 @@ export default immerKeyedReducer(DEFAULT_CHAT_STATE, {
 
   ['@chat/deactivateChannel'](state, action) {
     const { channelId } = action.payload
+
+    // The unread divider is only consumed once the read position has actually moved past it — a
+    // deactivation where the user never read anything new (including the mount/cleanup/remount
+    // cycle React's StrictMode runs in development) leaves the still-unread divider in place for
+    // the next visit.
+    const unreadLineTime = state.idToUnreadLineTime.get(channelId)
+    const lastReadTime = state.idToLastReadTime.get(channelId)
+    if (
+      unreadLineTime !== undefined &&
+      lastReadTime !== undefined &&
+      lastReadTime > unreadLineTime
+    ) {
+      state.idToUnreadLineTime.delete(channelId)
+    }
 
     const channelMessages = state.idToMessages.get(channelId)
     if (!channelMessages) {
@@ -566,6 +628,15 @@ export default immerKeyedReducer(DEFAULT_CHAT_STATE, {
     channelMessages.hasHistory = channelMessages.hasHistory || hasHistory
     state.activatedChannels.delete(channelId)
     state.atBottomChannels.delete(channelId)
+  },
+
+  ['@chat/updateLastReadTime'](state, action) {
+    const { channelId, lastReadTime } = action.payload
+
+    const existing = state.idToLastReadTime.get(channelId)
+    if (existing === undefined || lastReadTime > existing) {
+      state.idToLastReadTime.set(channelId, lastReadTime)
+    }
   },
 
   ['@chat/updateChannelAtBottom'](state, action) {

--- a/client/chat/chat-reducer.ts
+++ b/client/chat/chat-reducer.ts
@@ -475,6 +475,10 @@ export default immerKeyedReducer(DEFAULT_CHAT_STATE, {
   ['@chat/loadMessageHistory'](state, action) {
     if (action.error) {
       // TODO(2Pac): Handle errors
+      const channelMessages = state.idToMessages.get(action.meta.channelId)
+      if (channelMessages) {
+        channelMessages.loadingHistory = false
+      }
       return
     }
 
@@ -697,8 +701,10 @@ export default immerKeyedReducer(DEFAULT_CHAT_STATE, {
   },
 
   ['@whispers/loadMessageHistory'](state, action) {
-    updateChannelInfos(state, action.payload.channelMentions)
-    updateDeletedChannels(state, action.payload.deletedChannels)
+    if (!action.error) {
+      updateChannelInfos(state, action.payload.channelMentions)
+      updateDeletedChannels(state, action.payload.deletedChannels)
+    }
   },
 
   ['@lobbies/updateChatMessage'](state, action) {

--- a/client/messaging/chat.tsx
+++ b/client/messaging/chat.tsx
@@ -1,18 +1,22 @@
 import { AnimatePresence, Transition, Variants } from 'motion/react'
 import * as m from 'motion/react-m'
 import * as React from 'react'
-import { useCallback, useContext, useRef, useState } from 'react'
+import { useContext, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 import { Merge, Simplify } from 'type-fest'
 import { SbUserId } from '../../common/users/sb-user-id'
 import { MaterialIcon } from '../icons/material/material-icon'
 import { ElevatedButton } from '../material/button'
+import { buttonReset } from '../material/button-reset'
 import { MenuItem, MenuItemProps } from '../material/menu/item'
 import { MenuItemSymbol, MenuItemType } from '../material/menu/menu-item-symbol'
+import { UNREAD_LINE_SELECTOR } from '../messaging/common-message-layout'
 import { MessageInput, MessageInputHandle, MessageInputProps } from '../messaging/message-input'
 import { MessageList, MessageListProps } from '../messaging/message-list'
+import { isServerOriginMessage, SbMessage } from '../messaging/message-records'
 import { useAppDispatch } from '../redux-hooks'
+import { labelMedium } from '../styles/typography'
 import {
   BaseUserMenuItemsProvider,
   MenuItemCategory,
@@ -27,6 +31,35 @@ import { DefaultMessageMenu, MessageMenuComponent } from './message-context-menu
  * the jump-to-bottom button appears.
  */
 const JUMP_TO_BOTTOM_THRESHOLD_SCREENS = 1.5
+
+/** How much room to leave above the unread divider when jumping to it, in pixels. */
+const UNREAD_LINE_SCROLL_MARGIN_PX = 8
+
+/** An in-progress hunt through older history for the unread divider. */
+interface UnreadLineSeek {
+  /** Identifies the conversation the seek was started in. */
+  refreshToken: unknown
+  /** Where the divider sat when the seek was started. */
+  unreadLineTime: number
+  /**
+   * The message list the outstanding history request was issued against. A request only counts as
+   * answered once a different list arrives, since `loading` doesn't turn true until the render
+   * after the request.
+   */
+  requestedFor: ReadonlyArray<SbMessage>
+}
+
+function findUnreadLine(scroller: HTMLElement): HTMLElement | null {
+  return scroller.querySelector<HTMLElement>(UNREAD_LINE_SELECTOR)
+}
+
+function scrollToUnreadLine(scroller: HTMLElement, unreadLine: HTMLElement) {
+  // Positions are read as rects rather than offsets because the divider's offset parent isn't
+  // guaranteed to be the scroller.
+  const scrollerTop = scroller.getBoundingClientRect().top
+  const lineTop = unreadLine.getBoundingClientRect().top
+  scroller.scrollTop += lineTop - scrollerTop - UNREAD_LINE_SCROLL_MARGIN_PX
+}
 
 const MessagesAndInput = styled.div`
   position: relative;
@@ -64,6 +97,33 @@ const JumpToBottomButton = styled(ElevatedButton)`
   pointer-events: auto;
 `
 
+const UnreadBannerButton = styled(m.button)`
+  ${buttonReset};
+  ${labelMedium};
+
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 24px;
+  padding: 0 12px;
+
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+
+  background-color: var(--theme-amber-container);
+  border-radius: 0 0 4px 4px;
+  color: var(--theme-on-amber-container);
+  text-align: left;
+
+  &:focus-visible {
+    outline: 2px solid var(--theme-on-amber-container);
+    outline-offset: -2px;
+  }
+`
+
 const jumpToBottomVariants: Variants = {
   initial: {
     opacity: 0,
@@ -79,7 +139,22 @@ const jumpToBottomVariants: Variants = {
   },
 }
 
-const jumpToBottomTransition: Transition = {
+const unreadBannerVariants: Variants = {
+  initial: {
+    opacity: 0,
+    y: -8,
+  },
+  visible: {
+    opacity: 1,
+    y: 0,
+  },
+  exit: {
+    opacity: 0,
+    y: -8,
+  },
+}
+
+const overlayTransition: Transition = {
   type: 'tween',
   duration: 0.12,
 }
@@ -138,35 +213,122 @@ export function Chat({
   const dispatch = useAppDispatch()
   const [isScrolledUp, setIsScrolledUp] = useState<boolean>(false)
   const [showJumpToBottom, setShowJumpToBottom] = useState<boolean>(false)
+  const [showUnreadBanner, setShowUnreadBanner] = useState<boolean>(false)
   // Message lists mount pinned to the bottom, matching how `MessageList` initially scrolls.
   const wasAtBottomRef = useRef(true)
   const scrollerRef = useRef<HTMLDivElement | null>(null)
+  // Set while we're loading history until the unread divider comes into the loaded window, so we
+  // can jump to it. It carries what it was started for, so a seek can't outlive the conversation
+  // (or the divider position) it was aimed at.
+  const seekRef = useRef<UnreadLineSeek | undefined>(undefined)
+  // The divider the user has already had in view. The banner is a one-shot prompt for a divider
+  // they haven't laid eyes on yet — once it's been on screen, scrolling back down doesn't
+  // resurface the banner. Carries what it was recorded for, so a conversation switch or a newly
+  // frozen divider starts fresh.
+  const seenLineRef = useRef<{ refreshToken: unknown; unreadLineTime: number } | undefined>(
+    undefined,
+  )
 
-  const onScrollUpdate = useCallback(
-    (target: EventTarget) => {
-      const { scrollTop, scrollHeight, clientHeight } = target as HTMLDivElement
+  const { unreadLineTime, messages, loading, hasMoreHistory, onLoadMoreMessages, refreshToken } =
+    listProps
 
-      const newIsScrolledUp = scrollTop + clientHeight < scrollHeight
-      setIsScrolledUp(newIsScrolledUp)
+  const onScrollUpdate = (target: EventTarget) => {
+    const scroller = target as HTMLDivElement
+    const { scrollTop, scrollHeight, clientHeight } = scroller
 
-      const newAtBottom = !newIsScrolledUp
-      if (newAtBottom !== wasAtBottomRef.current) {
-        wasAtBottomRef.current = newAtBottom
-        onAtBottomChange?.(newAtBottom)
+    const newIsScrolledUp = scrollTop + clientHeight < scrollHeight
+    setIsScrolledUp(newIsScrolledUp)
+
+    const newAtBottom = !newIsScrolledUp
+    if (newAtBottom !== wasAtBottomRef.current) {
+      wasAtBottomRef.current = newAtBottom
+      onAtBottomChange?.(newAtBottom)
+    }
+
+    const distanceFromBottom = scrollHeight - clientHeight - scrollTop
+    setShowJumpToBottom(distanceFromBottom > clientHeight * JUMP_TO_BOTTOM_THRESHOLD_SCREENS)
+
+    scrollerRef.current = scroller
+
+    const unreadLine = findUnreadLine(scroller)
+
+    const seek = seekRef.current
+    if (seek) {
+      if (seek.refreshToken !== refreshToken || seek.unreadLineTime !== unreadLineTime) {
+        // The conversation, or where its divider sits, changed out from under the seek.
+        seekRef.current = undefined
+      } else if (unreadLine) {
+        seekRef.current = undefined
+        scrollToUnreadLine(scroller, unreadLine)
+      } else if (!hasMoreHistory) {
+        // All the history there is has been loaded without turning up a divider, so the top of the
+        // list is as close as we can get to where the user left off.
+        seekRef.current = undefined
+        scroller.scrollTop = 0
+      } else if (!loading && seek.requestedFor !== messages) {
+        seek.requestedFor = messages
+        onLoadMoreMessages?.()
+      }
+    }
+
+    // Rects are read after the scrolling above, so the banner reflects where the divider ended up.
+    let newShowUnreadBanner = false
+    if (unreadLineTime !== undefined) {
+      if (unreadLine) {
+        const scrollerRect = scroller.getBoundingClientRect()
+        const lineRect = unreadLine.getBoundingClientRect()
+        if (lineRect.bottom > scrollerRect.top && lineRect.top < scrollerRect.bottom) {
+          seenLineRef.current = { refreshToken, unreadLineTime }
+        }
+        newShowUnreadBanner = lineRect.bottom - scrollerRect.top < 0
+      } else {
+        // With no divider rendered, the boundary is above the loaded window if even the oldest
+        // loaded message is newer than the read position. Anything else means there's nothing
+        // unread to jump to.
+        const oldestServerMessage = messages.find(isServerOriginMessage)
+        newShowUnreadBanner =
+          oldestServerMessage !== undefined && oldestServerMessage.time > unreadLineTime
       }
 
-      const distanceFromBottom = scrollHeight - clientHeight - scrollTop
-      setShowJumpToBottom(distanceFromBottom > clientHeight * JUMP_TO_BOTTOM_THRESHOLD_SCREENS)
-
-      scrollerRef.current = target as HTMLDivElement
-    },
-    [onAtBottomChange],
-  )
+      const seen = seenLineRef.current
+      if (seen && seen.refreshToken === refreshToken && seen.unreadLineTime === unreadLineTime) {
+        newShowUnreadBanner = false
+      }
+    }
+    setShowUnreadBanner(newShowUnreadBanner)
+  }
 
   const onJumpToBottomClick = () => {
     const scroller = scrollerRef.current
     if (scroller) {
       scroller.scrollTop = scroller.scrollHeight
+    }
+  }
+
+  const onUnreadBannerClick = () => {
+    const scroller = scrollerRef.current
+    if (!scroller) {
+      return
+    }
+
+    const unreadLine = findUnreadLine(scroller)
+    if (unreadLine) {
+      scrollToUnreadLine(scroller, unreadLine)
+      return
+    }
+
+    if (unreadLineTime === undefined) {
+      return
+    }
+
+    if (!hasMoreHistory) {
+      scroller.scrollTop = 0
+      return
+    }
+
+    seekRef.current = { refreshToken, unreadLineTime, requestedFor: messages }
+    if (!loading) {
+      onLoadMoreMessages?.()
     }
   }
 
@@ -210,6 +372,21 @@ export function Chat({
           <MessageListContainer>
             <StyledMessageList {...listProps} onScrollUpdate={onScrollUpdate} />
             <AnimatePresence>
+              {showUnreadBanner && unreadLineTime !== undefined ? (
+                <UnreadBannerButton
+                  key='new-messages'
+                  variants={unreadBannerVariants}
+                  initial='initial'
+                  animate='visible'
+                  exit='exit'
+                  transition={overlayTransition}
+                  onClick={onUnreadBannerClick}>
+                  <span>{t('messaging.newMessages', 'New messages')}</span>
+                  <MaterialIcon icon='arrow_upward' size={16} />
+                </UnreadBannerButton>
+              ) : null}
+            </AnimatePresence>
+            <AnimatePresence>
               {showJumpToBottom ? (
                 <JumpToBottomButtonContainer
                   key='jump-to-bottom'
@@ -217,7 +394,7 @@ export function Chat({
                   initial='initial'
                   animate='visible'
                   exit='exit'
-                  transition={jumpToBottomTransition}>
+                  transition={overlayTransition}>
                   <JumpToBottomButton
                     iconStart={<MaterialIcon icon='arrow_downward' size={20} />}
                     label={t('messaging.jumpToBottom', 'Jump to bottom')}

--- a/client/messaging/common-message-layout.tsx
+++ b/client/messaging/common-message-layout.tsx
@@ -16,7 +16,7 @@ import {
   LobbyInviteCard,
 } from '../lobbies/lobby-invite-card'
 import { ExternalLink } from '../navigation/external-link'
-import { titleSmall } from '../styles/typography'
+import { labelSmall, titleSmall } from '../styles/typography'
 import { ConnectedUsername } from '../users/connected-username'
 import { ChatContext } from './chat-context'
 import { useMentionFilterClick } from './mention-hooks'
@@ -266,5 +266,62 @@ export const NewDayMessage = React.memo<{ time: number }>(props => {
         </Trans>
       </span>
     </SeparatedInfoMessage>
+  )
+})
+
+/**
+ * Selector for the unread divider, used by the code that scrolls the message list to it and by the
+ * banner that offers to.
+ */
+export const UNREAD_LINE_SELECTOR = '[data-unread-line]'
+
+const UnreadLineRoot = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 4px 0;
+  padding: 0 8px;
+
+  /**
+    The divider is chrome rather than content, so it must stay out of any text the user copies out
+    of the message list. The doubled selectors outrank the list container's rule that makes all of
+    its descendants selectable.
+  */
+  &&,
+  && * {
+    user-select: none;
+  }
+`
+
+const UnreadLineRule = styled.hr`
+  flex-grow: 1;
+  margin: 0;
+
+  border: none;
+  border-top: 1px solid var(--theme-amber);
+`
+
+const UnreadLineLabel = styled.div`
+  ${labelSmall};
+
+  flex-shrink: 0;
+  padding: 0 6px;
+
+  background-color: var(--theme-amber-container);
+  border-radius: 4px;
+  color: var(--theme-on-amber-container);
+  text-transform: uppercase;
+`
+
+/**
+ * A divider marking where the messages the user hasn't seen yet begin.
+ */
+export const UnreadLineMessage = React.memo(() => {
+  const { t } = useTranslation()
+  return (
+    <UnreadLineRoot data-unread-line=''>
+      <UnreadLineRule />
+      <UnreadLineLabel>{t('messaging.unreadLineLabel', 'New')}</UnreadLineLabel>
+    </UnreadLineRoot>
   )
 })

--- a/client/messaging/message-list.test.ts
+++ b/client/messaging/message-list.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, test } from 'vitest'
+import {
+  ClientChatMessageType,
+  makeSbChannelId,
+  ServerChatMessageType,
+  type ChatMessage,
+} from '../../common/chat'
+import { makeSbUserId } from '../../common/users/sb-user-id'
+import { findUnreadLineIndex } from './message-list'
+import { CommonMessageType, type CommonTextMessage, type SbMessage } from './message-records'
+
+const CHANNEL_ID = makeSbChannelId(1)
+const USER_ID = makeSbUserId(2)
+
+/** A channel text message, which the server persists and stamps with its own clock. */
+function channelText(id: string, time: number): ChatMessage {
+  return {
+    id,
+    type: ServerChatMessageType.TextMessage,
+    channelId: CHANNEL_ID,
+    time,
+    from: USER_ID,
+    text: 'hi',
+  }
+}
+
+/** A channel join banner, which is only ever generated on the client. */
+function clientLeave(id: string, time: number): ChatMessage {
+  return {
+    id,
+    type: ClientChatMessageType.LeaveChannel,
+    channelId: CHANNEL_ID,
+    time,
+    userId: USER_ID,
+  }
+}
+
+/** How whisper messages are stored once received from the server. */
+function whisperText(id: string, time: number): CommonTextMessage {
+  return {
+    id,
+    type: CommonMessageType.TextMessage,
+    time,
+    from: USER_ID,
+    text: 'hi',
+  }
+}
+
+describe('client/messaging/message-list/findUnreadLineIndex', () => {
+  test('no messages', () => {
+    expect(findUnreadLineIndex([], 1000, false)).toBe(-1)
+  })
+
+  test('no read position means no divider', () => {
+    expect(
+      findUnreadLineIndex([channelText('a', 1000), channelText('b', 2000)], undefined, false),
+    ).toBe(-1)
+  })
+
+  test('everything already read', () => {
+    const messages = [channelText('a', 1000), channelText('b', 2000)]
+
+    expect(findUnreadLineIndex(messages, 3000, false)).toBe(-1)
+  })
+
+  test('divider goes in front of the first message newer than the read position', () => {
+    const messages = [
+      channelText('a', 1000),
+      channelText('b', 2000),
+      channelText('c', 3000),
+      channelText('d', 4000),
+    ]
+
+    expect(findUnreadLineIndex(messages, 2000, false)).toBe(2)
+  })
+
+  test('a message exactly at the read position has been read', () => {
+    const messages = [channelText('a', 1000), channelText('b', 2000), channelText('c', 2001)]
+
+    expect(findUnreadLineIndex(messages, 2000, false)).toBe(2)
+  })
+
+  test('everything unread with no more history puts the divider in front of the first message', () => {
+    const messages = [channelText('a', 1000), channelText('b', 2000)]
+
+    expect(findUnreadLineIndex(messages, 500, false)).toBe(0)
+  })
+
+  test('everything unread with more history means the boundary is not loaded yet', () => {
+    const messages = [channelText('a', 1000), channelText('b', 2000)]
+
+    expect(findUnreadLineIndex(messages, 500, true)).toBe(-1)
+  })
+
+  test('a read message in the window anchors the divider even with more history', () => {
+    const messages = [channelText('a', 1000), channelText('b', 2000)]
+
+    expect(findUnreadLineIndex(messages, 1000, true)).toBe(1)
+  })
+
+  test('a leading client-only message is not evidence the boundary is loaded', () => {
+    const messages = [clientLeave('a', 900), channelText('b', 1000), channelText('c', 2000)]
+
+    expect(findUnreadLineIndex(messages, 500, true)).toBe(-1)
+  })
+
+  test('client-only messages are skipped', () => {
+    const messages = [
+      channelText('a', 1000),
+      // Stamped with the local clock, so its time means nothing next to a server read position.
+      clientLeave('b', 2000),
+      channelText('c', 3000),
+    ]
+
+    expect(findUnreadLineIndex(messages, 1500, false)).toBe(2)
+  })
+
+  test('a list of only client-only messages never gets a divider', () => {
+    const messages = [clientLeave('a', 2000), clientLeave('b', 3000)]
+
+    expect(findUnreadLineIndex(messages, 1000, false)).toBe(-1)
+  })
+
+  test('whisper messages count as server-origin', () => {
+    const messages: SbMessage[] = [whisperText('a', 1000), whisperText('b', 2000)]
+
+    expect(findUnreadLineIndex(messages, 1000, false)).toBe(1)
+  })
+
+  test('a join message can hold the divider position', () => {
+    const messages: SbMessage[] = [
+      channelText('a', 1000),
+      {
+        id: 'b',
+        type: ServerChatMessageType.JoinChannel,
+        channelId: CHANNEL_ID,
+        time: 2000,
+        userId: USER_ID,
+      },
+      channelText('c', 3000),
+    ]
+
+    expect(findUnreadLineIndex(messages, 1000, false)).toBe(1)
+  })
+})

--- a/client/messaging/message-list.tsx
+++ b/client/messaging/message-list.tsx
@@ -11,8 +11,48 @@ import { animationFrameHandler } from '../material/animation-frame-handler'
 import { useAppSelector } from '../redux-hooks'
 import { selectableTextContainer } from '../styles/text-selection'
 import { bodyLarge } from '../styles/typography'
-import { BlockedMessage, NewDayMessage, TextMessage } from './common-message-layout'
-import { CommonMessageType, CommonNewDayMessage, SbMessage } from './message-records'
+import {
+  BlockedMessage,
+  NewDayMessage,
+  TextMessage,
+  UnreadLineMessage,
+} from './common-message-layout'
+import {
+  CommonMessageType,
+  CommonNewDayMessage,
+  isServerOriginMessage,
+  SbMessage,
+} from './message-records'
+
+/**
+ * Returns the index of the message the unread divider should be rendered in front of, or -1 if the
+ * divider shouldn't be rendered. That's the first message with a server-recorded time newer than
+ * the given read position; messages that only exist on the client can't be compared against it at
+ * all, and a message at exactly the read position has been read.
+ *
+ * When every loaded server message is newer than the read position and more history exists, the
+ * true boundary lies above the loaded window, so no index is returned — rendering the divider at
+ * the top of the window would misrepresent where the unread messages start. Loading more history
+ * eventually brings a read message (or the very beginning) into the window, at which point the
+ * divider gets a real position.
+ */
+export function findUnreadLineIndex(
+  messages: ReadonlyArray<SbMessage>,
+  unreadLineTime: number | undefined,
+  hasMoreHistory: boolean | undefined,
+): number {
+  if (unreadLineTime === undefined) {
+    return -1
+  }
+
+  const index = messages.findIndex(m => isServerOriginMessage(m) && m.time > unreadLineTime)
+  if (index === -1) {
+    return -1
+  }
+
+  const hasReadMessageAbove = messages.slice(0, index).some(m => isServerOriginMessage(m))
+  return hasReadMessageAbove || !hasMoreHistory ? index : -1
+}
 
 function isSameDay(d1: Date, d2: Date) {
   return (
@@ -106,9 +146,17 @@ interface PureMessageListProps {
   messages: ReadonlyArray<SbMessage>
   showEmptyState: boolean
   MessageComponent?: MessageComponentType
+  unreadLineTime?: number
+  hasMoreHistory?: boolean
 }
 
-function PureMessageList({ messages, showEmptyState, MessageComponent }: PureMessageListProps) {
+function PureMessageList({
+  messages,
+  showEmptyState,
+  MessageComponent,
+  unreadLineTime,
+  hasMoreHistory,
+}: PureMessageListProps) {
   const { t } = useTranslation()
   const selfUserId = useSelfUser()!.id
   const blocks = useAppSelector(s => s.relationships.blocks)
@@ -118,6 +166,8 @@ function PureMessageList({ messages, showEmptyState, MessageComponent }: PureMes
       <EmptyList>{t('common.lists.empty', 'Nothing to see here')}</EmptyList>
     ) : undefined
   }
+
+  const unreadLineIndex = findUnreadLineIndex(messages, unreadLineTime, hasMoreHistory)
 
   return (
     <Messages>
@@ -133,25 +183,36 @@ function PureMessageList({ messages, showEmptyState, MessageComponent }: PureMes
         )
 
         const prevMessage = index > 0 ? messages[index - 1] : null
-        if (!prevMessage || isSameDay(new Date(prevMessage.time), new Date(m.time))) {
+        const needsNewDay =
+          !!prevMessage && !isSameDay(new Date(prevMessage.time), new Date(m.time))
+        const needsUnreadLine = index === unreadLineIndex
+
+        if (!needsNewDay && !needsUnreadLine) {
           return messageLayout
-        } else {
+        }
+
+        const dividers: React.ReactNode[] = []
+        if (needsNewDay) {
           const newDayMessage: CommonNewDayMessage = {
             id: m.time + '-' + CommonMessageType.NewDayMessage,
             type: CommonMessageType.NewDayMessage,
             time: m.time,
           }
 
-          return [
+          dividers.push(
             <CommonMessageOrFallback
               key={'newday-' + m.id}
               message={newDayMessage}
               selfUserId={selfUserId}
               blockedUsers={blocks}
             />,
-            messageLayout,
-          ]
+          )
         }
+        if (needsUnreadLine) {
+          dividers.push(<UnreadLineMessage key={'unread-' + m.id} />)
+        }
+
+        return [...dividers, messageLayout]
       })}
     </Messages>
   )
@@ -191,6 +252,12 @@ export interface MessageListProps {
    */
   onScrollUpdate?: (scrollTarget: EventTarget) => void
   onLoadMoreMessages?: () => void
+  /**
+   * The read position (epoch millis) the unread divider should be placed at, if the list should
+   * show one. The divider goes in front of the first message with a server-recorded time newer
+   * than this.
+   */
+  unreadLineTime?: number
 }
 
 interface MessageListSnapshot {
@@ -276,6 +343,7 @@ export class MessageList extends React.Component<MessageListProps> {
       MessageComponent,
       onLoadMoreMessages,
       showEmptyState = true,
+      unreadLineTime,
     } = this.props
 
     return (
@@ -293,6 +361,8 @@ export class MessageList extends React.Component<MessageListProps> {
             showEmptyState={showEmptyState}
             messages={messages}
             MessageComponent={MessageComponent}
+            unreadLineTime={unreadLineTime}
+            hasMoreHistory={hasMoreHistory}
           />
         </InfiniteScrollList>
       </Scrollable>

--- a/client/messaging/message-records.ts
+++ b/client/messaging/message-records.ts
@@ -1,4 +1,4 @@
-import { ChatMessage } from '../../common/chat'
+import { ChatMessage, ServerChatMessageType } from '../../common/chat'
 import { DraftChatMessage } from '../../common/matchmaking'
 import { SbUserId } from '../../common/users/sb-user-id'
 import { LobbyMessage } from '../lobbies/lobby-message-records'
@@ -26,3 +26,22 @@ export interface CommonNewDayMessage extends BaseMessage {
 
 export type CommonMessage = CommonTextMessage | CommonNewDayMessage
 export type SbMessage = CommonMessage | ChatMessage | LobbyMessage | DraftChatMessage
+
+const SERVER_ORIGIN_MESSAGE_TYPES: ReadonlySet<string> = new Set<string>([
+  // Chat messages the server persists. The client-only chat message types are deliberately absent.
+  ...Object.values(ServerChatMessageType),
+  // Text messages that arrive from the server but get stored as the common type (whispers), plus
+  // the lobby and draft text messages that share this type's value. All of them carry a
+  // server-recorded time.
+  CommonMessageType.TextMessage,
+])
+
+/**
+ * Returns whether a message's `time` is a server-recorded timestamp, i.e. it can be compared
+ * against times the server hands out (such as a read position). Messages that only ever exist on
+ * the client (join/leave banners, the synthesized day dividers) stamp `time` with the local clock,
+ * so their times mean nothing to the server.
+ */
+export function isServerOriginMessage(message: SbMessage): boolean {
+  return SERVER_ORIGIN_MESSAGE_TYPES.has(message.type)
+}

--- a/client/users/user-reducer.ts
+++ b/client/users/user-reducer.ts
@@ -195,8 +195,10 @@ export default immerKeyedReducer(DEFAULT_STATE, {
   },
 
   ['@whispers/loadMessageHistory'](state, action) {
-    updateUsers(state, action.payload.users)
-    updateUsers(state, action.payload.mentions)
+    if (!action.error) {
+      updateUsers(state, action.payload.users)
+      updateUsers(state, action.payload.mentions)
+    }
   },
 
   ['@whispers/updateMessage'](state, action) {

--- a/client/whispers/action-creators.ts
+++ b/client/whispers/action-creators.ts
@@ -40,7 +40,14 @@ export function getWhisperLastReadKey(targetId: SbUserId): string {
  * nothing needs to react to this request's outcome.
  */
 export function markWhisperRead(targetId: SbUserId, lastReadTime: number): ThunkAction {
-  return () => {
+  return dispatch => {
+    // Advances the local read position immediately; the reducer's monotonic guard keeps this
+    // correct even for reports the coalescer below ends up dropping.
+    dispatch({
+      type: '@whispers/updateLastReadTime',
+      payload: { targetId, lastReadTime },
+    })
+
     reportLastRead(getWhisperLastReadKey(targetId), lastReadTime, time => {
       fetchJson<void>(apiUrl`whispers/${targetId}/mark-read`, {
         method: 'POST',

--- a/client/whispers/action-creators.ts
+++ b/client/whispers/action-creators.ts
@@ -118,17 +118,19 @@ export function getMessageHistory(
     const sessionData = byId.get(target)!
     const earliestMessageTime = sessionData.messages.length ? sessionData.messages[0].time : -1
 
+    const promise = fetchJson<GetSessionHistoryResponse>(
+      apiUrl`whispers/${target}/messages2?limit=${limit}&beforeTime=${earliestMessageTime}`,
+    )
     dispatch({
       type: '@whispers/loadMessageHistory',
-      payload: fetchJson<GetSessionHistoryResponse>(
-        apiUrl`whispers/${target}/messages2?limit=${limit}&beforeTime=${earliestMessageTime}`,
-      ),
+      payload: promise,
       meta: {
         target,
         limit,
         beforeTime: earliestMessageTime,
       },
     })
+    await promise
   })
 }
 

--- a/client/whispers/actions.ts
+++ b/client/whispers/actions.ts
@@ -14,6 +14,7 @@ export type WhisperActions =
   | WhisperSessionClose
   | WhisperMessageUpdate
   | GetWhisperSessions
+  | UpdateLastReadTime
 
 /**
  * Get the list of whisper sessions for the current user.
@@ -69,6 +70,19 @@ export interface UpdateSessionAtBottom {
   payload: {
     target: SbUserId
     atBottom: boolean
+  }
+}
+
+/**
+ * The client's read position for a whisper session has advanced. Dispatched optimistically when
+ * the client reports a mark-read, shaped so a future cross-session update published by the server
+ * can dispatch it as well.
+ */
+export interface UpdateLastReadTime {
+  type: '@whispers/updateLastReadTime'
+  payload: {
+    targetId: SbUserId
+    lastReadTime: number
   }
 }
 

--- a/client/whispers/actions.ts
+++ b/client/whispers/actions.ts
@@ -4,9 +4,11 @@ import {
   GetWhisperSessionsResponse,
   WhisperMessageEvent,
 } from '../../common/whispers'
+import { BaseFetchFailure } from '../network/fetch-errors'
 
 export type WhisperActions =
   | LoadMessageHistory
+  | LoadMessageHistoryFailure
   | ActivateWhisperSession
   | DeactivateWhisperSession
   | UpdateSessionAtBottom
@@ -30,6 +32,15 @@ export interface GetWhisperSessions {
 export interface LoadMessageHistory {
   type: '@whispers/loadMessageHistory'
   payload: GetSessionHistoryResponse
+  meta: {
+    target: SbUserId
+    limit: number
+    beforeTime: number
+  }
+  error?: false
+}
+
+export interface LoadMessageHistoryFailure extends BaseFetchFailure<'@whispers/loadMessageHistory'> {
   meta: {
     target: SbUserId
     limit: number

--- a/client/whispers/whisper-reducer.ts
+++ b/client/whispers/whisper-reducer.ts
@@ -173,6 +173,10 @@ export default immerKeyedReducer(DEFAULT_STATE, {
   },
 
   ['@whispers/loadMessageHistory'](state, action) {
+    if (action.error) {
+      return
+    }
+
     const { target, limit } = action.meta
 
     const session = state.byId.get(target)

--- a/client/whispers/whisper-reducer.ts
+++ b/client/whispers/whisper-reducer.ts
@@ -16,6 +16,19 @@ export interface WhisperSession {
   /** Whether this session's message list is scrolled to the bottom. */
   atBottom: boolean
   hasUnread: boolean
+  /**
+   * The client's view of the server-recorded read position (epoch ms) for this session. Seeded
+   * from the server at init, and advanced optimistically whenever the client reports a mark-read
+   * for the session.
+   */
+  lastReadTime?: number
+  /**
+   * The frozen position of the unread divider for the current activation. Captured when an unread
+   * session activates, or when a message arrives while the session is activated and scrolled up,
+   * and held until deactivation so the divider doesn't chase `lastReadTime` as it keeps advancing
+   * underneath it.
+   */
+  unreadLineTime?: number
 }
 
 function defaultWhisperSession(target: SbUserId): WhisperSession {
@@ -26,6 +39,8 @@ function defaultWhisperSession(target: SbUserId): WhisperSession {
     activated: false,
     atBottom: false,
     hasUnread: false,
+    lastReadTime: undefined,
+    unreadLineTime: undefined,
   }
 }
 
@@ -69,6 +84,19 @@ function updateMessages(
     session.hasUnread = true
   }
 
+  // The session is being actively viewed but scrolled up, so a new message won't be seen right
+  // away. Freeze the unread divider at the read position so it marks where the user left off
+  // instead of chasing the read position as the eager mark-read keeps advancing it.
+  if (
+    makeUnread &&
+    session.activated &&
+    !session.atBottom &&
+    session.unreadLineTime === undefined &&
+    session.lastReadTime !== undefined
+  ) {
+    session.unreadLineTime = session.lastReadTime
+  }
+
   session.hasHistory = session.hasHistory || sliced
 }
 
@@ -92,6 +120,15 @@ export default immerKeyedReducer(DEFAULT_STATE, {
       const session = state.byId.get(target)
       if (session && !session.activated) {
         session.hasUnread = true
+      }
+    }
+
+    // Seeds each session's read position from the server, so the unread divider has somewhere to
+    // freeze at even before any local mark-read report has happened this session.
+    for (const { targetId, lastReadTime } of action.payload.lastReadTimes ?? []) {
+      const session = state.byId.get(targetId)
+      if (session) {
+        session.lastReadTime = lastReadTime
       }
     }
   },
@@ -165,6 +202,18 @@ export default immerKeyedReducer(DEFAULT_STATE, {
     }
 
     const session = state.byId.get(target)!
+
+    // Freeze the unread divider at the read position before clearing the unread flag, so the
+    // divider marks where the user left off instead of where the read position ends up after the
+    // eager mark-read this activation triggers.
+    if (
+      session.hasUnread &&
+      session.unreadLineTime === undefined &&
+      session.lastReadTime !== undefined
+    ) {
+      session.unreadLineTime = session.lastReadTime
+    }
+
     session.activated = true
     // Message lists mount pinned to the bottom.
     session.atBottom = true
@@ -185,6 +234,17 @@ export default immerKeyedReducer(DEFAULT_STATE, {
     session.hasHistory = session.hasHistory || hasHistory
     session.activated = false
     session.atBottom = false
+    // The unread divider is only consumed once the read position has actually moved past it — a
+    // deactivation where the user never read anything new (including the mount/cleanup/remount
+    // cycle React's StrictMode runs in development) leaves the still-unread divider in place for
+    // the next visit.
+    if (
+      session.unreadLineTime !== undefined &&
+      session.lastReadTime !== undefined &&
+      session.lastReadTime > session.unreadLineTime
+    ) {
+      session.unreadLineTime = undefined
+    }
   },
 
   ['@whispers/updateSessionAtBottom'](state, action) {
@@ -204,6 +264,19 @@ export default immerKeyedReducer(DEFAULT_STATE, {
 
       session.messages = session.messages.slice(-INACTIVE_SESSION_MAX_HISTORY)
       session.hasHistory = session.hasHistory || hasHistory
+    }
+  },
+
+  ['@whispers/updateLastReadTime'](state, action) {
+    const { targetId, lastReadTime } = action.payload
+
+    const session = state.byId.get(targetId)
+    if (!session) {
+      return
+    }
+
+    if (session.lastReadTime === undefined || lastReadTime > session.lastReadTime) {
+      session.lastReadTime = lastReadTime
     }
   },
 

--- a/client/whispers/whisper.tsx
+++ b/client/whispers/whisper.tsx
@@ -202,6 +202,7 @@ export function ConnectedWhisper({
           hasMoreHistory: whisperSession.hasHistory,
           refreshToken: targetId,
           onLoadMoreMessages,
+          unreadLineTime: whisperSession.unreadLineTime,
         }}
         inputProps={{
           onSendChatMessage,

--- a/common/chat.ts
+++ b/common/chat.ts
@@ -238,6 +238,12 @@ export interface InitialChannelData {
    * false means the channel should not be treated as unread.
    */
   hasUnread?: boolean
+  /**
+   * Epoch millis of the user's last recorded read position in the channel, if they have one. Used
+   * to place the unread-messages divider; `hasUnread` stays the authority for badge state since
+   * the client can't compute unreadness itself without messages loaded.
+   */
+  lastReadTime?: number
 }
 
 export interface ChatInitEvent extends InitialChannelData {

--- a/common/whispers.ts
+++ b/common/whispers.ts
@@ -135,4 +135,10 @@ export interface GetWhisperSessionsResponse {
    * unread. Additive over the base response so older clients ignore it.
    */
   unreadSessions?: SbUserId[]
+  /**
+   * Epoch millis of the user's last recorded read position for each whisper session that has one.
+   * A session whose target ID is absent from this list has no recorded read position. Additive
+   * over the base response so older clients ignore it.
+   */
+  lastReadTimes?: Array<{ targetId: SbUserId; lastReadTime: number }>
 }

--- a/server/lib/chat/chat-models.ts
+++ b/server/lib/chat/chat-models.ts
@@ -45,19 +45,37 @@ function convertUserChannelEntryFromDb(props: DbUserChannelEntry): UserChannelEn
 }
 
 /**
+ * A user channel entry, plus their read position in that channel. Only `getChannelsForUser`
+ * returns this; other queries over `channel_users` return the plain `UserChannelEntry`.
+ */
+export type JoinedChannelEntry = UserChannelEntry & {
+  /** The user's last recorded read position in the channel, if they have one. */
+  lastReadTime?: Date
+}
+
+type DbJoinedChannelEntry = Dbify<JoinedChannelEntry & ChannelPreferences & ChannelPermissions>
+
+function convertJoinedChannelEntryFromDb(props: DbJoinedChannelEntry): JoinedChannelEntry {
+  return {
+    ...convertUserChannelEntryFromDb(props),
+    lastReadTime: props.last_read_time ?? undefined,
+  }
+}
+
+/**
  * Gets a user channel entry for each channel that a particular user is in, ordered by their channel
  * join date.
  */
-export async function getChannelsForUser(userId: SbUserId): Promise<UserChannelEntry[]> {
+export async function getChannelsForUser(userId: SbUserId): Promise<JoinedChannelEntry[]> {
   const { client, done } = await db()
   try {
-    const result = await client.query<DbUserChannelEntry>(sql`
+    const result = await client.query<DbJoinedChannelEntry>(sql`
       SELECT *
       FROM channel_users
       WHERE user_id = ${userId}
       ORDER BY join_date;
     `)
-    return result.rows.map(row => convertUserChannelEntryFromDb(row))
+    return result.rows.map(row => convertJoinedChannelEntryFromDb(row))
   } finally {
     done()
   }

--- a/server/lib/chat/chat-service.ts
+++ b/server/lib/chat/chat-service.ts
@@ -171,6 +171,7 @@ export default class ChatService {
         selfPreferences: c.channelPreferences,
         selfPermissions: c.channelPermissions,
         hasUnread: unreadChannelsSet.has(c.channelId),
+        lastReadTime: c.lastReadTime?.getTime(),
       }
     })
   }
@@ -211,8 +212,8 @@ export default class ChatService {
       ])
 
       if (channelInfo && userChannelEntry) {
-        // `hasUnread` is omitted: a membership this fresh has no recorded read position yet, which
-        // `getUnreadChannels` always treats as fully read.
+        // `hasUnread`/`lastReadTime` are omitted: a membership this fresh has no recorded read
+        // position yet, which `getUnreadChannels` always treats as fully read.
         this.publisher.publish(getChannelUserPath(channelId, userSockets.userId), {
           action: 'init3',
           channelInfo: toBasicChannelInfo(channelInfo),

--- a/server/lib/whispers/whisper-models.ts
+++ b/server/lib/whispers/whisper-models.ts
@@ -5,11 +5,19 @@ import db from '../db'
 import { sql } from '../db/sql'
 import { Dbify } from '../db/types'
 
-export async function getWhisperSessionsForUser(userId: SbUserId): Promise<SbUserId[]> {
+/** A user's whisper session with another user, along with their read position in it. */
+export interface WhisperSessionEntry {
+  targetId: SbUserId
+  /** The user's last recorded read position in the session, if they have one. */
+  lastReadTime: Date | undefined
+}
+
+export async function getWhisperSessionsForUser(userId: SbUserId): Promise<WhisperSessionEntry[]> {
   const { client, done } = await db()
   try {
-    const result = await client.query<{ id: SbUserId }>(sql`
-      SELECT ws.target_user_id AS id, COALESCE(wm.sent, ws.start_date) AS last_sent
+    const result = await client.query<{ target_id: SbUserId; last_read_time: Date | null }>(sql`
+      SELECT ws.target_user_id AS target_id, ws.last_read_time,
+        COALESCE(wm.sent, ws.start_date) AS last_sent
       FROM whisper_sessions ws
       LEFT JOIN LATERAL (
         SELECT wm.sent
@@ -22,7 +30,10 @@ export async function getWhisperSessionsForUser(userId: SbUserId): Promise<SbUse
       WHERE ws.user_id = ${userId}
       ORDER BY last_sent DESC;
     `)
-    return result.rows.map(row => row.id)
+    return result.rows.map(row => ({
+      targetId: row.target_id,
+      lastReadTime: row.last_read_time ?? undefined,
+    }))
   } finally {
     done()
   }

--- a/server/lib/whispers/whisper-service.ts
+++ b/server/lib/whispers/whisper-service.ts
@@ -75,15 +75,22 @@ export default class WhisperService {
   }
 
   async getWhisperSessions(userId: SbUserId): Promise<GetWhisperSessionsResponse> {
-    const [sessions, unreadSessions] = await Promise.all([
+    const [sessionEntries, unreadSessions] = await Promise.all([
       getWhisperSessionsForUser(userId),
       getUnreadWhisperTargets(userId),
     ])
+    const sessions = sessionEntries.map(s => s.targetId)
+    const lastReadTimes = sessionEntries.flatMap(s =>
+      s.lastReadTime !== undefined
+        ? [{ targetId: s.targetId, lastReadTime: s.lastReadTime.getTime() }]
+        : [],
+    )
     const users = await findUsersById(sessions)
     return {
       sessions,
       users,
       unreadSessions,
+      lastReadTimes,
     }
   }
 
@@ -317,12 +324,13 @@ export default class WhisperService {
   }
 
   private async handleNewUser(userSockets: UserSocketsGroup) {
-    const whisperSessionIds = await getWhisperSessionsForUser(userSockets.userId)
+    const whisperSessionEntries = await getWhisperSessionsForUser(userSockets.userId)
     if (!userSockets.sockets.size) {
       // The user disconnected while we were waiting for their whisper sessions
       return
     }
 
+    const whisperSessionIds = whisperSessionEntries.map(s => s.targetId)
     const targetIdsSet = OrderedSet(whisperSessionIds)
     this.userSessions = this.userSessions.set(userSockets.userId, targetIdsSet)
     for (const id of whisperSessionIds) {

--- a/server/public/locales/en/global.json
+++ b/server/public/locales/en/global.json
@@ -1474,10 +1474,12 @@
     "messageTooLongContent": "Messages can be at most {{maxLength}} characters, and this one is {{length}}. Please shorten it before sending.",
     "messageTooLongTitle": "Message too long",
     "newDayMessage": "Day changed to <2>{{day}}</2>",
+    "newMessages": "New messages",
     "openLink": "Open link",
     "searchWithGoogle": "Search with Google",
     "sendMessage": "Send a message",
-    "sendMessageChatRestricted": "Restricted from sending messages until {{date}}"
+    "sendMessageChatRestricted": "Restricted from sending messages until {{date}}",
+    "unreadLineLabel": "New"
   },
   "navigation": {
     "bar": {


### PR DESCRIPTION
Adds the Discord-style unread divider and a jump-to-first-unread banner to chat channels and whispers, building on the read positions from #1438. This is the first piece of "item 3" of the chat roadmap; cross-session read sync, the unread-driven tray icon, and mention unread state will follow separately.

## What it does

- **Unread divider**: an amber line with a "New" tag renders in front of the first message newer than your read position. Its position is *frozen* when an unread conversation activates (or when a message arrives while you're scrolled up) and never moves while you're viewing — the eager mark-read keeps advancing the stored position underneath it, so freezing is what keeps the divider marking where you actually left off.
- **Jump banner**: while the divider sits above the viewport (or above the loaded history window), a slim banner at the top of the message list offers a jump. Clicking it scrolls to the divider, auto-loading older history first if the divider's position isn't loaded yet. The banner is a **one-shot prompt per divider**: once the divider has been on screen, scrolling back down doesn't resurface it (a fresh batch of unreads after you leave re-arms it).
- **Wire changes**: initial payloads now carry the recorded read position itself (`lastReadTime` per channel, `lastReadTimes` per whisper target) alongside the existing unread booleans — the booleans stay authoritative for badges since the client can't compute unreadness without messages loaded. Both additions are additive.

## Behavior details worth knowing

- **Divider lifetime**: it stays visible for the whole visit (even after you've read everything), and is consumed on deactivation *only if the read position actually advanced past it*. Leaving without ever reaching the bottom keeps the divider for the next visit, since those messages are still genuinely unread. This conditional clear is also what makes the feature survive StrictMode's dev-only mount→cleanup→remount cycle, which otherwise consumes the unread flag on the first activate and wipes the freshly frozen divider in the paired deactivate.
- **Boundary above the loaded window**: when *every* loaded message is unread and more history exists, no divider renders — placing it at the top of the window would misrepresent where the unread messages start. The banner covers this case, and its seek loads history until the true boundary (a read message, or the start of history) is in the window.
- **Placement skips client-local messages** (join banners etc.) — they're stamped with the local clock, so their times mean nothing next to a server read position. Note whisper messages are stored as `CommonMessageType.TextMessage`, so the server-origin predicate counts that type.
- Lobby/matchmaking chat passes no divider state and is unchanged.

## Verification

Live-verified in two browser clients against the dev server (plus 13 new unit tests for divider placement):

- live arrival while elsewhere → divider exactly before the first new message, badge cleared on open
- divider frozen while new messages arrive at the bottom; leave-and-return consumes it
- scrolled-up arrival freezes the divider at the last-seen boundary (no banner for below-viewport — that direction belongs to the jump-to-bottom pill)
- restart persistence: divider seeded from the server's stored position after a fresh boot
- 60-message backlog: no misleading divider, banner → one click → auto-loaded 51→101 messages → divider exactly before the first unread, scrolled just below the top edge
- banner one-shot: see the line, scroll back down → banner stays gone; new batch after leaving re-arms it
- whispers: divider from the init-seeded position

Typecheck, lint, and the full messaging test suite are green.
