### PR TITLE
Sync read positions across a user's sessions.

### DIFF
--- a/client/chat/actions.ts
+++ b/client/chat/actions.ts
@@ -284,9 +284,9 @@ export interface UpdateChannelAtBottom {
 }
 
 /**
- * The client's read position for a chat channel has advanced. Dispatched optimistically when the
- * client reports a mark-read, shaped so a future cross-session update published by the server can
- * dispatch it as well.
+ * The client's read position for a chat channel has advanced. Dispatched optimistically when this
+ * session reports a mark-read, and by the socket handler when the server relays a read position
+ * update from one of the user's other sessions.
  */
 export interface UpdateLastReadTime {
   type: '@chat/updateLastReadTime'

--- a/client/chat/chat-reducer.test.ts
+++ b/client/chat/chat-reducer.test.ts
@@ -1,0 +1,171 @@
+import { Immutable } from 'immer'
+import { describe, expect, test } from 'vitest'
+import {
+  ChannelTextMessage,
+  ChatMessage,
+  ClientChatMessageType,
+  SbChannelId,
+  SelfJoinChannelMessage,
+  ServerChatMessageType,
+  makeSbChannelId,
+} from '../../common/chat'
+import { makeSbUserId } from '../../common/users/sb-user-id'
+import { ChatActions } from './actions'
+import chatReducerImport, { ChatState } from './chat-reducer'
+
+// `immerKeyedReducer` accepts any action with a string `type`. These tests only ever feed it chat
+// actions, so narrow the parameter to those, both for the extra checking and so that action objects
+// can be written inline without tripping excess property checks.
+const chatReducer = chatReducerImport as unknown as (
+  state: Immutable<ChatState>,
+  action: ChatActions,
+) => Immutable<ChatState>
+
+const CHANNEL_ID: SbChannelId = makeSbChannelId(1)
+const USER_ID = makeSbUserId(2)
+
+function textMessage(time: number): ChannelTextMessage {
+  return {
+    id: `text-${time}`,
+    type: ServerChatMessageType.TextMessage,
+    channelId: CHANNEL_ID,
+    time,
+    from: USER_ID,
+    text: 'hello',
+  }
+}
+
+/** A client-only message: its `time` is stamped with the local clock, not the server's. */
+function selfJoinMessage(time: number): SelfJoinChannelMessage {
+  return {
+    id: `join-${time}`,
+    type: ClientChatMessageType.SelfJoinChannel,
+    channelId: CHANNEL_ID,
+    time,
+  }
+}
+
+function makeState(
+  overrides: {
+    messages?: ChatMessage[]
+    activated?: boolean
+    unread?: boolean
+    lastReadTime?: number
+    unreadLineTime?: number
+  } = {},
+): Immutable<ChatState> {
+  const state: ChatState = {
+    joinedChannels: new Set([CHANNEL_ID]),
+    idToBasicInfo: new Map(),
+    idToDetailedInfo: new Map(),
+    idToJoinedInfo: new Map(),
+    idToUsers: new Map(),
+    idToMessages: new Map([
+      [CHANNEL_ID, { messages: overrides.messages ?? [], loadingHistory: false, hasHistory: true }],
+    ]),
+    idToUserProfiles: new Map(),
+    idToSelfPreferences: new Map(),
+    idToSelfPermissions: new Map(),
+    activatedChannels: new Set(overrides.activated ? [CHANNEL_ID] : []),
+    atBottomChannels: new Set(),
+    unreadChannels: new Set(overrides.unread ? [CHANNEL_ID] : []),
+    deletedChannels: new Set(),
+    idToLastReadTime: new Map(
+      overrides.lastReadTime !== undefined ? [[CHANNEL_ID, overrides.lastReadTime]] : [],
+    ),
+    idToUnreadLineTime: new Map(
+      overrides.unreadLineTime !== undefined ? [[CHANNEL_ID, overrides.unreadLineTime]] : [],
+    ),
+  }
+
+  return state as Immutable<ChatState>
+}
+
+function updateLastReadTimeAction(lastReadTime: number): ChatActions {
+  return {
+    type: '@chat/updateLastReadTime',
+    payload: { channelId: CHANNEL_ID, lastReadTime },
+  }
+}
+
+describe('client/chat/chat-reducer', () => {
+  describe('@chat/updateLastReadTime', () => {
+    test('does not regress the stored position when the incoming time is stale', () => {
+      const state = makeState({ lastReadTime: 1000 })
+
+      const result = chatReducer(state, updateLastReadTimeAction(500))
+
+      expect(result.idToLastReadTime.get(CHANNEL_ID)).toBe(1000)
+    })
+
+    test('clears unread when no known server-origin message is newer than the incoming time', () => {
+      const state = makeState({
+        unread: true,
+        lastReadTime: 100,
+        messages: [textMessage(100)],
+      })
+
+      const result = chatReducer(state, updateLastReadTimeAction(200))
+
+      expect(result.unreadChannels.has(CHANNEL_ID)).toBe(false)
+    })
+
+    test('keeps unread when a server-origin message is newer than the incoming time', () => {
+      const state = makeState({
+        unread: true,
+        lastReadTime: 100,
+        messages: [textMessage(300)],
+      })
+
+      const result = chatReducer(state, updateLastReadTimeAction(200))
+
+      expect(result.unreadChannels.has(CHANNEL_ID)).toBe(true)
+    })
+
+    test('a client-local message newer than the incoming time does not keep unread', () => {
+      const state = makeState({
+        unread: true,
+        lastReadTime: 100,
+        messages: [textMessage(100), selfJoinMessage(999_999_999_999)],
+      })
+
+      const result = chatReducer(state, updateLastReadTimeAction(200))
+
+      expect(result.unreadChannels.has(CHANNEL_ID)).toBe(false)
+    })
+
+    test('clears the frozen divider when it is behind the incoming time', () => {
+      const state = makeState({ lastReadTime: 100, unreadLineTime: 150 })
+
+      const result = chatReducer(state, updateLastReadTimeAction(200))
+
+      expect(result.idToUnreadLineTime.has(CHANNEL_ID)).toBe(false)
+    })
+
+    test('keeps the frozen divider when it is at or ahead of the incoming time', () => {
+      const state = makeState({ lastReadTime: 100, unreadLineTime: 250 })
+
+      const result = chatReducer(state, updateLastReadTimeAction(200))
+
+      expect(result.idToUnreadLineTime.get(CHANNEL_ID)).toBe(250)
+    })
+
+    test('leaves the unread flag and divider untouched for an activated channel', () => {
+      const state = makeState({
+        activated: true,
+        unread: true,
+        lastReadTime: 100,
+        unreadLineTime: 150,
+        messages: [textMessage(100)],
+      })
+
+      const result = chatReducer(state, updateLastReadTimeAction(200))
+
+      expect(result.unreadChannels.has(CHANNEL_ID)).toBe(true)
+      expect(result.idToUnreadLineTime.get(CHANNEL_ID)).toBe(150)
+      // The read position itself still advances even while activated, since this is also the path
+      // this session's own optimistic mark-read reports take.
+      expect(result.idToLastReadTime.get(CHANNEL_ID)).toBe(200)
+    })
+  })
+})

--- a/client/chat/chat-reducer.ts
+++ b/client/chat/chat-reducer.ts
@@ -14,6 +14,7 @@ import {
   SbChannelId,
 } from '../../common/chat'
 import { SbUserId } from '../../common/users/sb-user-id'
+import { isServerOriginMessage } from '../messaging/message-records'
 import { immerKeyedReducer } from '../reducers/keyed-reducer'
 
 // How many messages should be kept for inactive channels
@@ -634,12 +635,40 @@ export default immerKeyedReducer(DEFAULT_CHAT_STATE, {
     state.atBottomChannels.delete(channelId)
   },
 
+  // This arrives both from this session's own optimistic mark-read reports (dispatched only while
+  // the channel is activated) and from the socket handler relaying a mark-read made in one of the
+  // user's other sessions (which can arrive for a channel this session isn't currently viewing).
+  // The unread flag and frozen divider are only re-evaluated in the latter case: an activated
+  // channel already has its unread flag cleared, and its divider is re-evaluated by
+  // `deactivateChannel` instead, so it must never move while the channel is being viewed here.
   ['@chat/updateLastReadTime'](state, action) {
     const { channelId, lastReadTime } = action.payload
 
     const existing = state.idToLastReadTime.get(channelId)
     if (existing === undefined || lastReadTime > existing) {
       state.idToLastReadTime.set(channelId, lastReadTime)
+    }
+    const effective = state.idToLastReadTime.get(channelId)!
+
+    if (!state.activatedChannels.has(channelId)) {
+      const messages = state.idToMessages.get(channelId)?.messages
+      let newestServerOriginTime: number | undefined
+      if (messages) {
+        for (let i = messages.length - 1; i >= 0; i--) {
+          if (isServerOriginMessage(messages[i])) {
+            newestServerOriginTime = messages[i].time
+            break
+          }
+        }
+      }
+      if (newestServerOriginTime === undefined || newestServerOriginTime <= effective) {
+        state.unreadChannels.delete(channelId)
+      }
+
+      const unreadLineTime = state.idToUnreadLineTime.get(channelId)
+      if (unreadLineTime !== undefined && effective > unreadLineTime) {
+        state.idToUnreadLineTime.delete(channelId)
+      }
     }
   },
 

--- a/client/chat/socket-handlers.ts
+++ b/client/chat/socket-handlers.ts
@@ -202,6 +202,13 @@ const eventToChatUserAction: EventToChatUserActionMap = {
       meta: { channelId },
     }
   },
+
+  lastReadTimeChanged(channelId, event) {
+    return {
+      type: '@chat/updateLastReadTime',
+      payload: { channelId, lastReadTime: event.lastReadTime },
+    }
+  },
 }
 
 const CHANNEL_PATH = '/chat3/:channelId'

--- a/client/whispers/actions.ts
+++ b/client/whispers/actions.ts
@@ -86,8 +86,8 @@ export interface UpdateSessionAtBottom {
 
 /**
  * The client's read position for a whisper session has advanced. Dispatched optimistically when
- * the client reports a mark-read, shaped so a future cross-session update published by the server
- * can dispatch it as well.
+ * this session reports a mark-read, and by the socket handler when the server relays a read
+ * position update from one of the user's other sessions.
  */
 export interface UpdateLastReadTime {
   type: '@whispers/updateLastReadTime'

--- a/client/whispers/socket-handlers.ts
+++ b/client/whispers/socket-handlers.ts
@@ -1,6 +1,6 @@
 import { NydusClient } from 'nydus-client'
 import { TypedIpcRenderer } from '../../common/ipc'
-import { WhisperEvent } from '../../common/whispers'
+import { WhisperEvent, WhisperUserEvent } from '../../common/whispers'
 import { audioManager, AvailableSound } from '../audio/audio-manager'
 import { dispatch, Dispatchable, ThunkAction } from '../dispatch-registry'
 import windowFocus from '../dom/window-focus'
@@ -70,12 +70,37 @@ const eventToAction: EventToActionMap = {
   },
 }
 
+type EventToUserActionMap = {
+  [E in WhisperUserEvent['action']]: (
+    event: Extract<WhisperUserEvent, { action: E }>,
+  ) => Dispatchable
+}
+
+const eventToUserAction: EventToUserActionMap = {
+  lastReadTimeChanged(event) {
+    return {
+      type: '@whispers/updateLastReadTime',
+      payload: {
+        targetId: event.target,
+        lastReadTime: event.lastReadTime,
+      },
+    }
+  },
+}
+
 export default function registerModule({ siteSocket }: { siteSocket: NydusClient }) {
   siteSocket.registerRoute('/whispers3/:userAndTarget', (route, event) => {
     const actionName = event.action as WhisperEvent['action']
     if (!eventToAction[actionName]) return
 
     const action = eventToAction[actionName]!(event)
+    if (action) dispatch(action)
+  })
+
+  siteSocket.registerRoute('/whispers3/users/:userId', (route, event: WhisperUserEvent) => {
+    if (!Object.hasOwn(eventToUserAction, event.action)) return
+
+    const action = eventToUserAction[event.action](event as any)
     if (action) dispatch(action)
   })
 }

--- a/client/whispers/whisper-reducer.test.ts
+++ b/client/whispers/whisper-reducer.test.ts
@@ -1,0 +1,134 @@
+import { Immutable } from 'immer'
+import { describe, expect, test } from 'vitest'
+import { makeSbUserId } from '../../common/users/sb-user-id'
+import { CommonMessageType, CommonTextMessage } from '../messaging/message-records'
+import { WhisperActions } from './actions'
+import whisperReducerImport, { WhisperSession, WhisperState } from './whisper-reducer'
+
+// `immerKeyedReducer` accepts any action with a string `type`. These tests only ever feed it
+// whisper actions, so narrow the parameter to those, both for the extra checking and so that action
+// objects can be written inline without tripping excess property checks.
+const whisperReducer = whisperReducerImport as unknown as (
+  state: Immutable<WhisperState>,
+  action: WhisperActions,
+) => Immutable<WhisperState>
+
+const TARGET_ID = makeSbUserId(2)
+
+// Every whisper message the client stores is a text message from the server, so (unlike chat
+// channels) there's no client-local whisper message type whose `time` isn't server-recorded.
+function textMessage(time: number): CommonTextMessage {
+  return {
+    id: `text-${time}`,
+    type: CommonMessageType.TextMessage,
+    time,
+    from: TARGET_ID,
+    text: 'hello',
+  }
+}
+
+function makeState(
+  overrides: {
+    messages?: CommonTextMessage[]
+    activated?: boolean
+    unread?: boolean
+    lastReadTime?: number
+    unreadLineTime?: number
+  } = {},
+): Immutable<WhisperState> {
+  const session: WhisperSession = {
+    target: TARGET_ID,
+    messages: overrides.messages ?? [],
+    hasHistory: true,
+    activated: overrides.activated ?? false,
+    atBottom: false,
+    hasUnread: overrides.unread ?? false,
+    lastReadTime: overrides.lastReadTime,
+    unreadLineTime: overrides.unreadLineTime,
+  }
+
+  const state: WhisperState = {
+    sessions: new Set([TARGET_ID]),
+    byId: new Map([[TARGET_ID, session]]),
+  }
+
+  return state as Immutable<WhisperState>
+}
+
+function updateLastReadTimeAction(lastReadTime: number): WhisperActions {
+  return {
+    type: '@whispers/updateLastReadTime',
+    payload: { targetId: TARGET_ID, lastReadTime },
+  }
+}
+
+describe('client/whispers/whisper-reducer', () => {
+  describe('@whispers/updateLastReadTime', () => {
+    test('does not regress the stored position when the incoming time is stale', () => {
+      const state = makeState({ lastReadTime: 1000 })
+
+      const result = whisperReducer(state, updateLastReadTimeAction(500))
+
+      expect(result.byId.get(TARGET_ID)!.lastReadTime).toBe(1000)
+    })
+
+    test('clears unread when no known message is newer than the incoming time', () => {
+      const state = makeState({
+        unread: true,
+        lastReadTime: 100,
+        messages: [textMessage(100)],
+      })
+
+      const result = whisperReducer(state, updateLastReadTimeAction(200))
+
+      expect(result.byId.get(TARGET_ID)!.hasUnread).toBe(false)
+    })
+
+    test('keeps unread when a message is newer than the incoming time', () => {
+      const state = makeState({
+        unread: true,
+        lastReadTime: 100,
+        messages: [textMessage(300)],
+      })
+
+      const result = whisperReducer(state, updateLastReadTimeAction(200))
+
+      expect(result.byId.get(TARGET_ID)!.hasUnread).toBe(true)
+    })
+
+    test('clears the frozen divider when it is behind the incoming time', () => {
+      const state = makeState({ lastReadTime: 100, unreadLineTime: 150 })
+
+      const result = whisperReducer(state, updateLastReadTimeAction(200))
+
+      expect(result.byId.get(TARGET_ID)!.unreadLineTime).toBeUndefined()
+    })
+
+    test('keeps the frozen divider when it is at or ahead of the incoming time', () => {
+      const state = makeState({ lastReadTime: 100, unreadLineTime: 250 })
+
+      const result = whisperReducer(state, updateLastReadTimeAction(200))
+
+      expect(result.byId.get(TARGET_ID)!.unreadLineTime).toBe(250)
+    })
+
+    test('leaves the unread flag and divider untouched for an activated session', () => {
+      const state = makeState({
+        activated: true,
+        unread: true,
+        lastReadTime: 100,
+        unreadLineTime: 150,
+        messages: [textMessage(100)],
+      })
+
+      const result = whisperReducer(state, updateLastReadTimeAction(200))
+
+      const session = result.byId.get(TARGET_ID)!
+      expect(session.hasUnread).toBe(true)
+      expect(session.unreadLineTime).toBe(150)
+      // The read position itself still advances even while activated, since this is also the path
+      // this session's own optimistic mark-read reports take.
+      expect(session.lastReadTime).toBe(200)
+    })
+  })
+})

--- a/client/whispers/whisper-reducer.ts
+++ b/client/whispers/whisper-reducer.ts
@@ -1,6 +1,10 @@
 import { Immutable } from 'immer'
 import { SbUserId } from '../../common/users/sb-user-id'
-import { CommonMessageType, CommonTextMessage } from '../messaging/message-records'
+import {
+  CommonMessageType,
+  CommonTextMessage,
+  isServerOriginMessage,
+} from '../messaging/message-records'
 import { immerKeyedReducer } from '../reducers/keyed-reducer'
 
 // How many messages should be kept for inactive channels
@@ -271,6 +275,13 @@ export default immerKeyedReducer(DEFAULT_STATE, {
     }
   },
 
+  // This arrives both from this session's own optimistic mark-read reports (dispatched only while
+  // the session is activated) and from the socket handler relaying a mark-read made in one of the
+  // user's other sessions (which can arrive for a session this session isn't currently viewing).
+  // The unread flag and frozen divider are only re-evaluated in the latter case: an activated
+  // session already has its unread flag cleared, and its divider is re-evaluated by
+  // `deactivateWhisperSession` instead, so it must never move while the session is being viewed
+  // here.
   ['@whispers/updateLastReadTime'](state, action) {
     const { targetId, lastReadTime } = action.payload
 
@@ -281,6 +292,25 @@ export default immerKeyedReducer(DEFAULT_STATE, {
 
     if (session.lastReadTime === undefined || lastReadTime > session.lastReadTime) {
       session.lastReadTime = lastReadTime
+    }
+    const effective = session.lastReadTime!
+
+    if (!session.activated) {
+      const messages = session.messages
+      let newestServerOriginTime: number | undefined
+      for (let i = messages.length - 1; i >= 0; i--) {
+        if (isServerOriginMessage(messages[i])) {
+          newestServerOriginTime = messages[i].time
+          break
+        }
+      }
+      if (newestServerOriginTime === undefined || newestServerOriginTime <= effective) {
+        session.hasUnread = false
+      }
+
+      if (session.unreadLineTime !== undefined && effective > session.unreadLineTime) {
+        session.unreadLineTime = undefined
+      }
     }
   },
 

--- a/client/whispers/whisper.tsx
+++ b/client/whispers/whisper.tsx
@@ -5,6 +5,7 @@ import { SbUserId } from '../../common/users/sb-user-id'
 import { useSelfUser } from '../auth/auth-utils'
 import { Chat } from '../messaging/chat'
 import { flushLastRead } from '../messaging/last-read'
+import { isServerOriginMessage } from '../messaging/message-records'
 import { push, replace } from '../navigation/routing'
 import LoadingIndicator from '../progress/dots'
 import { usePrevious, useStableCallback } from '../react/state-hooks'
@@ -123,9 +124,18 @@ export function ConnectedWhisper({
     }
   }, [isSessionOpen, isClosingWhisper, targetId, dispatch, t, snackbarController])
 
-  const newestMessageTime = whisperSession?.messages.length
-    ? whisperSession.messages[whisperSession.messages.length - 1].time
-    : undefined
+  // The newest server-recorded message time: only server-origin messages carry one, and a read
+  // position must never be reported from a locally-stamped time.
+  let newestMessageTime: number | undefined
+  if (whisperSession) {
+    for (let i = whisperSession.messages.length - 1; i >= 0; i--) {
+      const message = whisperSession.messages[i]
+      if (isServerOriginMessage(message)) {
+        newestMessageTime = message.time
+        break
+      }
+    }
+  }
 
   // Reports the read position whenever the session is both open and scrolled to the bottom, so
   // arriving at a session already at the bottom (or scrolling back down to it) reports the newest

--- a/common/chat.ts
+++ b/common/chat.ts
@@ -380,9 +380,18 @@ export interface ChatPermissionsChangedEvent {
   selfPermissions: ChannelPermissions
 }
 
+export interface ChatReadTimeChangedEvent {
+  action: 'lastReadTimeChanged'
+  /** Epoch ms of this user's server-recorded read position in the channel. */
+  lastReadTime: number
+}
+
 /** Events that are sent to a particular user in a particular chat channel. */
 export type ChatUserEvent =
-  ChatInitEvent | ChatPreferencesChangedEvent | ChatPermissionsChangedEvent
+  | ChatInitEvent
+  | ChatPreferencesChangedEvent
+  | ChatPermissionsChangedEvent
+  | ChatReadTimeChangedEvent
 
 /**
  * The response returned when joining a specific chat channel.

--- a/common/whispers.ts
+++ b/common/whispers.ts
@@ -53,6 +53,17 @@ export interface WhisperMessageEvent {
 
 export type WhisperEvent = WhisperSessionInitEvent | WhisperSessionCloseEvent | WhisperMessageEvent
 
+export interface WhisperReadTimeChangedEvent {
+  action: 'lastReadTimeChanged'
+  /** The other user in the conversation whose read position this is for. */
+  target: SbUserId
+  /** Epoch ms of this user's server-recorded read position in the conversation. */
+  lastReadTime: number
+}
+
+/** Events published to a single user (all of their sessions) rather than to a conversation. */
+export type WhisperUserEvent = WhisperReadTimeChangedEvent
+
 export interface SendWhisperMessageRequest {
   message: string
 }

--- a/server/lib/chat/chat-models.ts
+++ b/server/lib/chat/chat-models.ts
@@ -696,22 +696,27 @@ export async function updateUserPermissions(
  * moves the stored position backward) so a stale report from one device can't clobber a newer
  * position recorded by another, and clamped to `now()` so a client can't push the position into the
  * future. A silent no-op if the user isn't (or is no longer) a member of the channel.
+ *
+ * Returns the resulting stored read position, or `undefined` if the user isn't a member of the
+ * channel (nothing to update).
  */
 export async function updateLastReadTime(
   userId: SbUserId,
   channelId: SbChannelId,
   lastReadTime: Date,
   withClient?: DbClient,
-): Promise<void> {
+): Promise<Date | undefined> {
   const { client, done } = await db(withClient)
   try {
-    await client.query(sql`
+    const result = await client.query<{ last_read_time: Date }>(sql`
       UPDATE channel_users
       SET last_read_time = GREATEST(
         COALESCE(last_read_time, '-infinity'::timestamptz), LEAST(${lastReadTime}, now())
       )
-      WHERE user_id = ${userId} AND channel_id = ${channelId};
+      WHERE user_id = ${userId} AND channel_id = ${channelId}
+      RETURNING last_read_time;
     `)
+    return result.rows[0]?.last_read_time
   } finally {
     done()
   }

--- a/server/lib/chat/chat-service.ts
+++ b/server/lib/chat/chat-service.ts
@@ -1374,11 +1374,19 @@ export default class ChatService {
   }
 
   /**
-   * Records the newest message time a user has seen in a channel. A no-op if they aren't a member
+   * Records the newest message time a user has seen in a channel, and publishes the resulting
+   * read position to all of that user's connected sessions (so a mark-read made in one session
+   * updates the unread badges and read positions of their others). A no-op if they aren't a member
    * of the channel (e.g. a stale report arriving after they left).
    */
   async markRead(channelId: SbChannelId, userId: SbUserId, lastReadTime: Date): Promise<void> {
-    await updateLastReadTime(userId, channelId, lastReadTime)
+    const stored = await updateLastReadTime(userId, channelId, lastReadTime)
+    if (stored !== undefined) {
+      this.publisher.publish(getChannelUserPath(channelId, userId), {
+        action: 'lastReadTimeChanged',
+        lastReadTime: stored.getTime(),
+      })
+    }
   }
 
   async updateUserPermissions(

--- a/server/lib/whispers/whisper-models.ts
+++ b/server/lib/whispers/whisper-models.ts
@@ -79,21 +79,26 @@ export async function startWhisperSessionsBothDirections(
  * monotonic (never moves the stored position backward) so a stale report from one device can't
  * clobber a newer position recorded by another, and clamped to `now()` so a client can't push the
  * position into the future. A silent no-op if the session doesn't exist (e.g. it was closed).
+ *
+ * Returns the resulting stored read position, or `undefined` if the session doesn't exist (nothing
+ * to update).
  */
 export async function updateLastReadTime(
   userId: SbUserId,
   targetId: SbUserId,
   lastReadTime: Date,
-): Promise<void> {
+): Promise<Date | undefined> {
   const { client, done } = await db()
   try {
-    await client.query(sql`
+    const result = await client.query<{ last_read_time: Date }>(sql`
       UPDATE whisper_sessions
       SET last_read_time = GREATEST(
         COALESCE(last_read_time, '-infinity'::timestamptz), LEAST(${lastReadTime}, now())
       )
-      WHERE user_id = ${userId} AND target_user_id = ${targetId};
+      WHERE user_id = ${userId} AND target_user_id = ${targetId}
+      RETURNING last_read_time;
     `)
+    return result.rows[0]?.last_read_time
   } finally {
     done()
   }

--- a/server/lib/whispers/whisper-service.ts
+++ b/server/lib/whispers/whisper-service.ts
@@ -15,6 +15,7 @@ import {
   WhisperMessageType,
   WhisperServiceErrorCode,
   WhisperSessionInitEvent,
+  WhisperUserEvent,
 } from '../../../common/whispers'
 import { getChannelInfos, toBasicChannelInfo } from '../chat/chat-models'
 import logger from '../logging/logger'
@@ -49,6 +50,16 @@ export function getSessionPath(user: SbUserId, target: SbUserId) {
   return urlPath`/whispers3/${low}-${high}`
 }
 
+/**
+ * Path for events meant only for one user's own sessions, rather than for a conversation. Read
+ * position updates must be published here rather than on `getSessionPath`, since the shared session
+ * path is subscribed to by both participants and the other participant must not see this user's
+ * read position.
+ */
+export function getWhisperUserPath(userId: SbUserId) {
+  return urlPath`/whispers3/users/${userId}`
+}
+
 @singleton()
 export default class WhisperService {
   /** Maps user ID -> OrderedSet of their whisper sessions (as IDs of target users) */
@@ -57,7 +68,7 @@ export default class WhisperService {
   private sessionUsers = IMap<SbUserId, ISet<SbUserId>>()
 
   constructor(
-    private publisher: TypedPublisher<WhisperEvent>,
+    private publisher: TypedPublisher<WhisperEvent | WhisperUserEvent>,
     private userSocketsManager: UserSocketsManager,
     private restrictionService: RestrictionService,
   ) {
@@ -95,11 +106,20 @@ export default class WhisperService {
   }
 
   /**
-   * Records the newest message time a user has seen in a whisper conversation. A no-op if the
-   * session doesn't exist (e.g. it was closed, or never opened).
+   * Records the newest message time a user has seen in a whisper conversation, and publishes the
+   * resulting read position to all of that user's connected sessions (so a mark-read made in one
+   * session updates the unread badges and read positions of their others). A no-op if the session
+   * doesn't exist (e.g. it was closed, or never opened).
    */
   async markRead(userId: SbUserId, targetId: SbUserId, lastReadTime: Date): Promise<void> {
-    await updateLastReadTime(userId, targetId, lastReadTime)
+    const stored = await updateLastReadTime(userId, targetId, lastReadTime)
+    if (stored !== undefined) {
+      this.publisher.publish(getWhisperUserPath(userId), {
+        action: 'lastReadTimeChanged',
+        target: targetId,
+        lastReadTime: stored.getTime(),
+      })
+    }
   }
 
   async startWhisperSession(userId: SbUserId, targetUser: SbUserId) {
@@ -324,6 +344,10 @@ export default class WhisperService {
   }
 
   private async handleNewUser(userSockets: UserSocketsGroup) {
+    // Subscribed before the awaited DB fetch below so an update published to this user's own path
+    // while that fetch is in flight isn't missed.
+    userSockets.subscribe(getWhisperUserPath(userSockets.userId))
+
     const whisperSessionEntries = await getWhisperSessionsForUser(userSockets.userId)
     if (!userSockets.sockets.size) {
       // The user disconnected while we were waiting for their whisper sessions


### PR DESCRIPTION
Marking a channel or whisper conversation read in one session now updates the user's other connected sessions live, instead of leaving their unread badges stale until the next restart.

### Server

- `markRead` (chat + whispers) now publishes the resulting stored read position after the DB update. The models' `updateLastReadTime` gained `RETURNING last_read_time`, so the published value is the authoritative stored one (post-monotonic-clamp), not the client's report, and nothing is published when the update matched no row (not a member / no session).
- Chat publishes on the existing per-user channel path (`/chat3/:channelId/users/:userId`) as a new `lastReadTimeChanged` event in `ChatUserEvent`.
- Whispers get a new per-user path `/whispers3/users/:userId` (subscribed at connect, before the awaited session fetch so nothing is missed) with its own `WhisperUserEvent` union. The read position deliberately does **not** go on the shared `/whispers3/:low-:high` session path — the other participant is subscribed there and must not see your read position (that would be a read receipt).

### Client

The socket handlers dispatch the existing `@chat/updateLastReadTime` / `@whispers/updateLastReadTime` actions (which were shaped for exactly this). The reducers keep the monotonic advance, and additionally — only for a conversation that is **not** currently activated:

- clear the unread badge when no known server-origin message is newer than the incoming position (client-local messages are skipped since their `time` is a local clock); if a newer server message is known locally, the badge stays — the other session hasn't seen it;
- drop a frozen unread divider once the position moves past it (same rule deactivation uses).

An activated conversation is intentionally untouched beyond the position itself: its badge is already clear, and the frozen divider must never move while it's being viewed (deactivation re-evaluates it with the advanced position).

Known tradeoff: for a conversation with no locally-known messages, an incoming read position clears the badge without being able to compare against the true newest message. A stale-enough cross-session report could briefly clear a badge that init would have seeded; the next message event or init re-seed corrects it. Computing `hasUnread` server-side per mark-read would cost an extra query per report for a vanishingly rare race.

### Verification

- Unit: 13 new reducer tests (monotonicity, badge clear/keep vs newest server-origin message, client-local message skip, divider drop/keep, activated-conversation no-op). Typecheck/lint/tests green.
- Live (dev server, three browser tabs — two logged in as the same user, one as the sender):
  - channel: sender posts → both sessions show the unread badge; one session opens the channel → the other's badge clears live and its `lastReadTime` advances to the exact server-stored value, while sitting on the home page;
  - whisper: same flow, same result;
  - privacy: the sender's client state never saw the reader's position (nothing arrives on the session path).
