### PR TITLE
Treat never-read channels as unread since the member's join date

### DIFF
--- a/client/chat/chat-reducer.ts
+++ b/client/chat/chat-reducer.ts
@@ -106,12 +106,12 @@ const DEFAULT_CHAT_STATE: Immutable<ChatState> = {
 }
 
 /**
- * Returns whether `channelId` has an unread message that mentions the current user. `undefined`
- * `idToLastReadTime` is treated the same way the server treats a NULL `last_read_time`: as
- * "everything is read" rather than "everything is unread". The server never seeds mention state
- * for a channel with no recorded read position (there's nothing to compare newly-arrived messages
- * against yet), so the client has to apply the same rule here, or a fresh channel would flip its
- * badge to urgent the moment a message with a stale mention time got merged in.
+ * Returns whether `channelId` has an unread message that mentions the current user. The server
+ * always sends a read marker for a joined channel (falling back to one millisecond before the
+ * member's join date when none has been recorded), so a joined channel with mention state should
+ * always have an `idToLastReadTime` entry; if one is somehow missing, `?? Infinity` fails toward
+ * "everything is read" rather than flipping the badge to urgent with nothing to compare the
+ * mention time against.
  */
 export function channelHasUnreadMention(
   chatState: Immutable<ChatState>,

--- a/common/chat.ts
+++ b/common/chat.ts
@@ -239,9 +239,10 @@ export interface InitialChannelData {
    */
   hasUnread?: boolean
   /**
-   * Epoch millis of the user's last recorded read position in the channel, if they have one. Used
-   * to place the unread-messages divider; `hasUnread` stays the authority for badge state since
-   * the client can't compute unreadness itself without messages loaded.
+   * Epoch millis of the user's read position in the channel: their last recorded read position, or
+   * one millisecond before their join date if they've never recorded one. Used to place the
+   * unread-messages divider; `hasUnread` stays the authority for badge state since the client can't
+   * compute unreadness itself without messages loaded.
    */
   lastReadTime?: number
   /**

--- a/common/whispers.ts
+++ b/common/whispers.ts
@@ -147,9 +147,9 @@ export interface GetWhisperSessionsResponse {
    */
   unreadSessions?: SbUserId[]
   /**
-   * Epoch millis of the user's last recorded read position for each whisper session that has one.
-   * A session whose target ID is absent from this list has no recorded read position. Additive
-   * over the base response so older clients ignore it.
+   * Epoch millis of the user's read position for each whisper session: their last recorded read
+   * position, or one millisecond before the session's start date if they've never recorded one.
+   * Every session is listed. Additive over the base response so older clients ignore it.
    */
   lastReadTimes?: Array<{ targetId: SbUserId; lastReadTime: number }>
 }

--- a/migrations/20260830120000_backfill_channel_last_read_time.sql
+++ b/migrations/20260830120000_backfill_channel_last_read_time.sql
@@ -1,0 +1,9 @@
+-- For channel members, a NULL last_read_time means "unread since joining the channel" (the unread
+-- queries fall back to channel_users.join_date), matching the start_date rule for whisper
+-- sessions. Existing rows predate read tracking entirely, so they're stamped as read-up-to-now
+-- once: without this, the first deploy would surface every channel as unread since each member
+-- joined, years of already-seen messages and mentions included. This supersedes the channels
+-- paragraph of the whisper backfill migration, which described NULL as "everything is read".
+UPDATE channel_users
+SET last_read_time = now()
+WHERE last_read_time IS NULL;

--- a/server/lib/chat/chat-models.ts
+++ b/server/lib/chat/chat-models.ts
@@ -737,12 +737,12 @@ export interface UnreadChannelInfo {
 
 /**
  * Returns unread state for each of a user's joined channels that has a text message sent by
- * someone else after their last recorded read position in that channel. A channel with no
- * recorded read position never counts as unread here, since there's nothing to compare
- * newly-arrived messages against; `markRead` establishes that baseline the first time a client
- * reports one. Only text messages count, mirroring the client's own `makeUnread` flag: join/leave/
- * moderation events never mark a channel unread. A single set-based query over all of the user's
- * channels, rather than one query per channel. `sent` columns store naive UTC wall time (see the
+ * someone else after their last recorded read position in that channel. When no read position has
+ * been recorded yet, messages sent by others at or after the member's `join_date` count as unread
+ * instead, mirroring the whisper query's `start_date` fallback. Only text messages count,
+ * mirroring the client's own `makeUnread` flag: join/leave/moderation events never mark a channel
+ * unread. A single set-based query over all of the user's channels, rather than one query per
+ * channel. `sent` columns store naive UTC wall time (see the
  * timestamp parser setup in `server/lib/db`), so the read position is converted to naive UTC for
  * the comparison instead of being left to the connection's session time zone. The comparison works
  * at millisecond granularity (`sent >= read + 1ms` rather than `sent > read`): read positions
@@ -770,7 +770,7 @@ export async function getUnreadChannelInfo(userId: SbUserId): Promise<UnreadChan
           AND m.user_id != cu.user_id
           AND m.sent >= COALESCE(
             (cu.last_read_time AT TIME ZONE 'UTC') + interval '1 millisecond',
-            'infinity'::timestamp
+            cu.join_date
           )
           AND m.data ? 'mentions'
           AND m.data->'mentions' @> to_jsonb(cu.user_id)
@@ -791,7 +791,7 @@ export async function getUnreadChannelInfo(userId: SbUserId): Promise<UnreadChan
             AND m.user_id != cu.user_id
             AND m.sent >= COALESCE(
               (cu.last_read_time AT TIME ZONE 'UTC') + interval '1 millisecond',
-              'infinity'::timestamp
+              cu.join_date
             )
             AND m.data ->> 'type' = ${ServerChatMessageType.TextMessage}
         )

--- a/server/lib/chat/chat-service.test.ts
+++ b/server/lib/chat/chat-service.test.ts
@@ -541,6 +541,7 @@ describe('chat/chat-service', () => {
           selfPreferences: channelPreferences,
           selfPermissions: channelPermissions,
           hasUnread: false,
+          lastReadTime: user1ShieldBatteryChannelEntry.joinDate.getTime() - 1,
         },
         {
           channelInfo: testBasicInfo,
@@ -549,6 +550,7 @@ describe('chat/chat-service', () => {
           selfPreferences: channelPreferences,
           selfPermissions: channelPermissions,
           hasUnread: false,
+          lastReadTime: user1TestChannelEntry.joinDate.getTime() - 1,
         },
       ])
     })
@@ -580,6 +582,7 @@ describe('chat/chat-service', () => {
           selfPreferences: channelPreferences,
           selfPermissions: channelPermissions,
           hasUnread: true,
+          lastReadTime: user1ShieldBatteryChannelEntry.joinDate.getTime() - 1,
         },
       ])
     })
@@ -613,7 +616,40 @@ describe('chat/chat-service', () => {
           selfPreferences: channelPreferences,
           selfPermissions: channelPermissions,
           hasUnread: true,
+          lastReadTime: user1ShieldBatteryChannelEntry.joinDate.getTime() - 1,
           latestMentionTime: latestMentionTime.getTime(),
+        },
+      ])
+    })
+
+    test('uses the recorded read position when one exists, without falling back to join date', async () => {
+      await joinUserToChannel(
+        user1,
+        shieldBatteryChannel,
+        user1ShieldBatteryChannelEntry,
+        joinUser1ShieldBatteryChannelMessage,
+      )
+
+      const lastReadTime = new Date('2023-03-15T00:00:00.000Z')
+
+      asMockedFunction(getChannelsForUser).mockResolvedValue([
+        { ...user1ShieldBatteryChannelEntry, lastReadTime },
+      ])
+      asMockedFunction(getChannelInfos).mockResolvedValue([shieldBatteryChannel])
+
+      const result = await chatService.getJoinedChannels(user1.id)
+
+      asMockedFunction(getChannelsForUser).mockResolvedValue([])
+
+      expect(result).toEqual([
+        {
+          channelInfo: shieldBatteryBasicInfo,
+          detailedChannelInfo: shieldBatteryDetailedInfo,
+          joinedChannelInfo: shieldBatteryJoinedInfo,
+          selfPreferences: channelPreferences,
+          selfPermissions: channelPermissions,
+          hasUnread: false,
+          lastReadTime: lastReadTime.getTime(),
         },
       ])
     })
@@ -703,6 +739,7 @@ describe('chat/chat-service', () => {
           joinedChannelInfo: shieldBatteryJoinedInfo,
           selfPreferences: channelPreferences,
           selfPermissions: channelPermissions,
+          lastReadTime: user1ShieldBatteryChannelEntry.joinDate.getTime() - 1,
         },
       )
     })
@@ -843,6 +880,7 @@ describe('chat/chat-service', () => {
           joinedChannelInfo: shieldBatteryJoinedInfo,
           selfPreferences: channelPreferences,
           selfPermissions: channelPermissions,
+          lastReadTime: user1ShieldBatteryChannelEntry.joinDate.getTime() - 1,
         },
       )
     })
@@ -887,6 +925,7 @@ describe('chat/chat-service', () => {
         channelInfo: testBasicInfo,
         detailedChannelInfo: testDetailedInfo,
         joinedChannelInfo: testJoinedInfo,
+        lastReadTime: user1TestChannelEntry.joinDate.getTime() - 1,
         selfPreferences: channelPreferences,
         selfPermissions: channelPermissions,
       })

--- a/server/lib/chat/chat-service.ts
+++ b/server/lib/chat/chat-service.ts
@@ -172,7 +172,10 @@ export default class ChatService {
         selfPreferences: c.channelPreferences,
         selfPermissions: c.channelPermissions,
         hasUnread: unreadInfo !== undefined,
-        lastReadTime: c.lastReadTime?.getTime(),
+        // The unread queries treat everything from others since `joinDate` as unread when no read
+        // position has been recorded, and the divider goes before the first message *after* the
+        // reported marker, so the marker has to sit one millisecond before the join.
+        lastReadTime: c.lastReadTime?.getTime() ?? c.joinDate.getTime() - 1,
         latestMentionTime: unreadInfo?.latestMentionTime?.getTime(),
       }
     })
@@ -214,8 +217,9 @@ export default class ChatService {
       ])
 
       if (channelInfo && userChannelEntry) {
-        // `hasUnread`/`lastReadTime`/`latestMentionTime` are omitted: a membership this fresh has
-        // no recorded read position yet, which `getUnreadChannelInfo` always treats as fully read.
+        // `hasUnread` and `latestMentionTime` are omitted: nothing can be unread or mention the
+        // user at the instant they join. `lastReadTime` is still sent, one millisecond before the
+        // join, so the client can place the unread divider once messages arrive.
         this.publisher.publish(getChannelUserPath(channelId, userSockets.userId), {
           action: 'init3',
           channelInfo: toBasicChannelInfo(channelInfo),
@@ -223,6 +227,7 @@ export default class ChatService {
           joinedChannelInfo: toJoinedChannelInfo(channelInfo),
           selfPreferences: userChannelEntry.channelPreferences,
           selfPermissions: userChannelEntry.channelPermissions,
+          lastReadTime: userChannelEntry.joinDate.getTime() - 1,
         })
       }
     }

--- a/server/lib/whispers/whisper-models.ts
+++ b/server/lib/whispers/whisper-models.ts
@@ -10,13 +10,19 @@ export interface WhisperSessionEntry {
   targetId: SbUserId
   /** The user's last recorded read position in the session, if they have one. */
   lastReadTime: Date | undefined
+  /** When the user started this whisper session. */
+  startDate: Date
 }
 
 export async function getWhisperSessionsForUser(userId: SbUserId): Promise<WhisperSessionEntry[]> {
   const { client, done } = await db()
   try {
-    const result = await client.query<{ target_id: SbUserId; last_read_time: Date | null }>(sql`
-      SELECT ws.target_user_id AS target_id, ws.last_read_time,
+    const result = await client.query<{
+      target_id: SbUserId
+      last_read_time: Date | null
+      start_date: Date
+    }>(sql`
+      SELECT ws.target_user_id AS target_id, ws.last_read_time, ws.start_date,
         COALESCE(wm.sent, ws.start_date) AS last_sent
       FROM whisper_sessions ws
       LEFT JOIN LATERAL (
@@ -33,6 +39,7 @@ export async function getWhisperSessionsForUser(userId: SbUserId): Promise<Whisp
     return result.rows.map(row => ({
       targetId: row.target_id,
       lastReadTime: row.last_read_time ?? undefined,
+      startDate: row.start_date,
     }))
   } finally {
     done()

--- a/server/lib/whispers/whisper-service.ts
+++ b/server/lib/whispers/whisper-service.ts
@@ -91,11 +91,12 @@ export default class WhisperService {
       getUnreadWhisperTargets(userId),
     ])
     const sessions = sessionEntries.map(s => s.targetId)
-    const lastReadTimes = sessionEntries.flatMap(s =>
-      s.lastReadTime !== undefined
-        ? [{ targetId: s.targetId, lastReadTime: s.lastReadTime.getTime() }]
-        : [],
-    )
+    // The whisper unread query counts messages `sent >= start_date` when no read position has been
+    // recorded, so a session without one still gets a marker here, one millisecond before its start.
+    const lastReadTimes = sessionEntries.map(s => ({
+      targetId: s.targetId,
+      lastReadTime: s.lastReadTime?.getTime() ?? s.startDate.getTime() - 1,
+    }))
     const users = await findUsersById(sessions)
     return {
       sessions,


### PR DESCRIPTION
## Problem

A channel member with no recorded read position (`last_read_time IS NULL`) never counted as having unread messages: `getUnreadChannelInfo` coalesced the missing position to `'infinity'`. Any member who never opens a channel never establishes a baseline, so that channel can never go unread for them — and since read tracking (#1438) hasn't shipped yet, at first deploy that would be every member of every channel. Whispers already handle the NULL case (falling back to the session's `start_date`), so the two systems disagreed.

A second layer of the same gap: the client's unread-divider freeze requires a `lastReadTime`, which the server omitted when none was recorded — so even where the badge worked (whispers), never-read conversations could show a badge but no divider line.

## Fix

- `getUnreadChannelInfo` falls back to `cu.join_date` in both the unread EXISTS predicate and the latest-mention subquery: with no recorded position, messages from others since the member joined count as unread (mirroring the whisper query).
- The server now always sends a `lastReadTime` marker: the recorded position, or one millisecond before the join date (channels) / session start (whispers). The `init3` publish on joining a channel carries it too.
- **Backfill migration**: existing `channel_users` rows with NULL `last_read_time` are stamped read-up-to-now once, mirroring the whisper backfill from #1442. Read tracking has never been released, so no real read positions are lost — and without this, the first deploy would light every channel (and mention badge) as unread since each member joined, years back. After the backfill, the join-date fallback only governs memberships created once tracking is live (fresh joins, where join ≈ now), plus it keeps the divider working for them.

The one-millisecond offset keeps SQL and client agreeing at the boundary: the SQL fallback counts `sent >= join_date` as unread (no +1ms shift, unlike recorded positions), while the client places the divider before the first message with `time > lastReadTime` — so a message in the join's own millisecond must sit after the marker.

## Notes

- Known leftover (behavior unchanged): a whisper session created live by an incoming message has no read marker until the next connect (`initSession3` doesn't carry one), so it gets a badge but no divider on first open. Seeding it would mean a per-session fetch on the subscribe path; left out deliberately.

## Verification

- Full unit suite green (2233 tests), typecheck green, eslint/prettier clean on changed files.
- The fixed query run manually against dev data flips exactly the NULL-read members to unread while caught-up members with recorded positions stay read.
- `EXPLAIN` confirms both index scans survive the new fallback, including the partial `channel_messages_mentions_idx` (its `data ? 'mentions'` predicate is untouched).