### PR TITLE
Drive the tray unread icon from tracked read state

### DIFF
--- a/app/app.ts
+++ b/app/app.ts
@@ -697,12 +697,18 @@ function setupIpc(localSettings: LocalSettingsManager, scrSettings: ScrSettingsM
   ipcMain.on('chatNewMessage', (event, data) => {
     if (mainWindow && !mainWindow.isFocused()) {
       if (systemTray) {
-        systemTray.showUnreadIcon(data.urgent)
+        systemTray.showTransientUnreadIcon(data.urgent)
       }
 
       if (data.urgent) {
         mainWindow.flashFrame(true)
       }
+    }
+  })
+
+  ipcMain.on('chatUnreadState', (event, data) => {
+    if (systemTray) {
+      systemTray.setTrackedUnread(data.hasUnread)
     }
   })
 
@@ -1247,7 +1253,7 @@ async function createWindow() {
     })
     .on('focus', () => {
       if (systemTray) {
-        systemTray.clearUnreadIcon()
+        systemTray.clearTransientUnreadIcon()
       }
       mainWindow?.flashFrame(false)
       TypedIpcSender.from(mainWindow?.webContents).send('windowFocusChanged', true)
@@ -1257,7 +1263,7 @@ async function createWindow() {
     })
     .on('show', () => {
       if (systemTray) {
-        systemTray.clearUnreadIcon()
+        systemTray.clearTransientUnreadIcon()
       }
       if (needsMaximize && mainWindow) {
         mainWindow.maximize()

--- a/app/system-tray.ts
+++ b/app/system-tray.ts
@@ -10,15 +10,25 @@ const URGENT_ICON = path.join(APP_ROOT, 'assets', 'shieldbattery-tray-urgent.png
 const BALLOON_ICON = path.join(APP_ROOT, 'assets', 'shieldbattery-64.png')
 
 export default class SystemTray {
-  private isShowingUrgentIcon: boolean
+  /**
+   * Whether any conversation with tracked read state has unread messages, as reported by the
+   * renderer. Cleared only by the messages actually being read (possibly from another of the
+   * user's sessions), never by window focus.
+   */
+  private hasTrackedUnread = false
+  /**
+   * Attention state for messages with no tracked read state (lobby/matchmaking chat) and urgent
+   * messages, accumulated while the window is unfocused and cleared when it gains focus.
+   */
+  private hasTransientUnread = false
+  private hasTransientUrgent = false
+  private shownIcon = NORMAL_ICON
   private systemTray: Tray
 
   constructor(
     readonly mainWindow: BrowserWindow | null,
     readonly onQuitClick: () => void,
   ) {
-    this.isShowingUrgentIcon = false
-
     this.systemTray = new Tray(NORMAL_ICON)
     this.systemTray.setToolTip(app.name)
     this.systemTray.setContextMenu(this.buildContextMenu())
@@ -60,17 +70,34 @@ export default class SystemTray {
     })
   }
 
-  showUnreadIcon = (urgent = false) => {
-    if (!this.isShowingUrgentIcon) {
-      this.systemTray.setImage(urgent ? URGENT_ICON : UNREAD_ICON)
-    }
-    if (urgent) {
-      this.isShowingUrgentIcon = true
-    }
+  setTrackedUnread = (hasUnread: boolean) => {
+    this.hasTrackedUnread = hasUnread
+    this.updateIcon()
   }
 
-  clearUnreadIcon = () => {
-    this.isShowingUrgentIcon = false
-    this.systemTray.setImage(NORMAL_ICON)
+  showTransientUnreadIcon = (urgent = false) => {
+    this.hasTransientUnread = true
+    this.hasTransientUrgent ||= urgent
+    this.updateIcon()
+  }
+
+  clearTransientUnreadIcon = () => {
+    this.hasTransientUnread = false
+    this.hasTransientUrgent = false
+    this.updateIcon()
+  }
+
+  private updateIcon() {
+    let icon = NORMAL_ICON
+    if (this.hasTransientUrgent) {
+      icon = URGENT_ICON
+    } else if (this.hasTrackedUnread || this.hasTransientUnread) {
+      icon = UNREAD_ICON
+    }
+
+    if (icon !== this.shownIcon) {
+      this.shownIcon = icon
+      this.systemTray.setImage(icon)
+    }
   }
 }

--- a/client/app.tsx
+++ b/client/app.tsx
@@ -23,6 +23,7 @@ import { logger } from './logging/logger'
 import { MainLayout, MainLayoutContent, MainLayoutLoadingDotsArea } from './main-layout'
 import { DraftScreenOverlay } from './matchmaking/draft-screen-overlay'
 import { zIndexSettings } from './material/zindex'
+import { UnreadTraySync } from './messaging/unread-tray-sync'
 import { NavigationTrapProvider } from './navigation/navigation-trap'
 import { UNAUTHORIZED_EMITTER } from './network/fetch'
 import { createGraphqlClient } from './network/graphql-client'
@@ -261,6 +262,7 @@ const AppContent = React.memo(() => {
       <RedirectOnUnauthorized />
       <SiteSocketManager />
       <RestrictionClearer />
+      <UnreadTraySync />
       <React.Suspense fallback={<LoadingDotsArea />}>
         <Switch>
           {!IS_PRODUCTION ? <Route path='/dev/*?' component={LoadableDev} /> : <></>}

--- a/client/chat/socket-handlers.ts
+++ b/client/chat/socket-handlers.ts
@@ -104,10 +104,11 @@ const eventToChatAction: EventToChatActionMap = {
 
       const isBlocked = blocks.has(event.message.from)
       const isUrgent = !isBlocked && event.mentions.some(m => m.id === auth.self!.user.id)
-      if (!isBlocked) {
-        // Notify the main process of the new message, so it can display an appropriate notification
+      if (isUrgent) {
+        // Mentions get the main process's transient attention treatment (urgent tray icon +
+        // taskbar flash); regular messages reach it through the tracked unread state instead.
         ipcRenderer.send('chatNewMessage', {
-          urgent: isUrgent,
+          urgent: true,
         })
       }
 

--- a/client/messaging/unread-tray-sync.tsx
+++ b/client/messaging/unread-tray-sync.tsx
@@ -1,0 +1,24 @@
+import { useEffect } from 'react'
+import { TypedIpcRenderer } from '../../common/ipc'
+import { useAppSelector } from '../redux-hooks'
+
+const ipcRenderer = new TypedIpcRenderer()
+
+function UnreadTraySyncImpl() {
+  const hasUnread = useAppSelector(
+    s => s.chat.unreadChannels.size > 0 || s.whispers.byId.values().some(w => w.hasUnread),
+  )
+
+  useEffect(() => {
+    ipcRenderer.send('chatUnreadState', { hasUnread })
+  }, [hasUnread])
+
+  return null
+}
+
+/**
+ * Mirrors whether any chat channel or whisper conversation has unread messages to the main
+ * process, which reflects it on the system tray icon. Reports the current value on mount (the main
+ * process's view goes stale across renderer reloads) and on every change after that.
+ */
+export const UnreadTraySync = IS_ELECTRON ? UnreadTraySyncImpl : () => null

--- a/common/ipc.ts
+++ b/common/ipc.ts
@@ -343,6 +343,12 @@ interface IpcInvokeables {
 /** Events that can be sent from the renderer process to the main process. */
 interface IpcRendererSendables {
   chatNewMessage: (data: { urgent: boolean }) => void
+  /**
+   * Reports whether any conversation with tracked read state (chat channels, whispers) currently
+   * has unread messages. Sent on every change, including cases where the messages were read from
+   * another of the user's sessions.
+   */
+  chatUnreadState: (data: { hasUnread: boolean }) => void
 
   gameServerRegionsSetList: (regions: GameServerRegion[]) => void
 


### PR DESCRIPTION
Follows up on #1438/#1440: now that channel and whisper read positions are tracked server-side and synced across sessions, the system tray icon can reflect real unread state instead of guessing from message arrival.

### What changed

- New \`chatUnreadState\` IPC: a small \`UnreadTraySync\` component derives "any unread channel or whisper" from Redux and reports it to the main process on mount and on every transition (mount-time report also covers the main process's view going stale across renderer reloads).
- \`SystemTray\` now composes two inputs:
  - **Tracked unread** — set/cleared only by actual read state. Focusing the window no longer clears it; reading the messages does, including reading them from another of the user's sessions (via #1440's cross-session sync).
  - **Transient attention** — the existing \`chatNewMessage\` path for things with no tracked read state (lobby/matchmaking chat) and urgent mentions: accumulates while unfocused, clears on focus, unchanged behavior.
- Icon priority is urgent > unread > normal, with \`setImage\` deduped on actual changes.
- Channel messages no longer send the per-message \`chatNewMessage\` IPC except for mentions (which keep the urgent icon + taskbar flash). Whisper/lobby/matchmaking senders are untouched.

### Behavior note

A message to the channel you currently have open while the app is backgrounded gets auto-marked read (read reporting has no focus gate), so it no longer lights the tray the way the old per-message path did. That's consistent with the sidebar badge and other sessions' state; if we want Discord-style "don't mark read while unfocused" semantics, that's a separate change to read reporting rather than to the tray.

### Verification

Live-verified with temporary main-process logging (removed): boot reports \`false\`; a channel message from another user flips the tray to unread; reading it from a *browser* session as the same user clears the app's tray without touching the app; a whisper sets it; reading in the app clears it.