### PR TITLE
Track per-channel mention unread state and surface urgent badges

### DIFF
--- a/app/app.ts
+++ b/app/app.ts
@@ -708,7 +708,7 @@ function setupIpc(localSettings: LocalSettingsManager, scrSettings: ScrSettingsM
 
   ipcMain.on('chatUnreadState', (event, data) => {
     if (systemTray) {
-      systemTray.setTrackedUnread(data.hasUnread)
+      systemTray.setTrackedUnread(data)
     }
   })
 

--- a/app/system-tray.ts
+++ b/app/system-tray.ts
@@ -17,6 +17,12 @@ export default class SystemTray {
    */
   private hasTrackedUnread = false
   /**
+   * Whether any of the tracked-read-state unread state reported by the renderer is urgent: a
+   * channel message mentioning the user, or any unread whisper. Cleared the same way as
+   * `hasTrackedUnread`, never by window focus.
+   */
+  private hasTrackedUrgent = false
+  /**
    * Attention state for messages with no tracked read state (lobby/matchmaking chat) and urgent
    * messages, accumulated while the window is unfocused and cleared when it gains focus.
    */
@@ -70,8 +76,9 @@ export default class SystemTray {
     })
   }
 
-  setTrackedUnread = (hasUnread: boolean) => {
-    this.hasTrackedUnread = hasUnread
+  setTrackedUnread = (data: { hasUnread: boolean; hasUnreadUrgent: boolean }) => {
+    this.hasTrackedUnread = data.hasUnread
+    this.hasTrackedUrgent = data.hasUnreadUrgent
     this.updateIcon()
   }
 
@@ -89,7 +96,7 @@ export default class SystemTray {
 
   private updateIcon() {
     let icon = NORMAL_ICON
-    if (this.hasTransientUrgent) {
+    if (this.hasTransientUrgent || this.hasTrackedUrgent) {
       icon = URGENT_ICON
     } else if (this.hasTrackedUnread || this.hasTransientUnread) {
       icon = UNREAD_ICON

--- a/client/chat/actions.ts
+++ b/client/chat/actions.ts
@@ -380,7 +380,13 @@ export interface UpdateChannelOwner {
 export interface UpdateMessage {
   type: '@chat/updateMessage'
   payload: ChatMessageEvent
-  meta: { channelId: SbChannelId }
+  meta: {
+    channelId: SbChannelId
+    /**
+     * Whether the message mentions the current user and wasn't sent by someone they've blocked.
+     */
+    mentionsSelf: boolean
+  }
 }
 
 /**

--- a/client/chat/chat-reducer.test.ts
+++ b/client/chat/chat-reducer.test.ts
@@ -1,17 +1,21 @@
 import { Immutable } from 'immer'
 import { describe, expect, test } from 'vitest'
 import {
+  BasicChannelInfo,
   ChannelTextMessage,
   ChatMessage,
+  ChatMessageEvent,
   ClientChatMessageType,
+  InitialChannelData,
   SbChannelId,
   SelfJoinChannelMessage,
   ServerChatMessageType,
   makeSbChannelId,
 } from '../../common/chat'
+import { SbUser } from '../../common/users/sb-user'
 import { makeSbUserId } from '../../common/users/sb-user-id'
 import { ChatActions } from './actions'
-import chatReducerImport, { ChatState } from './chat-reducer'
+import chatReducerImport, { ChatState, channelHasUnreadMention } from './chat-reducer'
 
 // `immerKeyedReducer` accepts any action with a string `type`. These tests only ever feed it chat
 // actions, so narrow the parameter to those, both for the extra checking and so that action objects
@@ -51,6 +55,7 @@ function makeState(
     activated?: boolean
     unread?: boolean
     lastReadTime?: number
+    latestMentionTime?: number
     unreadLineTime?: number
   } = {},
 ): Immutable<ChatState> {
@@ -73,6 +78,9 @@ function makeState(
     idToLastReadTime: new Map(
       overrides.lastReadTime !== undefined ? [[CHANNEL_ID, overrides.lastReadTime]] : [],
     ),
+    idToLatestMentionTime: new Map(
+      overrides.latestMentionTime !== undefined ? [[CHANNEL_ID, overrides.latestMentionTime]] : [],
+    ),
     idToUnreadLineTime: new Map(
       overrides.unreadLineTime !== undefined ? [[CHANNEL_ID, overrides.unreadLineTime]] : [],
     ),
@@ -85,6 +93,61 @@ function updateLastReadTimeAction(lastReadTime: number): ChatActions {
   return {
     type: '@chat/updateLastReadTime',
     payload: { channelId: CHANNEL_ID, lastReadTime },
+  }
+}
+
+const CHANNEL_BASIC_INFO: BasicChannelInfo = {
+  id: CHANNEL_ID,
+  name: 'test-channel',
+  private: false,
+  official: false,
+}
+
+const SENDER: SbUser = { id: USER_ID, name: 'sender', created: 0 }
+
+function initialChannelData(overrides: { latestMentionTime?: number } = {}): InitialChannelData {
+  return {
+    channelInfo: CHANNEL_BASIC_INFO,
+    detailedChannelInfo: { id: CHANNEL_ID, userCount: 1 },
+    joinedChannelInfo: { id: CHANNEL_ID },
+    selfPreferences: { hideBanner: false },
+    selfPermissions: {
+      kick: false,
+      ban: false,
+      changeTopic: false,
+      togglePrivate: false,
+      editPermissions: false,
+    },
+    latestMentionTime: overrides.latestMentionTime,
+  }
+}
+
+function getJoinedChannelsAction(data: InitialChannelData): ChatActions {
+  return {
+    type: '@chat/getJoinedChannels',
+    payload: [data],
+  }
+}
+
+function updateMessageAction(time: number, mentionsSelf: boolean): ChatActions {
+  const payload: ChatMessageEvent = {
+    action: 'message2',
+    message: textMessage(time),
+    user: SENDER,
+    mentions: [],
+    channelMentions: [],
+  }
+  return {
+    type: '@chat/updateMessage',
+    payload,
+    meta: { channelId: CHANNEL_ID, mentionsSelf },
+  }
+}
+
+function updateLeaveSelfAction(): ChatActions {
+  return {
+    type: '@chat/updateLeaveSelf',
+    meta: { channelId: CHANNEL_ID },
   }
 }
 
@@ -166,6 +229,135 @@ describe('client/chat/chat-reducer', () => {
       // The read position itself still advances even while activated, since this is also the path
       // this session's own optimistic mark-read reports take.
       expect(result.idToLastReadTime.get(CHANNEL_ID)).toBe(200)
+    })
+  })
+
+  describe('channelHasUnreadMention', () => {
+    test('is false when there is no known mention time', () => {
+      const state = makeState({ lastReadTime: 100 })
+
+      expect(channelHasUnreadMention(state, CHANNEL_ID)).toBe(false)
+    })
+
+    test('is false when there is no recorded read position, even with a mention time', () => {
+      const state = makeState({ latestMentionTime: 100 })
+
+      expect(channelHasUnreadMention(state, CHANNEL_ID)).toBe(false)
+    })
+
+    test('is true when the mention time is newer than the read position', () => {
+      const state = makeState({ lastReadTime: 100, latestMentionTime: 200 })
+
+      expect(channelHasUnreadMention(state, CHANNEL_ID)).toBe(true)
+    })
+
+    test('is false when the read position has caught up to the mention time', () => {
+      const state = makeState({ lastReadTime: 200, latestMentionTime: 200 })
+
+      expect(channelHasUnreadMention(state, CHANNEL_ID)).toBe(false)
+    })
+
+    test('is false for an activated channel, even with an unread mention', () => {
+      const state = makeState({ activated: true, lastReadTime: 100, latestMentionTime: 200 })
+
+      expect(channelHasUnreadMention(state, CHANNEL_ID)).toBe(false)
+    })
+  })
+
+  describe('@chat/getJoinedChannels / @chat/initChannel', () => {
+    test('seeds the mention time from the initial channel data', () => {
+      const state = makeState()
+
+      const result = chatReducer(
+        state,
+        getJoinedChannelsAction(initialChannelData({ latestMentionTime: 500 })),
+      )
+
+      expect(result.idToLatestMentionTime.get(CHANNEL_ID)).toBe(500)
+    })
+
+    test('does not regress an existing mention time when re-initialized with an older one', () => {
+      const state = makeState({ latestMentionTime: 500 })
+
+      const result = chatReducer(
+        state,
+        getJoinedChannelsAction(initialChannelData({ latestMentionTime: 300 })),
+      )
+
+      expect(result.idToLatestMentionTime.get(CHANNEL_ID)).toBe(500)
+    })
+
+    test('advances an existing mention time when re-initialized with a newer one', () => {
+      const state = makeState({ latestMentionTime: 300 })
+
+      const result = chatReducer(
+        state,
+        getJoinedChannelsAction(initialChannelData({ latestMentionTime: 500 })),
+      )
+
+      expect(result.idToLatestMentionTime.get(CHANNEL_ID)).toBe(500)
+    })
+
+    test('leaves the mention time unset when the initial data carries none', () => {
+      const state = makeState()
+
+      const result = chatReducer(state, getJoinedChannelsAction(initialChannelData()))
+
+      expect(result.idToLatestMentionTime.has(CHANNEL_ID)).toBe(false)
+    })
+  })
+
+  describe('@chat/updateMessage', () => {
+    test('sets the mention time when the message mentions self', () => {
+      const state = makeState()
+
+      const result = chatReducer(state, updateMessageAction(100, true))
+
+      expect(result.idToLatestMentionTime.get(CHANNEL_ID)).toBe(100)
+    })
+
+    test('does not set the mention time when the message does not mention self', () => {
+      const state = makeState()
+
+      const result = chatReducer(state, updateMessageAction(100, false))
+
+      expect(result.idToLatestMentionTime.has(CHANNEL_ID)).toBe(false)
+    })
+
+    test('advances the mention time when a newer mention arrives', () => {
+      const state = makeState({ latestMentionTime: 100 })
+
+      const result = chatReducer(state, updateMessageAction(200, true))
+
+      expect(result.idToLatestMentionTime.get(CHANNEL_ID)).toBe(200)
+    })
+
+    test('does not regress the mention time when an older mention arrives', () => {
+      const state = makeState({ latestMentionTime: 200 })
+
+      const result = chatReducer(state, updateMessageAction(100, true))
+
+      expect(result.idToLatestMentionTime.get(CHANNEL_ID)).toBe(200)
+    })
+
+    test('a read-time advance past the mention clears the derived unread-mention state', () => {
+      let state = makeState({ lastReadTime: 50 })
+
+      state = chatReducer(state, updateMessageAction(100, true))
+      expect(channelHasUnreadMention(state, CHANNEL_ID)).toBe(true)
+
+      state = chatReducer(state, updateLastReadTimeAction(150))
+      expect(channelHasUnreadMention(state, CHANNEL_ID)).toBe(false)
+    })
+  })
+
+  describe('leaving a channel', () => {
+    test('clears the mention time', () => {
+      const state = makeState({ lastReadTime: 100, latestMentionTime: 200 })
+
+      const result = chatReducer(state, updateLeaveSelfAction())
+
+      expect(result.idToLatestMentionTime.has(CHANNEL_ID)).toBe(false)
     })
   })
 })

--- a/client/chat/chat-reducer.ts
+++ b/client/chat/chat-reducer.ts
@@ -70,6 +70,14 @@ export interface ChatState {
    */
   idToLastReadTime: Map<SbChannelId, number>
   /**
+   * A map of channel ID -> the newest known time (epoch ms) of a server message from another,
+   * non-blocked user that mentions the current user. Compared against `idToLastReadTime` (via
+   * `channelHasUnreadMention`) to derive whether the channel has an unread mention; there is no
+   * separate boolean flag or clear logic for this, since the read position advancing past it is
+   * exactly what "read" means here.
+   */
+  idToLatestMentionTime: Map<SbChannelId, number>
+  /**
    * A map of channel ID -> the frozen position of the unread divider for the current activation.
    * Captured when an unread channel activates, or when a message arrives while the channel is
    * activated and scrolled up, and held until deactivation so the divider doesn't chase
@@ -93,7 +101,32 @@ const DEFAULT_CHAT_STATE: Immutable<ChatState> = {
   unreadChannels: new Set(),
   deletedChannels: new Set(),
   idToLastReadTime: new Map(),
+  idToLatestMentionTime: new Map(),
   idToUnreadLineTime: new Map(),
+}
+
+/**
+ * Returns whether `channelId` has an unread message that mentions the current user. `undefined`
+ * `idToLastReadTime` is treated the same way the server treats a NULL `last_read_time`: as
+ * "everything is read" rather than "everything is unread". The server never seeds mention state
+ * for a channel with no recorded read position (there's nothing to compare newly-arrived messages
+ * against yet), so the client has to apply the same rule here, or a fresh channel would flip its
+ * badge to urgent the moment a message with a stale mention time got merged in.
+ */
+export function channelHasUnreadMention(
+  chatState: Immutable<ChatState>,
+  channelId: SbChannelId,
+): boolean {
+  if (chatState.activatedChannels.has(channelId)) {
+    return false
+  }
+
+  const latestMentionTime = chatState.idToLatestMentionTime.get(channelId)
+  if (latestMentionTime === undefined) {
+    return false
+  }
+
+  return latestMentionTime > (chatState.idToLastReadTime.get(channelId) ?? Infinity)
 }
 
 function removeUserFromChannel(
@@ -175,6 +208,7 @@ function removeSelfFromChannel(state: ChatState, channelId: SbChannelId) {
   state.atBottomChannels.delete(channelId)
   state.unreadChannels.delete(channelId)
   state.idToLastReadTime.delete(channelId)
+  state.idToLatestMentionTime.delete(channelId)
   state.idToUnreadLineTime.delete(channelId)
 }
 
@@ -286,6 +320,7 @@ function initChannel(state: ChatState, channelId: SbChannelId, data: InitialChan
     selfPermissions,
     hasUnread,
     lastReadTime,
+    latestMentionTime,
   } = data
 
   const messagesState: MessagesState = {
@@ -305,6 +340,14 @@ function initChannel(state: ChatState, channelId: SbChannelId, data: InitialChan
 
   if (lastReadTime !== undefined) {
     state.idToLastReadTime.set(channelId, lastReadTime)
+  }
+
+  if (latestMentionTime !== undefined) {
+    const existing = state.idToLatestMentionTime.get(channelId)
+    state.idToLatestMentionTime.set(
+      channelId,
+      existing === undefined ? latestMentionTime : Math.max(existing, latestMentionTime),
+    )
   }
 
   // Seeds the unread badge from the server's recorded read position, so it survives a restart
@@ -411,13 +454,20 @@ export default immerKeyedReducer(DEFAULT_CHAT_STATE, {
 
   ['@chat/updateMessage'](state, action) {
     const { message: newMessage, channelMentions } = action.payload
-    const { channelId } = action.meta
+    const { channelId, mentionsSelf } = action.meta
 
     updateMessages(state, channelId, true, m => {
       m.push(newMessage)
       return m
     })
     updateChannelInfos(state, channelMentions)
+
+    if (mentionsSelf) {
+      const existing = state.idToLatestMentionTime.get(channelId)
+      if (existing === undefined || newMessage.time > existing) {
+        state.idToLatestMentionTime.set(channelId, newMessage.time)
+      }
+    }
   },
 
   ['@chat/updateUserActive'](state, action) {

--- a/client/chat/socket-handlers.ts
+++ b/client/chat/socket-handlers.ts
@@ -115,7 +115,7 @@ const eventToChatAction: EventToChatActionMap = {
       dispatch({
         type: '@chat/updateMessage',
         payload: event,
-        meta: { channelId },
+        meta: { channelId, mentionsSelf: isUrgent },
       })
 
       const isChannelActivated = activatedChannels.has(channelId)

--- a/client/messaging/unread-tray-sync.tsx
+++ b/client/messaging/unread-tray-sync.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from 'react'
 import { TypedIpcRenderer } from '../../common/ipc'
+import { channelHasUnreadMention } from '../chat/chat-reducer'
 import { useAppSelector } from '../redux-hooks'
 
 const ipcRenderer = new TypedIpcRenderer()
@@ -8,10 +9,17 @@ function UnreadTraySyncImpl() {
   const hasUnread = useAppSelector(
     s => s.chat.unreadChannels.size > 0 || s.whispers.byId.values().some(w => w.hasUnread),
   )
+  // A whisper is inherently directed at the current user, so any unread whisper counts as urgent
+  // alongside a channel message that mentions them.
+  const hasUnreadUrgent = useAppSelector(
+    s =>
+      s.chat.joinedChannels.values().some(id => channelHasUnreadMention(s.chat, id)) ||
+      s.whispers.byId.values().some(w => w.hasUnread),
+  )
 
   useEffect(() => {
-    ipcRenderer.send('chatUnreadState', { hasUnread })
-  }, [hasUnread])
+    ipcRenderer.send('chatUnreadState', { hasUnread, hasUnreadUrgent })
+  }, [hasUnread, hasUnreadUrgent])
 
   return null
 }

--- a/client/social/social-sidebar-button.tsx
+++ b/client/social/social-sidebar-button.tsx
@@ -59,9 +59,7 @@ export function SocialSidebarButton({ onClick, icon, isOpen }: SocialSidebarButt
         tabIndex={-1}>
         <IconButton icon={icon} onClick={onClick} testName='social-sidebar-button' />
       </Tooltip>
-      {!isOpen && (hasUnreadChat || hasUnreadWhispers) ? (
-        <UnreadIndicator $urgent={hasUrgent} />
-      ) : null}
+      {!isOpen && (hasUnreadChat || hasUrgent) ? <UnreadIndicator $urgent={hasUrgent} /> : null}
     </ButtonContainer>
   )
 }

--- a/client/social/social-sidebar-button.tsx
+++ b/client/social/social-sidebar-button.tsx
@@ -1,18 +1,19 @@
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
+import { channelHasUnreadMention } from '../chat/chat-reducer'
 import { IconButton } from '../material/button'
 import { Tooltip } from '../material/tooltip'
 import { useAppSelector } from '../redux-hooks'
 
-const UnreadIndicator = styled.div`
+const UnreadIndicator = styled.div<{ $urgent?: boolean }>`
   width: 12px;
   height: 12px;
   position: absolute;
   left: 6px;
   top: 10px;
 
-  background-color: var(--color-amber80);
+  background-color: ${props => (props.$urgent ? 'var(--theme-error)' : 'var(--color-amber80)')};
   border-radius: 50%;
   border: 2px solid rgb(from var(--color-grey-blue10) r g b / 100%);
 
@@ -42,6 +43,13 @@ export function SocialSidebarButton({ onClick, icon, isOpen }: SocialSidebarButt
 
   const hasUnreadChat = useAppSelector(s => s.chat.unreadChannels.size > 0)
   const hasUnreadWhispers = useAppSelector(s => s.whispers.byId.values().some(w => w.hasUnread))
+  // Whisper unread counts as urgent since a whisper is inherently directed at the current user,
+  // matching how the tray's tracked-unread state treats it.
+  const hasUrgent = useAppSelector(
+    s =>
+      s.chat.joinedChannels.values().some(id => channelHasUnreadMention(s.chat, id)) ||
+      hasUnreadWhispers,
+  )
 
   return (
     <ButtonContainer>
@@ -51,7 +59,9 @@ export function SocialSidebarButton({ onClick, icon, isOpen }: SocialSidebarButt
         tabIndex={-1}>
         <IconButton icon={icon} onClick={onClick} testName='social-sidebar-button' />
       </Tooltip>
-      {!isOpen && (hasUnreadChat || hasUnreadWhispers) ? <UnreadIndicator /> : null}
+      {!isOpen && (hasUnreadChat || hasUnreadWhispers) ? (
+        <UnreadIndicator $urgent={hasUrgent} />
+      ) : null}
     </ButtonContainer>
   )
 }

--- a/client/social/social-sidebar.tsx
+++ b/client/social/social-sidebar.tsx
@@ -19,6 +19,7 @@ import {
   leaveChannelWithConfirmation,
 } from '../chat/action-creators'
 import { ConnectedChannelBadge } from '../chat/channel-badge'
+import { channelHasUnreadMention } from '../chat/chat-reducer'
 import { openDialog } from '../dialogs/action-creators'
 import { DialogType } from '../dialogs/dialog-type'
 import { useWindowSize } from '../dom/dimension-hooks'
@@ -519,6 +520,7 @@ function ChannelEntry({
   const dispatch = useAppDispatch()
   const basicInfo = useAppSelector(s => s.chat.idToBasicInfo.get(channelId))
   const hasUnread = useAppSelector(s => s.chat.unreadChannels.has(channelId))
+  const hasUnreadMention = useAppSelector(s => channelHasUnreadMention(s.chat, channelId))
   const { onNavigation } = useNavigationTracker()
 
   useEffect(() => {
@@ -547,7 +549,8 @@ function ChannelEntry({
   return (
     <Entry
       link={urlPath`/chat/${channelId}/${basicInfo?.name}`}
-      needsAttention={hasUnread}
+      needsAttention={hasUnread || hasUnreadMention}
+      urgentAttention={hasUnreadMention}
       title={basicInfo ? `#${basicInfo.name}` : undefined}
       button={button}
       icon={<ConnectedChannelBadge channelId={channelId} />}
@@ -617,6 +620,7 @@ function WhisperEntry({ userId }: { userId: SbUserId }) {
         button={button}
         icon={<ConnectedAvatar userId={userId} />}
         needsAttention={hasUnread}
+        urgentAttention={hasUnread}
         isActive={isOverlayOpen}
         onContextMenu={onContextMenu}
         onClick={event => {
@@ -699,7 +703,7 @@ const EntryButton = styled.div`
   }
 `
 
-const AttentionIndicator = styled.div`
+const AttentionIndicator = styled.div<{ $urgent?: boolean }>`
   width: 8px;
   height: 8px;
   position: absolute;
@@ -707,7 +711,7 @@ const AttentionIndicator = styled.div`
   top: calc(50% - 4px);
 
   border-radius: 50%;
-  background-color: var(--color-amber80);
+  background-color: ${props => (props.$urgent ? 'var(--theme-error)' : 'var(--color-amber80)')};
 `
 
 const EntryIcon = styled.div`
@@ -733,6 +737,11 @@ interface EntryProps {
   button?: React.ReactNode
   icon?: React.ReactNode
   needsAttention?: boolean
+  /**
+   * Whether the attention indicator should render in its urgent color, e.g. for a channel message
+   * that mentions the current user or a whisper (which is inherently directed at them).
+   */
+  urgentAttention?: boolean
   isActive?: boolean
   className?: string
   onContextMenu?: (event: React.MouseEvent) => void
@@ -745,6 +754,7 @@ function Entry({
   button,
   icon,
   needsAttention,
+  urgentAttention,
   isActive,
   className,
   children,
@@ -772,7 +782,7 @@ function Entry({
       className={className}
       onContextMenu={onContextMenu}>
       {icon ? <EntryIcon>{icon}</EntryIcon> : null}
-      {needsAttention ? <AttentionIndicator /> : null}
+      {needsAttention ? <AttentionIndicator $urgent={urgentAttention} /> : null}
       <EntryText ref={textRef} title={isOverflowing ? title : undefined} data-testid='entry-text'>
         {children}
       </EntryText>

--- a/common/chat.ts
+++ b/common/chat.ts
@@ -244,6 +244,11 @@ export interface InitialChannelData {
    * the client can't compute unreadness itself without messages loaded.
    */
   lastReadTime?: number
+  /**
+   * Time (as a Unix timestamp in milliseconds) of the newest message that mentions this user and
+   * is newer than their read position for the channel. Omitted when there is no such message.
+   */
+  latestMentionTime?: number
 }
 
 export interface ChatInitEvent extends InitialChannelData {

--- a/common/ipc.ts
+++ b/common/ipc.ts
@@ -345,10 +345,12 @@ interface IpcRendererSendables {
   chatNewMessage: (data: { urgent: boolean }) => void
   /**
    * Reports whether any conversation with tracked read state (chat channels, whispers) currently
-   * has unread messages. Sent on every change, including cases where the messages were read from
-   * another of the user's sessions.
+   * has unread messages, and whether any of that unread state is urgent. Sent on every change,
+   * including cases where the messages were read from another of the user's sessions. Urgent means
+   * an unread message that demands attention: a channel message mentioning the user, or any unread
+   * whisper (whispers are inherently directed at the user).
    */
-  chatUnreadState: (data: { hasUnread: boolean }) => void
+  chatUnreadState: (data: { hasUnread: boolean; hasUnreadUrgent: boolean }) => void
 
   gameServerRegionsSetList: (regions: GameServerRegion[]) => void
 

--- a/migrations/20260830100000_channel_messages_mentions_index.sql
+++ b/migrations/20260830100000_channel_messages_mentions_index.sql
@@ -1,0 +1,4 @@
+-- no-transaction
+CREATE INDEX CONCURRENTLY channel_messages_mentions_idx
+  ON channel_messages (channel_id, sent DESC)
+  WHERE data ? 'mentions';

--- a/migrations/20260830100000_channel_messages_mentions_index.sql
+++ b/migrations/20260830100000_channel_messages_mentions_index.sql
@@ -1,4 +1,14 @@
 -- no-transaction
+
+-- Index to serve the latest-unread-mention subquery in server/lib/chat/chat-models.ts
+-- (getUnreadChannelInfo), which scans a channel's messages newest-first for ones whose `data`
+-- has a `mentions` key. Messages that mention someone are a small fraction of all chat messages,
+-- so a partial index keeps it cheap; the query's `m.data ? 'mentions'` predicate has to stay in
+-- sync with this index's WHERE clause for the planner to use it.
+--
+-- Builds CONCURRENTLY (hence `-- no-transaction`, since CREATE INDEX CONCURRENTLY can't run
+-- inside a transaction) to avoid locking out writes to `channel_messages` while it builds.
+
 CREATE INDEX CONCURRENTLY channel_messages_mentions_idx
   ON channel_messages (channel_id, sent DESC)
   WHERE data ? 'mentions';

--- a/migrations/20260830110000_backfill_whisper_last_read_time.sql
+++ b/migrations/20260830110000_backfill_whisper_last_read_time.sql
@@ -1,0 +1,11 @@
+-- For whisper sessions, a NULL last_read_time means "unread since the session started" (the
+-- recipient of a first-ever whisper has never had a chance to record a read position, and their
+-- unread badge must survive a restart). Existing rows predate that rule, so they're stamped as
+-- read-up-to-now once: without this, every conversation with any inbound message would surface an
+-- unread badge the first time its owner's client loads read state.
+--
+-- channel_users.last_read_time keeps NULL = "everything is read": channels record a read position
+-- on every visit, so NULL there only describes members who haven't viewed the channel at all yet.
+UPDATE whisper_sessions
+SET last_read_time = now()
+WHERE last_read_time IS NULL;

--- a/server/lib/chat/chat-models.ts
+++ b/server/lib/chat/chat-models.ts
@@ -23,6 +23,7 @@ import transact from '../db/transaction'
 import { Dbify } from '../db/types'
 import { getUrl } from '../files'
 import { findUsersByIdQuery } from '../users/user-model'
+import { MutualKind } from '../users/user-relationship-models'
 
 type DbUserChannelEntry = Dbify<UserChannelEntry & ChannelPreferences & ChannelPermissions>
 
@@ -723,24 +724,66 @@ export async function updateLastReadTime(
 }
 
 /**
- * Returns the IDs of a user's joined channels that have a text message sent by someone else after
- * their last recorded read position in that channel. A channel with no recorded read position
- * never counts as unread here, since there's nothing to compare newly-arrived messages against;
- * `markRead` establishes that baseline the first time a client reports one. Only text messages
- * count, mirroring the client's own `makeUnread` flag: join/leave/moderation events never mark a
- * channel unread. A single set-based query over all of the user's channels, rather than one query
- * per channel. `sent` columns store naive UTC wall time (see the timestamp parser setup in
- * `server/lib/db`), so the read position is converted to naive UTC for the comparison instead of
- * being left to the connection's session time zone. The comparison works at millisecond
- * granularity (`sent >= read + 1ms` rather than `sent > read`): read positions arrive as epoch
- * milliseconds while `sent` keeps microseconds, so a full-precision strict comparison would leave
- * the newest message permanently unread.
+ * A joined channel's unread state for a user, as returned by `getUnreadChannelInfo`.
  */
-export async function getUnreadChannels(userId: SbUserId): Promise<SbChannelId[]> {
+export interface UnreadChannelInfo {
+  channelId: SbChannelId
+  /**
+   * The time of the newest unread message that mentions the user and wasn't sent by someone
+   * they've blocked, or `undefined` if none of the channel's unread messages mention them.
+   */
+  latestMentionTime: Date | undefined
+}
+
+/**
+ * Returns unread state for each of a user's joined channels that has a text message sent by
+ * someone else after their last recorded read position in that channel. A channel with no
+ * recorded read position never counts as unread here, since there's nothing to compare
+ * newly-arrived messages against; `markRead` establishes that baseline the first time a client
+ * reports one. Only text messages count, mirroring the client's own `makeUnread` flag: join/leave/
+ * moderation events never mark a channel unread. A single set-based query over all of the user's
+ * channels, rather than one query per channel. `sent` columns store naive UTC wall time (see the
+ * timestamp parser setup in `server/lib/db`), so the read position is converted to naive UTC for
+ * the comparison instead of being left to the connection's session time zone. The comparison works
+ * at millisecond granularity (`sent >= read + 1ms` rather than `sent > read`): read positions
+ * arrive as epoch milliseconds while `sent` keeps microseconds, so a full-precision strict
+ * comparison would leave the newest message permanently unread.
+ *
+ * Alongside the unread predicate itself, this also computes the time of the newest unread message
+ * that mentions the user, ignoring mentions from users they've blocked (the live client applies the
+ * same block check before treating an incoming mention as urgent, so the seeded state has to agree
+ * with it). That subquery is served by the partial `channel_messages_mentions_idx` index, which
+ * only covers rows whose `data` has a `mentions` key; the `m.data ? 'mentions'` predicate below has
+ * to stay in sync with that index's `WHERE` clause for the index to actually get used.
+ */
+export async function getUnreadChannelInfo(userId: SbUserId): Promise<UnreadChannelInfo[]> {
   const { client, done } = await db()
   try {
-    const result = await client.query<{ channel_id: SbChannelId }>(sql`
-      SELECT cu.channel_id FROM channel_users cu
+    const result = await client.query<{
+      channel_id: SbChannelId
+      latest_mention_time: Date | null
+    }>(sql`
+      SELECT cu.channel_id, (
+        SELECT MAX(m.sent)
+        FROM channel_messages m
+        WHERE m.channel_id = cu.channel_id
+          AND m.user_id != cu.user_id
+          AND m.sent >= COALESCE(
+            (cu.last_read_time AT TIME ZONE 'UTC') + interval '1 millisecond',
+            'infinity'::timestamp
+          )
+          AND m.data ? 'mentions'
+          AND m.data->'mentions' @> to_jsonb(cu.user_id)
+          AND NOT EXISTS (
+            SELECT 1 FROM user_relationships r
+            WHERE r.user_low = LEAST(cu.user_id, m.user_id)
+              AND r.user_high = GREATEST(cu.user_id, m.user_id)
+              AND (r.kind = ${MutualKind.BlockBoth}
+                OR (cu.user_id < m.user_id AND r.kind = ${MutualKind.BlockLowToHigh})
+                OR (cu.user_id > m.user_id AND r.kind = ${MutualKind.BlockHighToLow}))
+          )
+      ) AS latest_mention_time
+      FROM channel_users cu
       WHERE cu.user_id = ${userId}
         AND EXISTS (
           SELECT 1 FROM channel_messages m
@@ -753,7 +796,10 @@ export async function getUnreadChannels(userId: SbUserId): Promise<SbChannelId[]
             AND m.data ->> 'type' = ${ServerChatMessageType.TextMessage}
         )
     `)
-    return result.rows.map(row => row.channel_id)
+    return result.rows.map(row => ({
+      channelId: row.channel_id,
+      latestMentionTime: row.latest_mention_time ?? undefined,
+    }))
   } finally {
     done()
   }

--- a/server/lib/chat/chat-service.test.ts
+++ b/server/lib/chat/chat-service.test.ts
@@ -54,7 +54,7 @@ import {
   getChannelInfos,
   getChannelsForUser,
   getMessagesForChannel,
-  getUnreadChannels,
+  getUnreadChannelInfo,
   getUserChannelEntriesForChannel,
   getUserChannelEntriesForUser,
   getUserChannelEntryForUser,
@@ -128,7 +128,7 @@ vi.mock('./chat-models', async () => {
   const originalModule = await vi.importActual<typeof import('./chat-models')>('./chat-models')
   return {
     getChannelsForUser: vi.fn().mockResolvedValue([]),
-    getUnreadChannels: vi.fn().mockResolvedValue([]),
+    getUnreadChannelInfo: vi.fn().mockResolvedValue([]),
     updateLastReadTime: vi.fn(),
     getUsersForChannel: vi.fn().mockResolvedValue([]),
     getUserChannelEntryForUser: vi.fn(),
@@ -563,12 +563,14 @@ describe('chat/chat-service', () => {
 
       asMockedFunction(getChannelsForUser).mockResolvedValue([user1ShieldBatteryChannelEntry])
       asMockedFunction(getChannelInfos).mockResolvedValue([shieldBatteryChannel])
-      asMockedFunction(getUnreadChannels).mockResolvedValue([shieldBatteryChannel.id])
+      asMockedFunction(getUnreadChannelInfo).mockResolvedValue([
+        { channelId: shieldBatteryChannel.id, latestMentionTime: undefined },
+      ])
 
       const result = await chatService.getJoinedChannels(user1.id)
 
       asMockedFunction(getChannelsForUser).mockResolvedValue([])
-      asMockedFunction(getUnreadChannels).mockResolvedValue([])
+      asMockedFunction(getUnreadChannelInfo).mockResolvedValue([])
 
       expect(result).toEqual([
         {
@@ -578,6 +580,40 @@ describe('chat/chat-service', () => {
           selfPreferences: channelPreferences,
           selfPermissions: channelPermissions,
           hasUnread: true,
+        },
+      ])
+    })
+
+    test('marks a channel with an unread mention', async () => {
+      await joinUserToChannel(
+        user1,
+        shieldBatteryChannel,
+        user1ShieldBatteryChannelEntry,
+        joinUser1ShieldBatteryChannelMessage,
+      )
+
+      const latestMentionTime = new Date(1577836800000)
+
+      asMockedFunction(getChannelsForUser).mockResolvedValue([user1ShieldBatteryChannelEntry])
+      asMockedFunction(getChannelInfos).mockResolvedValue([shieldBatteryChannel])
+      asMockedFunction(getUnreadChannelInfo).mockResolvedValue([
+        { channelId: shieldBatteryChannel.id, latestMentionTime },
+      ])
+
+      const result = await chatService.getJoinedChannels(user1.id)
+
+      asMockedFunction(getChannelsForUser).mockResolvedValue([])
+      asMockedFunction(getUnreadChannelInfo).mockResolvedValue([])
+
+      expect(result).toEqual([
+        {
+          channelInfo: shieldBatteryBasicInfo,
+          detailedChannelInfo: shieldBatteryDetailedInfo,
+          joinedChannelInfo: shieldBatteryJoinedInfo,
+          selfPreferences: channelPreferences,
+          selfPermissions: channelPermissions,
+          hasUnread: true,
+          latestMentionTime: latestMentionTime.getTime(),
         },
       ])
     })

--- a/server/lib/chat/chat-service.ts
+++ b/server/lib/chat/chat-service.ts
@@ -78,7 +78,7 @@ import {
   getChannelInfos,
   getChannelsForUser,
   getMessagesForChannel,
-  getUnreadChannels,
+  getUnreadChannelInfo,
   getUserChannelEntriesForChannel,
   getUserChannelEntriesForUser,
   getUserChannelEntryForUser,
@@ -152,17 +152,18 @@ export default class ChatService {
   }
 
   async getJoinedChannels(userId: SbUserId): Promise<InitialChannelData[]> {
-    const [joinedChannels, unreadChannels] = await Promise.all([
+    const [joinedChannels, unreadChannelInfo] = await Promise.all([
       getChannelsForUser(userId),
-      getUnreadChannels(userId),
+      getUnreadChannelInfo(userId),
     ])
     const channelInfos = await getChannelInfos(joinedChannels.map(c => c.channelId))
 
     const channelInfosMap = new global.Map(channelInfos.map(c => [c.id, c]))
-    const unreadChannelsSet = new global.Set(unreadChannels)
+    const unreadChannelsMap = new global.Map(unreadChannelInfo.map(c => [c.channelId, c]))
 
     return joinedChannels.map(c => {
       const channelInfo = channelInfosMap.get(c.channelId)!
+      const unreadInfo = unreadChannelsMap.get(c.channelId)
 
       return {
         channelInfo: toBasicChannelInfo(channelInfo),
@@ -170,8 +171,9 @@ export default class ChatService {
         joinedChannelInfo: toJoinedChannelInfo(channelInfo),
         selfPreferences: c.channelPreferences,
         selfPermissions: c.channelPermissions,
-        hasUnread: unreadChannelsSet.has(c.channelId),
+        hasUnread: unreadInfo !== undefined,
         lastReadTime: c.lastReadTime?.getTime(),
+        latestMentionTime: unreadInfo?.latestMentionTime?.getTime(),
       }
     })
   }
@@ -212,8 +214,8 @@ export default class ChatService {
       ])
 
       if (channelInfo && userChannelEntry) {
-        // `hasUnread`/`lastReadTime` are omitted: a membership this fresh has no recorded read
-        // position yet, which `getUnreadChannels` always treats as fully read.
+        // `hasUnread`/`lastReadTime`/`latestMentionTime` are omitted: a membership this fresh has
+        // no recorded read position yet, which `getUnreadChannelInfo` always treats as fully read.
         this.publisher.publish(getChannelUserPath(channelId, userSockets.userId), {
           action: 'init3',
           channelInfo: toBasicChannelInfo(channelInfo),

--- a/server/lib/users/user-relationship-models.ts
+++ b/server/lib/users/user-relationship-models.ts
@@ -26,7 +26,7 @@ import { Dbify } from '../db/types'
 // the external API here. Instead, those focus on particular actions (requesting/accepting requests,
 // removing friendship, blocking, etc.).
 
-enum MutualKind {
+export enum MutualKind {
   /**
    * Represents a mutual friend relationship between 2 users.
    */

--- a/server/lib/whispers/whisper-models.ts
+++ b/server/lib/whispers/whisper-models.ts
@@ -105,18 +105,22 @@ export async function updateLastReadTime(
 }
 
 /**
- * Returns the IDs of the target users in a user's whisper sessions that have a message from that
- * target after the user's last recorded read position for the session. A session with no recorded
- * read position never counts as unread here, since there's nothing to compare newly-arrived
- * messages against; `markRead` establishes that baseline the first time a client reports one.
+ * Returns the IDs of the target users in a user's whisper sessions that have an unread message
+ * from that target: one sent after the user's last recorded read position for the session, or —
+ * when no read position has been recorded yet — sent at or after the session started. A session
+ * row is created no later than the first message of a conversation (see `sendWhisperMessage`), so
+ * a conversation the user has never opened counts as unread from its very first message;
+ * `markRead` records a read position the first time a client reports one. Closing a session
+ * deletes its row (and read position), so a conversation re-opened by a later message only counts
+ * messages from the new `start_date` on — older history isn't resurrected as unread.
  * Every whisper message is a text message (`WhisperMessageData` has a single variant), so every
  * message from the target counts. A single set-based query over all of the user's sessions, rather
- * than one query per session. `sent` columns store naive UTC wall time (see the timestamp parser
- * setup in `server/lib/db`), so the read position is converted to naive UTC for the comparison
- * instead of being left to the connection's session time zone. The comparison works at millisecond
- * granularity (`sent >= read + 1ms` rather than `sent > read`): read positions arrive as epoch
- * milliseconds while `sent` keeps microseconds, so a full-precision strict comparison would leave
- * the newest message permanently unread.
+ * than one query per session. `sent` and `start_date` columns store naive UTC wall time (see the
+ * timestamp parser setup in `server/lib/db`), so the read position is converted to naive UTC for
+ * the comparison instead of being left to the connection's session time zone. The comparison works
+ * at millisecond granularity (`sent >= read + 1ms` rather than `sent > read`): read positions
+ * arrive as epoch milliseconds while `sent` keeps microseconds, so a full-precision strict
+ * comparison would leave the newest message permanently unread.
  */
 export async function getUnreadWhisperTargets(userId: SbUserId): Promise<SbUserId[]> {
   const { client, done } = await db()
@@ -131,7 +135,7 @@ export async function getUnreadWhisperTargets(userId: SbUserId): Promise<SbUserI
             AND m.from_id = ws.target_user_id
             AND m.sent >= COALESCE(
               (ws.last_read_time AT TIME ZONE 'UTC') + interval '1 millisecond',
-              'infinity'::timestamp
+              ws.start_date
             )
         )
     `)

--- a/server/lib/whispers/whisper-service.ts
+++ b/server/lib/whispers/whisper-service.ts
@@ -190,16 +190,21 @@ export default class WhisperService {
     const [processedText, userMentions, channelMentions] = await processMessageContents(text)
     const mentionedUserIds = userMentions.map(u => u.id)
     const mentionedChannelIds = channelMentions.map(c => c.id)
+
+    // Both session rows must exist before the message does: a session with no recorded read
+    // position counts messages from `start_date` on as unread (see `getUnreadWhisperTargets`), so
+    // a `start_date` that postdates the conversation's first message would hide that message from
+    // the recipient's unread state.
+    // TODO(tec27): This makes the start throttle rather useless, doesn't it? Think of a better way
+    // to throttle people starting tons of tons of sessions with different people
+    await dbStartWhisperSessionsBothDirections(user.id, target.id)
+
     const result = await addMessageToWhisper(user.id, target.id, {
       type: WhisperMessageType.TextMessage,
       text: processedText,
       mentions: mentionedUserIds.length > 0 ? mentionedUserIds : undefined,
       channelMentions: mentionedChannelIds.length > 0 ? mentionedChannelIds : undefined,
     })
-
-    // TODO(tec27): This makes the start throttle rather useless, doesn't it? Think of a better way
-    // to throttle people starting tons of tons of sessions with different people
-    await dbStartWhisperSessionsBothDirections(user.id, target.id)
     this.applyWhisperSessionState(user, target)
     this.applyWhisperSessionState(target, user)
 


### PR DESCRIPTION
Adds persistent, server-seeded mention unread state on top of the read-position work (#1438/#1440), and makes urgency survive restarts and sync across sessions.

## Server
- `getUnreadChannelInfo` (was `getUnreadChannels`) also returns `latestMentionTime` per unread channel: the newest unread message whose `mentions` JSONB contains the user, excluding senders the user has blocked (the live client path applies the same block check before treating a mention as urgent, so the seed has to agree).
- New partial index `channel_messages (channel_id, sent DESC) WHERE data ? 'mentions'` keeps that subquery from scanning non-mention rows; mention-carrying messages are sparse so the index stays tiny. EXPLAIN confirms the subquery uses it.
- `InitialChannelData.latestMentionTime?: number` is the only wire addition. No new events: live updates ride the existing `message2` (which already carries resolved `mentions`) and `lastReadTimeChanged`.

## Client
- New per-channel fact `idToLatestMentionTime`; mention unreadness is **derived** (`latestMentionTime > lastReadTime`, suppressed while activated) via `channelHasUnreadMention`. There is no boolean flag and no clear logic: any read-position advance (own session or another of the user's sessions) clears it automatically, and the derived state cannot diverge from what the server would seed after a restart. A channel with no recorded read position derives false, mirroring the server's NULL-`last_read_time` rule.
- `message2` handling passes `mentionsSelf` (existing self-mention + not-blocked check) into the reducer, which maxes the fact forward.

## UI
- Social sidebar: the attention dot renders in `--theme-error` for channels with unread mentions and for unread whispers (a whisper is inherently directed at the user - same rule the transient tray path already applied). The sidebar toggle button dot does the same.
- Tray: `chatUnreadState` IPC now carries `hasUnreadUrgent`; the tray composes it as a tracked-urgent level (urgent > unread > normal), so the urgent icon persists until the messages are actually read instead of clearing on window focus. `flashFrame` stays transient-only, so nothing flashes at boot from old unread state.

## Verification
- Unit: reducer/helper tests for seeding, maxing, derived clears, activation suppression, no-read-position rule, leave cleanup; service test for `latestMentionTime` propagation. Full suite green (2232 tests), lint + typecheck clean.
- Live (browser sessions vs real server): mention -> red channel dot + seeded state identical after full reload; read in one session cleared the badge in the idle session via the published read position; whisper unread -> red dot, read whisper -> none; block relationship hides the mention from the seed (SQL-verified in a rolled-back transaction).
- Live (real Electron app): logging in with a seeded unread whisper set the urgent tray icon immediately; reading it from a *browser* session dropped the app tray to normal within seconds; a channel mention with no session viewing the channel held the urgent icon; a mention while another session sat in the channel flipped urgent->normal in 20ms as that session's instant mark-read propagated (correct behavior, observed live).

Follow-up candidates (not in this PR): mention *counts* (Discord-style pill) if wanted, and jump-to-mention once F2 fetch-around lands.