### PR TITLE
Add a detachable message window with two-sided chat loading

### DIFF
--- a/client/chat/action-creators.ts
+++ b/client/chat/action-creators.ts
@@ -41,7 +41,13 @@ import { RequestCoalescer } from '../network/request-coalescer'
 import { RootState } from '../root-reducer'
 import { externalShowSnackbar } from '../snackbars/snackbar-controller-registry'
 import { DURATION_LONG } from '../snackbars/snackbar-durations'
-import { ActivateChannel, DeactivateChannel, UpdateChannelAtBottom } from './actions'
+import {
+  ActivateChannel,
+  DeactivateChannel,
+  ResetMessageWindow,
+  UpdateChannelAtBottom,
+} from './actions'
+import { newestServerOriginTime } from './chat-reducer'
 
 export function getJoinedChannels(spec: RequestHandlingSpec<void>): ThunkAction {
   return abortableThunk(spec, async dispatch => {
@@ -383,7 +389,12 @@ export function getMessageHistory(channelId: SbChannelId, limit: number): ThunkA
     const earliestMessageTime = channelMessages?.messages.length
       ? channelMessages.messages[0].time
       : -1
-    const params = { channelId, limit, beforeTime: earliestMessageTime }
+    const params = {
+      channelId,
+      limit,
+      beforeTime: earliestMessageTime,
+      windowGen: channelMessages?.windowGen ?? 0,
+    }
 
     dispatch({
       type: '@chat/loadMessageHistoryBegin',
@@ -397,6 +408,114 @@ export function getMessageHistory(channelId: SbChannelId, limit: number): ThunkA
       ),
       meta: params,
     })
+  }
+}
+
+/**
+ * Loads the page of messages that follows the newest one currently loaded for a channel, moving a
+ * window that sits behind the present a page closer to it. Does nothing if the channel holds no
+ * message with a server-recorded time, since there'd be nothing the server could seek from.
+ */
+export function getNewerMessages(channelId: SbChannelId, limit: number): ThunkAction {
+  return (dispatch, getStore) => {
+    const {
+      chat: { idToMessages },
+    } = getStore()
+    const channelMessages = idToMessages.get(channelId)
+    if (!channelMessages) {
+      return
+    }
+
+    const afterTime = newestServerOriginTime(channelMessages.messages)
+    if (afterTime === undefined) {
+      return
+    }
+
+    const params = {
+      channelId,
+      limit,
+      afterTime,
+      windowGen: channelMessages.windowGen,
+      knownNewestTime: Math.max(afterTime, channelMessages.detachedNewestTime ?? -Infinity),
+    }
+
+    dispatch({
+      type: '@chat/loadNewerMessagesBegin',
+      payload: params,
+    })
+    dispatch({
+      type: '@chat/loadNewerMessages',
+      payload: fetchJson<GetChannelHistoryServerResponse>(
+        apiUrl`chat/${channelId}/messages2?limit=${limit}&afterTime=${afterTime}`,
+        { method: 'GET' },
+      ),
+      meta: params,
+    })
+  }
+}
+
+/**
+ * Loads a window of messages centered on `aroundTime`, replacing whatever is currently loaded for
+ * the channel. This is how the client reaches a position that isn't adjacent to what it holds, such
+ * as an unread divider that sits further back than the loaded history reaches.
+ */
+export function getMessagesAround(
+  channelId: SbChannelId,
+  limit: number,
+  aroundTime: number,
+): ThunkAction {
+  return (dispatch, getStore) => {
+    const {
+      chat: { idToMessages },
+    } = getStore()
+    const channelMessages = idToMessages.get(channelId)
+    if (!channelMessages) {
+      return
+    }
+
+    const knownNewest = Math.max(
+      newestServerOriginTime(channelMessages.messages) ?? -Infinity,
+      channelMessages.detachedNewestTime ?? -Infinity,
+    )
+    const params = {
+      channelId,
+      limit,
+      aroundTime,
+      windowGen: channelMessages.windowGen,
+      knownNewestTime: knownNewest === -Infinity ? undefined : knownNewest,
+    }
+
+    dispatch({
+      type: '@chat/loadMessagesAroundBegin',
+      payload: params,
+    })
+    dispatch({
+      type: '@chat/loadMessagesAround',
+      payload: fetchJson<GetChannelHistoryServerResponse>(
+        apiUrl`chat/${channelId}/messages2?limit=${limit}&aroundTime=${aroundTime}`,
+        { method: 'GET' },
+      ),
+      meta: params,
+    })
+  }
+}
+
+export function resetMessageWindow(channelId: SbChannelId): ResetMessageWindow {
+  return {
+    type: '@chat/resetMessageWindow',
+    payload: { channelId },
+  }
+}
+
+/**
+ * Returns a channel's message list to the present, however far back it was left. The loaded window
+ * is dropped and the newest page requested in the same tick, so the list never renders an empty
+ * channel in between.
+ */
+export function jumpToPresent(channelId: SbChannelId, limit: number): ThunkAction {
+  return dispatch => {
+    dispatch(resetMessageWindow(channelId))
+    dispatch(getMessageHistory(channelId, limit))
   }
 }
 

--- a/client/chat/actions.ts
+++ b/client/chat/actions.ts
@@ -38,6 +38,13 @@ export type ChatActions =
   | LoadMessageHistoryBegin
   | LoadMessageHistory
   | LoadMessageHistoryFailure
+  | LoadNewerMessagesBegin
+  | LoadNewerMessages
+  | LoadNewerMessagesFailure
+  | LoadMessagesAroundBegin
+  | LoadMessagesAround
+  | LoadMessagesAroundFailure
+  | ResetMessageWindow
   | RetrieveUserListBegin
   | RetrieveUserList
   | RetrieveUserListFailure
@@ -161,6 +168,12 @@ export interface LoadMessageHistoryBegin {
     channelId: SbChannelId
     limit: number
     beforeTime: number
+    /**
+     * The generation of the loaded message window this page was requested for. The reducer drops
+     * pages whose generation no longer matches the channel's, since a window that has since been
+     * replaced or dropped shares no boundary with them.
+     */
+    windowGen: number
   }
 }
 
@@ -174,6 +187,7 @@ export interface LoadMessageHistory {
     channelId: SbChannelId
     limit: number
     beforeTime: number
+    windowGen: number
   }
   error?: false
 }
@@ -183,6 +197,135 @@ export interface LoadMessageHistoryFailure extends BaseFetchFailure<'@chat/loadM
     channelId: SbChannelId
     limit: number
     beforeTime: number
+    windowGen: number
+  }
+}
+
+export interface LoadNewerMessagesBegin {
+  type: '@chat/loadNewerMessagesBegin'
+  payload: {
+    channelId: SbChannelId
+    limit: number
+    afterTime: number
+    windowGen: number
+    /**
+     * The newest server-recorded message time (epoch ms) this client knew existed when the request
+     * was dispatched, whether loaded or only observed live. Responses that report nothing newer are
+     * authoritative for messages known this early — the server announces messages only after
+     * storing them — so their absence proves deletion rather than a race.
+     */
+    knownNewestTime: number
+  }
+}
+
+/**
+ * Loads the `limit` oldest messages in a chat channel that are newer than a particular time,
+ * extending a loaded window that sits behind the present toward it.
+ */
+export interface LoadNewerMessages {
+  type: '@chat/loadNewerMessages'
+  payload: GetChannelHistoryServerResponse
+  meta: {
+    channelId: SbChannelId
+    limit: number
+    afterTime: number
+    windowGen: number
+    /**
+     * The newest server-recorded message time (epoch ms) this client knew existed when the request
+     * was dispatched, whether loaded or only observed live. Responses that report nothing newer are
+     * authoritative for messages known this early — the server announces messages only after
+     * storing them — so their absence proves deletion rather than a race.
+     */
+    knownNewestTime: number
+  }
+  error?: false
+}
+
+export interface LoadNewerMessagesFailure extends BaseFetchFailure<'@chat/loadNewerMessages'> {
+  meta: {
+    channelId: SbChannelId
+    limit: number
+    afterTime: number
+    windowGen: number
+    /**
+     * The newest server-recorded message time (epoch ms) this client knew existed when the request
+     * was dispatched, whether loaded or only observed live. Responses that report nothing newer are
+     * authoritative for messages known this early — the server announces messages only after
+     * storing them — so their absence proves deletion rather than a race.
+     */
+    knownNewestTime: number
+  }
+}
+
+export interface LoadMessagesAroundBegin {
+  type: '@chat/loadMessagesAroundBegin'
+  payload: {
+    channelId: SbChannelId
+    limit: number
+    aroundTime: number
+    windowGen: number
+    /**
+     * The newest server-recorded message time (epoch ms) this client knew existed when the request
+     * was dispatched, whether loaded or only observed live, or `undefined` when it knew of none.
+     * Responses that report nothing newer are authoritative for messages known this early — the
+     * server announces messages only after storing them — so their absence proves deletion rather
+     * than a race.
+     */
+    knownNewestTime: number | undefined
+  }
+}
+
+/**
+ * Loads a window of up to `limit` messages in a chat channel centered on a particular time. The
+ * result replaces whatever was loaded for the channel, since the fetched range doesn't have to
+ * touch it.
+ */
+export interface LoadMessagesAround {
+  type: '@chat/loadMessagesAround'
+  payload: GetChannelHistoryServerResponse
+  meta: {
+    channelId: SbChannelId
+    limit: number
+    aroundTime: number
+    windowGen: number
+    /**
+     * The newest server-recorded message time (epoch ms) this client knew existed when the request
+     * was dispatched, whether loaded or only observed live, or `undefined` when it knew of none.
+     * Responses that report nothing newer are authoritative for messages known this early — the
+     * server announces messages only after storing them — so their absence proves deletion rather
+     * than a race.
+     */
+    knownNewestTime: number | undefined
+  }
+  error?: false
+}
+
+export interface LoadMessagesAroundFailure extends BaseFetchFailure<'@chat/loadMessagesAround'> {
+  meta: {
+    channelId: SbChannelId
+    limit: number
+    aroundTime: number
+    windowGen: number
+    /**
+     * The newest server-recorded message time (epoch ms) this client knew existed when the request
+     * was dispatched, whether loaded or only observed live, or `undefined` when it knew of none.
+     * Responses that report nothing newer are authoritative for messages known this early — the
+     * server announces messages only after storing them — so their absence proves deletion rather
+     * than a race.
+     */
+    knownNewestTime: number | undefined
+  }
+}
+
+/**
+ * Discard everything loaded for a chat channel, returning it to the state a freshly-joined channel
+ * is in: nothing loaded, older history assumed to exist, and attached to the present so live
+ * messages append again.
+ */
+export interface ResetMessageWindow {
+  type: '@chat/resetMessageWindow'
+  payload: {
+    channelId: SbChannelId
   }
 }
 

--- a/client/chat/channel.tsx
+++ b/client/chat/channel.tsx
@@ -28,6 +28,9 @@ import {
   getChannelInfo,
   getChannelLastReadKey,
   getMessageHistory,
+  getMessagesAround,
+  getNewerMessages,
+  jumpToPresent,
   leaveChannelWithConfirmation,
   markChannelRead,
   retrieveUserList,
@@ -266,6 +269,20 @@ export function ConnectedChatChannel({
     dispatch(getMessageHistory(channelId, MESSAGES_LIMIT)),
   )
 
+  const onLoadNewerMessages = () => {
+    dispatch(getNewerMessages(channelId, MESSAGES_LIMIT))
+  }
+
+  const onJumpToPresent = () => {
+    dispatch(jumpToPresent(channelId, MESSAGES_LIMIT))
+  }
+
+  const onSeekToUnread = () => {
+    if (unreadLineTime !== undefined) {
+      dispatch(getMessagesAround(channelId, MESSAGES_LIMIT, unreadLineTime))
+    }
+  }
+
   const onAtBottomChange = (atBottom: boolean) => {
     dispatch(updateChannelAtBottom(channelId, atBottom))
   }
@@ -287,9 +304,12 @@ export function ConnectedChatChannel({
               messages: channelMessages?.messages ?? [],
               loading: channelMessages?.loadingHistory,
               hasMoreHistory: channelMessages?.hasHistory,
+              loadingNewer: channelMessages?.loadingNewer,
+              hasNewerMessages: channelMessages?.hasNewer,
               refreshToken: channelId,
               MessageComponent: ChannelMessage,
               onLoadMoreMessages,
+              onLoadNewerMessages,
               unreadLineTime,
             }}
             inputProps={{
@@ -299,6 +319,8 @@ export function ConnectedChatChannel({
               baseMentionableUsers,
             }}
             onAtBottomChange={onAtBottomChange}
+            onJumpToPresent={onJumpToPresent}
+            onSeekToUnread={onSeekToUnread}
             header={
               // These are basically guaranteed to be defined here, but still doing the check instead
               // of asserting them with ! because better to be safe than sorry, or something.

--- a/client/chat/channel.tsx
+++ b/client/chat/channel.tsx
@@ -306,6 +306,7 @@ export function ConnectedChatChannel({
               hasMoreHistory: channelMessages?.hasHistory,
               loadingNewer: channelMessages?.loadingNewer,
               hasNewerMessages: channelMessages?.hasNewer,
+              windowGeneration: channelMessages?.windowGen,
               refreshToken: channelId,
               MessageComponent: ChannelMessage,
               onLoadMoreMessages,

--- a/client/chat/chat-reducer.test.ts
+++ b/client/chat/chat-reducer.test.ts
@@ -6,9 +6,11 @@ import {
   ChatMessage,
   ChatMessageEvent,
   ClientChatMessageType,
+  GetChannelHistoryServerResponse,
   InitialChannelData,
   SbChannelId,
   SelfJoinChannelMessage,
+  ServerChatMessage,
   ServerChatMessageType,
   makeSbChannelId,
 } from '../../common/chat'
@@ -53,10 +55,17 @@ function makeState(
   overrides: {
     messages?: ChatMessage[]
     activated?: boolean
+    atBottom?: boolean
     unread?: boolean
     lastReadTime?: number
     latestMentionTime?: number
     unreadLineTime?: number
+    hasHistory?: boolean
+    loadingHistory?: boolean
+    loadingNewer?: boolean
+    hasNewer?: boolean
+    detachedNewestTime?: number
+    windowGen?: number
   } = {},
 ): Immutable<ChatState> {
   const state: ChatState = {
@@ -66,13 +75,24 @@ function makeState(
     idToJoinedInfo: new Map(),
     idToUsers: new Map(),
     idToMessages: new Map([
-      [CHANNEL_ID, { messages: overrides.messages ?? [], loadingHistory: false, hasHistory: true }],
+      [
+        CHANNEL_ID,
+        {
+          messages: overrides.messages ?? [],
+          loadingHistory: overrides.loadingHistory ?? false,
+          hasHistory: overrides.hasHistory ?? true,
+          loadingNewer: overrides.loadingNewer ?? false,
+          hasNewer: overrides.hasNewer ?? false,
+          detachedNewestTime: overrides.detachedNewestTime,
+          windowGen: overrides.windowGen ?? 0,
+        },
+      ],
     ]),
     idToUserProfiles: new Map(),
     idToSelfPreferences: new Map(),
     idToSelfPermissions: new Map(),
     activatedChannels: new Set(overrides.activated ? [CHANNEL_ID] : []),
-    atBottomChannels: new Set(),
+    atBottomChannels: new Set(overrides.atBottom ? [CHANNEL_ID] : []),
     unreadChannels: new Set(overrides.unread ? [CHANNEL_ID] : []),
     deletedChannels: new Set(),
     idToLastReadTime: new Map(
@@ -149,6 +169,98 @@ function updateLeaveSelfAction(): ChatActions {
     type: '@chat/updateLeaveSelf',
     meta: { channelId: CHANNEL_ID },
   }
+}
+
+const HISTORY_LIMIT = 50
+
+function historyResponse(
+  messages: ServerChatMessage[],
+  {
+    hasMoreBefore = true,
+    hasMoreAfter = true,
+  }: { hasMoreBefore?: boolean; hasMoreAfter?: boolean } = {},
+): GetChannelHistoryServerResponse {
+  return {
+    messages,
+    users: [],
+    mentions: [],
+    channelMentions: [],
+    deletedChannels: [],
+    hasMoreBefore,
+    hasMoreAfter,
+  }
+}
+
+function loadMessageHistoryAction(
+  payload: GetChannelHistoryServerResponse,
+  { windowGen = 0, beforeTime = -1 }: { windowGen?: number; beforeTime?: number } = {},
+): ChatActions {
+  return {
+    type: '@chat/loadMessageHistory',
+    payload,
+    meta: { channelId: CHANNEL_ID, limit: HISTORY_LIMIT, beforeTime, windowGen },
+  }
+}
+
+function loadNewerMessagesAction(
+  payload: GetChannelHistoryServerResponse,
+  {
+    windowGen = 0,
+    afterTime = 0,
+    knownNewestTime = afterTime,
+  }: { windowGen?: number; afterTime?: number; knownNewestTime?: number } = {},
+): ChatActions {
+  return {
+    type: '@chat/loadNewerMessages',
+    payload,
+    meta: { channelId: CHANNEL_ID, limit: HISTORY_LIMIT, afterTime, windowGen, knownNewestTime },
+  }
+}
+
+function loadMessagesAroundAction(
+  payload: GetChannelHistoryServerResponse,
+  {
+    windowGen = 0,
+    aroundTime = 0,
+    knownNewestTime,
+  }: { windowGen?: number; aroundTime?: number; knownNewestTime?: number } = {},
+): ChatActions {
+  return {
+    type: '@chat/loadMessagesAround',
+    payload,
+    meta: { channelId: CHANNEL_ID, limit: HISTORY_LIMIT, aroundTime, windowGen, knownNewestTime },
+  }
+}
+
+function resetMessageWindowAction(): ChatActions {
+  return {
+    type: '@chat/resetMessageWindow',
+    payload: { channelId: CHANNEL_ID },
+  }
+}
+
+function deactivateChannelAction(): ChatActions {
+  return {
+    type: '@chat/deactivateChannel',
+    payload: { channelId: CHANNEL_ID },
+  }
+}
+
+function windowOf(state: Immutable<ChatState>) {
+  return state.idToMessages.get(CHANNEL_ID)!
+}
+
+function messageIdsOf(state: Immutable<ChatState>): string[] {
+  return windowOf(state).messages.map(m => m.id)
+}
+
+/** Rewrites a request action into the rejected form the promise middleware dispatches. */
+function asFailure(action: ChatActions): ChatActions {
+  return {
+    ...action,
+    payload: new Error('request failed'),
+    error: true,
+  } as unknown as ChatActions
 }
 
 describe('client/chat/chat-reducer', () => {
@@ -358,6 +470,441 @@ describe('client/chat/chat-reducer', () => {
       const result = chatReducer(state, updateLeaveSelfAction())
 
       expect(result.idToLatestMentionTime.has(CHANNEL_ID)).toBe(false)
+    })
+  })
+
+  describe('@chat/loadMessageHistory', () => {
+    test('takes the older edge straight from the response instead of inferring it', () => {
+      const state = makeState()
+
+      // A short page that nonetheless has more behind it: the count says nothing about the edge.
+      const result = chatReducer(
+        state,
+        loadMessageHistoryAction(historyResponse([textMessage(100)], { hasMoreBefore: true })),
+      )
+
+      expect(windowOf(result).hasHistory).toBe(true)
+      expect(windowOf(result).loadingHistory).toBe(false)
+    })
+
+    test('clears the older edge when the response says there is nothing more', () => {
+      const state = makeState()
+
+      const result = chatReducer(
+        state,
+        loadMessageHistoryAction(historyResponse([textMessage(100)], { hasMoreBefore: false })),
+      )
+
+      expect(windowOf(result).hasHistory).toBe(false)
+    })
+
+    test('drops messages the window already holds at the seam', () => {
+      const state = makeState({ messages: [textMessage(100), textMessage(200)] })
+
+      const result = chatReducer(
+        state,
+        loadMessageHistoryAction(historyResponse([textMessage(50), textMessage(100)])),
+      )
+
+      expect(messageIdsOf(result)).toEqual(['text-50', 'text-100', 'text-200'])
+    })
+
+    test('ignores a page fetched for a window that has since been replaced', () => {
+      const state = makeState({ messages: [textMessage(200)], windowGen: 3 })
+
+      const result = chatReducer(
+        state,
+        loadMessageHistoryAction(historyResponse([textMessage(100)], { hasMoreBefore: false }), {
+          windowGen: 2,
+        }),
+      )
+
+      expect(messageIdsOf(result)).toEqual(['text-200'])
+      expect(windowOf(result).hasHistory).toBe(true)
+    })
+
+    test('a failed page clears the loading flag without touching the window', () => {
+      const state = makeState({ messages: [textMessage(200)], loadingHistory: true })
+
+      const result = chatReducer(state, asFailure(loadMessageHistoryAction(historyResponse([]))))
+
+      expect(windowOf(result).loadingHistory).toBe(false)
+      expect(messageIdsOf(result)).toEqual(['text-200'])
+      expect(windowOf(result).hasHistory).toBe(true)
+    })
+  })
+
+  describe('@chat/loadMessagesAround', () => {
+    test('replaces the window and detaches it from the present', () => {
+      const state = makeState({
+        messages: [textMessage(900), selfJoinMessage(950)],
+        loadingHistory: true,
+        loadingNewer: true,
+      })
+
+      const result = chatReducer(
+        state,
+        loadMessagesAroundAction(
+          historyResponse([textMessage(100), textMessage(200)], {
+            hasMoreBefore: true,
+            hasMoreAfter: true,
+          }),
+          { aroundTime: 150 },
+        ),
+      )
+
+      const window = windowOf(result)
+      expect(messageIdsOf(result)).toEqual(['text-100', 'text-200'])
+      expect(window.hasHistory).toBe(true)
+      expect(window.hasNewer).toBe(true)
+      expect(window.loadingHistory).toBe(false)
+      expect(window.loadingNewer).toBe(false)
+      expect(window.windowGen).toBe(1)
+    })
+
+    test('lands attached when the fetched window reaches the newest message', () => {
+      const state = makeState({ hasNewer: true, detachedNewestTime: 500 })
+
+      const result = chatReducer(
+        state,
+        loadMessagesAroundAction(
+          historyResponse([textMessage(400), textMessage(500)], {
+            hasMoreBefore: false,
+            hasMoreAfter: false,
+          }),
+        ),
+      )
+
+      expect(windowOf(result).hasNewer).toBe(false)
+      expect(windowOf(result).hasHistory).toBe(false)
+      expect(windowOf(result).detachedNewestTime).toBeUndefined()
+    })
+
+    test('stays detached when a message arrived while the request was in flight', () => {
+      // The window held messages up to 500 when the request was dispatched (knownNewestTime), and
+      // another message arrived at 600 before the response landed, so the replacement window ending
+      // at 200 cannot have caught the present even though the server saw nothing newer.
+      const state = makeState({ messages: [textMessage(500), textMessage(600)] })
+
+      const result = chatReducer(
+        state,
+        loadMessagesAroundAction(
+          historyResponse([textMessage(100), textMessage(200)], {
+            hasMoreBefore: true,
+            hasMoreAfter: false,
+          }),
+          { aroundTime: 150, knownNewestTime: 500 },
+        ),
+      )
+
+      const window = windowOf(result)
+      expect(messageIdsOf(result)).toEqual(['text-100', 'text-200'])
+      expect(window.hasNewer).toBe(true)
+      expect(window.detachedNewestTime).toBe(600)
+    })
+
+    test('lands attached when everything past the window was already known at dispatch', () => {
+      // The newest loaded message (600) was known when the request was dispatched, so the server
+      // not returning anything newer than 200 means the newer messages have been deleted.
+      const state = makeState({ messages: [textMessage(500), textMessage(600)] })
+
+      const result = chatReducer(
+        state,
+        loadMessagesAroundAction(
+          historyResponse([textMessage(100), textMessage(200)], {
+            hasMoreBefore: true,
+            hasMoreAfter: false,
+          }),
+          { aroundTime: 150, knownNewestTime: 600 },
+        ),
+      )
+
+      const window = windowOf(result)
+      expect(window.hasNewer).toBe(false)
+      expect(window.detachedNewestTime).toBeUndefined()
+    })
+
+    test('ignores a response fetched for a window that has since been replaced', () => {
+      const state = makeState({ messages: [textMessage(900)], windowGen: 2 })
+
+      const result = chatReducer(
+        state,
+        loadMessagesAroundAction(historyResponse([textMessage(100)]), { windowGen: 1 }),
+      )
+
+      expect(messageIdsOf(result)).toEqual(['text-900'])
+      expect(windowOf(result).windowGen).toBe(2)
+    })
+  })
+
+  describe('a detached message window', () => {
+    test('does not append a live message, but records how far the present has run ahead', () => {
+      const state = makeState({ hasNewer: true, messages: [textMessage(100)] })
+
+      const result = chatReducer(state, updateMessageAction(500, false))
+
+      expect(messageIdsOf(result)).toEqual(['text-100'])
+      expect(windowOf(result).detachedNewestTime).toBe(500)
+    })
+
+    test('keeps the newest time when an older message arrives afterwards', () => {
+      const state = makeState({ hasNewer: true, detachedNewestTime: 500 })
+
+      const result = chatReducer(state, updateMessageAction(400, false))
+
+      expect(windowOf(result).detachedNewestTime).toBe(500)
+    })
+
+    test('a live message still marks the channel unread and records a mention', () => {
+      const state = makeState({ hasNewer: true })
+
+      const result = chatReducer(state, updateMessageAction(500, true))
+
+      expect(result.unreadChannels.has(CHANNEL_ID)).toBe(true)
+      expect(result.idToLatestMentionTime.get(CHANNEL_ID)).toBe(500)
+    })
+
+    test('a live message freezes the unread divider even at the bottom of the loaded window', () => {
+      const state = makeState({
+        hasNewer: true,
+        activated: true,
+        atBottom: true,
+        lastReadTime: 100,
+      })
+
+      const result = chatReducer(state, updateMessageAction(500, false))
+
+      expect(result.idToUnreadLineTime.get(CHANNEL_ID)).toBe(100)
+    })
+
+    test('an attached channel at the bottom does not freeze the divider', () => {
+      const state = makeState({ activated: true, atBottom: true, lastReadTime: 100 })
+
+      const result = chatReducer(state, updateMessageAction(500, false))
+
+      expect(result.idToUnreadLineTime.has(CHANNEL_ID)).toBe(false)
+    })
+
+    test('is never trimmed while it grows, even when the view is at the bottom of it', () => {
+      const messages = Array.from({ length: 200 }, (_, i) => textMessage(i + 1))
+      const state = makeState({
+        hasNewer: true,
+        activated: true,
+        atBottom: true,
+        messages,
+      })
+
+      const result = chatReducer(
+        state,
+        loadNewerMessagesAction(historyResponse([textMessage(1000)]), { afterTime: 200 }),
+      )
+
+      expect(windowOf(result).messages.length).toBe(201)
+    })
+
+    test('is not trimmed when the view returns to the bottom of it', () => {
+      const messages = Array.from({ length: 200 }, (_, i) => textMessage(i + 1))
+      const state = makeState({ hasNewer: true, activated: true, messages })
+
+      const result = chatReducer(state, {
+        type: '@chat/updateChannelAtBottom',
+        payload: { channelId: CHANNEL_ID, atBottom: true },
+      })
+
+      expect(windowOf(result).messages.length).toBe(200)
+    })
+  })
+
+  describe('@chat/loadNewerMessages', () => {
+    test('appends the page and reattaches once the server has nothing newer', () => {
+      const state = makeState({ hasNewer: true, messages: [textMessage(100)] })
+
+      const result = chatReducer(
+        state,
+        loadNewerMessagesAction(historyResponse([textMessage(200)], { hasMoreAfter: false }), {
+          afterTime: 100,
+        }),
+      )
+
+      expect(messageIdsOf(result)).toEqual(['text-100', 'text-200'])
+      expect(windowOf(result).hasNewer).toBe(false)
+      expect(windowOf(result).loadingNewer).toBe(false)
+    })
+
+    test('drops messages the window already holds at the seam', () => {
+      const state = makeState({ hasNewer: true, messages: [textMessage(100), textMessage(200)] })
+
+      const result = chatReducer(
+        state,
+        loadNewerMessagesAction(historyResponse([textMessage(200), textMessage(300)])),
+      )
+
+      expect(messageIdsOf(result)).toEqual(['text-100', 'text-200', 'text-300'])
+    })
+
+    test('stays detached while the server still has newer messages', () => {
+      const state = makeState({ hasNewer: true, messages: [textMessage(100)] })
+
+      const result = chatReducer(
+        state,
+        loadNewerMessagesAction(historyResponse([textMessage(200)], { hasMoreAfter: true })),
+      )
+
+      expect(windowOf(result).hasNewer).toBe(true)
+    })
+
+    test('stays detached when a message arrived past the end of the final page', () => {
+      const state = makeState({
+        hasNewer: true,
+        detachedNewestTime: 300,
+        messages: [textMessage(100)],
+      })
+
+      const result = chatReducer(
+        state,
+        loadNewerMessagesAction(historyResponse([textMessage(200)], { hasMoreAfter: false })),
+      )
+
+      expect(windowOf(result).hasNewer).toBe(true)
+      expect(windowOf(result).detachedNewestTime).toBe(300)
+    })
+
+    test('reattaches when the awaited message was already known at dispatch (deleted)', () => {
+      const state = makeState({
+        hasNewer: true,
+        detachedNewestTime: 300,
+        messages: [textMessage(100)],
+      })
+
+      const result = chatReducer(
+        state,
+        loadNewerMessagesAction(historyResponse([textMessage(200)], { hasMoreAfter: false }), {
+          afterTime: 100,
+          knownNewestTime: 300,
+        }),
+      )
+
+      expect(windowOf(result).hasNewer).toBe(false)
+      expect(windowOf(result).detachedNewestTime).toBeUndefined()
+    })
+
+    test('reattaches once the window catches up to what arrived while detached', () => {
+      const state = makeState({
+        hasNewer: true,
+        detachedNewestTime: 300,
+        messages: [textMessage(100)],
+      })
+
+      const result = chatReducer(
+        state,
+        loadNewerMessagesAction(
+          historyResponse([textMessage(200), textMessage(300)], {
+            hasMoreAfter: false,
+          }),
+        ),
+      )
+
+      expect(windowOf(result).hasNewer).toBe(false)
+      expect(windowOf(result).detachedNewestTime).toBeUndefined()
+    })
+
+    test('ignores a page fetched for a window that has since been replaced', () => {
+      const state = makeState({
+        hasNewer: true,
+        windowGen: 4,
+        loadingNewer: true,
+        messages: [textMessage(100)],
+      })
+
+      const result = chatReducer(
+        state,
+        loadNewerMessagesAction(historyResponse([textMessage(200)], { hasMoreAfter: false }), {
+          windowGen: 3,
+        }),
+      )
+
+      expect(messageIdsOf(result)).toEqual(['text-100'])
+      expect(windowOf(result).hasNewer).toBe(true)
+      expect(windowOf(result).loadingNewer).toBe(true)
+    })
+
+    test('a failed page clears the loading flag and leaves the window detached', () => {
+      const state = makeState({ hasNewer: true, loadingNewer: true, messages: [textMessage(100)] })
+
+      const result = chatReducer(state, asFailure(loadNewerMessagesAction(historyResponse([]))))
+
+      expect(windowOf(result).loadingNewer).toBe(false)
+      expect(windowOf(result).hasNewer).toBe(true)
+      expect(messageIdsOf(result)).toEqual(['text-100'])
+    })
+  })
+
+  describe('@chat/resetMessageWindow', () => {
+    test('empties the window and returns it to the present', () => {
+      const state = makeState({
+        messages: [textMessage(100)],
+        hasHistory: false,
+        hasNewer: true,
+        detachedNewestTime: 500,
+        loadingNewer: true,
+        windowGen: 2,
+      })
+
+      const result = chatReducer(state, resetMessageWindowAction())
+
+      const window = windowOf(result)
+      expect(window.messages).toEqual([])
+      expect(window.hasHistory).toBe(true)
+      expect(window.hasNewer).toBe(false)
+      expect(window.detachedNewestTime).toBeUndefined()
+      expect(window.loadingNewer).toBe(false)
+      expect(window.windowGen).toBe(3)
+    })
+  })
+
+  describe('@chat/deactivateChannel', () => {
+    test('drops a detached window entirely', () => {
+      const messages = Array.from({ length: 200 }, (_, i) => textMessage(i + 1))
+      const state = makeState({
+        activated: true,
+        hasNewer: true,
+        detachedNewestTime: 500,
+        messages,
+      })
+
+      const result = chatReducer(state, deactivateChannelAction())
+
+      const window = windowOf(result)
+      expect(window.messages).toEqual([])
+      expect(window.hasNewer).toBe(false)
+      expect(window.detachedNewestTime).toBeUndefined()
+      expect(window.hasHistory).toBe(true)
+      expect(window.windowGen).toBe(1)
+    })
+
+    test('dropping a detached window lowers the loading flags of in-flight requests', () => {
+      const state = makeState({
+        activated: true,
+        hasNewer: true,
+        loadingHistory: true,
+        loadingNewer: true,
+        messages: [textMessage(100)],
+      })
+
+      const result = chatReducer(state, deactivateChannelAction())
+
+      expect(windowOf(result).loadingHistory).toBe(false)
+      expect(windowOf(result).loadingNewer).toBe(false)
+    })
+
+    test('trims an attached window down to the history cap', () => {
+      const messages = Array.from({ length: 200 }, (_, i) => textMessage(i + 1))
+      const state = makeState({ activated: true, messages })
+
+      const result = chatReducer(state, deactivateChannelAction())
+
+      expect(windowOf(result).messages.length).toBe(150)
+      expect(windowOf(result).windowGen).toBe(0)
     })
   })
 })

--- a/client/chat/chat-reducer.ts
+++ b/client/chat/chat-reducer.ts
@@ -34,6 +34,26 @@ export interface MessagesState {
 
   loadingHistory: boolean
   hasHistory: boolean
+  loadingNewer: boolean
+  /**
+   * Whether messages newer than the loaded window exist on the server, i.e. the window is detached
+   * from the present. While this is set, live messages are not appended (they belong on the far
+   * side of the gap), and the window is never trimmed.
+   */
+  hasNewer: boolean
+  /**
+   * The newest server-recorded time (epoch ms) of a message that arrived live while the window was
+   * detached and so was not appended to it. The window has caught back up to the present only once
+   * it has loaded at least this far, which closes the race where a message arrives between the
+   * server running the last page's query and this client applying its response.
+   */
+  detachedNewestTime?: number
+  /**
+   * Counts how many times the loaded window has been replaced or dropped. Every history request
+   * carries the generation it was issued for, and the reducer discards responses that no longer
+   * match, since a page has no boundary in common with a window it wasn't fetched for.
+   */
+  windowGen: number
 }
 
 export interface ChatState {
@@ -213,6 +233,84 @@ function removeSelfFromChannel(state: ChatState, channelId: SbChannelId) {
 }
 
 /**
+ * Returns the time (epoch ms) of the newest message in `messages` that carries a server-recorded
+ * timestamp, or `undefined` if there is none. Client-only messages (join/leave banners and the
+ * like) are stamped with the local clock, so their times can't be compared against or handed back
+ * to the server.
+ */
+export function newestServerOriginTime(messages: readonly ChatMessage[]): number | undefined {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (isServerOriginMessage(messages[i])) {
+      return messages[i].time
+    }
+  }
+
+  return undefined
+}
+
+/**
+ * Returns `incoming` with every message already present in `existing` removed. The history
+ * endpoints seek by millisecond-precision time, so a page boundary landing inside a group of
+ * messages that share a timestamp can hand back messages the window already holds.
+ */
+function dedupeAgainst(incoming: ChatMessage[], existing: readonly ChatMessage[]): ChatMessage[] {
+  if (!existing.length) {
+    return incoming
+  }
+
+  const existingIds = new Set(existing.map(m => m.id))
+  return incoming.filter(m => !existingIds.has(m.id))
+}
+
+/**
+ * Records that a message the user hasn't seen has arrived in a channel: raises the unread flag and,
+ * where applicable, freezes the unread divider. Kept separate from `updateMessages` because a
+ * message arriving while the loaded window is detached from the present isn't added to the window
+ * at all, yet counts as unread exactly the same.
+ */
+function markChannelUnread(state: ChatState, channelId: SbChannelId) {
+  const isChannelActivated = state.activatedChannels.has(channelId)
+
+  if (!state.unreadChannels.has(channelId) && !isChannelActivated) {
+    state.unreadChannels.add(channelId)
+  }
+
+  // The channel is being actively viewed, but the message still won't be seen right away: either
+  // the view is scrolled up, or the loaded window sits behind the present, where the bottom of the
+  // list isn't the newest message. Freeze the unread divider at the read position so it marks where
+  // the user left off instead of chasing the read position as the eager mark-read keeps advancing
+  // it.
+  const isDetached = state.idToMessages.get(channelId)?.hasNewer ?? false
+  if (
+    isChannelActivated &&
+    (!state.atBottomChannels.has(channelId) || isDetached) &&
+    !state.idToUnreadLineTime.has(channelId)
+  ) {
+    const lastReadTime = state.idToLastReadTime.get(channelId)
+    if (lastReadTime !== undefined) {
+      state.idToUnreadLineTime.set(channelId, lastReadTime)
+    }
+  }
+}
+
+/**
+ * Discards everything loaded for a channel, returning it to the shape a freshly-joined channel has:
+ * nothing loaded, older history assumed to exist, attached to the present. Advancing the generation
+ * makes the reducer discard any page still in flight for the window that was just dropped.
+ */
+function dropMessageWindow(channelMessages: MessagesState) {
+  channelMessages.messages = []
+  channelMessages.hasHistory = true
+  channelMessages.hasNewer = false
+  channelMessages.detachedNewestTime = undefined
+  // In-flight requests for the dropped window will be discarded by the generation check when they
+  // land, so their loading flags have to be lowered here or they'd stay raised forever.
+  channelMessages.loadingHistory = false
+  channelMessages.loadingNewer = false
+  channelMessages.windowGen += 1
+}
+
+/**
  * Update the messages field for a channel, keeping the `hasUnread` flag in proper sync.
  *
  * @param state The complete chat state which holds all of the channels.
@@ -236,11 +334,13 @@ function updateMessages(
   channelMessages.messages = updateFn(channelMessages.messages)
 
   const isChannelActivated = state.activatedChannels.has(channelId)
-  const isChannelUnread = state.unreadChannels.has(channelId)
 
   // Trimming is safe when nobody is reading scrollback: either the channel isn't being viewed, or
-  // the viewer is pinned to the bottom, where auto-scroll makes removing top messages invisible.
-  const canTrim = !isChannelActivated || state.atBottomChannels.has(channelId)
+  // the viewer is pinned to the bottom, where auto-scroll makes removing top messages invisible. A
+  // detached window is never trimmed: the user is paging through it in both directions, and there's
+  // no scroll compensation for messages disappearing off its top.
+  const canTrim =
+    !channelMessages.hasNewer && (!isChannelActivated || state.atBottomChannels.has(channelId))
 
   let sliced = false
   if (canTrim && channelMessages.messages.length > INACTIVE_CHANNEL_MAX_HISTORY) {
@@ -248,23 +348,8 @@ function updateMessages(
     sliced = true
   }
 
-  if (makeUnread && !isChannelUnread && !isChannelActivated) {
-    state.unreadChannels.add(channelId)
-  }
-
-  // The channel is being actively viewed but scrolled up, so a new message won't be seen right
-  // away. Freeze the unread divider at the read position so it marks where the user left off
-  // instead of chasing the read position as the eager mark-read keeps advancing it.
-  if (
-    makeUnread &&
-    isChannelActivated &&
-    !state.atBottomChannels.has(channelId) &&
-    !state.idToUnreadLineTime.has(channelId)
-  ) {
-    const lastReadTime = state.idToLastReadTime.get(channelId)
-    if (lastReadTime !== undefined) {
-      state.idToUnreadLineTime.set(channelId, lastReadTime)
-    }
+  if (makeUnread) {
+    markChannelUnread(state, channelId)
   }
 
   channelMessages.hasHistory = channelMessages.hasHistory || sliced
@@ -327,6 +412,10 @@ function initChannel(state: ChatState, channelId: SbChannelId, data: InitialChan
     messages: [],
     loadingHistory: false,
     hasHistory: true,
+    loadingNewer: false,
+    hasNewer: false,
+    detachedNewestTime: undefined,
+    windowGen: 0,
   }
   state.joinedChannels.add(channelId)
   state.idToBasicInfo.set(channelId, channelInfo)
@@ -456,10 +545,23 @@ export default immerKeyedReducer(DEFAULT_CHAT_STATE, {
     const { message: newMessage, channelMentions } = action.payload
     const { channelId, mentionsSelf } = action.meta
 
-    updateMessages(state, channelId, true, m => {
-      m.push(newMessage)
-      return m
-    })
+    const channelMessages = state.idToMessages.get(channelId)
+    if (channelMessages?.hasNewer) {
+      // The loaded window sits behind the present, so this message belongs past the gap at its far
+      // end rather than at the end of what's loaded. Remembering how far the present has run ahead
+      // is what lets the window tell, once it has paged forward, that it has actually caught up.
+      channelMessages.detachedNewestTime = Math.max(
+        channelMessages.detachedNewestTime ?? -Infinity,
+        newMessage.time,
+      )
+      markChannelUnread(state, channelId)
+    } else {
+      updateMessages(state, channelId, true, m => {
+        m.push(newMessage)
+        return m
+      })
+    }
+
     updateChannelInfos(state, channelMentions)
 
     if (mentionsSelf) {
@@ -524,19 +626,17 @@ export default immerKeyedReducer(DEFAULT_CHAT_STATE, {
   },
 
   ['@chat/loadMessageHistory'](state, action) {
-    if (action.error) {
-      // TODO(2Pac): Handle errors
-      const channelMessages = state.idToMessages.get(action.meta.channelId)
-      if (channelMessages) {
-        channelMessages.loadingHistory = false
-      }
+    const { channelId, windowGen } = action.meta
+
+    const channelMessages = state.idToMessages.get(channelId)
+    if (!channelMessages || channelMessages.windowGen !== windowGen) {
       return
     }
 
-    const { channelId, limit } = action.meta
+    channelMessages.loadingHistory = false
 
-    const channelMessages = state.idToMessages.get(channelId)
-    if (!channelMessages) {
+    if (action.error) {
+      // TODO(2Pac): Handle errors
       return
     }
 
@@ -544,14 +644,149 @@ export default immerKeyedReducer(DEFAULT_CHAT_STATE, {
     // concatenated with the existing messages which could also contain client chat messages.
     const newMessages = action.payload.messages as ChatMessage[]
 
-    channelMessages.loadingHistory = false
-    if (newMessages.length < limit) {
-      channelMessages.hasHistory = false
-    }
+    channelMessages.hasHistory = action.payload.hasMoreBefore
 
-    updateMessages(state, channelId, false, messages => newMessages.concat(messages))
+    updateMessages(state, channelId, false, messages =>
+      dedupeAgainst(newMessages, messages).concat(messages),
+    )
     updateChannelInfos(state, action.payload.channelMentions)
     updateDeletedChannels(state, action.payload.deletedChannels)
+  },
+
+  ['@chat/loadNewerMessagesBegin'](state, action) {
+    const { channelId } = action.payload
+
+    const channelMessages = state.idToMessages.get(channelId)
+    if (!channelMessages) {
+      return
+    }
+
+    channelMessages.loadingNewer = true
+  },
+
+  ['@chat/loadNewerMessages'](state, action) {
+    const { channelId, windowGen } = action.meta
+
+    const channelMessages = state.idToMessages.get(channelId)
+    if (!channelMessages || channelMessages.windowGen !== windowGen) {
+      return
+    }
+
+    channelMessages.loadingNewer = false
+
+    if (action.error) {
+      // TODO(2Pac): Handle errors
+      return
+    }
+
+    const newMessages = action.payload.messages as ChatMessage[]
+
+    updateMessages(state, channelId, false, messages =>
+      messages.concat(dedupeAgainst(newMessages, messages)),
+    )
+
+    // Rejoining the present takes both the server saying nothing is newer and the window having
+    // reached everything that arrived live while it was detached. A message sent between the server
+    // running this page's query and this response landing leaves the window one page short, so
+    // `hasNewer` stays set and the list's next-edge sentinel asks again until it converges. The
+    // exception is a request issued when this client already knew of the messages it's waiting on:
+    // live messages are only announced after they're stored, so such a request's query ran late
+    // enough to see them, and them being absent from the response means they've since been deleted.
+    // Attaching then (rather than holding out for a time no remaining message will ever reach)
+    // keeps a deletion from turning the sentinel's retries into an endless loop.
+    if (!action.payload.hasMoreAfter) {
+      const newestLoadedTime = newestServerOriginTime(channelMessages.messages)
+      const { detachedNewestTime } = channelMessages
+      if (
+        detachedNewestTime === undefined ||
+        (newestLoadedTime !== undefined && newestLoadedTime >= detachedNewestTime) ||
+        detachedNewestTime <= action.meta.knownNewestTime
+      ) {
+        channelMessages.hasNewer = false
+        channelMessages.detachedNewestTime = undefined
+      }
+    }
+  },
+
+  ['@chat/loadMessagesAroundBegin'](state, action) {
+    const { channelId } = action.payload
+
+    const channelMessages = state.idToMessages.get(channelId)
+    if (!channelMessages) {
+      return
+    }
+
+    // The whole window is about to be replaced, so there's no one edge the wait belongs to; the
+    // older edge's affordance stands in for both.
+    channelMessages.loadingHistory = true
+  },
+
+  ['@chat/loadMessagesAround'](state, action) {
+    const { channelId, windowGen } = action.meta
+
+    const channelMessages = state.idToMessages.get(channelId)
+    if (!channelMessages || channelMessages.windowGen !== windowGen) {
+      return
+    }
+
+    channelMessages.loadingHistory = false
+    channelMessages.loadingNewer = false
+
+    if (action.error) {
+      // TODO(2Pac): Handle errors
+      return
+    }
+
+    // Everything this client knows the present ran at least as far as: the newest message it had
+    // loaded (live messages keep appending to an attached window while the request is in flight)
+    // and the newest it observed while detached. The replacement window has caught up to the
+    // present only if it reaches this far.
+    const knownNewest = Math.max(
+      newestServerOriginTime(channelMessages.messages) ?? -Infinity,
+      channelMessages.detachedNewestTime ?? -Infinity,
+    )
+
+    // The fetched range doesn't have to touch what was loaded, so there may be no seam to splice
+    // them together at and the window is replaced outright. Client-only messages go with it: they
+    // only ever existed at the position this session happened to be scrolled to.
+    channelMessages.messages = action.payload.messages as ChatMessage[]
+    channelMessages.hasHistory = action.payload.hasMoreBefore
+    channelMessages.windowGen += 1
+
+    if (action.payload.hasMoreAfter) {
+      channelMessages.hasNewer = true
+      channelMessages.detachedNewestTime = knownNewest === -Infinity ? undefined : knownNewest
+    } else {
+      // The server saw nothing newer than the replacement window, but a message that arrived
+      // between its query running and this response landing exists only past the window's newer
+      // edge, so the window must stay detached and page forward to it. A message this client
+      // already knew of when the request was issued is the exception: the query ran late enough to
+      // have seen it, so its absence means it's been deleted (see the matching reasoning where
+      // newer pages land).
+      const newestLoadedTime = newestServerOriginTime(channelMessages.messages) ?? -Infinity
+      const knownNewestAtDispatch = action.meta.knownNewestTime ?? -Infinity
+      if (newestLoadedTime < knownNewest && knownNewest > knownNewestAtDispatch) {
+        channelMessages.hasNewer = true
+        channelMessages.detachedNewestTime = knownNewest
+      } else {
+        channelMessages.hasNewer = false
+        channelMessages.detachedNewestTime = undefined
+      }
+    }
+
+    updateChannelInfos(state, action.payload.channelMentions)
+    updateDeletedChannels(state, action.payload.deletedChannels)
+  },
+
+  ['@chat/resetMessageWindow'](state, action) {
+    const { channelId } = action.payload
+
+    const channelMessages = state.idToMessages.get(channelId)
+    if (!channelMessages) {
+      return
+    }
+
+    dropMessageWindow(channelMessages)
   },
 
   ['@chat/updateMessageDeleted'](state, action) {
@@ -677,10 +912,18 @@ export default immerKeyedReducer(DEFAULT_CHAT_STATE, {
       return
     }
 
-    const hasHistory = channelMessages.messages.length > INACTIVE_CHANNEL_MAX_HISTORY
+    if (channelMessages.hasNewer) {
+      // Keeping a window that sits mid-history would put the user back where they were reading with
+      // no indication that the channel has run on past it, so a detached window is dropped whole
+      // and the next visit starts from the present like any other fresh open.
+      dropMessageWindow(channelMessages)
+    } else {
+      const hasHistory = channelMessages.messages.length > INACTIVE_CHANNEL_MAX_HISTORY
 
-    channelMessages.messages = channelMessages.messages.slice(-INACTIVE_CHANNEL_MAX_HISTORY)
-    channelMessages.hasHistory = channelMessages.hasHistory || hasHistory
+      channelMessages.messages = channelMessages.messages.slice(-INACTIVE_CHANNEL_MAX_HISTORY)
+      channelMessages.hasHistory = channelMessages.hasHistory || hasHistory
+    }
+
     state.activatedChannels.delete(channelId)
     state.atBottomChannels.delete(channelId)
   },
@@ -702,16 +945,8 @@ export default immerKeyedReducer(DEFAULT_CHAT_STATE, {
 
     if (!state.activatedChannels.has(channelId)) {
       const messages = state.idToMessages.get(channelId)?.messages
-      let newestServerOriginTime: number | undefined
-      if (messages) {
-        for (let i = messages.length - 1; i >= 0; i--) {
-          if (isServerOriginMessage(messages[i])) {
-            newestServerOriginTime = messages[i].time
-            break
-          }
-        }
-      }
-      if (newestServerOriginTime === undefined || newestServerOriginTime <= effective) {
+      const newestKnownTime = messages ? newestServerOriginTime(messages) : undefined
+      if (newestKnownTime === undefined || newestKnownTime <= effective) {
         state.unreadChannels.delete(channelId)
       }
 
@@ -734,9 +969,11 @@ export default immerKeyedReducer(DEFAULT_CHAT_STATE, {
 
     if (atBottom && !wasAtBottom) {
       // The user returned to the bottom after reading scrollback that accumulated past the cap;
-      // drop it now, where the removal is invisible.
+      // drop it now, where the removal is invisible. For a detached window the bottom is only the
+      // end of what's loaded rather than the newest message, and the user is still paging through
+      // it, so nothing is dropped there.
       const channelMessages = state.idToMessages.get(channelId)
-      if (channelMessages) {
+      if (channelMessages && !channelMessages.hasNewer) {
         const hasHistory = channelMessages.messages.length > INACTIVE_CHANNEL_MAX_HISTORY
 
         channelMessages.messages = channelMessages.messages.slice(-INACTIVE_CHANNEL_MAX_HISTORY)

--- a/client/chat/chat-reducer.ts
+++ b/client/chat/chat-reducer.ts
@@ -684,6 +684,8 @@ export default immerKeyedReducer(DEFAULT_CHAT_STATE, {
     updateMessages(state, channelId, false, messages =>
       messages.concat(dedupeAgainst(newMessages, messages)),
     )
+    updateChannelInfos(state, action.payload.channelMentions)
+    updateDeletedChannels(state, action.payload.deletedChannels)
 
     // Rejoining the present takes both the server saying nothing is newer and the window having
     // reached everything that arrived live while it was detached. A message sent between the server
@@ -1017,6 +1019,20 @@ export default immerKeyedReducer(DEFAULT_CHAT_STATE, {
   },
 
   ['@whispers/loadMessageHistory'](state, action) {
+    if (!action.error) {
+      updateChannelInfos(state, action.payload.channelMentions)
+      updateDeletedChannels(state, action.payload.deletedChannels)
+    }
+  },
+
+  ['@whispers/loadNewerMessages'](state, action) {
+    if (!action.error) {
+      updateChannelInfos(state, action.payload.channelMentions)
+      updateDeletedChannels(state, action.payload.deletedChannels)
+    }
+  },
+
+  ['@whispers/loadMessagesAround'](state, action) {
     if (!action.error) {
       updateChannelInfos(state, action.payload.channelMentions)
       updateDeletedChannels(state, action.payload.deletedChannels)

--- a/client/messaging/chat.tsx
+++ b/client/messaging/chat.tsx
@@ -14,7 +14,7 @@ import { MenuItemSymbol, MenuItemType } from '../material/menu/menu-item-symbol'
 import { UNREAD_LINE_SELECTOR } from '../messaging/common-message-layout'
 import { MessageInput, MessageInputHandle, MessageInputProps } from '../messaging/message-input'
 import { MessageList, MessageListProps } from '../messaging/message-list'
-import { isServerOriginMessage, SbMessage } from '../messaging/message-records'
+import { isServerOriginMessage } from '../messaging/message-records'
 import { useAppDispatch } from '../redux-hooks'
 import { labelMedium } from '../styles/typography'
 import {
@@ -35,18 +35,12 @@ const JUMP_TO_BOTTOM_THRESHOLD_SCREENS = 1.5
 /** How much room to leave above the unread divider when jumping to it, in pixels. */
 const UNREAD_LINE_SCROLL_MARGIN_PX = 8
 
-/** An in-progress hunt through older history for the unread divider. */
+/** An in-progress hunt for the unread divider, waiting on history the list doesn't hold yet. */
 interface UnreadLineSeek {
   /** Identifies the conversation the seek was started in. */
   refreshToken: unknown
   /** Where the divider sat when the seek was started. */
   unreadLineTime: number
-  /**
-   * The message list the outstanding history request was issued against. A request only counts as
-   * answered once a different list arrives, since `loading` doesn't turn true until the render
-   * after the request.
-   */
-  requestedFor: ReadonlyArray<SbMessage>
 }
 
 function findUnreadLine(scroller: HTMLElement): HTMLElement | null {
@@ -189,6 +183,19 @@ export interface ChatProps {
    * bottom, so owners should assume at-bottom initially.
    */
   onAtBottomChange?: (atBottom: boolean) => void
+  /**
+   * Called when the user asks to go back to the newest messages while the list is showing a window
+   * of history detached from the present. Owners are expected to load that newest page. Only
+   * meaningful for surfaces that keep history on the server; without it the jump button can only
+   * reach the bottom of what's loaded.
+   */
+  onJumpToPresent?: () => void
+  /**
+   * Called when the user asks to jump to the unread divider but it sits outside the loaded window.
+   * Owners are expected to load a window of history around the read position. Only meaningful for
+   * surfaces that keep history on the server; without it the jump can't reach past what's loaded.
+   */
+  onSeekToUnread?: () => void
 }
 
 /**
@@ -208,6 +215,8 @@ export function Chat({
   MessageMenu = DefaultMessageMenu,
   disallowMentionInteraction: disallowUserInteraction,
   onAtBottomChange,
+  onJumpToPresent,
+  onSeekToUnread,
 }: ChatProps) {
   const { t } = useTranslation()
   const dispatch = useAppDispatch()
@@ -217,9 +226,9 @@ export function Chat({
   // Message lists mount pinned to the bottom, matching how `MessageList` initially scrolls.
   const wasAtBottomRef = useRef(true)
   const scrollerRef = useRef<HTMLDivElement | null>(null)
-  // Set while we're loading history until the unread divider comes into the loaded window, so we
-  // can jump to it. It carries what it was started for, so a seek can't outlive the conversation
-  // (or the divider position) it was aimed at.
+  // Set while we're waiting for the unread divider to come into the loaded window, so we can jump
+  // to it once it does. It carries what it was started for, so a seek can't outlive the
+  // conversation (or the divider position) it was aimed at.
   const seekRef = useRef<UnreadLineSeek | undefined>(undefined)
   // The divider the user has already had in view. The banner is a one-shot prompt for a divider
   // they haven't laid eyes on yet — once it's been on screen, scrolling back down doesn't
@@ -229,7 +238,7 @@ export function Chat({
     undefined,
   )
 
-  const { unreadLineTime, messages, loading, hasMoreHistory, onLoadMoreMessages, refreshToken } =
+  const { unreadLineTime, messages, loading, hasMoreHistory, hasNewerMessages, refreshToken } =
     listProps
 
   const onScrollUpdate = (target: EventTarget) => {
@@ -260,14 +269,10 @@ export function Chat({
       } else if (unreadLine) {
         seekRef.current = undefined
         scrollToUnreadLine(scroller, unreadLine)
-      } else if (!hasMoreHistory) {
-        // All the history there is has been loaded without turning up a divider, so the top of the
-        // list is as close as we can get to where the user left off.
+      } else if (!loading) {
+        // The window the seek was waiting on has arrived and holds no divider, which means there
+        // was nothing unread to move to after all.
         seekRef.current = undefined
-        scroller.scrollTop = 0
-      } else if (!loading && seek.requestedFor !== messages) {
-        seek.requestedFor = messages
-        onLoadMoreMessages?.()
       }
     }
 
@@ -299,6 +304,12 @@ export function Chat({
   }
 
   const onJumpToBottomClick = () => {
+    if (hasNewerMessages) {
+      // The bottom of the loaded window isn't the newest message, so getting there takes a fetch.
+      onJumpToPresent?.()
+      return
+    }
+
     const scroller = scrollerRef.current
     if (scroller) {
       scroller.scrollTop = scroller.scrollHeight
@@ -322,13 +333,17 @@ export function Chat({
     }
 
     if (!hasMoreHistory) {
+      // Everything there is has been loaded without turning up a divider, so the top of the list is
+      // as close as we can get to where the user left off.
       scroller.scrollTop = 0
       return
     }
 
-    seekRef.current = { refreshToken, unreadLineTime, requestedFor: messages }
-    if (!loading) {
-      onLoadMoreMessages?.()
+    if (onSeekToUnread) {
+      // The divider is above the loaded window: ask for a window that contains it, and let the seek
+      // do the scrolling once it renders.
+      seekRef.current = { refreshToken, unreadLineTime }
+      onSeekToUnread()
     }
   }
 
@@ -387,7 +402,7 @@ export function Chat({
               ) : null}
             </AnimatePresence>
             <AnimatePresence>
-              {showJumpToBottom ? (
+              {showJumpToBottom || hasNewerMessages ? (
                 <JumpToBottomButtonContainer
                   key='jump-to-bottom'
                   variants={jumpToBottomVariants}
@@ -397,7 +412,11 @@ export function Chat({
                   transition={overlayTransition}>
                   <JumpToBottomButton
                     iconStart={<MaterialIcon icon='arrow_downward' size={20} />}
-                    label={t('messaging.jumpToBottom', 'Jump to bottom')}
+                    label={
+                      hasNewerMessages
+                        ? t('messaging.jumpToPresent', 'Jump to present')
+                        : t('messaging.jumpToBottom', 'Jump to bottom')
+                    }
                     onClick={onJumpToBottomClick}
                   />
                 </JumpToBottomButtonContainer>

--- a/client/messaging/message-list.tsx
+++ b/client/messaging/message-list.tsx
@@ -242,6 +242,13 @@ export interface MessageListProps {
   /** Whether this message list has more history available that could be requested. */
   hasMoreHistory?: boolean
   /**
+   * Whether messages newer than the loaded window exist, that is, whether the window is detached
+   * from the present.
+   */
+  hasNewerMessages?: boolean
+  /** Whether we are currently requesting newer messages for this message list. */
+  loadingNewer?: boolean
+  /**
    * A value that changes when the values the list is displaying change, e.g. if the list is now
    * displaying a different chat channel.
    */
@@ -252,6 +259,7 @@ export interface MessageListProps {
    */
   onScrollUpdate?: (scrollTarget: EventTarget) => void
   onLoadMoreMessages?: () => void
+  onLoadNewerMessages?: () => void
   /**
    * The read position (epoch millis) the unread divider should be placed at, if the list should
    * show one. The divider goes in front of the first message with a server-recorded time newer
@@ -315,11 +323,26 @@ export class MessageList extends React.Component<MessageListProps> {
       return
     }
 
-    if (snapshot.wasAtBottom) {
-      // Auto-scroll
-      scrollable.scrollTop = scrollable.scrollHeight
-    } else if (prevProps.messages !== this.props.messages) {
-      if (
+    // A window that was swapped out for a different one (rather than having messages added to one
+    // of its ends) leaves no previous content to hold in view, so whoever asked for the swap places
+    // the viewport instead.
+    const messagesReplaced =
+      prevProps.messages !== this.props.messages &&
+      prevProps.messages.length > 0 &&
+      this.props.messages.length > 0 &&
+      prevProps.messages[0] !== this.props.messages[0] &&
+      prevProps.messages.at(-1) !== this.props.messages.at(-1)
+    // A window detached from the present only ever grows by loading pages, so pinning to the bottom
+    // would drag the user past a page that just appeared below them. The previous props matter as
+    // much as the current ones: the update that loads the last page is also the one that reattaches
+    // the window.
+    const detached = prevProps.hasNewerMessages || this.props.hasNewerMessages
+
+    if (!messagesReplaced) {
+      if (snapshot.wasAtBottom && !detached) {
+        // Auto-scroll
+        scrollable.scrollTop = scrollable.scrollHeight
+      } else if (
         prevProps.messages.length < this.props.messages.length &&
         prevProps.messages[0] !== this.props.messages[0]
       ) {
@@ -339,9 +362,12 @@ export class MessageList extends React.Component<MessageListProps> {
       messages,
       loading,
       hasMoreHistory,
+      hasNewerMessages,
+      loadingNewer,
       refreshToken,
       MessageComponent,
       onLoadMoreMessages,
+      onLoadNewerMessages,
       showEmptyState = true,
       unreadLineTime,
     } = this.props
@@ -353,10 +379,14 @@ export class MessageList extends React.Component<MessageListProps> {
         onScroll={this.props.onScrollUpdate ? this.onScroll.handler : undefined}>
         <InfiniteScrollList
           prevLoadingEnabled={true}
+          nextLoadingEnabled={true}
           isLoadingPrev={loading}
+          isLoadingNext={loadingNewer}
           hasPrevData={hasMoreHistory}
+          hasNextData={hasNewerMessages}
           refreshToken={refreshToken}
-          onLoadPrevData={onLoadMoreMessages}>
+          onLoadPrevData={onLoadMoreMessages}
+          onLoadNextData={onLoadNewerMessages}>
           <PureMessageList
             showEmptyState={showEmptyState}
             messages={messages}

--- a/client/messaging/message-list.tsx
+++ b/client/messaging/message-list.tsx
@@ -246,6 +246,12 @@ export interface MessageListProps {
    * from the present.
    */
   hasNewerMessages?: boolean
+  /**
+   * A value that changes exactly when the loaded window is replaced or dropped wholesale (rather
+   * than having messages added at one of its ends). On such an update the list leaves the viewport
+   * alone — there's no previous content to hold in view — and whoever asked for the swap places it.
+   */
+  windowGeneration?: number
   /** Whether we are currently requesting newer messages for this message list. */
   loadingNewer?: boolean
   /**
@@ -325,13 +331,10 @@ export class MessageList extends React.Component<MessageListProps> {
 
     // A window that was swapped out for a different one (rather than having messages added to one
     // of its ends) leaves no previous content to hold in view, so whoever asked for the swap places
-    // the viewport instead.
-    const messagesReplaced =
-      prevProps.messages !== this.props.messages &&
-      prevProps.messages.length > 0 &&
-      this.props.messages.length > 0 &&
-      prevProps.messages[0] !== this.props.messages[0] &&
-      prevProps.messages.at(-1) !== this.props.messages.at(-1)
+    // the viewport instead. This has to come from the explicit generation signal: comparing the
+    // arrays' endpoints can't tell a swap from an ordinary append that trimmed the top in the same
+    // update, which changes both ends too.
+    const messagesReplaced = prevProps.windowGeneration !== this.props.windowGeneration
     // A window detached from the present only ever grows by loading pages, so pinning to the bottom
     // would drag the user past a page that just appeared below them. The previous props matter as
     // much as the current ones: the update that loads the last page is also the one that reattaches

--- a/client/users/user-reducer.ts
+++ b/client/users/user-reducer.ts
@@ -77,6 +77,20 @@ export default immerKeyedReducer(DEFAULT_STATE, {
     }
   },
 
+  ['@chat/loadNewerMessages'](state, action) {
+    if (!action.error) {
+      updateUsers(state, action.payload.users)
+      updateUsers(state, action.payload.mentions)
+    }
+  },
+
+  ['@chat/loadMessagesAround'](state, action) {
+    if (!action.error) {
+      updateUsers(state, action.payload.users)
+      updateUsers(state, action.payload.mentions)
+    }
+  },
+
   ['@chat/updateMessage'](state, action) {
     updateUsers(state, [action.payload.user])
     updateUsers(state, action.payload.mentions)
@@ -195,6 +209,20 @@ export default immerKeyedReducer(DEFAULT_STATE, {
   },
 
   ['@whispers/loadMessageHistory'](state, action) {
+    if (!action.error) {
+      updateUsers(state, action.payload.users)
+      updateUsers(state, action.payload.mentions)
+    }
+  },
+
+  ['@whispers/loadNewerMessages'](state, action) {
+    if (!action.error) {
+      updateUsers(state, action.payload.users)
+      updateUsers(state, action.payload.mentions)
+    }
+  },
+
+  ['@whispers/loadMessagesAround'](state, action) {
     if (!action.error) {
       updateUsers(state, action.payload.users)
       updateUsers(state, action.payload.mentions)

--- a/client/whispers/action-creators.ts
+++ b/client/whispers/action-creators.ts
@@ -13,7 +13,13 @@ import { reportLastRead } from '../messaging/last-read'
 import { push, replace } from '../navigation/routing'
 import { RequestHandlingSpec, abortableThunk } from '../network/abortable-thunk'
 import { encodeBodyAsParams, fetchJson } from '../network/fetch'
-import { ActivateWhisperSession, DeactivateWhisperSession, UpdateSessionAtBottom } from './actions'
+import {
+  ActivateWhisperSession,
+  DeactivateWhisperSession,
+  ResetMessageWindow,
+  UpdateSessionAtBottom,
+} from './actions'
+import { newestServerOriginTime } from './whisper-reducer'
 
 export function getWhisperSessions(spec: RequestHandlingSpec<void>): ThunkAction {
   return abortableThunk(spec, async dispatch => {
@@ -128,10 +134,118 @@ export function getMessageHistory(
         target,
         limit,
         beforeTime: earliestMessageTime,
+        windowGen: sessionData.windowGen,
       },
     })
     await promise
   })
+}
+
+/**
+ * Loads the page of messages that follows the newest one currently loaded for a session, moving a
+ * window that sits behind the present a page closer to it. Does nothing if the session holds no
+ * message with a server-recorded time, since there'd be nothing the server could seek from.
+ */
+export function getNewerMessages(
+  target: SbUserId,
+  limit: number,
+  spec: RequestHandlingSpec,
+): ThunkAction {
+  return abortableThunk(spec, async (dispatch, getStore) => {
+    const {
+      whispers: { byId },
+    } = getStore()
+    const sessionData = byId.get(target)
+    if (!sessionData) {
+      return
+    }
+
+    const afterTime = newestServerOriginTime(sessionData.messages)
+    if (afterTime === undefined) {
+      return
+    }
+
+    const promise = fetchJson<GetSessionHistoryResponse>(
+      apiUrl`whispers/${target}/messages2?limit=${limit}&afterTime=${afterTime}`,
+    )
+    dispatch({
+      type: '@whispers/loadNewerMessages',
+      payload: promise,
+      meta: {
+        target,
+        limit,
+        afterTime,
+        windowGen: sessionData.windowGen,
+        knownNewestTime: Math.max(afterTime, sessionData.detachedNewestTime ?? -Infinity),
+      },
+    })
+    await promise
+  })
+}
+
+/**
+ * Loads a window of messages centered on `aroundTime`, replacing whatever is currently loaded for
+ * the session. This is how the client reaches a position that isn't adjacent to what it holds, such
+ * as an unread divider that sits further back than the loaded history reaches.
+ */
+export function getMessagesAround(
+  target: SbUserId,
+  limit: number,
+  aroundTime: number,
+  spec: RequestHandlingSpec,
+): ThunkAction {
+  return abortableThunk(spec, async (dispatch, getStore) => {
+    const {
+      whispers: { byId },
+    } = getStore()
+    const sessionData = byId.get(target)
+    if (!sessionData) {
+      return
+    }
+
+    const knownNewest = Math.max(
+      newestServerOriginTime(sessionData.messages) ?? -Infinity,
+      sessionData.detachedNewestTime ?? -Infinity,
+    )
+    const promise = fetchJson<GetSessionHistoryResponse>(
+      apiUrl`whispers/${target}/messages2?limit=${limit}&aroundTime=${aroundTime}`,
+    )
+    dispatch({
+      type: '@whispers/loadMessagesAround',
+      payload: promise,
+      meta: {
+        target,
+        limit,
+        aroundTime,
+        windowGen: sessionData.windowGen,
+        knownNewestTime: knownNewest === -Infinity ? undefined : knownNewest,
+      },
+    })
+    await promise
+  })
+}
+
+export function resetMessageWindow(target: SbUserId): ResetMessageWindow {
+  return {
+    type: '@whispers/resetMessageWindow',
+    payload: { target },
+  }
+}
+
+/**
+ * Returns a session's message list to the present, however far back it was left. The loaded window
+ * is dropped and the newest page requested in the same tick, so the list never renders an empty
+ * conversation in between.
+ */
+export function jumpToPresent(
+  target: SbUserId,
+  limit: number,
+  spec: RequestHandlingSpec,
+): ThunkAction {
+  return dispatch => {
+    dispatch(resetMessageWindow(target))
+    dispatch(getMessageHistory(target, limit, spec))
+  }
 }
 
 export function activateWhisperSession(target: SbUserId): ActivateWhisperSession {

--- a/client/whispers/actions.ts
+++ b/client/whispers/actions.ts
@@ -9,6 +9,11 @@ import { BaseFetchFailure } from '../network/fetch-errors'
 export type WhisperActions =
   | LoadMessageHistory
   | LoadMessageHistoryFailure
+  | LoadNewerMessages
+  | LoadNewerMessagesFailure
+  | LoadMessagesAround
+  | LoadMessagesAroundFailure
+  | ResetMessageWindow
   | ActivateWhisperSession
   | DeactivateWhisperSession
   | UpdateSessionAtBottom
@@ -36,6 +41,12 @@ export interface LoadMessageHistory {
     target: SbUserId
     limit: number
     beforeTime: number
+    /**
+     * The generation of the loaded message window this page was requested for. The reducer drops
+     * pages whose generation no longer matches the session's, since a window that has since been
+     * replaced or dropped shares no boundary with them.
+     */
+    windowGen: number
   }
   error?: false
 }
@@ -45,6 +56,100 @@ export interface LoadMessageHistoryFailure extends BaseFetchFailure<'@whispers/l
     target: SbUserId
     limit: number
     beforeTime: number
+    windowGen: number
+  }
+}
+
+/**
+ * Load the `limit` oldest messages in a whisper session that are newer than a particular time,
+ * extending a loaded window that sits behind the present toward it.
+ */
+export interface LoadNewerMessages {
+  type: '@whispers/loadNewerMessages'
+  payload: GetSessionHistoryResponse
+  meta: {
+    target: SbUserId
+    limit: number
+    afterTime: number
+    windowGen: number
+    /**
+     * The newest server-recorded message time (epoch ms) this client knew existed when the request
+     * was dispatched, whether loaded or only observed live. Responses that report nothing newer are
+     * authoritative for messages known this early — the server announces messages only after
+     * storing them — so their absence proves deletion rather than a race.
+     */
+    knownNewestTime: number
+  }
+  error?: false
+}
+
+export interface LoadNewerMessagesFailure extends BaseFetchFailure<'@whispers/loadNewerMessages'> {
+  meta: {
+    target: SbUserId
+    limit: number
+    afterTime: number
+    windowGen: number
+    /**
+     * The newest server-recorded message time (epoch ms) this client knew existed when the request
+     * was dispatched, whether loaded or only observed live. Responses that report nothing newer are
+     * authoritative for messages known this early — the server announces messages only after
+     * storing them — so their absence proves deletion rather than a race.
+     */
+    knownNewestTime: number
+  }
+}
+
+/**
+ * Load a window of up to `limit` messages in a whisper session centered on a particular time. The
+ * result replaces whatever was loaded for the session, since the fetched range doesn't have to
+ * touch it.
+ */
+export interface LoadMessagesAround {
+  type: '@whispers/loadMessagesAround'
+  payload: GetSessionHistoryResponse
+  meta: {
+    target: SbUserId
+    limit: number
+    aroundTime: number
+    windowGen: number
+    /**
+     * The newest server-recorded message time (epoch ms) this client knew existed when the request
+     * was dispatched, whether loaded or only observed live, or `undefined` when it knew of none.
+     * Responses that report nothing newer are authoritative for messages known this early — the
+     * server announces messages only after storing them — so their absence proves deletion rather
+     * than a race.
+     */
+    knownNewestTime: number | undefined
+  }
+  error?: false
+}
+
+export interface LoadMessagesAroundFailure extends BaseFetchFailure<'@whispers/loadMessagesAround'> {
+  meta: {
+    target: SbUserId
+    limit: number
+    aroundTime: number
+    windowGen: number
+    /**
+     * The newest server-recorded message time (epoch ms) this client knew existed when the request
+     * was dispatched, whether loaded or only observed live, or `undefined` when it knew of none.
+     * Responses that report nothing newer are authoritative for messages known this early — the
+     * server announces messages only after storing them — so their absence proves deletion rather
+     * than a race.
+     */
+    knownNewestTime: number | undefined
+  }
+}
+
+/**
+ * Discard everything loaded for a whisper session, returning it to the state a freshly-opened
+ * session is in: nothing loaded, older history assumed to exist, and attached to the present so
+ * live messages append again.
+ */
+export interface ResetMessageWindow {
+  type: '@whispers/resetMessageWindow'
+  payload: {
+    target: SbUserId
   }
 }
 

--- a/client/whispers/whisper-reducer.test.ts
+++ b/client/whispers/whisper-reducer.test.ts
@@ -1,6 +1,11 @@
 import { Immutable } from 'immer'
 import { describe, expect, test } from 'vitest'
 import { makeSbUserId } from '../../common/users/sb-user-id'
+import {
+  GetSessionHistoryResponse,
+  WhisperMessage,
+  WhisperMessageType,
+} from '../../common/whispers'
 import { CommonMessageType, CommonTextMessage } from '../messaging/message-records'
 import { WhisperActions } from './actions'
 import whisperReducerImport, { WhisperSession, WhisperState } from './whisper-reducer'
@@ -14,6 +19,7 @@ const whisperReducer = whisperReducerImport as unknown as (
 ) => Immutable<WhisperState>
 
 const TARGET_ID = makeSbUserId(2)
+const SELF_ID = makeSbUserId(3)
 
 // Every whisper message the client stores is a text message from the server, so (unlike chat
 // channels) there's no client-local whisper message type whose `time` isn't server-recorded.
@@ -31,17 +37,25 @@ function makeState(
   overrides: {
     messages?: CommonTextMessage[]
     activated?: boolean
+    atBottom?: boolean
     unread?: boolean
     lastReadTime?: number
     unreadLineTime?: number
+    hasHistory?: boolean
+    hasNewer?: boolean
+    detachedNewestTime?: number
+    windowGen?: number
   } = {},
 ): Immutable<WhisperState> {
   const session: WhisperSession = {
     target: TARGET_ID,
     messages: overrides.messages ?? [],
-    hasHistory: true,
+    hasHistory: overrides.hasHistory ?? true,
+    hasNewer: overrides.hasNewer ?? false,
+    detachedNewestTime: overrides.detachedNewestTime,
+    windowGen: overrides.windowGen ?? 0,
     activated: overrides.activated ?? false,
-    atBottom: false,
+    atBottom: overrides.atBottom ?? false,
     hasUnread: overrides.unread ?? false,
     lastReadTime: overrides.lastReadTime,
     unreadLineTime: overrides.unreadLineTime,
@@ -60,6 +74,124 @@ function updateLastReadTimeAction(lastReadTime: number): WhisperActions {
     type: '@whispers/updateLastReadTime',
     payload: { targetId: TARGET_ID, lastReadTime },
   }
+}
+
+/** A message in the shape the server sends it, before the reducer converts it for the list. */
+function serverMessage(time: number): WhisperMessage {
+  return {
+    id: `text-${time}`,
+    type: WhisperMessageType.TextMessage,
+    from: TARGET_ID,
+    to: SELF_ID,
+    time,
+    text: 'hello',
+  }
+}
+
+const HISTORY_LIMIT = 50
+
+function historyResponse(
+  messages: WhisperMessage[],
+  {
+    hasMoreBefore = true,
+    hasMoreAfter = true,
+  }: { hasMoreBefore?: boolean; hasMoreAfter?: boolean } = {},
+): GetSessionHistoryResponse {
+  return {
+    messages,
+    users: [],
+    mentions: [],
+    channelMentions: [],
+    deletedChannels: [],
+    hasMoreBefore,
+    hasMoreAfter,
+  }
+}
+
+function loadMessageHistoryAction(
+  payload: GetSessionHistoryResponse,
+  { windowGen = 0, beforeTime = -1 }: { windowGen?: number; beforeTime?: number } = {},
+): WhisperActions {
+  return {
+    type: '@whispers/loadMessageHistory',
+    payload,
+    meta: { target: TARGET_ID, limit: HISTORY_LIMIT, beforeTime, windowGen },
+  }
+}
+
+function loadNewerMessagesAction(
+  payload: GetSessionHistoryResponse,
+  {
+    windowGen = 0,
+    afterTime = 0,
+    knownNewestTime = afterTime,
+  }: { windowGen?: number; afterTime?: number; knownNewestTime?: number } = {},
+): WhisperActions {
+  return {
+    type: '@whispers/loadNewerMessages',
+    payload,
+    meta: { target: TARGET_ID, limit: HISTORY_LIMIT, afterTime, windowGen, knownNewestTime },
+  }
+}
+
+function loadMessagesAroundAction(
+  payload: GetSessionHistoryResponse,
+  {
+    windowGen = 0,
+    aroundTime = 0,
+    knownNewestTime,
+  }: { windowGen?: number; aroundTime?: number; knownNewestTime?: number } = {},
+): WhisperActions {
+  return {
+    type: '@whispers/loadMessagesAround',
+    payload,
+    meta: { target: TARGET_ID, limit: HISTORY_LIMIT, aroundTime, windowGen, knownNewestTime },
+  }
+}
+
+function updateMessageAction(time: number): WhisperActions {
+  return {
+    type: '@whispers/updateMessage',
+    payload: {
+      action: 'message',
+      message: serverMessage(time),
+      users: [],
+      mentions: [],
+      channelMentions: [],
+    },
+    meta: { target: TARGET_ID },
+  }
+}
+
+function resetMessageWindowAction(): WhisperActions {
+  return {
+    type: '@whispers/resetMessageWindow',
+    payload: { target: TARGET_ID },
+  }
+}
+
+function deactivateSessionAction(): WhisperActions {
+  return {
+    type: '@whispers/deactivateWhisperSession',
+    payload: { target: TARGET_ID },
+  }
+}
+
+/** Rewrites a request action into the rejected form the promise middleware dispatches. */
+function asFailure(action: WhisperActions): WhisperActions {
+  return {
+    ...action,
+    payload: new Error('request failed'),
+    error: true,
+  } as unknown as WhisperActions
+}
+
+function sessionOf(state: Immutable<WhisperState>) {
+  return state.byId.get(TARGET_ID)!
+}
+
+function messageIdsOf(state: Immutable<WhisperState>): string[] {
+  return sessionOf(state).messages.map(m => m.id)
 }
 
 describe('client/whispers/whisper-reducer', () => {
@@ -129,6 +261,397 @@ describe('client/whispers/whisper-reducer', () => {
       // The read position itself still advances even while activated, since this is also the path
       // this session's own optimistic mark-read reports take.
       expect(session.lastReadTime).toBe(200)
+    })
+  })
+
+  describe('@whispers/loadMessageHistory', () => {
+    test('takes the older edge straight from the response instead of inferring it', () => {
+      const state = makeState()
+
+      // A short page that nonetheless has more behind it: the count says nothing about the edge.
+      const result = whisperReducer(
+        state,
+        loadMessageHistoryAction(historyResponse([serverMessage(100)], { hasMoreBefore: true })),
+      )
+
+      expect(sessionOf(result).hasHistory).toBe(true)
+    })
+
+    test('clears the older edge when the response says there is nothing more', () => {
+      const state = makeState()
+
+      const result = whisperReducer(
+        state,
+        loadMessageHistoryAction(historyResponse([serverMessage(100)], { hasMoreBefore: false })),
+      )
+
+      expect(sessionOf(result).hasHistory).toBe(false)
+    })
+
+    test('drops messages the window already holds at the seam', () => {
+      const state = makeState({ messages: [textMessage(100), textMessage(200)] })
+
+      const result = whisperReducer(
+        state,
+        loadMessageHistoryAction(historyResponse([serverMessage(50), serverMessage(100)])),
+      )
+
+      expect(messageIdsOf(result)).toEqual(['text-50', 'text-100', 'text-200'])
+    })
+
+    test('ignores a page fetched for a window that has since been replaced', () => {
+      const state = makeState({ messages: [textMessage(200)], windowGen: 3 })
+
+      const result = whisperReducer(
+        state,
+        loadMessageHistoryAction(historyResponse([serverMessage(100)], { hasMoreBefore: false }), {
+          windowGen: 2,
+        }),
+      )
+
+      expect(messageIdsOf(result)).toEqual(['text-200'])
+      expect(sessionOf(result).hasHistory).toBe(true)
+    })
+
+    test('a failed page leaves the window untouched', () => {
+      const state = makeState({ messages: [textMessage(200)] })
+
+      const result = whisperReducer(state, asFailure(loadMessageHistoryAction(historyResponse([]))))
+
+      expect(messageIdsOf(result)).toEqual(['text-200'])
+      expect(sessionOf(result).hasHistory).toBe(true)
+    })
+  })
+
+  describe('@whispers/loadMessagesAround', () => {
+    test('replaces the window and detaches it from the present', () => {
+      const state = makeState({ messages: [textMessage(900)] })
+
+      const result = whisperReducer(
+        state,
+        loadMessagesAroundAction(
+          historyResponse([serverMessage(100), serverMessage(200)], {
+            hasMoreBefore: true,
+            hasMoreAfter: true,
+          }),
+          { aroundTime: 150 },
+        ),
+      )
+
+      const session = sessionOf(result)
+      expect(messageIdsOf(result)).toEqual(['text-100', 'text-200'])
+      expect(session.hasHistory).toBe(true)
+      expect(session.hasNewer).toBe(true)
+      expect(session.windowGen).toBe(1)
+    })
+
+    test('lands attached when the fetched window reaches the newest message', () => {
+      const state = makeState({ hasNewer: true, detachedNewestTime: 500 })
+
+      const result = whisperReducer(
+        state,
+        loadMessagesAroundAction(
+          historyResponse([serverMessage(400), serverMessage(500)], {
+            hasMoreBefore: false,
+            hasMoreAfter: false,
+          }),
+        ),
+      )
+
+      expect(sessionOf(result).hasNewer).toBe(false)
+      expect(sessionOf(result).hasHistory).toBe(false)
+      expect(sessionOf(result).detachedNewestTime).toBeUndefined()
+    })
+
+    test('stays detached when a message arrived while the request was in flight', () => {
+      // Messages up to 500 were known when the request was dispatched (knownNewestTime), and
+      // another arrived at 600 before the response landed, so the replacement window ending at 200
+      // cannot have caught the present even though the server saw nothing newer.
+      const state = makeState({ messages: [textMessage(500), textMessage(600)] })
+
+      const result = whisperReducer(
+        state,
+        loadMessagesAroundAction(
+          historyResponse([serverMessage(100), serverMessage(200)], {
+            hasMoreBefore: true,
+            hasMoreAfter: false,
+          }),
+          { aroundTime: 150, knownNewestTime: 500 },
+        ),
+      )
+
+      expect(sessionOf(result).hasNewer).toBe(true)
+      expect(sessionOf(result).detachedNewestTime).toBe(600)
+    })
+
+    test('lands attached when everything past the window was already known at dispatch', () => {
+      // The newest loaded message (600) was known when the request was dispatched, so the server
+      // not returning anything newer than 200 means the newer messages have been deleted.
+      const state = makeState({ messages: [textMessage(500), textMessage(600)] })
+
+      const result = whisperReducer(
+        state,
+        loadMessagesAroundAction(
+          historyResponse([serverMessage(100), serverMessage(200)], {
+            hasMoreBefore: true,
+            hasMoreAfter: false,
+          }),
+          { aroundTime: 150, knownNewestTime: 600 },
+        ),
+      )
+
+      expect(sessionOf(result).hasNewer).toBe(false)
+      expect(sessionOf(result).detachedNewestTime).toBeUndefined()
+    })
+
+    test('ignores a response fetched for a window that has since been replaced', () => {
+      const state = makeState({ messages: [textMessage(900)], windowGen: 2 })
+
+      const result = whisperReducer(
+        state,
+        loadMessagesAroundAction(historyResponse([serverMessage(100)]), { windowGen: 1 }),
+      )
+
+      expect(messageIdsOf(result)).toEqual(['text-900'])
+      expect(sessionOf(result).windowGen).toBe(2)
+    })
+  })
+
+  describe('a detached message window', () => {
+    test('does not append a live message, but records how far the present has run ahead', () => {
+      const state = makeState({ hasNewer: true, messages: [textMessage(100)] })
+
+      const result = whisperReducer(state, updateMessageAction(500))
+
+      expect(messageIdsOf(result)).toEqual(['text-100'])
+      expect(sessionOf(result).detachedNewestTime).toBe(500)
+    })
+
+    test('keeps the newest time when an older message arrives afterwards', () => {
+      const state = makeState({ hasNewer: true, detachedNewestTime: 500 })
+
+      const result = whisperReducer(state, updateMessageAction(400))
+
+      expect(sessionOf(result).detachedNewestTime).toBe(500)
+    })
+
+    test('a live message still marks the session unread', () => {
+      const state = makeState({ hasNewer: true })
+
+      const result = whisperReducer(state, updateMessageAction(500))
+
+      expect(sessionOf(result).hasUnread).toBe(true)
+    })
+
+    test('a live message freezes the unread divider even at the bottom of the loaded window', () => {
+      const state = makeState({
+        hasNewer: true,
+        activated: true,
+        atBottom: true,
+        lastReadTime: 100,
+      })
+
+      const result = whisperReducer(state, updateMessageAction(500))
+
+      expect(sessionOf(result).unreadLineTime).toBe(100)
+    })
+
+    test('an attached session at the bottom does not freeze the divider', () => {
+      const state = makeState({ activated: true, atBottom: true, lastReadTime: 100 })
+
+      const result = whisperReducer(state, updateMessageAction(500))
+
+      expect(sessionOf(result).unreadLineTime).toBeUndefined()
+    })
+
+    test('is never trimmed while it grows, even when the view is at the bottom of it', () => {
+      const messages = Array.from({ length: 200 }, (_, i) => textMessage(i + 1))
+      const state = makeState({ hasNewer: true, activated: true, atBottom: true, messages })
+
+      const result = whisperReducer(
+        state,
+        loadNewerMessagesAction(historyResponse([serverMessage(1000)]), { afterTime: 200 }),
+      )
+
+      expect(sessionOf(result).messages.length).toBe(201)
+    })
+
+    test('is not trimmed when the view returns to the bottom of it', () => {
+      const messages = Array.from({ length: 200 }, (_, i) => textMessage(i + 1))
+      const state = makeState({ hasNewer: true, activated: true, messages })
+
+      const result = whisperReducer(state, {
+        type: '@whispers/updateSessionAtBottom',
+        payload: { target: TARGET_ID, atBottom: true },
+      })
+
+      expect(sessionOf(result).messages.length).toBe(200)
+    })
+  })
+
+  describe('@whispers/loadNewerMessages', () => {
+    test('appends the page and reattaches once the server has nothing newer', () => {
+      const state = makeState({ hasNewer: true, messages: [textMessage(100)] })
+
+      const result = whisperReducer(
+        state,
+        loadNewerMessagesAction(historyResponse([serverMessage(200)], { hasMoreAfter: false }), {
+          afterTime: 100,
+        }),
+      )
+
+      expect(messageIdsOf(result)).toEqual(['text-100', 'text-200'])
+      expect(sessionOf(result).hasNewer).toBe(false)
+    })
+
+    test('drops messages the window already holds at the seam', () => {
+      const state = makeState({ hasNewer: true, messages: [textMessage(100), textMessage(200)] })
+
+      const result = whisperReducer(
+        state,
+        loadNewerMessagesAction(historyResponse([serverMessage(200), serverMessage(300)])),
+      )
+
+      expect(messageIdsOf(result)).toEqual(['text-100', 'text-200', 'text-300'])
+    })
+
+    test('stays detached while the server still has newer messages', () => {
+      const state = makeState({ hasNewer: true, messages: [textMessage(100)] })
+
+      const result = whisperReducer(
+        state,
+        loadNewerMessagesAction(historyResponse([serverMessage(200)], { hasMoreAfter: true })),
+      )
+
+      expect(sessionOf(result).hasNewer).toBe(true)
+    })
+
+    test('stays detached when a message arrived past the end of the final page', () => {
+      const state = makeState({
+        hasNewer: true,
+        detachedNewestTime: 300,
+        messages: [textMessage(100)],
+      })
+
+      const result = whisperReducer(
+        state,
+        loadNewerMessagesAction(historyResponse([serverMessage(200)], { hasMoreAfter: false })),
+      )
+
+      expect(sessionOf(result).hasNewer).toBe(true)
+      expect(sessionOf(result).detachedNewestTime).toBe(300)
+    })
+
+    test('reattaches when the awaited message was already known at dispatch (deleted)', () => {
+      const state = makeState({
+        hasNewer: true,
+        detachedNewestTime: 300,
+        messages: [textMessage(100)],
+      })
+
+      const result = whisperReducer(
+        state,
+        loadNewerMessagesAction(historyResponse([serverMessage(200)], { hasMoreAfter: false }), {
+          afterTime: 100,
+          knownNewestTime: 300,
+        }),
+      )
+
+      expect(sessionOf(result).hasNewer).toBe(false)
+      expect(sessionOf(result).detachedNewestTime).toBeUndefined()
+    })
+
+    test('reattaches once the window catches up to what arrived while detached', () => {
+      const state = makeState({
+        hasNewer: true,
+        detachedNewestTime: 300,
+        messages: [textMessage(100)],
+      })
+
+      const result = whisperReducer(
+        state,
+        loadNewerMessagesAction(
+          historyResponse([serverMessage(200), serverMessage(300)], { hasMoreAfter: false }),
+        ),
+      )
+
+      expect(sessionOf(result).hasNewer).toBe(false)
+      expect(sessionOf(result).detachedNewestTime).toBeUndefined()
+    })
+
+    test('ignores a page fetched for a window that has since been replaced', () => {
+      const state = makeState({ hasNewer: true, windowGen: 4, messages: [textMessage(100)] })
+
+      const result = whisperReducer(
+        state,
+        loadNewerMessagesAction(historyResponse([serverMessage(200)], { hasMoreAfter: false }), {
+          windowGen: 3,
+        }),
+      )
+
+      expect(messageIdsOf(result)).toEqual(['text-100'])
+      expect(sessionOf(result).hasNewer).toBe(true)
+    })
+
+    test('a failed page leaves the window detached and untouched', () => {
+      const state = makeState({ hasNewer: true, messages: [textMessage(100)] })
+
+      const result = whisperReducer(state, asFailure(loadNewerMessagesAction(historyResponse([]))))
+
+      expect(sessionOf(result).hasNewer).toBe(true)
+      expect(messageIdsOf(result)).toEqual(['text-100'])
+    })
+  })
+
+  describe('@whispers/resetMessageWindow', () => {
+    test('empties the window and returns it to the present', () => {
+      const state = makeState({
+        messages: [textMessage(100)],
+        hasHistory: false,
+        hasNewer: true,
+        detachedNewestTime: 500,
+        windowGen: 2,
+      })
+
+      const result = whisperReducer(state, resetMessageWindowAction())
+
+      const session = sessionOf(result)
+      expect(session.messages).toEqual([])
+      expect(session.hasHistory).toBe(true)
+      expect(session.hasNewer).toBe(false)
+      expect(session.detachedNewestTime).toBeUndefined()
+      expect(session.windowGen).toBe(3)
+    })
+  })
+
+  describe('@whispers/deactivateWhisperSession', () => {
+    test('drops a detached window entirely', () => {
+      const messages = Array.from({ length: 200 }, (_, i) => textMessage(i + 1))
+      const state = makeState({
+        activated: true,
+        hasNewer: true,
+        detachedNewestTime: 500,
+        messages,
+      })
+
+      const result = whisperReducer(state, deactivateSessionAction())
+
+      const session = sessionOf(result)
+      expect(session.messages).toEqual([])
+      expect(session.hasNewer).toBe(false)
+      expect(session.detachedNewestTime).toBeUndefined()
+      expect(session.hasHistory).toBe(true)
+      expect(session.windowGen).toBe(1)
+    })
+
+    test('trims an attached window down to the history cap', () => {
+      const messages = Array.from({ length: 200 }, (_, i) => textMessage(i + 1))
+      const state = makeState({ activated: true, messages })
+
+      const result = whisperReducer(state, deactivateSessionAction())
+
+      expect(sessionOf(result).messages.length).toBe(150)
+      expect(sessionOf(result).windowGen).toBe(0)
     })
   })
 })

--- a/client/whispers/whisper-reducer.ts
+++ b/client/whispers/whisper-reducer.ts
@@ -1,5 +1,6 @@
 import { Immutable } from 'immer'
 import { SbUserId } from '../../common/users/sb-user-id'
+import { WhisperMessage } from '../../common/whispers'
 import {
   CommonMessageType,
   CommonTextMessage,
@@ -15,6 +16,25 @@ export interface WhisperSession {
   messages: CommonTextMessage[]
 
   hasHistory: boolean
+  /**
+   * Whether messages newer than the loaded window exist on the server, i.e. the window is detached
+   * from the present. While this is set, live messages are not appended (they belong on the far
+   * side of the gap), and the window is never trimmed.
+   */
+  hasNewer: boolean
+  /**
+   * The newest time (epoch ms) of a message that arrived live while the window was detached and so
+   * was not appended to it. The window has caught back up to the present only once it has loaded at
+   * least this far, which closes the race where a message arrives between the server running the
+   * last page's query and this client applying its response.
+   */
+  detachedNewestTime?: number
+  /**
+   * Counts how many times the loaded window has been replaced or dropped. Every history request
+   * carries the generation it was issued for, and the reducer discards responses that no longer
+   * match, since a page has no boundary in common with a window it wasn't fetched for.
+   */
+  windowGen: number
 
   activated: boolean
   /** Whether this session's message list is scrolled to the bottom. */
@@ -40,6 +60,9 @@ function defaultWhisperSession(target: SbUserId): WhisperSession {
     target,
     messages: [],
     hasHistory: true,
+    hasNewer: false,
+    detachedNewestTime: undefined,
+    windowGen: 0,
     activated: false,
     atBottom: false,
     hasUnread: false,
@@ -56,6 +79,88 @@ export interface WhisperState {
 const DEFAULT_STATE: Immutable<WhisperState> = {
   sessions: new Set(),
   byId: new Map(),
+}
+
+/** Converts messages as the server sends them into the shape the message list renders. */
+function toTextMessages(messages: WhisperMessage[]): CommonTextMessage[] {
+  return messages.map<CommonTextMessage>(msg => ({
+    id: msg.id,
+    type: CommonMessageType.TextMessage,
+    time: msg.time,
+    from: msg.from,
+    text: msg.text,
+  }))
+}
+
+/**
+ * Returns the time (epoch ms) of the newest message in `messages` that carries a server-recorded
+ * timestamp, or `undefined` if there is none. Only such times can be compared against or handed
+ * back to the server.
+ */
+export function newestServerOriginTime(messages: readonly CommonTextMessage[]): number | undefined {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (isServerOriginMessage(messages[i])) {
+      return messages[i].time
+    }
+  }
+
+  return undefined
+}
+
+/**
+ * Returns `incoming` with every message already present in `existing` removed. The history
+ * endpoints seek by millisecond-precision time, so a page boundary landing inside a group of
+ * messages that share a timestamp can hand back messages the window already holds.
+ */
+function dedupeAgainst(
+  incoming: CommonTextMessage[],
+  existing: readonly CommonTextMessage[],
+): CommonTextMessage[] {
+  if (!existing.length) {
+    return incoming
+  }
+
+  const existingIds = new Set(existing.map(m => m.id))
+  return incoming.filter(m => !existingIds.has(m.id))
+}
+
+/**
+ * Records that a message the user hasn't seen has arrived in a whisper session: raises the unread
+ * flag and, where applicable, freezes the unread divider. Kept separate from `updateMessages`
+ * because a message arriving while the loaded window is detached from the present isn't added to
+ * the window at all, yet counts as unread exactly the same.
+ */
+function markSessionUnread(session: WhisperSession) {
+  if (!session.hasUnread && !session.activated) {
+    session.hasUnread = true
+  }
+
+  // The session is being actively viewed, but the message still won't be seen right away: either
+  // the view is scrolled up, or the loaded window sits behind the present, where the bottom of the
+  // list isn't the newest message. Freeze the unread divider at the read position so it marks where
+  // the user left off instead of chasing the read position as the eager mark-read keeps advancing
+  // it.
+  if (
+    session.activated &&
+    (!session.atBottom || session.hasNewer) &&
+    session.unreadLineTime === undefined &&
+    session.lastReadTime !== undefined
+  ) {
+    session.unreadLineTime = session.lastReadTime
+  }
+}
+
+/**
+ * Discards everything loaded for a session, returning it to the shape a freshly-opened session has:
+ * nothing loaded, older history assumed to exist, attached to the present. Advancing the generation
+ * makes the reducer discard any page still in flight for the window that was just dropped.
+ */
+function dropMessageWindow(session: WhisperSession) {
+  session.messages = []
+  session.hasHistory = true
+  session.hasNewer = false
+  session.detachedNewestTime = undefined
+  session.windowGen += 1
 }
 
 /**
@@ -75,8 +180,10 @@ function updateMessages(
   session.messages = updateFn(session.messages)
 
   // Trimming is safe when nobody is reading scrollback: either the session isn't being viewed, or
-  // the viewer is pinned to the bottom, where auto-scroll makes removing top messages invisible.
-  const canTrim = !session.activated || session.atBottom
+  // the viewer is pinned to the bottom, where auto-scroll makes removing top messages invisible. A
+  // detached window is never trimmed: the user is paging through it in both directions, and there's
+  // no scroll compensation for messages disappearing off its top.
+  const canTrim = !session.hasNewer && (!session.activated || session.atBottom)
 
   let sliced = false
   if (canTrim && session.messages.length > INACTIVE_SESSION_MAX_HISTORY) {
@@ -84,21 +191,8 @@ function updateMessages(
     sliced = true
   }
 
-  if (makeUnread && !session.hasUnread && !session.activated) {
-    session.hasUnread = true
-  }
-
-  // The session is being actively viewed but scrolled up, so a new message won't be seen right
-  // away. Freeze the unread divider at the read position so it marks where the user left off
-  // instead of chasing the read position as the eager mark-read keeps advancing it.
-  if (
-    makeUnread &&
-    session.activated &&
-    !session.atBottom &&
-    session.unreadLineTime === undefined &&
-    session.lastReadTime !== undefined
-  ) {
-    session.unreadLineTime = session.lastReadTime
+  if (makeUnread) {
+    markSessionUnread(session)
   }
 
   session.hasHistory = session.hasHistory || sliced
@@ -170,37 +264,132 @@ export default immerKeyedReducer(DEFAULT_STATE, {
     // Reorder the sessions to put the one that got the message on top of the list
     state.sessions = new Set([target, ...state.sessions])
 
-    return updateMessages(state, target, true, m => {
-      m.push(newMessage)
-      return m
-    })
+    const session = state.byId.get(target)
+    if (session?.hasNewer) {
+      // The loaded window sits behind the present, so this message belongs past the gap at its far
+      // end rather than at the end of what's loaded. Remembering how far the present has run ahead
+      // is what lets the window tell, once it has paged forward, that it has actually caught up.
+      session.detachedNewestTime = Math.max(
+        session.detachedNewestTime ?? -Infinity,
+        newMessage.time,
+      )
+      markSessionUnread(session)
+    } else {
+      updateMessages(state, target, true, m => {
+        m.push(newMessage)
+        return m
+      })
+    }
   },
 
   ['@whispers/loadMessageHistory'](state, action) {
-    if (action.error) {
+    const { target, windowGen } = action.meta
+
+    const session = state.byId.get(target)
+    if (!session || session.windowGen !== windowGen || action.error) {
       return
     }
 
-    const { target, limit } = action.meta
+    const newMessages = toTextMessages(action.payload.messages)
+
+    session.hasHistory = action.payload.hasMoreBefore
+
+    updateMessages(state, target, false, messages =>
+      dedupeAgainst(newMessages, messages).concat(messages),
+    )
+  },
+
+  ['@whispers/loadNewerMessages'](state, action) {
+    const { target, windowGen } = action.meta
+
+    const session = state.byId.get(target)
+    if (!session || session.windowGen !== windowGen || action.error) {
+      return
+    }
+
+    const newMessages = toTextMessages(action.payload.messages)
+
+    updateMessages(state, target, false, messages =>
+      messages.concat(dedupeAgainst(newMessages, messages)),
+    )
+
+    // Rejoining the present takes both the server saying nothing is newer and the window having
+    // reached everything that arrived live while it was detached. A message sent between the server
+    // running this page's query and this response landing leaves the window one page short, so
+    // `hasNewer` stays set and the list's next-edge sentinel asks again until it converges. The
+    // exception is a request issued when this client already knew of the messages it's waiting on:
+    // live messages are only announced after they're stored, so such a request's query ran late
+    // enough to see them, and them being absent from the response means they've since been deleted.
+    // Attaching then (rather than holding out for a time no remaining message will ever reach)
+    // keeps a deletion from turning the sentinel's retries into an endless loop.
+    if (!action.payload.hasMoreAfter) {
+      const newestLoadedTime = newestServerOriginTime(session.messages)
+      const { detachedNewestTime } = session
+      if (
+        detachedNewestTime === undefined ||
+        (newestLoadedTime !== undefined && newestLoadedTime >= detachedNewestTime) ||
+        detachedNewestTime <= action.meta.knownNewestTime
+      ) {
+        session.hasNewer = false
+        session.detachedNewestTime = undefined
+      }
+    }
+  },
+
+  ['@whispers/loadMessagesAround'](state, action) {
+    const { target, windowGen } = action.meta
+
+    const session = state.byId.get(target)
+    if (!session || session.windowGen !== windowGen || action.error) {
+      return
+    }
+
+    // Everything this client knows the present ran at least as far as: the newest message it had
+    // loaded (live messages keep appending to an attached window while the request is in flight)
+    // and the newest it observed while detached. The replacement window has caught up to the
+    // present only if it reaches this far.
+    const knownNewest = Math.max(
+      newestServerOriginTime(session.messages) ?? -Infinity,
+      session.detachedNewestTime ?? -Infinity,
+    )
+
+    // The fetched range doesn't have to touch what was loaded, so there may be no seam to splice
+    // them together at and the window is replaced outright.
+    session.messages = toTextMessages(action.payload.messages)
+    session.hasHistory = action.payload.hasMoreBefore
+    session.windowGen += 1
+
+    if (action.payload.hasMoreAfter) {
+      session.hasNewer = true
+      session.detachedNewestTime = knownNewest === -Infinity ? undefined : knownNewest
+    } else {
+      // The server saw nothing newer than the replacement window, but a message that arrived
+      // between its query running and this response landing exists only past the window's newer
+      // edge, so the window must stay detached and page forward to it. A message this client
+      // already knew of when the request was issued is the exception: the query ran late enough to
+      // have seen it, so its absence means it's been deleted (see the matching reasoning where
+      // newer pages land).
+      const newestLoadedTime = newestServerOriginTime(session.messages) ?? -Infinity
+      const knownNewestAtDispatch = action.meta.knownNewestTime ?? -Infinity
+      if (newestLoadedTime < knownNewest && knownNewest > knownNewestAtDispatch) {
+        session.hasNewer = true
+        session.detachedNewestTime = knownNewest
+      } else {
+        session.hasNewer = false
+        session.detachedNewestTime = undefined
+      }
+    }
+  },
+
+  ['@whispers/resetMessageWindow'](state, action) {
+    const { target } = action.payload
 
     const session = state.byId.get(target)
     if (!session) {
       return
     }
 
-    const newMessages = action.payload.messages.map<CommonTextMessage>(msg => ({
-      id: msg.id,
-      type: CommonMessageType.TextMessage,
-      time: msg.time,
-      from: msg.from,
-      text: msg.text,
-    }))
-
-    if (newMessages.length < limit) {
-      session.hasHistory = false
-    }
-
-    updateMessages(state, target, false, messages => newMessages.concat(messages))
+    dropMessageWindow(session)
   },
 
   ['@whispers/activateWhisperSession'](state, action) {
@@ -236,10 +425,18 @@ export default immerKeyedReducer(DEFAULT_STATE, {
 
     const session = state.byId.get(target)!
 
-    const hasHistory = session.messages.length > INACTIVE_SESSION_MAX_HISTORY
+    if (session.hasNewer) {
+      // Keeping a window that sits mid-history would put the user back where they were reading with
+      // no indication that the conversation has run on past it, so a detached window is dropped
+      // whole and the next visit starts from the present like any other fresh open.
+      dropMessageWindow(session)
+    } else {
+      const hasHistory = session.messages.length > INACTIVE_SESSION_MAX_HISTORY
 
-    session.messages = session.messages.slice(-INACTIVE_SESSION_MAX_HISTORY)
-    session.hasHistory = session.hasHistory || hasHistory
+      session.messages = session.messages.slice(-INACTIVE_SESSION_MAX_HISTORY)
+      session.hasHistory = session.hasHistory || hasHistory
+    }
+
     session.activated = false
     session.atBottom = false
     // The unread divider is only consumed once the read position has actually moved past it — a
@@ -265,9 +462,11 @@ export default immerKeyedReducer(DEFAULT_STATE, {
     const wasAtBottom = session.atBottom
     session.atBottom = atBottom
 
-    if (atBottom && !wasAtBottom) {
+    if (atBottom && !wasAtBottom && !session.hasNewer) {
       // The user returned to the bottom after reading scrollback that accumulated past the cap;
-      // drop it now, where the removal is invisible.
+      // drop it now, where the removal is invisible. For a detached window the bottom is only the
+      // end of what's loaded rather than the newest message, and the user is still paging through
+      // it, so nothing is dropped there.
       const hasHistory = session.messages.length > INACTIVE_SESSION_MAX_HISTORY
 
       session.messages = session.messages.slice(-INACTIVE_SESSION_MAX_HISTORY)
@@ -296,15 +495,8 @@ export default immerKeyedReducer(DEFAULT_STATE, {
     const effective = session.lastReadTime!
 
     if (!session.activated) {
-      const messages = session.messages
-      let newestServerOriginTime: number | undefined
-      for (let i = messages.length - 1; i >= 0; i--) {
-        if (isServerOriginMessage(messages[i])) {
-          newestServerOriginTime = messages[i].time
-          break
-        }
-      }
-      if (newestServerOriginTime === undefined || newestServerOriginTime <= effective) {
+      const newestKnownTime = newestServerOriginTime(session.messages)
+      if (newestKnownTime === undefined || newestKnownTime <= effective) {
         session.hasUnread = false
       }
 

--- a/client/whispers/whisper.tsx
+++ b/client/whispers/whisper.tsx
@@ -274,6 +274,7 @@ export function ConnectedWhisper({
           hasMoreHistory: whisperSession.hasHistory,
           loadingNewer: isLoadingNewer,
           hasNewerMessages: whisperSession.hasNewer,
+          windowGeneration: whisperSession.windowGen,
           refreshToken: targetId,
           onLoadMoreMessages,
           onLoadNewerMessages,

--- a/client/whispers/whisper.tsx
+++ b/client/whispers/whisper.tsx
@@ -19,7 +19,10 @@ import {
   correctUsernameForWhisper,
   deactivateWhisperSession,
   getMessageHistory,
+  getMessagesAround,
+  getNewerMessages,
   getWhisperLastReadKey,
+  jumpToPresent,
   markWhisperRead,
   sendMessage,
   startWhisperSessionById,
@@ -148,7 +151,23 @@ export function ConnectedWhisper({
 
   useEffect(() => () => flushLastRead(getWhisperLastReadKey(targetId)), [targetId])
 
+  const unreadLineTime = whisperSession?.unreadLineTime
+
+  const showMessageLoadError = (err: Error) => {
+    // TODO(tec27): This would probably be better to show at the position the message loading
+    // failed in the message list (and offer a button to retry)
+    snackbarController.showSnackbar(
+      t('whispers.errors.loadingHistory', {
+        defaultValue: 'Error loading message history: {{errorMessage}}',
+        errorMessage: err.message,
+      }),
+      DURATION_LONG,
+    )
+  }
+
   const [isLoadingHistory, setIsLoadingHistory] = useState(false)
+  const [isLoadingNewer, setIsLoadingNewer] = useState(false)
+
   const onLoadMoreMessages = useStableCallback(() => {
     setIsLoadingHistory(true)
     dispatch(
@@ -158,19 +177,62 @@ export function ConnectedWhisper({
         },
         onError: err => {
           setIsLoadingHistory(false)
-          // TODO(tec27): This would probably be better to show at the position the message loading
-          // failed in the message list (and offer a button to retry)
-          snackbarController.showSnackbar(
-            t('whispers.errors.loadingHistory', {
-              defaultValue: 'Error loading message history: {{errorMessage}}',
-              errorMessage: err.message,
-            }),
-            DURATION_LONG,
-          )
+          showMessageLoadError(err)
         },
       }),
     )
   })
+
+  const onLoadNewerMessages = () => {
+    setIsLoadingNewer(true)
+    dispatch(
+      getNewerMessages(targetId, MESSAGES_LIMIT, {
+        onSuccess: () => {
+          setIsLoadingNewer(false)
+        },
+        onError: err => {
+          setIsLoadingNewer(false)
+          showMessageLoadError(err)
+        },
+      }),
+    )
+  }
+
+  const onJumpToPresent = () => {
+    setIsLoadingHistory(true)
+    dispatch(
+      jumpToPresent(targetId, MESSAGES_LIMIT, {
+        onSuccess: () => {
+          setIsLoadingHistory(false)
+        },
+        onError: err => {
+          setIsLoadingHistory(false)
+          showMessageLoadError(err)
+        },
+      }),
+    )
+  }
+
+  const onSeekToUnread = () => {
+    if (unreadLineTime === undefined) {
+      return
+    }
+
+    // The whole window is about to be replaced, so there's no one edge the wait belongs to; the
+    // older edge's affordance stands in for both.
+    setIsLoadingHistory(true)
+    dispatch(
+      getMessagesAround(targetId, MESSAGES_LIMIT, unreadLineTime, {
+        onSuccess: () => {
+          setIsLoadingHistory(false)
+        },
+        onError: err => {
+          setIsLoadingHistory(false)
+          showMessageLoadError(err)
+        },
+      }),
+    )
+  }
 
   const onAtBottomChange = (atBottom: boolean) => {
     dispatch(updateSessionAtBottom(targetId, atBottom))
@@ -210,15 +272,20 @@ export function ConnectedWhisper({
           messages: whisperSession.messages,
           loading: isLoadingHistory,
           hasMoreHistory: whisperSession.hasHistory,
+          loadingNewer: isLoadingNewer,
+          hasNewerMessages: whisperSession.hasNewer,
           refreshToken: targetId,
           onLoadMoreMessages,
-          unreadLineTime: whisperSession.unreadLineTime,
+          onLoadNewerMessages,
+          unreadLineTime,
         }}
         inputProps={{
           onSendChatMessage,
           storageKey: `whisper.${targetId}`,
         }}
         onAtBottomChange={onAtBottomChange}
+        onJumpToPresent={onJumpToPresent}
+        onSeekToUnread={onSeekToUnread}
         extraContent={
           <UserInfoContainer>
             <UserProfileOverlayContents userId={targetId} showHintText={false} />

--- a/common/chat.ts
+++ b/common/chat.ts
@@ -462,6 +462,17 @@ export interface GetChannelHistoryServerResponse {
   channelMentions: BasicChannelInfo[]
   /** A list of channel IDs saved in various channel messages that no longer exist. */
   deletedChannels: SbChannelId[]
+  /**
+   * Whether messages older than the returned window exist. For requests with `afterTime`, this is
+   * always true (the cursor implies the client already holds older messages).
+   */
+  hasMoreBefore: boolean
+  /**
+   * Whether messages newer than the returned window existed when the query executed. For requests
+   * with `beforeTime`, this is always true (the cursor implies the client already holds newer
+   * messages); for requests with no cursor (a newest-page fetch), it is always false.
+   */
+  hasMoreAfter: boolean
 }
 
 /**

--- a/common/whispers.ts
+++ b/common/whispers.ts
@@ -93,6 +93,17 @@ export interface GetSessionHistoryResponse {
   channelMentions: BasicChannelInfo[]
   /** A list of channel IDs saved in various whisper messages that no longer exist. */
   deletedChannels: SbChannelId[]
+  /**
+   * Whether messages older than the returned window exist. For requests with `afterTime`, this is
+   * always true (the cursor implies the client already holds older messages).
+   */
+  hasMoreBefore: boolean
+  /**
+   * Whether messages newer than the returned window existed when the query executed. For requests
+   * with `beforeTime`, this is always true (the cursor implies the client already holds newer
+   * messages); for requests with no cursor (a newest-page fetch), it is always false.
+   */
+  hasMoreAfter: boolean
 }
 
 export enum WhisperServiceErrorCode {

--- a/server/lib/chat/chat-api.ts
+++ b/server/lib/chat/chat-api.ts
@@ -365,12 +365,19 @@ export class ChatApi {
   async getChannelHistory(ctx: RouterContext): Promise<GetChannelHistoryServerResponse> {
     const channelId = getValidatedChannelId(ctx)
     const {
-      query: { limit, beforeTime },
+      query: { limit, beforeTime, afterTime, aroundTime },
     } = validateRequest(ctx, {
-      query: Joi.object<{ limit: number; beforeTime: number }>({
+      query: Joi.object<{
+        limit: number
+        beforeTime?: number
+        afterTime?: number
+        aroundTime?: number
+      }>({
         limit: Joi.number().min(1).max(100),
         beforeTime: Joi.number().min(-1),
-      }),
+        afterTime: Joi.number().min(0),
+        aroundTime: Joi.number().min(0),
+      }).oxor('beforeTime', 'afterTime', 'aroundTime'),
     })
 
     return await this.chatService.getChannelHistory({
@@ -378,6 +385,8 @@ export class ChatApi {
       userId: ctx.session!.user.id,
       limit,
       beforeTime,
+      afterTime,
+      aroundTime,
     })
   }
 

--- a/server/lib/chat/chat-models.ts
+++ b/server/lib/chat/chat-models.ts
@@ -484,38 +484,141 @@ export async function addMessageToChannel<T extends ChatMessageData>(
   }
 }
 
+/**
+ * Where to start a page of message history from, and in which direction to read: `newest` gets
+ * the most recent page with no time bound, `before`/`after` get a page strictly older/newer than
+ * `date`, and `around` gets messages from both sides of `date` (inclusive on the newer side).
+ */
+export type HistoryCursor = { kind: 'newest' } | { kind: 'before' | 'after' | 'around'; date: Date }
+
+/**
+ * A page of channel messages, along with whether messages exist beyond either edge of the
+ * returned window (evaluated at query time via a `limit`+1 probe row per edge).
+ */
+export interface ChannelMessagePage {
+  /** Messages in the page, ordered oldest to newest. */
+  messages: ChatMessage[]
+  /** Whether messages older than the returned window exist. */
+  hasMoreBefore: boolean
+  /** Whether messages newer than the returned window exist. */
+  hasMoreAfter: boolean
+}
+
+function convertChatMessageRow(row: DbChatMessage): ChatMessage {
+  return {
+    msgId: row.msg_id,
+    userId: row.user_id,
+    channelId: row.channel_id,
+    sent: row.sent,
+    data: row.data,
+  }
+}
+
 export async function getMessagesForChannel(
   channelId: SbChannelId,
   limit = 50,
-  beforeDate?: Date,
-): Promise<ChatMessage[]> {
+  cursor: HistoryCursor = { kind: 'newest' },
+): Promise<ChannelMessagePage> {
   const { client, done } = await db()
 
-  let query = sql`
-      WITH messages AS (
-        SELECT m.id AS msg_id, m.user_id, m.channel_id, m.sent, m.data
-        FROM channel_messages as m
-        WHERE m.channel_id = ${channelId} `
-
-  if (beforeDate !== undefined) {
-    query = query.append(sql`AND m.sent < ${beforeDate}`)
-  }
-
-  query = query.append(sql`
-        ORDER BY m.sent DESC
-        LIMIT ${limit}
-      ) SELECT * FROM messages ORDER BY sent ASC`)
-
   try {
-    const result = await client.query<DbChatMessage>(query)
+    switch (cursor.kind) {
+      case 'newest':
+      case 'before': {
+        let query = sql`
+          SELECT m.id AS msg_id, m.user_id, m.channel_id, m.sent, m.data
+          FROM channel_messages m
+          WHERE m.channel_id = ${channelId}
+        `
+        if (cursor.kind === 'before') {
+          query = query.append(sql` AND m.sent < ${cursor.date}`)
+        }
+        query = query.append(sql`
+          ORDER BY m.sent DESC
+          LIMIT ${limit + 1};
+        `)
 
-    return result.rows.map(row => ({
-      msgId: row.msg_id,
-      userId: row.user_id,
-      channelId: row.channel_id,
-      sent: row.sent,
-      data: row.data,
-    }))
+        const result = await client.query<DbChatMessage>(query)
+        // A `limit`+1'th row means messages older than the page exist; it's dropped below rather
+        // than returned.
+        const hasMoreBefore = result.rows.length > limit
+        const rows = hasMoreBefore ? result.rows.slice(0, limit) : result.rows
+
+        return {
+          messages: rows.map(convertChatMessageRow).reverse(),
+          hasMoreBefore,
+          hasMoreAfter: cursor.kind === 'before',
+        }
+      }
+
+      case 'after': {
+        const result = await client.query<DbChatMessage>(sql`
+          SELECT m.id AS msg_id, m.user_id, m.channel_id, m.sent, m.data
+          FROM channel_messages m
+          WHERE m.channel_id = ${channelId} AND m.sent > ${cursor.date}
+          ORDER BY m.sent ASC
+          LIMIT ${limit + 1};
+        `)
+        // Ascending scan, so the extra probe row (if present) is the newest of the batch.
+        const hasMoreAfter = result.rows.length > limit
+        const rows = hasMoreAfter ? result.rows.slice(0, limit) : result.rows
+
+        return {
+          messages: rows.map(convertChatMessageRow),
+          hasMoreBefore: true,
+          hasMoreAfter,
+        }
+      }
+
+      case 'around': {
+        const beforeLimit = Math.floor(limit / 2)
+        const afterLimit = limit - beforeLimit
+        // `is_before` lets the two halves be told apart in JS without comparing timestamps
+        // against `cursor.date` there (the DB's microsecond-precision `sent` loses precision when
+        // parsed into a JS `Date`, so that comparison has to stay server-side). Each half keeps
+        // its own scan order in the output (`is_before DESC` groups before-half rows first, each
+        // half internally ascending by `sent`), so the probe row for each half is always at a
+        // fixed end: the before-half's oldest row, or the after-half's newest row.
+        const result = await client.query<DbChatMessage & { is_before: boolean }>(sql`
+          WITH before_half AS (
+            SELECT m.id AS msg_id, m.user_id, m.channel_id, m.sent, m.data
+            FROM channel_messages m
+            WHERE m.channel_id = ${channelId} AND m.sent < ${cursor.date}
+            ORDER BY m.sent DESC
+            LIMIT ${beforeLimit + 1}
+          ), after_half AS (
+            SELECT m.id AS msg_id, m.user_id, m.channel_id, m.sent, m.data
+            FROM channel_messages m
+            WHERE m.channel_id = ${channelId} AND m.sent >= ${cursor.date}
+            ORDER BY m.sent ASC
+            LIMIT ${afterLimit + 1}
+          )
+          SELECT *, TRUE AS is_before FROM before_half
+          UNION ALL
+          SELECT *, FALSE AS is_before FROM after_half
+          ORDER BY is_before DESC, sent ASC;
+        `)
+
+        const beforeRows = result.rows.filter(row => row.is_before)
+        const afterRows = result.rows.filter(row => !row.is_before)
+        const hasMoreBefore = beforeRows.length > beforeLimit
+        const hasMoreAfter = afterRows.length > afterLimit
+        // Both halves are already in ascending order (see the query comment above), so the probe
+        // sits at a known end: the before-half's first (oldest) row, or the after-half's last
+        // (newest) row.
+        const trimmedBefore = hasMoreBefore ? beforeRows.slice(1) : beforeRows
+        const trimmedAfter = hasMoreAfter ? afterRows.slice(0, -1) : afterRows
+
+        return {
+          messages: [...trimmedBefore, ...trimmedAfter].map(convertChatMessageRow),
+          hasMoreBefore,
+          hasMoreAfter,
+        }
+      }
+
+      default:
+        return assertUnreachable(cursor)
+    }
   } finally {
     done()
   }

--- a/server/lib/chat/chat-service.test.ts
+++ b/server/lib/chat/chat-service.test.ts
@@ -139,7 +139,9 @@ vi.mock('./chat-models', async () => {
     transferChannelOwnership: vi.fn(),
     addUserToChannel: vi.fn(),
     addMessageToChannel: vi.fn(),
-    getMessagesForChannel: vi.fn().mockResolvedValue([]),
+    getMessagesForChannel: vi
+      .fn()
+      .mockResolvedValue({ messages: [], hasMoreBefore: false, hasMoreAfter: false }),
     deleteChannelMessage: vi.fn(),
     removeUserFromChannel: vi.fn(),
     updateUserPreferences: vi.fn(),
@@ -2137,13 +2139,17 @@ describe('chat/chat-service', () => {
 
     const mockTextMessages = () => {
       asMockedFunction(getUserChannelEntryForUser).mockResolvedValue(user1TestChannelEntry)
-      asMockedFunction(getMessagesForChannel).mockResolvedValue([
-        joinUser1TestChannelMessage,
-        textMessage1,
-        textMessage2,
-        textMessage3,
-        textMessage4,
-      ])
+      asMockedFunction(getMessagesForChannel).mockResolvedValue({
+        messages: [
+          joinUser1TestChannelMessage,
+          textMessage1,
+          textMessage2,
+          textMessage3,
+          textMessage4,
+        ],
+        hasMoreBefore: true,
+        hasMoreAfter: false,
+      })
       asMockedFunction(getChannelInfos).mockResolvedValue([shieldBatteryChannel, testChannel])
     }
     const expectItWorks = (result: GetChannelHistoryServerResponse) => {
@@ -2162,6 +2168,8 @@ describe('chat/chat-service', () => {
           toBasicChannelInfo(testChannel),
         ],
         deletedChannels: [],
+        hasMoreBefore: true,
+        hasMoreAfter: false,
       })
     }
 
@@ -2256,7 +2264,11 @@ describe('chat/chat-service', () => {
         },
       }
 
-      asMockedFunction(getMessagesForChannel).mockResolvedValue([message])
+      asMockedFunction(getMessagesForChannel).mockResolvedValue({
+        messages: [message],
+        hasMoreBefore: false,
+        hasMoreAfter: false,
+      })
       asMockedFunction(getChannelInfos).mockResolvedValue([shieldBatteryChannel, testChannel])
 
       const result = await chatService.getChannelHistory({
@@ -2274,6 +2286,87 @@ describe('chat/chat-service', () => {
           toBasicChannelInfo(testChannel),
         ],
         deletedChannels: [DELETED_ID],
+        hasMoreBefore: false,
+        hasMoreAfter: false,
+      })
+    })
+
+    describe('cursor selection', () => {
+      beforeEach(() => {
+        asMockedFunction(getUserChannelEntryForUser).mockResolvedValue(user1TestChannelEntry)
+        asMockedFunction(getMessagesForChannel).mockResolvedValue({
+          messages: [],
+          hasMoreBefore: true,
+          hasMoreAfter: true,
+        })
+        asMockedFunction(getChannelInfos).mockResolvedValue([])
+      })
+
+      test('uses a newest cursor and carries through the flags when no time param is given', async () => {
+        const result = await chatService.getChannelHistory({
+          channelId: testChannel.id,
+          userId: user1.id,
+          limit: 50,
+        })
+
+        expect(getMessagesForChannel).toHaveBeenCalledWith(testChannel.id, 50, { kind: 'newest' })
+        expect(result.hasMoreBefore).toBe(true)
+        expect(result.hasMoreAfter).toBe(true)
+      })
+
+      test('uses a before cursor when beforeTime is greater than -1', async () => {
+        await chatService.getChannelHistory({
+          channelId: testChannel.id,
+          userId: user1.id,
+          limit: 50,
+          beforeTime: 1000,
+        })
+
+        expect(getMessagesForChannel).toHaveBeenCalledWith(testChannel.id, 50, {
+          kind: 'before',
+          date: new Date(1000),
+        })
+      })
+
+      test('uses a newest cursor when beforeTime is -1', async () => {
+        await chatService.getChannelHistory({
+          channelId: testChannel.id,
+          userId: user1.id,
+          limit: 50,
+          beforeTime: -1,
+        })
+
+        expect(getMessagesForChannel).toHaveBeenCalledWith(testChannel.id, 50, { kind: 'newest' })
+      })
+
+      test('uses an after cursor when afterTime is given', async () => {
+        const result = await chatService.getChannelHistory({
+          channelId: testChannel.id,
+          userId: user1.id,
+          limit: 50,
+          afterTime: 2000,
+        })
+
+        expect(getMessagesForChannel).toHaveBeenCalledWith(testChannel.id, 50, {
+          kind: 'after',
+          date: new Date(2000),
+        })
+        expect(result.hasMoreBefore).toBe(true)
+        expect(result.hasMoreAfter).toBe(true)
+      })
+
+      test('uses an around cursor when aroundTime is given', async () => {
+        await chatService.getChannelHistory({
+          channelId: testChannel.id,
+          userId: user1.id,
+          limit: 50,
+          aroundTime: 3000,
+        })
+
+        expect(getMessagesForChannel).toHaveBeenCalledWith(testChannel.id, 50, {
+          kind: 'around',
+          date: new Date(3000),
+        })
       })
     })
   })

--- a/server/lib/chat/chat-service.ts
+++ b/server/lib/chat/chat-service.ts
@@ -64,6 +64,7 @@ import {
   ChatMessage,
   EditableChannelFields,
   FullChannelInfo,
+  HistoryCursor,
   LeaveChannelResult,
   addMessageToChannel,
   addUserToChannel,
@@ -957,12 +958,16 @@ export default class ChatService {
     userId,
     limit,
     beforeTime,
+    afterTime,
+    aroundTime,
     isAdmin,
   }: {
     channelId: SbChannelId
     userId: SbUserId
     limit?: number
     beforeTime?: number
+    afterTime?: number
+    aroundTime?: number
     isAdmin?: boolean
   }): Promise<GetChannelHistoryServerResponse> {
     const isUserInChannel = Boolean(await getUserChannelEntryForUser(userId, channelId))
@@ -973,11 +978,21 @@ export default class ChatService {
       )
     }
 
-    const dbMessages = await getMessagesForChannel(
-      channelId,
-      limit,
-      beforeTime && beforeTime > -1 ? new Date(beforeTime) : undefined,
-    )
+    // Joi's `.oxor` guarantees at most one of these is present on the request.
+    let cursor: HistoryCursor = { kind: 'newest' }
+    if (beforeTime && beforeTime > -1) {
+      cursor = { kind: 'before', date: new Date(beforeTime) }
+    } else if (afterTime !== undefined && afterTime >= 0) {
+      cursor = { kind: 'after', date: new Date(afterTime) }
+    } else if (aroundTime !== undefined && aroundTime >= 0) {
+      cursor = { kind: 'around', date: new Date(aroundTime) }
+    }
+
+    const {
+      messages: dbMessages,
+      hasMoreBefore,
+      hasMoreAfter,
+    } = await getMessagesForChannel(channelId, limit, cursor)
 
     const messages: ServerChatMessage[] = []
     const userIds = new global.Set<SbUserId>()
@@ -1042,6 +1057,8 @@ export default class ChatService {
       mentions: userMentions,
       channelMentions: channelMentions.map(c => toBasicChannelInfo(c)),
       deletedChannels,
+      hasMoreBefore,
+      hasMoreAfter,
     }
   }
 

--- a/server/lib/whispers/whisper-api.ts
+++ b/server/lib/whispers/whisper-api.ts
@@ -190,7 +190,10 @@ export class WhisperApi {
   @httpBefore(throttleMiddleware(retrievalThrottle, throttleByUser))
   getSessionHistoryOld(
     ctx: RouterContext,
-  ): Omit<GetSessionHistoryResponse, 'mentions' | 'channelMentions' | 'deletedChannels'> {
+  ): Omit<
+    GetSessionHistoryResponse,
+    'mentions' | 'channelMentions' | 'deletedChannels' | 'hasMoreBefore' | 'hasMoreAfter'
+  > {
     return {
       messages: [],
       users: [],
@@ -202,15 +205,22 @@ export class WhisperApi {
   async getSessionHistory(ctx: RouterContext): Promise<GetSessionHistoryResponse> {
     const {
       params: { targetId },
-      query: { limit, beforeTime },
+      query: { limit, beforeTime, afterTime, aroundTime },
     } = validateRequest(ctx, {
       params: Joi.object<{ targetId: SbUserId }>({
         targetId: joiUserId().required(),
       }),
-      query: Joi.object<{ limit: number; beforeTime: number }>({
+      query: Joi.object<{
+        limit: number
+        beforeTime?: number
+        afterTime?: number
+        aroundTime?: number
+      }>({
         limit: Joi.number().min(1).max(100),
         beforeTime: Joi.number().min(-1),
-      }),
+        afterTime: Joi.number().min(0),
+        aroundTime: Joi.number().min(0),
+      }).oxor('beforeTime', 'afterTime', 'aroundTime'),
     })
 
     return await this.whisperService.getSessionHistory(
@@ -218,6 +228,8 @@ export class WhisperApi {
       targetId,
       limit,
       beforeTime,
+      afterTime,
+      aroundTime,
     )
   }
 }

--- a/server/lib/whispers/whisper-models.ts
+++ b/server/lib/whispers/whisper-models.ts
@@ -1,6 +1,8 @@
+import { assertUnreachable } from '../../../common/assert-unreachable'
 import { SbChannelId } from '../../../common/chat'
 import { SbUserId } from '../../../common/users/sb-user-id'
 import { WhisperMessageType } from '../../../common/whispers'
+import { HistoryCursor } from '../chat/chat-models'
 import db from '../db'
 import { sql } from '../db/sql'
 import { Dbify } from '../db/types'
@@ -228,32 +230,127 @@ export async function addMessageToWhisper(
   }
 }
 
+/**
+ * A page of whisper session messages, along with whether messages exist beyond either edge of the
+ * returned window (evaluated at query time via a `limit`+1 probe row per edge).
+ */
+export interface WhisperMessagePage {
+  /** Messages in the page, ordered oldest to newest. */
+  messages: WhisperMessage[]
+  /** Whether messages older than the returned window exist. */
+  hasMoreBefore: boolean
+  /** Whether messages newer than the returned window exist. */
+  hasMoreAfter: boolean
+}
+
 export async function getMessagesForWhisperSession(
   userId1: SbUserId,
   userId2: SbUserId,
   limit = 50,
-  beforeDate?: Date,
-): Promise<WhisperMessage[]> {
+  cursor: HistoryCursor = { kind: 'newest' },
+): Promise<WhisperMessagePage> {
   const [userLow, userHigh] = userId1 < userId2 ? [userId1, userId2] : [userId2, userId1]
   const { client, done } = await db()
 
   try {
-    const result = await client.query<DbWhisperMessage>(sql`
-      WITH messages AS (
-        SELECT m.id, m.from_id AS "from", m.to_id AS "to", m.sent, m.data
-        FROM whisper_messages AS m
-        WHERE m.user_low  = ${userLow}::int4
-          AND m.user_high = ${userHigh}::int4
-          ${beforeDate !== undefined ? sql`AND m.sent < ${beforeDate}` : sql``}
-        ORDER BY m.sent DESC
-        LIMIT ${limit}
-      )
-      SELECT *
-      FROM messages
-      ORDER BY sent ASC;
-    `)
+    switch (cursor.kind) {
+      case 'newest':
+      case 'before': {
+        const result = await client.query<DbWhisperMessage>(sql`
+          SELECT m.id, m.from_id AS "from", m.to_id AS "to", m.sent, m.data
+          FROM whisper_messages AS m
+          WHERE m.user_low  = ${userLow}::int4
+            AND m.user_high = ${userHigh}::int4
+            ${cursor.kind === 'before' ? sql`AND m.sent < ${cursor.date}` : sql``}
+          ORDER BY m.sent DESC
+          LIMIT ${limit + 1};
+        `)
+        // A `limit`+1'th row means messages older than the page exist; it's dropped below rather
+        // than returned.
+        const hasMoreBefore = result.rows.length > limit
+        const rows = hasMoreBefore ? result.rows.slice(0, limit) : result.rows
 
-    return result.rows.map(row => convertMessageFromDb(row))
+        return {
+          messages: rows.map(row => convertMessageFromDb(row)).reverse(),
+          hasMoreBefore,
+          hasMoreAfter: cursor.kind === 'before',
+        }
+      }
+
+      case 'after': {
+        const result = await client.query<DbWhisperMessage>(sql`
+          SELECT m.id, m.from_id AS "from", m.to_id AS "to", m.sent, m.data
+          FROM whisper_messages AS m
+          WHERE m.user_low  = ${userLow}::int4
+            AND m.user_high = ${userHigh}::int4
+            AND m.sent > ${cursor.date}
+          ORDER BY m.sent ASC
+          LIMIT ${limit + 1};
+        `)
+        // Ascending scan, so the extra probe row (if present) is the newest of the batch.
+        const hasMoreAfter = result.rows.length > limit
+        const rows = hasMoreAfter ? result.rows.slice(0, limit) : result.rows
+
+        return {
+          messages: rows.map(row => convertMessageFromDb(row)),
+          hasMoreBefore: true,
+          hasMoreAfter,
+        }
+      }
+
+      case 'around': {
+        const beforeLimit = Math.floor(limit / 2)
+        const afterLimit = limit - beforeLimit
+        // `is_before` lets the two halves be told apart in JS without comparing timestamps
+        // against `cursor.date` there (the DB's microsecond-precision `sent` loses precision when
+        // parsed into a JS `Date`, so that comparison has to stay server-side). Each half keeps
+        // its own scan order in the output (`is_before DESC` groups before-half rows first, each
+        // half internally ascending by `sent`), so the probe row for each half is always at a
+        // fixed end: the before-half's oldest row, or the after-half's newest row.
+        const result = await client.query<DbWhisperMessage & { is_before: boolean }>(sql`
+          WITH before_half AS (
+            SELECT m.id, m.from_id AS "from", m.to_id AS "to", m.sent, m.data
+            FROM whisper_messages AS m
+            WHERE m.user_low  = ${userLow}::int4
+              AND m.user_high = ${userHigh}::int4
+              AND m.sent < ${cursor.date}
+            ORDER BY m.sent DESC
+            LIMIT ${beforeLimit + 1}
+          ), after_half AS (
+            SELECT m.id, m.from_id AS "from", m.to_id AS "to", m.sent, m.data
+            FROM whisper_messages AS m
+            WHERE m.user_low  = ${userLow}::int4
+              AND m.user_high = ${userHigh}::int4
+              AND m.sent >= ${cursor.date}
+            ORDER BY m.sent ASC
+            LIMIT ${afterLimit + 1}
+          )
+          SELECT *, TRUE AS is_before FROM before_half
+          UNION ALL
+          SELECT *, FALSE AS is_before FROM after_half
+          ORDER BY is_before DESC, sent ASC;
+        `)
+
+        const beforeRows = result.rows.filter(row => row.is_before)
+        const afterRows = result.rows.filter(row => !row.is_before)
+        const hasMoreBefore = beforeRows.length > beforeLimit
+        const hasMoreAfter = afterRows.length > afterLimit
+        // Both halves are already in ascending order (see the query comment above), so the probe
+        // sits at a known end: the before-half's first (oldest) row, or the after-half's last
+        // (newest) row.
+        const trimmedBefore = hasMoreBefore ? beforeRows.slice(1) : beforeRows
+        const trimmedAfter = hasMoreAfter ? afterRows.slice(0, -1) : afterRows
+
+        return {
+          messages: [...trimmedBefore, ...trimmedAfter].map(row => convertMessageFromDb(row)),
+          hasMoreBefore,
+          hasMoreAfter,
+        }
+      }
+
+      default:
+        return assertUnreachable(cursor)
+    }
   } finally {
     done()
   }

--- a/server/lib/whispers/whisper-service.ts
+++ b/server/lib/whispers/whisper-service.ts
@@ -17,7 +17,7 @@ import {
   WhisperSessionInitEvent,
   WhisperUserEvent,
 } from '../../../common/whispers'
-import { getChannelInfos, toBasicChannelInfo } from '../chat/chat-models'
+import { getChannelInfos, HistoryCursor, toBasicChannelInfo } from '../chat/chat-models'
 import logger from '../logging/logger'
 import filterChatMessage from '../messaging/filter-chat-message'
 import { processMessageContents } from '../messaging/process-chat-message'
@@ -229,6 +229,8 @@ export default class WhisperService {
     targetUser: SbUserId,
     limit?: number,
     beforeTime?: number,
+    afterTime?: number,
+    aroundTime?: number,
   ): Promise<GetSessionHistoryResponse> {
     const [user, target] = await Promise.all([
       this.getUserById(userId),
@@ -242,12 +244,21 @@ export default class WhisperService {
       )
     }
 
-    const dbMessages = await getMessagesForWhisperSession(
-      user.id,
-      target.id,
-      limit,
-      beforeTime && beforeTime > -1 ? new Date(beforeTime) : undefined,
-    )
+    // Joi's `.oxor` guarantees at most one of these is present on the request.
+    let cursor: HistoryCursor = { kind: 'newest' }
+    if (beforeTime && beforeTime > -1) {
+      cursor = { kind: 'before', date: new Date(beforeTime) }
+    } else if (afterTime !== undefined && afterTime >= 0) {
+      cursor = { kind: 'after', date: new Date(afterTime) }
+    } else if (aroundTime !== undefined && aroundTime >= 0) {
+      cursor = { kind: 'around', date: new Date(aroundTime) }
+    }
+
+    const {
+      messages: dbMessages,
+      hasMoreBefore,
+      hasMoreAfter,
+    } = await getMessagesForWhisperSession(user.id, target.id, limit, cursor)
 
     const messages: WhisperMessage[] = []
     const userMentionIds = new Set<SbUserId>()
@@ -298,6 +309,8 @@ export default class WhisperService {
       mentions: userMentions,
       channelMentions: channelMentions.map(c => toBasicChannelInfo(c)),
       deletedChannels,
+      hasMoreBefore,
+      hasMoreAfter,
     }
   }
 

--- a/server/public/locales/en/global.json
+++ b/server/public/locales/en/global.json
@@ -1470,6 +1470,7 @@
     "copyLinkAddress": "Copy link address",
     "copyMessage": "Copy message",
     "jumpToBottom": "Jump to bottom",
+    "jumpToPresent": "Jump to present",
     "mention": "Mention",
     "messageTooLongContent": "Messages can be at most {{maxLength}} characters, and this one is {{length}}. Please shorten it before sending.",
     "messageTooLongTitle": "Message too long",

--- a/server/public/locales/es/global.json
+++ b/server/public/locales/es/global.json
@@ -1465,13 +1465,20 @@
   },
   "messaging": {
     "blockedMessage": "Mensaje bloqueado",
+    "copyLinkAddress": "Copiar dirección del enlace",
+    "copyMessage": "Copiar mensaje",
+    "jumpToBottom": "Saltar al final",
+    "jumpToPresent": "Saltar al presente",
     "mention": "Mención",
     "messageTooLongContent": "Los mensajes pueden tener como máximo {{maxLength}} caracteres, y este tiene {{length}}. Acórtalo antes de enviarlo.",
     "messageTooLongTitle": "Mensaje demasiado largo",
     "newDayMessage": "Día cambiado a <2>{{day}}</2>",
+    "newMessages": "Mensajes nuevos",
+    "openLink": "Abrir enlace",
     "searchWithGoogle": "Buscar con Google",
     "sendMessage": "Enviar un mensaje",
-    "sendMessageChatRestricted": "Restringido de enviar mensajes hasta {{date}}"
+    "sendMessageChatRestricted": "Restringido de enviar mensajes hasta {{date}}",
+    "unreadLineLabel": "Nuevo"
   },
   "navigation": {
     "bar": {

--- a/server/public/locales/ko/global.json
+++ b/server/public/locales/ko/global.json
@@ -1431,13 +1431,20 @@
   },
   "messaging": {
     "blockedMessage": "차단된 메시지",
+    "copyLinkAddress": "링크 주소 복사",
+    "copyMessage": "메시지 복사",
+    "jumpToBottom": "맨 아래로 이동",
+    "jumpToPresent": "최신 메시지로 이동",
     "mention": "멘션",
     "messageTooLongContent": "메시지는 최대 {{maxLength}}자까지 보낼 수 있는데, 이 메시지는 {{length}}자입니다. 줄여서 다시 보내 주세요.",
     "messageTooLongTitle": "메시지가 너무 깁니다",
     "newDayMessage": "날짜가 <2>{{day}}</2>(으)로 바뀌었습니다",
+    "newMessages": "새 메시지",
+    "openLink": "링크 열기",
     "searchWithGoogle": "Google에서 검색",
     "sendMessage": "메시지를 입력하세요",
-    "sendMessageChatRestricted": "{{date}}까지 메시지 전송이 제한됩니다"
+    "sendMessageChatRestricted": "{{date}}까지 메시지 전송이 제한됩니다",
+    "unreadLineLabel": "신규"
   },
   "navigation": {
     "bar": {

--- a/server/public/locales/ru/global.json
+++ b/server/public/locales/ru/global.json
@@ -1482,13 +1482,20 @@
   },
   "messaging": {
     "blockedMessage": "Заблокированное сообщение",
+    "copyLinkAddress": "Копировать адрес ссылки",
+    "copyMessage": "Копировать сообщение",
+    "jumpToBottom": "Перейти в конец",
+    "jumpToPresent": "Перейти к последним",
     "mention": "Упомянуть",
     "messageTooLongContent": "Сообщение может содержать не более {{maxLength}} символов, а в этом их {{length}}. Сократите его перед отправкой.",
     "messageTooLongTitle": "Слишком длинное сообщение",
     "newDayMessage": "День изменен на <2>{{day}}</2>",
+    "newMessages": "Новые сообщения",
+    "openLink": "Открыть ссылку",
     "searchWithGoogle": "Искать в Google",
     "sendMessage": "Отправить сообщение",
-    "sendMessageChatRestricted": "Отправка сообщений ограничена до {{date}}"
+    "sendMessageChatRestricted": "Отправка сообщений ограничена до {{date}}",
+    "unreadLineLabel": "Новое"
   },
   "navigation": {
     "bar": {

--- a/server/public/locales/zh-Hans/global.json
+++ b/server/public/locales/zh-Hans/global.json
@@ -1431,13 +1431,20 @@
   },
   "messaging": {
     "blockedMessage": "消息被屏蔽",
+    "copyLinkAddress": "复制链接地址",
+    "copyMessage": "复制消息",
+    "jumpToBottom": "跳至底部",
+    "jumpToPresent": "跳至最新消息",
     "mention": "提到",
     "messageTooLongContent": "消息最多只能有 {{maxLength}} 个字符，这条有 {{length}} 个。请缩短后再发送。",
     "messageTooLongTitle": "消息过长",
     "newDayMessage": "日期已变为<2>{{day}}</2>",
+    "newMessages": "新消息",
+    "openLink": "打开链接",
     "searchWithGoogle": "用谷歌搜索",
     "sendMessage": "发送消息",
-    "sendMessageChatRestricted": "限制发送消息至 {{date}}"
+    "sendMessageChatRestricted": "限制发送消息至 {{date}}",
+    "unreadLineLabel": "新"
   },
   "navigation": {
     "bar": {


### PR DESCRIPTION
Implements F2 of the chat roadmap: the loaded message window for channels and whispers can detach from the present, enabling jumps to any depth of history.

## Server
- `GET …/messages2` (chat + whispers) gains `afterTime` and `aroundTime` query params, mutually exclusive with `beforeTime` (Joi `.oxor`). `aroundTime` returns `floor(limit/2)` messages before the cursor and the rest at-or-after it (inclusive on the newer side, so the message at exactly T is captured — the unread-jump case) in a single two-CTE statement with an `is_before` marker column so the halves split exactly in JS despite sub-ms precision loss in `Date` parsing.
- Responses now carry explicit `hasMoreBefore`/`hasMoreAfter` flags (limit+1 probe rows); the client's `messages.length < limit` inference is gone — it couldn't describe an around-fetch's two edges.
- EXPLAIN-verified: both around halves use `channel_messages_channel_id_sent_idx` (forward + backward index scans, 0.135 ms on the dev DB).

## Client window model
- `MessagesState`/`WhisperSession` gain `hasNewer` (window detached from present), `loadingNewer`, `detachedNewestTime`, and `windowGen` (in-flight pages for a dropped/replaced window are discarded).
- **Don't-append-while-detached:** a live message arriving while detached is not appended — it belongs past the gap. It still drives all unread/mention/divider bookkeeping, and its time is recorded so reattachment can prove the window caught up.
- **Reattachment convergence:** an `afterTime` page reattaches only when the server says nothing is newer *and* the window has reached everything observed live. Requests are stamped with the newest message time known at dispatch, so a message that was deleted mid-flight attaches cleanly (its absence from a late-enough query proves deletion) instead of looping the sentinel forever, while a genuine mid-flight arrival keeps the window detached until the next page catches it.
- The unread banner's far-jump now does **one** `aroundTime` fetch replacing the window (the interim page-older-until-found loop from #1439 is deleted); the seek machinery survives only to position the viewport once the divider renders.
- Jump-to-bottom becomes **"Jump to present"** while detached: drops the window and refetches the newest page in the same tick.
- Detached windows are never trimmed (there's no scroll compensation for top-removals) and are dropped whole on deactivation, so reopening a channel always starts from the present.
- `MessageList` suppresses the at-bottom auto-pin while detached (appends-below must not yank) — including on the reattaching update — and skips both pin and prepend compensation when the window is replaced wholesale.

## Verified
- Unit: 2294 tests pass (new reducer coverage: detach/reattach, convergence races, deletion-attach, windowGen staleness, drop-vs-trim on deactivate, seam dedupe); typecheck + lint clean.
- Live (2 Electron clients, seeded 300-deep unread in #ShieldBattery + a whisper conversation): banner far-jump = exactly one `aroundTime` request, divider lands visible at viewport top; four `afterTime` pages to reattach; a live message sent while detached was not appended, only tracked, and the reattach caught it; trim resumed only after reattach (99→276 growth while detached, then 276→150); "Jump to present" dropped the window, did one `beforeTime=-1` fetch, and pinned to bottom; whisper surface verified for the same flows.

New `messaging.*` strings translated (es/ko/ru/zh-Hans), including the #1419/#1439 strings that had no translations yet. The rendered-UI language pass for these seven short labels was skipped (auto-sizing pill/labels).