### PR TITLE
Restore chat reading position and keep the unread divider until caught up.

### DIFF
--- a/client/chat/action-creators.ts
+++ b/client/chat/action-creators.ts
@@ -747,10 +747,10 @@ export function unbanUser(
   })
 }
 
-export function activateChannel(channelId: SbChannelId): ActivateChannel {
+export function activateChannel(channelId: SbChannelId, atBottom: boolean): ActivateChannel {
   return {
     type: '@chat/activateChannel',
-    payload: { channelId },
+    payload: { channelId, atBottom },
   }
 }
 

--- a/client/chat/action-creators.ts
+++ b/client/chat/action-creators.ts
@@ -47,7 +47,7 @@ import {
   ResetMessageWindow,
   UpdateChannelAtBottom,
 } from './actions'
-import { newestServerOriginTime } from './chat-reducer'
+import { newestServerOriginTime, oldestServerOriginTime } from './chat-reducer'
 
 export function getJoinedChannels(spec: RequestHandlingSpec<void>): ThunkAction {
   return abortableThunk(spec, async dispatch => {
@@ -386,8 +386,13 @@ export function getMessageHistory(channelId: SbChannelId, limit: number): ThunkA
       chat: { idToMessages },
     } = getStore()
     const channelMessages = idToMessages.get(channelId)
-    const earliestMessageTime = channelMessages?.messages.length
-      ? channelMessages.messages[0].time
+    // The window's first entry can be a client-only message (the self-join banner right after
+    // joining, or a carried message left behind by a drop that hasn't found a covering window
+    // yet), whose time is stamped with the local clock and means nothing as a server cursor. -1
+    // is the "newest page" sentinel, used both when nothing is loaded and when nothing loaded
+    // carries a server-recorded time.
+    const earliestMessageTime = channelMessages
+      ? (oldestServerOriginTime(channelMessages.messages) ?? -1)
       : -1
     const params = {
       channelId,

--- a/client/chat/action-creators.ts
+++ b/client/chat/action-creators.ts
@@ -752,10 +752,10 @@ export function unbanUser(
   })
 }
 
-export function activateChannel(channelId: SbChannelId, atBottom: boolean): ActivateChannel {
+export function activateChannel(channelId: SbChannelId): ActivateChannel {
   return {
     type: '@chat/activateChannel',
-    payload: { channelId, atBottom },
+    payload: { channelId },
   }
 }
 

--- a/client/chat/actions.ts
+++ b/client/chat/actions.ts
@@ -392,18 +392,15 @@ export interface SearchChannels {
 
 /**
  * Activate a particular chat channel. This is a purely client-side action which marks the channel
- * as "active", and removes the unread indicator if there is one.
+ * as "active", and removes the unread indicator if there is one. The message list reports the
+ * at-bottom state it opened in (`UpdateChannelAtBottom`) ahead of this being dispatched, so the
+ * reducer reads the current flag to tell an open at the newest messages from one restoring a
+ * position further back.
  */
 export interface ActivateChannel {
   type: '@chat/activateChannel'
   payload: {
     channelId: SbChannelId
-    /**
-     * Whether the message list is opening at the newest messages. It isn't when the view is being
-     * restored to a position further back, which means the user hasn't necessarily caught up with
-     * the channel just by opening it.
-     */
-    atBottom: boolean
   }
 }
 
@@ -419,10 +416,10 @@ export interface DeactivateChannel {
 }
 
 /**
- * Update whether an activated chat channel's message list is scrolled to the bottom. This is a
- * purely client-side action; the reducer uses it to trim message history down to the same cap
- * applied to inactive channels, since removing old messages while pinned to the bottom is
- * invisible to the user (auto-scroll keeps the view at the newest message).
+ * Update whether a viewed chat channel's message list is scrolled to the bottom. This is a purely
+ * client-side action; the reducer uses it to trim message history down to the same cap applied to
+ * inactive channels, since removing old messages while pinned to the bottom is invisible to the
+ * user (auto-scroll keeps the view at the newest message).
  */
 export interface UpdateChannelAtBottom {
   type: '@chat/updateChannelAtBottom'

--- a/client/chat/actions.ts
+++ b/client/chat/actions.ts
@@ -398,6 +398,12 @@ export interface ActivateChannel {
   type: '@chat/activateChannel'
   payload: {
     channelId: SbChannelId
+    /**
+     * Whether the message list is opening at the newest messages. It isn't when the view is being
+     * restored to a position further back, which means the user hasn't necessarily caught up with
+     * the channel just by opening it.
+     */
+    atBottom: boolean
   }
 }
 

--- a/client/chat/channel.tsx
+++ b/client/chat/channel.tsx
@@ -261,7 +261,7 @@ export function ConnectedChatChannel({
     dispatch(retrieveUserList(channelId))
 
     const anchor = chatViewAnchorStore.get(viewStateKey)
-    dispatch(activateChannel(channelId, anchor === undefined))
+    dispatch(activateChannel(channelId))
 
     if (anchor && anchorNeedsFetch(channelMessages?.messages ?? [], anchor)) {
       // Getting back to where the user was reading takes a window the client doesn't hold, so that

--- a/client/chat/channel.tsx
+++ b/client/chat/channel.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react'
+import React, { useEffect, useEffectEvent, useMemo, useState } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 import {
@@ -10,6 +10,7 @@ import {
 } from '../../common/chat'
 import { SbUserId } from '../../common/users/sb-user-id'
 import { Chat } from '../messaging/chat'
+import { anchorNeedsFetch, chatViewAnchorStore } from '../messaging/chat-view-anchor'
 import { flushLastRead } from '../messaging/last-read'
 import { MAX_MENTIONED_USERS } from '../messaging/message-input'
 import { MessageComponentProps } from '../messaging/message-list'
@@ -95,17 +96,46 @@ const BackgroundImage = styled.img`
 export function ChannelMessage({ message }: MessageComponentProps) {
   switch (message.type) {
     case ClientChatMessageType.BanUser:
-      return <BanUserMessage key={message.id} time={message.time} userId={message.userId} />
+      return (
+        <BanUserMessage
+          key={message.id}
+          msgId={message.id}
+          time={message.time}
+          userId={message.userId}
+        />
+      )
     case ClientChatMessageType.KickUser:
-      return <KickUserMessage key={message.id} time={message.time} userId={message.userId} />
+      return (
+        <KickUserMessage
+          key={message.id}
+          msgId={message.id}
+          time={message.time}
+          userId={message.userId}
+        />
+      )
     case ServerChatMessageType.JoinChannel:
-      return <JoinChannelMessage key={message.id} time={message.time} userId={message.userId} />
+      return (
+        <JoinChannelMessage
+          key={message.id}
+          msgId={message.id}
+          time={message.time}
+          userId={message.userId}
+        />
+      )
     case ClientChatMessageType.LeaveChannel:
-      return <LeaveChannelMessage key={message.id} time={message.time} userId={message.userId} />
+      return (
+        <LeaveChannelMessage
+          key={message.id}
+          msgId={message.id}
+          time={message.time}
+          userId={message.userId}
+        />
+      )
     case ClientChatMessageType.NewChannelOwner:
       return (
         <NewChannelOwnerMessage
           key={message.id}
+          msgId={message.id}
           time={message.time}
           newOwnerId={message.newOwnerId}
         />
@@ -224,10 +254,25 @@ export function ConnectedChatChannel({
     }
   }, [isLeavingChannel])
 
+  const viewStateKey = `chat.${channelId}`
+
+  const onActivate = useEffectEvent(() => {
+    dispatch(retrieveUserList(channelId))
+
+    const anchor = chatViewAnchorStore.get(viewStateKey)
+    dispatch(activateChannel(channelId, anchor === undefined))
+
+    if (anchor && anchorNeedsFetch(channelMessages?.messages ?? [], anchor)) {
+      // Getting back to where the user was reading takes a window the client doesn't hold, so that
+      // window is this activation's history request instead of the newest page the list would
+      // otherwise ask for.
+      dispatch(getMessagesAround(channelId, MESSAGES_LIMIT, anchor.sentTime))
+    }
+  })
+
   useEffect(() => {
     if (isInChannel) {
-      dispatch(retrieveUserList(channelId))
-      dispatch(activateChannel(channelId))
+      onActivate()
     }
 
     return () => {
@@ -308,6 +353,7 @@ export function ConnectedChatChannel({
               hasNewerMessages: channelMessages?.hasNewer,
               windowGeneration: channelMessages?.windowGen,
               refreshToken: channelId,
+              viewStateKey,
               MessageComponent: ChannelMessage,
               onLoadMoreMessages,
               onLoadNewerMessages,
@@ -315,7 +361,7 @@ export function ConnectedChatChannel({
             }}
             inputProps={{
               onSendChatMessage,
-              storageKey: `chat.${channelId}`,
+              storageKey: viewStateKey,
               mentionableUsers,
               baseMentionableUsers,
             }}

--- a/client/chat/channel.tsx
+++ b/client/chat/channel.tsx
@@ -34,6 +34,7 @@ import {
   jumpToPresent,
   leaveChannelWithConfirmation,
   markChannelRead,
+  resetMessageWindow,
   retrieveUserList,
   sendMessage,
   updateChannelAtBottom,
@@ -265,7 +266,11 @@ export function ConnectedChatChannel({
     if (anchor && anchorNeedsFetch(channelMessages?.messages ?? [], anchor)) {
       // Getting back to where the user was reading takes a window the client doesn't hold, so that
       // window is this activation's history request instead of the newest page the list would
-      // otherwise ask for.
+      // otherwise ask for. Whatever window is still loaded doesn't contain the position either and
+      // is about to be replaced anyway, so it's dropped up front rather than left on screen: leaving
+      // it in place would show the user a spot they weren't (its bottom) only to yank them away once
+      // the requested window lands, whereas an empty window renders as loading for that same wait.
+      dispatch(resetMessageWindow(channelId))
       dispatch(getMessagesAround(channelId, MESSAGES_LIMIT, anchor.sentTime))
     }
   })

--- a/client/chat/chat-message-layout.tsx
+++ b/client/chat/chat-message-layout.tsx
@@ -13,13 +13,13 @@ import {
 import { ConnectedUsername } from '../users/connected-username'
 import { ConnectedChannelName } from './connected-channel-name'
 
-export const JoinChannelMessage = memo<{ time: number; userId: SbUserId }>(props => {
-  const { time, userId } = props
+export const JoinChannelMessage = memo<{ msgId: string; time: number; userId: SbUserId }>(props => {
+  const { msgId, time, userId } = props
   const { t } = useTranslation()
   const filterClick = useMentionFilterClick()
   const { UserMenu } = useContext(ChatContext)
   return (
-    <SystemMessage time={time}>
+    <SystemMessage time={time} msgId={msgId}>
       <span>
         <Trans t={t} i18nKey='chat.messageLayout.joinChannel'>
           <SystemImportant>
@@ -32,32 +32,34 @@ export const JoinChannelMessage = memo<{ time: number; userId: SbUserId }>(props
   )
 })
 
-export const LeaveChannelMessage = memo<{ time: number; userId: SbUserId }>(props => {
-  const { time, userId } = props
-  const { t } = useTranslation()
-  const filterClick = useMentionFilterClick()
-  const { UserMenu } = useContext(ChatContext)
-  return (
-    <SystemMessage time={time}>
-      <span>
-        <Trans t={t} i18nKey='chat.messageLayout.leaveChannel'>
-          <SystemImportant>
-            <ConnectedUsername userId={userId} filterClick={filterClick} UserMenu={UserMenu} />
-          </SystemImportant>{' '}
-          has left the channel
-        </Trans>
-      </span>
-    </SystemMessage>
-  )
-})
+export const LeaveChannelMessage = memo<{ msgId: string; time: number; userId: SbUserId }>(
+  props => {
+    const { msgId, time, userId } = props
+    const { t } = useTranslation()
+    const filterClick = useMentionFilterClick()
+    const { UserMenu } = useContext(ChatContext)
+    return (
+      <SystemMessage time={time} msgId={msgId}>
+        <span>
+          <Trans t={t} i18nKey='chat.messageLayout.leaveChannel'>
+            <SystemImportant>
+              <ConnectedUsername userId={userId} filterClick={filterClick} UserMenu={UserMenu} />
+            </SystemImportant>{' '}
+            has left the channel
+          </Trans>
+        </span>
+      </SystemMessage>
+    )
+  },
+)
 
-export const KickUserMessage = memo<{ time: number; userId: SbUserId }>(props => {
-  const { time, userId } = props
+export const KickUserMessage = memo<{ msgId: string; time: number; userId: SbUserId }>(props => {
+  const { msgId, time, userId } = props
   const { t } = useTranslation()
   // NOTE(tec27): We don't use UserMenu from the ChatContext here because the user is no longer in
   // the channel, so their menu shouldn't have channel-related things
   return (
-    <SystemMessage time={time}>
+    <SystemMessage time={time} msgId={msgId}>
       <span>
         <Trans t={t} i18nKey='chat.messageLayout.kickUser'>
           <SystemImportant>
@@ -70,13 +72,13 @@ export const KickUserMessage = memo<{ time: number; userId: SbUserId }>(props =>
   )
 })
 
-export const BanUserMessage = memo<{ time: number; userId: SbUserId }>(props => {
-  const { time, userId } = props
+export const BanUserMessage = memo<{ msgId: string; time: number; userId: SbUserId }>(props => {
+  const { msgId, time, userId } = props
   const { t } = useTranslation()
   // NOTE(tec27): We don't use UserMenu from the ChatContext here because the user is no longer in
   // the channel, so their menu shouldn't have channel-related things
   return (
-    <SystemMessage time={time}>
+    <SystemMessage time={time} msgId={msgId}>
       <span>
         <Trans t={t} i18nKey='chat.messageLayout.banUser'>
           <SystemImportant>
@@ -89,13 +91,17 @@ export const BanUserMessage = memo<{ time: number; userId: SbUserId }>(props => 
   )
 })
 
-export const NewChannelOwnerMessage = memo<{ time: number; newOwnerId: SbUserId }>(props => {
-  const { time, newOwnerId } = props
+export const NewChannelOwnerMessage = memo<{
+  msgId: string
+  time: number
+  newOwnerId: SbUserId
+}>(props => {
+  const { msgId, time, newOwnerId } = props
   const { t } = useTranslation()
   const filterClick = useMentionFilterClick()
   const { UserMenu } = useContext(ChatContext)
   return (
-    <SystemMessage time={time}>
+    <SystemMessage time={time} msgId={msgId}>
       <span>
         <Trans t={t} i18nKey='chat.messageLayout.newChannelOwner'>
           <SystemImportant>

--- a/client/chat/chat-reducer.test.ts
+++ b/client/chat/chat-reducer.test.ts
@@ -17,7 +17,11 @@ import {
 import { SbUser } from '../../common/users/sb-user'
 import { makeSbUserId } from '../../common/users/sb-user-id'
 import { ChatActions } from './actions'
-import chatReducerImport, { ChatState, channelHasUnreadMention } from './chat-reducer'
+import chatReducerImport, {
+  ChatState,
+  channelHasUnreadMention,
+  oldestServerOriginTime,
+} from './chat-reducer'
 
 // `immerKeyedReducer` accepts any action with a string `type`. These tests only ever feed it chat
 // actions, so narrow the parameter to those, both for the extra checking and so that action objects
@@ -54,6 +58,7 @@ function selfJoinMessage(time: number): SelfJoinChannelMessage {
 function makeState(
   overrides: {
     messages?: ChatMessage[]
+    carriedClientMessages?: ChatMessage[]
     activated?: boolean
     atBottom?: boolean
     unread?: boolean
@@ -79,6 +84,7 @@ function makeState(
         CHANNEL_ID,
         {
           messages: overrides.messages ?? [],
+          carriedClientMessages: overrides.carriedClientMessages ?? [],
           loadingHistory: overrides.loadingHistory ?? false,
           hasHistory: overrides.hasHistory ?? true,
           loadingNewer: overrides.loadingNewer ?? false,
@@ -1006,6 +1012,104 @@ describe('client/chat/chat-reducer', () => {
 
       expect(windowOf(result).messages.length).toBe(150)
       expect(windowOf(result).windowGen).toBe(0)
+    })
+  })
+
+  describe('oldestServerOriginTime', () => {
+    test('returns the oldest server-recorded time, skipping a client-only message at the head', () => {
+      expect(
+        oldestServerOriginTime([
+          selfJoinMessage(999_999_999_999),
+          textMessage(100),
+          textMessage(200),
+        ]),
+      ).toBe(100)
+    })
+
+    test('returns undefined when the window holds no server-origin message', () => {
+      expect(oldestServerOriginTime([selfJoinMessage(100), selfJoinMessage(200)])).toBeUndefined()
+    })
+  })
+
+  describe('carried client-only messages', () => {
+    test('jump to present: a dropped self-join banner returns on the next newest-page fetch', () => {
+      const banner = selfJoinMessage(1_000_000)
+      const state = makeState({ messages: [textMessage(100), textMessage(200), banner] })
+
+      let result = chatReducer(state, resetMessageWindowAction())
+      expect(messageIdsOf(result)).toEqual([])
+      expect(windowOf(result).carriedClientMessages.map(m => m.id)).toEqual([banner.id])
+
+      result = chatReducer(
+        result,
+        loadMessageHistoryAction(
+          historyResponse([textMessage(300), textMessage(400)], { hasMoreBefore: true }),
+          { windowGen: 1 },
+        ),
+      )
+
+      expect(messageIdsOf(result)).toEqual(['text-300', 'text-400', banner.id])
+      expect(windowOf(result).carriedClientMessages).toEqual([])
+    })
+
+    test('deep detour: a banner stays carried through an old-range fetch, then returns on reattach', () => {
+      const banner = selfJoinMessage(1_000_000)
+      const state = makeState({
+        activated: true,
+        hasNewer: true,
+        messages: [textMessage(500), banner],
+      })
+
+      // Deactivating a window detached from the present drops it whole, carrying the banner.
+      let result = chatReducer(state, deactivateChannelAction())
+      expect(messageIdsOf(result)).toEqual([])
+      expect(windowOf(result).carriedClientMessages.map(m => m.id)).toEqual([banner.id])
+
+      // A detour into an old range: the fetched page doesn't reach anywhere near the banner's
+      // time, and the server still has newer messages behind it, so the banner stays carried.
+      result = chatReducer(
+        result,
+        loadMessagesAroundAction(
+          historyResponse([textMessage(100), textMessage(200)], {
+            hasMoreBefore: true,
+            hasMoreAfter: true,
+          }),
+          { windowGen: 1, aroundTime: 150 },
+        ),
+      )
+      expect(messageIdsOf(result)).toEqual(['text-100', 'text-200'])
+      expect(windowOf(result).carriedClientMessages.map(m => m.id)).toEqual([banner.id])
+
+      // Paging forward until the server reports nothing newer reattaches the window, which now
+      // covers everything newer than what's loaded and reclaims the banner.
+      result = chatReducer(
+        result,
+        loadNewerMessagesAction(historyResponse([textMessage(300)], { hasMoreAfter: false }), {
+          windowGen: 2,
+          afterTime: 200,
+          knownNewestTime: 200,
+        }),
+      )
+
+      expect(messageIdsOf(result)).toEqual(['text-100', 'text-200', 'text-300', banner.id])
+      expect(windowOf(result).carriedClientMessages).toEqual([])
+      expect(windowOf(result).hasNewer).toBe(false)
+    })
+
+    test('evicts the oldest carried message once the cap is exceeded', () => {
+      const existingCarried = Array.from({ length: 50 }, (_, i) => selfJoinMessage(i + 1))
+      const newBanner = selfJoinMessage(1000)
+      const state = makeState({
+        carriedClientMessages: existingCarried,
+        messages: [textMessage(500), newBanner],
+      })
+
+      const result = chatReducer(state, resetMessageWindowAction())
+
+      const carried = windowOf(result).carriedClientMessages
+      expect(carried.length).toBe(50)
+      expect(carried.map(m => m.id)).not.toContain(existingCarried[0].id)
+      expect(carried.map(m => m.id)).toContain(newBanner.id)
     })
   })
 })

--- a/client/chat/chat-reducer.test.ts
+++ b/client/chat/chat-reducer.test.ts
@@ -245,10 +245,10 @@ function resetMessageWindowAction(): ChatActions {
   }
 }
 
-function activateChannelAction(atBottom: boolean): ChatActions {
+function activateChannelAction(): ChatActions {
   return {
     type: '@chat/activateChannel',
-    payload: { channelId: CHANNEL_ID, atBottom },
+    payload: { channelId: CHANNEL_ID },
   }
 }
 
@@ -877,30 +877,30 @@ describe('client/chat/chat-reducer', () => {
 
   describe('@chat/activateChannel', () => {
     test('freezes the divider at the read position when the channel has unread messages', () => {
-      const state = makeState({ unread: true, lastReadTime: 100 })
+      const state = makeState({ unread: true, lastReadTime: 100, atBottom: true })
 
-      const result = chatReducer(state, activateChannelAction(true))
+      const result = chatReducer(state, activateChannelAction())
 
       expect(result.idToUnreadLineTime.get(CHANNEL_ID)).toBe(100)
       expect(result.unreadChannels.has(CHANNEL_ID)).toBe(false)
       expect(result.activatedChannels.has(CHANNEL_ID)).toBe(true)
     })
 
-    test('records the at-bottom state the view is opening in', () => {
-      const state = makeState()
-
-      expect(chatReducer(state, activateChannelAction(true)).atBottomChannels.has(CHANNEL_ID)).toBe(
-        true,
-      )
+    test('leaves the at-bottom state the view reported in place', () => {
       expect(
-        chatReducer(state, activateChannelAction(false)).atBottomChannels.has(CHANNEL_ID),
+        chatReducer(makeState({ atBottom: true }), activateChannelAction()).atBottomChannels.has(
+          CHANNEL_ID,
+        ),
+      ).toBe(true)
+      expect(
+        chatReducer(makeState(), activateChannelAction()).atBottomChannels.has(CHANNEL_ID),
       ).toBe(false)
     })
 
     test('consumes a divider the read position has passed when opening at the bottom', () => {
-      const state = makeState({ lastReadTime: 200, unreadLineTime: 100 })
+      const state = makeState({ lastReadTime: 200, unreadLineTime: 100, atBottom: true })
 
-      const result = chatReducer(state, activateChannelAction(true))
+      const result = chatReducer(state, activateChannelAction())
 
       expect(result.idToUnreadLineTime.has(CHANNEL_ID)).toBe(false)
     })
@@ -908,23 +908,23 @@ describe('client/chat/chat-reducer', () => {
     test('keeps a divider the read position has passed when opening away from the bottom', () => {
       const state = makeState({ lastReadTime: 200, unreadLineTime: 100 })
 
-      const result = chatReducer(state, activateChannelAction(false))
+      const result = chatReducer(state, activateChannelAction())
 
       expect(result.idToUnreadLineTime.get(CHANNEL_ID)).toBe(100)
     })
 
     test('keeps a divider the read position has not passed', () => {
-      const state = makeState({ lastReadTime: 100, unreadLineTime: 100 })
+      const state = makeState({ lastReadTime: 100, unreadLineTime: 100, atBottom: true })
 
-      const result = chatReducer(state, activateChannelAction(true))
+      const result = chatReducer(state, activateChannelAction())
 
       expect(result.idToUnreadLineTime.get(CHANNEL_ID)).toBe(100)
     })
 
     test('keeps a divider frozen by this activation', () => {
-      const state = makeState({ unread: true, lastReadTime: 100 })
+      const state = makeState({ unread: true, lastReadTime: 100, atBottom: true })
 
-      const result = chatReducer(state, activateChannelAction(true))
+      const result = chatReducer(state, activateChannelAction())
 
       expect(result.idToUnreadLineTime.get(CHANNEL_ID)).toBe(100)
     })

--- a/client/chat/chat-reducer.test.ts
+++ b/client/chat/chat-reducer.test.ts
@@ -239,6 +239,13 @@ function resetMessageWindowAction(): ChatActions {
   }
 }
 
+function activateChannelAction(atBottom: boolean): ChatActions {
+  return {
+    type: '@chat/activateChannel',
+    payload: { channelId: CHANNEL_ID, atBottom },
+  }
+}
+
 function deactivateChannelAction(): ChatActions {
   return {
     type: '@chat/deactivateChannel',
@@ -862,7 +869,101 @@ describe('client/chat/chat-reducer', () => {
     })
   })
 
+  describe('@chat/activateChannel', () => {
+    test('freezes the divider at the read position when the channel has unread messages', () => {
+      const state = makeState({ unread: true, lastReadTime: 100 })
+
+      const result = chatReducer(state, activateChannelAction(true))
+
+      expect(result.idToUnreadLineTime.get(CHANNEL_ID)).toBe(100)
+      expect(result.unreadChannels.has(CHANNEL_ID)).toBe(false)
+      expect(result.activatedChannels.has(CHANNEL_ID)).toBe(true)
+    })
+
+    test('records the at-bottom state the view is opening in', () => {
+      const state = makeState()
+
+      expect(chatReducer(state, activateChannelAction(true)).atBottomChannels.has(CHANNEL_ID)).toBe(
+        true,
+      )
+      expect(
+        chatReducer(state, activateChannelAction(false)).atBottomChannels.has(CHANNEL_ID),
+      ).toBe(false)
+    })
+
+    test('consumes a divider the read position has passed when opening at the bottom', () => {
+      const state = makeState({ lastReadTime: 200, unreadLineTime: 100 })
+
+      const result = chatReducer(state, activateChannelAction(true))
+
+      expect(result.idToUnreadLineTime.has(CHANNEL_ID)).toBe(false)
+    })
+
+    test('keeps a divider the read position has passed when opening away from the bottom', () => {
+      const state = makeState({ lastReadTime: 200, unreadLineTime: 100 })
+
+      const result = chatReducer(state, activateChannelAction(false))
+
+      expect(result.idToUnreadLineTime.get(CHANNEL_ID)).toBe(100)
+    })
+
+    test('keeps a divider the read position has not passed', () => {
+      const state = makeState({ lastReadTime: 100, unreadLineTime: 100 })
+
+      const result = chatReducer(state, activateChannelAction(true))
+
+      expect(result.idToUnreadLineTime.get(CHANNEL_ID)).toBe(100)
+    })
+
+    test('keeps a divider frozen by this activation', () => {
+      const state = makeState({ unread: true, lastReadTime: 100 })
+
+      const result = chatReducer(state, activateChannelAction(true))
+
+      expect(result.idToUnreadLineTime.get(CHANNEL_ID)).toBe(100)
+    })
+  })
+
   describe('@chat/deactivateChannel', () => {
+    test('consumes a divider the read position has passed when left at the bottom', () => {
+      const state = makeState({
+        activated: true,
+        atBottom: true,
+        lastReadTime: 200,
+        unreadLineTime: 100,
+      })
+
+      const result = chatReducer(state, deactivateChannelAction())
+
+      expect(result.idToUnreadLineTime.has(CHANNEL_ID)).toBe(false)
+    })
+
+    test('keeps a divider the read position has passed when left away from the bottom', () => {
+      const state = makeState({
+        activated: true,
+        atBottom: false,
+        lastReadTime: 200,
+        unreadLineTime: 100,
+      })
+
+      const result = chatReducer(state, deactivateChannelAction())
+
+      expect(result.idToUnreadLineTime.get(CHANNEL_ID)).toBe(100)
+    })
+
+    test('keeps a divider the read position has not passed', () => {
+      const state = makeState({
+        activated: true,
+        atBottom: true,
+        lastReadTime: 100,
+        unreadLineTime: 100,
+      })
+
+      const result = chatReducer(state, deactivateChannelAction())
+
+      expect(result.idToUnreadLineTime.get(CHANNEL_ID)).toBe(100)
+    })
+
     test('drops a detached window entirely', () => {
       const messages = Array.from({ length: 200 }, (_, i) => textMessage(i + 1))
       const state = makeState({

--- a/client/chat/chat-reducer.ts
+++ b/client/chat/chat-reducer.ts
@@ -873,11 +873,11 @@ export default immerKeyedReducer(DEFAULT_CHAT_STATE, {
   },
 
   ['@chat/activateChannel'](state, action) {
-    const { channelId } = action.payload
+    const { channelId, atBottom } = action.payload
 
     // Freeze the unread divider at the read position before clearing the unread flag, so the
     // divider marks where the user left off instead of where the read position ends up after the
-    // eager mark-read this activation triggers.
+    // eager mark-read opening at the newest messages triggers.
     if (
       state.unreadChannels.has(channelId) &&
       !state.idToUnreadLineTime.has(channelId) &&
@@ -886,22 +886,43 @@ export default immerKeyedReducer(DEFAULT_CHAT_STATE, {
       state.idToUnreadLineTime.set(channelId, state.idToLastReadTime.get(channelId)!)
     }
 
+    // A divider the read position has already moved past outlives that only for as long as the
+    // view keeps returning to where the user stopped reading; opening at the newest messages means
+    // they're caught up and the divider has served its purpose.
+    if (atBottom) {
+      const unreadLineTime = state.idToUnreadLineTime.get(channelId)
+      const lastReadTime = state.idToLastReadTime.get(channelId)
+      if (
+        unreadLineTime !== undefined &&
+        lastReadTime !== undefined &&
+        lastReadTime > unreadLineTime
+      ) {
+        state.idToUnreadLineTime.delete(channelId)
+      }
+    }
+
     state.unreadChannels.delete(channelId)
     state.activatedChannels.add(channelId)
-    // Message lists mount pinned to the bottom.
-    state.atBottomChannels.add(channelId)
+    if (atBottom) {
+      state.atBottomChannels.add(channelId)
+    } else {
+      state.atBottomChannels.delete(channelId)
+    }
   },
 
   ['@chat/deactivateChannel'](state, action) {
     const { channelId } = action.payload
 
-    // The unread divider is only consumed once the read position has actually moved past it — a
-    // deactivation where the user never read anything new (including the mount/cleanup/remount
-    // cycle React's StrictMode runs in development) leaves the still-unread divider in place for
-    // the next visit.
+    // The unread divider is only consumed once the read position has actually moved past it *and*
+    // the user was looking at the newest messages when they left. A deactivation where they never
+    // read anything new (including the mount/cleanup/remount cycle React's StrictMode runs in
+    // development) leaves the still-unread divider in place, and so does one from the middle of the
+    // backlog, where the read position running ahead is an artifact of having passed the bottom on
+    // the way in rather than of having caught up.
     const unreadLineTime = state.idToUnreadLineTime.get(channelId)
     const lastReadTime = state.idToLastReadTime.get(channelId)
     if (
+      state.atBottomChannels.has(channelId) &&
       unreadLineTime !== undefined &&
       lastReadTime !== undefined &&
       lastReadTime > unreadLineTime

--- a/client/chat/chat-reducer.ts
+++ b/client/chat/chat-reducer.ts
@@ -990,7 +990,13 @@ export default immerKeyedReducer(DEFAULT_CHAT_STATE, {
   },
 
   ['@chat/activateChannel'](state, action) {
-    const { channelId, atBottom } = action.payload
+    const { channelId } = action.payload
+
+    // Whether the view is opening at the newest messages. The view reports where its viewport
+    // settles (`updateChannelAtBottom`) ahead of this dispatch, so the current flag reflects this
+    // activation's viewport; a view still on its way back to a saved reading position hasn't
+    // reported yet and counts as away from the bottom, which is where it's headed.
+    const atBottom = state.atBottomChannels.has(channelId)
 
     // Freeze the unread divider at the read position before clearing the unread flag, so the
     // divider marks where the user left off instead of where the read position ends up after the
@@ -1020,11 +1026,6 @@ export default immerKeyedReducer(DEFAULT_CHAT_STATE, {
 
     state.unreadChannels.delete(channelId)
     state.activatedChannels.add(channelId)
-    if (atBottom) {
-      state.atBottomChannels.add(channelId)
-    } else {
-      state.atBottomChannels.delete(channelId)
-    }
   },
 
   ['@chat/deactivateChannel'](state, action) {

--- a/client/chat/chat-reducer.ts
+++ b/client/chat/chat-reducer.ts
@@ -20,6 +20,12 @@ import { immerKeyedReducer } from '../reducers/keyed-reducer'
 // How many messages should be kept for inactive channels
 const INACTIVE_CHANNEL_MAX_HISTORY = 150
 
+// How many client-only messages (join/leave banners and the like) a channel keeps waiting for a
+// loaded window that covers their time, once the window they were loaded in has been dropped or
+// replaced. These messages exist nowhere but this session's memory, so this bounds how much of a
+// long session's history of channel detours it can carry rather than dropping any of it.
+const MAX_CARRIED_CLIENT_MESSAGES = 50
+
 export interface UsersState {
   active: Set<SbUserId>
   idle: Set<SbUserId>
@@ -54,6 +60,14 @@ export interface MessagesState {
    * match, since a page has no boundary in common with a window it wasn't fetched for.
    */
   windowGen: number
+  /**
+   * Client-only messages (join/leave banners and the like) that were in a window dropped or
+   * replaced wholesale, held here until a loaded window's covered time range reaches where they
+   * happened, at which point they're spliced back into `messages`. These messages are never
+   * persisted anywhere but this session's memory, so this is the only thing standing between a
+   * window drop and losing them for good.
+   */
+  carriedClientMessages: ChatMessage[]
 }
 
 export interface ChatState {
@@ -249,6 +263,23 @@ export function newestServerOriginTime(messages: readonly ChatMessage[]): number
 }
 
 /**
+ * Returns the time (epoch ms) of the oldest message in `messages` that carries a server-recorded
+ * timestamp, or `undefined` if there is none. See `newestServerOriginTime` for why client-only
+ * messages are excluded: a window can open with one at its head (the self-join banner, or all
+ * that's left after a drop leaves only carried messages behind), and such a message's local-clock
+ * time is meaningless as a server request cursor or a window boundary.
+ */
+export function oldestServerOriginTime(messages: readonly ChatMessage[]): number | undefined {
+  for (const message of messages) {
+    if (isServerOriginMessage(message)) {
+      return message.time
+    }
+  }
+
+  return undefined
+}
+
+/**
  * Returns `incoming` with every message already present in `existing` removed. The history
  * endpoints seek by millisecond-precision time, so a page boundary landing inside a group of
  * messages that share a timestamp can hand back messages the window already holds.
@@ -294,11 +325,83 @@ function markChannelUnread(state: ChatState, channelId: SbChannelId) {
 }
 
 /**
+ * Moves every client-only message out of `channelMessages.messages` and into its carry list, ahead
+ * of the window being dropped or replaced wholesale. Unlike a server message, a client-only message
+ * (a join/leave banner and the like) can never be re-fetched, so losing the window it was loaded in
+ * would otherwise erase it for good; `mergeCarriedMessages` is what eventually gives it back a home.
+ * Idempotent against a message already carried from an earlier drop (deduped by id), and caps the
+ * list at `MAX_CARRIED_CLIENT_MESSAGES`, evicting the oldest by time.
+ */
+function carryClientMessages(channelMessages: MessagesState) {
+  const carriedIds = new Set(channelMessages.carriedClientMessages.map(m => m.id))
+  for (const message of channelMessages.messages) {
+    if (!isServerOriginMessage(message) && !carriedIds.has(message.id)) {
+      channelMessages.carriedClientMessages.push(message)
+      carriedIds.add(message.id)
+    }
+  }
+
+  if (channelMessages.carriedClientMessages.length > MAX_CARRIED_CLIENT_MESSAGES) {
+    channelMessages.carriedClientMessages.sort((a, b) => a.time - b.time)
+    channelMessages.carriedClientMessages = channelMessages.carriedClientMessages.slice(
+      -MAX_CARRIED_CLIENT_MESSAGES,
+    )
+  }
+}
+
+/**
+ * Splices carried client-only messages (see `carryClientMessages`) back into the loaded window
+ * wherever the window now covers the moment they happened, removing them from the carry list so a
+ * later call can't merge the same message twice. Must run after anything that changes what time
+ * range the window covers — a fetched page or a reattach — since that's the only way a carried
+ * message's moment can come back into view.
+ *
+ * The covered range runs from the oldest server-origin message's time to the newest, extended to
+ * unbounded-older when `hasHistory` is false (nothing precedes what's loaded) and to
+ * unbounded-newer when `hasNewer` is false (the window is attached to the present, so it covers
+ * everything from here on, same as a live message keeps appending to it). A bound whose flag says
+ * it's *not* unbounded but which has no server-origin message to anchor to (an empty or
+ * all-client-only window) covers nothing on that side.
+ */
+function mergeCarriedMessages(channelMessages: MessagesState) {
+  if (!channelMessages.carriedClientMessages.length) {
+    return
+  }
+
+  const lowerBound = channelMessages.hasHistory
+    ? (oldestServerOriginTime(channelMessages.messages) ?? Infinity)
+    : -Infinity
+  const upperBound = channelMessages.hasNewer
+    ? (newestServerOriginTime(channelMessages.messages) ?? -Infinity)
+    : Infinity
+
+  const stillCarried: ChatMessage[] = []
+  const reclaimed: ChatMessage[] = []
+  for (const message of channelMessages.carriedClientMessages) {
+    if (message.time >= lowerBound && message.time <= upperBound) {
+      reclaimed.push(message)
+    } else {
+      stillCarried.push(message)
+    }
+  }
+
+  if (!reclaimed.length) {
+    return
+  }
+
+  channelMessages.carriedClientMessages = stillCarried
+  channelMessages.messages = channelMessages.messages
+    .concat(reclaimed)
+    .sort((a, b) => a.time - b.time)
+}
+
+/**
  * Discards everything loaded for a channel, returning it to the shape a freshly-joined channel has:
  * nothing loaded, older history assumed to exist, attached to the present. Advancing the generation
  * makes the reducer discard any page still in flight for the window that was just dropped.
  */
 function dropMessageWindow(channelMessages: MessagesState) {
+  carryClientMessages(channelMessages)
   channelMessages.messages = []
   channelMessages.hasHistory = true
   channelMessages.hasNewer = false
@@ -416,6 +519,7 @@ function initChannel(state: ChatState, channelId: SbChannelId, data: InitialChan
     hasNewer: false,
     detachedNewestTime: undefined,
     windowGen: 0,
+    carriedClientMessages: [],
   }
   state.joinedChannels.add(channelId)
   state.idToBasicInfo.set(channelId, channelInfo)
@@ -649,6 +753,9 @@ export default immerKeyedReducer(DEFAULT_CHAT_STATE, {
     updateMessages(state, channelId, false, messages =>
       dedupeAgainst(newMessages, messages).concat(messages),
     )
+    // The older edge just moved (or, for a window left holding only carried messages by a prior
+    // drop, was established for the first time), so re-check whether it now reaches any of them.
+    mergeCarriedMessages(channelMessages)
     updateChannelInfos(state, action.payload.channelMentions)
     updateDeletedChannels(state, action.payload.deletedChannels)
   },
@@ -708,6 +815,10 @@ export default immerKeyedReducer(DEFAULT_CHAT_STATE, {
         channelMessages.detachedNewestTime = undefined
       }
     }
+
+    // The newer edge just moved, and reattaching extends coverage all the way to the present, so
+    // re-check whether the window now reaches any carried message.
+    mergeCarriedMessages(channelMessages)
   },
 
   ['@chat/loadMessagesAroundBegin'](state, action) {
@@ -749,8 +860,10 @@ export default immerKeyedReducer(DEFAULT_CHAT_STATE, {
     )
 
     // The fetched range doesn't have to touch what was loaded, so there may be no seam to splice
-    // them together at and the window is replaced outright. Client-only messages go with it: they
-    // only ever existed at the position this session happened to be scrolled to.
+    // them together at and the window is replaced outright. A client-only message can't be
+    // refetched at the new range even if it belongs there, so it's carried instead of discarded;
+    // `mergeCarriedMessages` below gives it back a home if the replacement window covers it.
+    carryClientMessages(channelMessages)
     channelMessages.messages = action.payload.messages as ChatMessage[]
     channelMessages.hasHistory = action.payload.hasMoreBefore
     channelMessages.windowGen += 1
@@ -775,6 +888,10 @@ export default immerKeyedReducer(DEFAULT_CHAT_STATE, {
         channelMessages.detachedNewestTime = undefined
       }
     }
+
+    // The window's coverage was just established from scratch, so check it against everything
+    // still carried rather than just what changed.
+    mergeCarriedMessages(channelMessages)
 
     updateChannelInfos(state, action.payload.channelMentions)
     updateDeletedChannels(state, action.payload.deletedChannels)

--- a/client/messaging/__snapshots__/common-message-layout.test.tsx.snap
+++ b/client/messaging/__snapshots__/common-message-layout.test.tsx.snap
@@ -6,6 +6,7 @@ exports[`client/messaging/common-message-layout/TextMessage > message as a norma
 >
   <div
     class="sc-jvDgNt jfqicU"
+    data-message-id="MESSAGE_ID"
     role="document"
   >
     <div
@@ -62,6 +63,7 @@ exports[`client/messaging/common-message-layout/TextMessage > message with a lin
 >
   <div
     class="sc-jvDgNt jfqicU"
+    data-message-id="MESSAGE_ID"
     role="document"
   >
     <div
@@ -125,6 +127,7 @@ exports[`client/messaging/common-message-layout/TextMessage > message with a lin
 >
   <div
     class="sc-jvDgNt jfqicU"
+    data-message-id="MESSAGE_ID"
     role="document"
   >
     <div
@@ -201,6 +204,7 @@ exports[`client/messaging/common-message-layout/TextMessage > message with a lin
 >
   <div
     class="sc-jvDgNt jfqicU"
+    data-message-id="MESSAGE_ID"
     role="document"
   >
     <div
@@ -292,6 +296,7 @@ exports[`client/messaging/common-message-layout/TextMessage > message with a men
 >
   <div
     class="sc-jvDgNt jfqicU"
+    data-message-id="MESSAGE_ID"
     role="document"
   >
     <div
@@ -361,6 +366,7 @@ exports[`client/messaging/common-message-layout/TextMessage > message with a men
 >
   <div
     class="sc-jvDgNt jfqicU"
+    data-message-id="MESSAGE_ID"
     role="document"
   >
     <div
@@ -436,6 +442,7 @@ exports[`client/messaging/common-message-layout/TextMessage > message with a men
 >
   <div
     class="sc-jvDgNt jfqicU"
+    data-message-id="MESSAGE_ID"
     role="document"
   >
     <div
@@ -520,6 +527,7 @@ exports[`client/messaging/common-message-layout/TextMessage > message with a men
 >
   <div
     class="sc-jvDgNt TFjef"
+    data-message-id="MESSAGE_ID"
     role="document"
   >
     <div

--- a/client/messaging/chat-view-anchor.test.ts
+++ b/client/messaging/chat-view-anchor.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, test } from 'vitest'
 import { ClientChatMessageType, makeSbChannelId, ServerChatMessageType } from '../../common/chat'
 import { makeSbUserId } from '../../common/users/sb-user-id'
-import { anchorNeedsFetch, ChatViewAnchor, findChatViewPlacement } from './chat-view-anchor'
+import {
+  anchorNeedsFetch,
+  ChatViewAnchor,
+  findChatViewPlacement,
+  MESSAGE_ID_ATTRIBUTE,
+  scrollToAnchoredMessage,
+} from './chat-view-anchor'
 import { SbMessage } from './message-records'
 
 const CHANNEL_ID = makeSbChannelId(1)
@@ -114,5 +120,89 @@ describe('messaging/chat-view-anchor/anchorNeedsFetch', () => {
     expect(anchorNeedsFetch([], anchor())).toBe(true)
     expect(anchorNeedsFetch([serverMessage('b', 200)], anchor())).toBe(false)
     expect(anchorNeedsFetch([serverMessage('a', 100)], anchor())).toBe(false)
+  })
+})
+
+/** Where the top of the stubbed scroller sits on screen. */
+const SCROLLER_TOP = 40
+
+/**
+ * Builds a scroller holding one element per given message id, positioned at the given viewport
+ * coordinate. The test environment lays nothing out, so the rects the scrolling reads and the range
+ * a scroll offset is clamped to are both supplied here: writes past `maxScrollTop` land on it, the
+ * way a real scroller stops at the end of its content.
+ */
+function makeScroller({
+  messageTops,
+  scrollTop = 0,
+  maxScrollTop = Number.MAX_SAFE_INTEGER,
+  roundScrollTop = false,
+}: {
+  messageTops: Record<string, number>
+  scrollTop?: number
+  maxScrollTop?: number
+  roundScrollTop?: boolean
+}): HTMLElement {
+  const scroller = document.createElement('div')
+  scroller.getBoundingClientRect = () => ({ top: SCROLLER_TOP }) as DOMRect
+
+  for (const [messageId, top] of Object.entries(messageTops)) {
+    const element = document.createElement('div')
+    element.setAttribute(MESSAGE_ID_ATTRIBUTE, messageId)
+    element.getBoundingClientRect = () => ({ top }) as DOMRect
+    scroller.appendChild(element)
+  }
+
+  let current = scrollTop
+  Object.defineProperty(scroller, 'scrollTop', {
+    get: () => current,
+    set: (value: number) => {
+      const clamped = Math.min(Math.max(value, 0), maxScrollTop)
+      current = roundScrollTop ? Math.round(clamped) : clamped
+    },
+  })
+
+  return scroller
+}
+
+describe('messaging/chat-view-anchor/scrollToAnchoredMessage', () => {
+  test('puts the message where the position asks for it', () => {
+    const scroller = makeScroller({ messageTops: { b: 250 }, scrollTop: 100, maxScrollTop: 1000 })
+
+    expect(scrollToAnchoredMessage(scroller, 'b', -12)).toBe('placed')
+    expect(scroller.scrollTop).toBe(322)
+  })
+
+  test('reports a clamp when the content below the position runs out', () => {
+    const scroller = makeScroller({ messageTops: { b: 340 }, scrollTop: 500, maxScrollTop: 778 })
+
+    expect(scrollToAnchoredMessage(scroller, 'b', 0)).toBe('clamped')
+    expect(scroller.scrollTop).toBe(778)
+  })
+
+  test('counts a rounded offset as reaching the position', () => {
+    const scroller = makeScroller({
+      messageTops: { b: 250.4 },
+      scrollTop: 100,
+      maxScrollTop: 1000,
+      roundScrollTop: true,
+    })
+
+    expect(scrollToAnchoredMessage(scroller, 'b', 0)).toBe('placed')
+    expect(scroller.scrollTop).toBe(310)
+  })
+
+  test('counts stopping at the top of the content as reaching the position', () => {
+    const scroller = makeScroller({ messageTops: { b: 40 }, scrollTop: 0, maxScrollTop: 1000 })
+
+    expect(scrollToAnchoredMessage(scroller, 'b', 24)).toBe('placed')
+    expect(scroller.scrollTop).toBe(0)
+  })
+
+  test('reports a missing message when the list holds no element for it', () => {
+    const scroller = makeScroller({ messageTops: { a: 100, c: 300 }, scrollTop: 100 })
+
+    expect(scrollToAnchoredMessage(scroller, 'b', -12)).toBe('missing')
+    expect(scroller.scrollTop).toBe(100)
   })
 })

--- a/client/messaging/chat-view-anchor.test.ts
+++ b/client/messaging/chat-view-anchor.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, test } from 'vitest'
+import { ClientChatMessageType, makeSbChannelId, ServerChatMessageType } from '../../common/chat'
+import { makeSbUserId } from '../../common/users/sb-user-id'
+import { anchorNeedsFetch, ChatViewAnchor, findChatViewPlacement } from './chat-view-anchor'
+import { SbMessage } from './message-records'
+
+const CHANNEL_ID = makeSbChannelId(1)
+const USER_ID = makeSbUserId(2)
+
+/** A channel text message, which the server persists and stamps with its own clock. */
+function serverMessage(id: string, time: number): SbMessage {
+  return {
+    id,
+    type: ServerChatMessageType.TextMessage,
+    channelId: CHANNEL_ID,
+    time,
+    from: USER_ID,
+    text: 'hi',
+  }
+}
+
+/** A channel leave banner, whose time comes from the local clock. */
+function clientMessage(id: string, time: number): SbMessage {
+  return {
+    id,
+    type: ClientChatMessageType.LeaveChannel,
+    channelId: CHANNEL_ID,
+    time,
+    userId: USER_ID,
+  }
+}
+
+function anchor(overrides: Partial<ChatViewAnchor> = {}): ChatViewAnchor {
+  return { messageId: 'b', sentTime: 200, offsetPx: -12, ...overrides }
+}
+
+describe('messaging/chat-view-anchor/findChatViewPlacement', () => {
+  test('positions against the anchor message when the window still holds it', () => {
+    const messages = [serverMessage('a', 100), serverMessage('b', 200), serverMessage('c', 300)]
+
+    expect(findChatViewPlacement(messages, anchor())).toEqual({
+      kind: 'message',
+      messageId: 'b',
+      offsetPx: -12,
+    })
+  })
+
+  test('positions against the next message when the anchor message is gone', () => {
+    const messages = [serverMessage('a', 100), serverMessage('c', 300)]
+
+    expect(findChatViewPlacement(messages, anchor())).toEqual({
+      kind: 'message',
+      messageId: 'c',
+      offsetPx: 0,
+    })
+  })
+
+  test('positions against a message sent at exactly the anchor time', () => {
+    const messages = [serverMessage('a', 100), serverMessage('c', 200)]
+
+    expect(findChatViewPlacement(messages, anchor())).toEqual({
+      kind: 'message',
+      messageId: 'c',
+      offsetPx: 0,
+    })
+  })
+
+  test('asks for a fetch when the whole window is newer than the anchor', () => {
+    const messages = [serverMessage('c', 300), serverMessage('d', 400)]
+
+    expect(findChatViewPlacement(messages, anchor())).toEqual({ kind: 'fetch' })
+  })
+
+  test('asks for a fetch when nothing is loaded', () => {
+    expect(findChatViewPlacement([], anchor())).toEqual({ kind: 'fetch' })
+  })
+
+  test('asks for a fetch when the window holds only client-stamped messages', () => {
+    const messages = [clientMessage('x', 100), clientMessage('y', 300)]
+
+    expect(findChatViewPlacement(messages, anchor())).toEqual({ kind: 'fetch' })
+  })
+
+  test('falls back to the bottom when the whole window predates the anchor', () => {
+    const messages = [serverMessage('a', 50), serverMessage('b2', 100)]
+
+    expect(findChatViewPlacement(messages, anchor())).toEqual({ kind: 'bottom' })
+  })
+
+  test('ignores client-stamped times when deciding what stands in for the anchor', () => {
+    const messages = [serverMessage('a', 100), clientMessage('x', 250), serverMessage('c', 300)]
+
+    expect(findChatViewPlacement(messages, anchor())).toEqual({
+      kind: 'message',
+      messageId: 'c',
+      offsetPx: 0,
+    })
+  })
+
+  test('keeps the anchor message even when its own time is client-stamped', () => {
+    const messages = [serverMessage('a', 100), clientMessage('b', 200), serverMessage('c', 300)]
+
+    expect(findChatViewPlacement(messages, anchor())).toEqual({
+      kind: 'message',
+      messageId: 'b',
+      offsetPx: -12,
+    })
+  })
+})
+
+describe('messaging/chat-view-anchor/anchorNeedsFetch', () => {
+  test('is true only when the position sits before the loaded window', () => {
+    expect(anchorNeedsFetch([serverMessage('c', 300)], anchor())).toBe(true)
+    expect(anchorNeedsFetch([], anchor())).toBe(true)
+    expect(anchorNeedsFetch([serverMessage('b', 200)], anchor())).toBe(false)
+    expect(anchorNeedsFetch([serverMessage('a', 100)], anchor())).toBe(false)
+  })
+})

--- a/client/messaging/chat-view-anchor.ts
+++ b/client/messaging/chat-view-anchor.ts
@@ -1,0 +1,134 @@
+import { createViewStateStore } from '../navigation/view-state-store'
+import { isServerOriginMessage, SbMessage } from './message-records'
+
+/**
+ * How long a saved reading position stays usable. A place in a conversation keeps its meaning
+ * longer than a list's scroll offset does, but not indefinitely: coming back much later, the newest
+ * messages are the interesting ones.
+ */
+const ANCHOR_MAX_AGE_MS = 45 * 60 * 1000
+
+/** Attribute carrying a message's id on the element that renders it. */
+export const MESSAGE_ID_ATTRIBUTE = 'data-message-id'
+
+/** Where in a conversation a message list was sitting when the user left it. */
+export interface ChatViewAnchor {
+  /** Id of the message the position is measured against. */
+  messageId: string
+  /**
+   * Server-recorded time of the anchor message, in epoch millis. It outlives the message itself
+   * being deleted, and locates the position in a window that has to be fetched again.
+   */
+  sentTime: number
+  /**
+   * How far the top of the anchor message sits below the top of the viewport, in pixels. Negative
+   * when the message starts above the viewport.
+   */
+  offsetPx: number
+}
+
+/**
+ * Reading positions for conversations the user has left, keyed by the same per-place key the
+ * message input keys its drafts by. A place with no entry is one that was left at the bottom, which
+ * needs no restoring: message lists open there anyway.
+ */
+export const chatViewAnchorStore = createViewStateStore<ChatViewAnchor>('chat-anchor', {
+  maxAgeMs: ANCHOR_MAX_AGE_MS,
+})
+
+/**
+ * Reads a reading position out of a message list's scroller: the topmost message that's at least
+ * partially in view, and where its top sits relative to the top of the viewport. Messages whose
+ * time the server never recorded are passed over — a position measured against one of those
+ * couldn't be found again in a window that has to be fetched. Returns undefined when the list holds
+ * nothing that can be anchored to.
+ */
+export function captureChatViewAnchor(
+  scroller: HTMLElement,
+  messages: ReadonlyArray<SbMessage>,
+): ChatViewAnchor | undefined {
+  // Positions are read as rects rather than offsets because a message's offset parent isn't
+  // guaranteed to be the scroller.
+  const scrollerTop = scroller.getBoundingClientRect().top
+
+  for (const element of scroller.querySelectorAll<HTMLElement>(`[${MESSAGE_ID_ATTRIBUTE}]`)) {
+    const rect = element.getBoundingClientRect()
+    if (rect.bottom <= scrollerTop) {
+      continue
+    }
+
+    const messageId = element.getAttribute(MESSAGE_ID_ATTRIBUTE)!
+    const message = messages.find(m => m.id === messageId)
+    if (!message || !isServerOriginMessage(message)) {
+      continue
+    }
+
+    return { messageId, sentTime: message.time, offsetPx: rect.top - scrollerTop }
+  }
+
+  return undefined
+}
+
+/** How a saved reading position can be reached from a particular window of loaded messages. */
+export type ChatViewPlacement =
+  /** Put the named message's top `offsetPx` below the top of the viewport. */
+  | { kind: 'message'; messageId: string; offsetPx: number }
+  /** The position sits before the window, which has to be replaced by one that covers it. */
+  | { kind: 'fetch' }
+  /** Everything loaded predates the position, so the bottom of the window is as close as it gets. */
+  | { kind: 'bottom' }
+
+/**
+ * Works out how to reach a saved reading position within a window of loaded messages. The anchor
+ * message itself is preferred; failing that (it was deleted, say), the first message sent at or
+ * after the same time stands in for it, at the top of the viewport.
+ */
+export function findChatViewPlacement(
+  messages: ReadonlyArray<SbMessage>,
+  anchor: ChatViewAnchor,
+): ChatViewPlacement {
+  if (messages.some(m => m.id === anchor.messageId)) {
+    return { kind: 'message', messageId: anchor.messageId, offsetPx: anchor.offsetPx }
+  }
+
+  const serverMessages = messages.filter(isServerOriginMessage)
+  if (!serverMessages.length || anchor.sentTime < serverMessages[0].time) {
+    return { kind: 'fetch' }
+  }
+
+  const standIn = serverMessages.find(m => m.time >= anchor.sentTime)
+  return standIn ? { kind: 'message', messageId: standIn.id, offsetPx: 0 } : { kind: 'bottom' }
+}
+
+/**
+ * Whether reaching a saved reading position takes loading a window of messages around it, because
+ * what's loaded doesn't reach back that far.
+ */
+export function anchorNeedsFetch(
+  messages: ReadonlyArray<SbMessage>,
+  anchor: ChatViewAnchor,
+): boolean {
+  return findChatViewPlacement(messages, anchor).kind === 'fetch'
+}
+
+/**
+ * Scrolls a message list so the top of the given message sits `offsetPx` below the top of the
+ * viewport. Returns whether the message was there to scroll to.
+ */
+export function scrollToAnchoredMessage(
+  scroller: HTMLElement,
+  messageId: string,
+  offsetPx: number,
+): boolean {
+  const element = scroller.querySelector<HTMLElement>(
+    `[${MESSAGE_ID_ATTRIBUTE}="${CSS.escape(messageId)}"]`,
+  )
+  if (!element) {
+    return false
+  }
+
+  const scrollerTop = scroller.getBoundingClientRect().top
+  const elementTop = element.getBoundingClientRect().top
+  scroller.scrollTop += elementTop - scrollerTop - offsetPx
+  return true
+}

--- a/client/messaging/chat-view-anchor.ts
+++ b/client/messaging/chat-view-anchor.ts
@@ -112,23 +112,49 @@ export function anchorNeedsFetch(
 }
 
 /**
+ * How far, in pixels, the offset a scroller ends up at may sit from the one it was asked for and
+ * still count as reaching it. Scroll offsets can be fractional, and writing one back is allowed to
+ * round it.
+ */
+const SCROLL_PLACEMENT_TOLERANCE_PX = 1
+
+/** What came of moving a message list to a saved reading position. */
+export type AnchorScrollResult =
+  /** The viewport sits at the position. */
+  | 'placed'
+  /**
+   * The list ran out of content below the position, so the viewport stopped above it. A page of
+   * messages added below lets the same move land.
+   */
+  | 'clamped'
+  /** Nothing in the list renders the message the position is measured against. */
+  | 'missing'
+
+/**
  * Scrolls a message list so the top of the given message sits `offsetPx` below the top of the
- * viewport. Returns whether the message was there to scroll to.
+ * viewport, reporting how close it got.
  */
 export function scrollToAnchoredMessage(
   scroller: HTMLElement,
   messageId: string,
   offsetPx: number,
-): boolean {
+): AnchorScrollResult {
   const element = scroller.querySelector<HTMLElement>(
     `[${MESSAGE_ID_ATTRIBUTE}="${CSS.escape(messageId)}"]`,
   )
   if (!element) {
-    return false
+    return 'missing'
   }
 
   const scrollerTop = scroller.getBoundingClientRect().top
   const elementTop = element.getBoundingClientRect().top
-  scroller.scrollTop += elementTop - scrollerTop - offsetPx
-  return true
+  const targetScrollTop = scroller.scrollTop + elementTop - scrollerTop - offsetPx
+  scroller.scrollTop = targetScrollTop
+
+  // A scroller silently clamps a write to the range its content allows. Stopping short of the
+  // target is the case worth reporting: the content the position needs below it isn't loaded, and a
+  // page added there brings the same move within reach. Stopping past the target (a position that
+  // would sit above the very top of the content) is as close as the list can get whatever else
+  // loads below.
+  return scroller.scrollTop < targetScrollTop - SCROLL_PLACEMENT_TOLERANCE_PX ? 'clamped' : 'placed'
 }

--- a/client/messaging/chat.tsx
+++ b/client/messaging/chat.tsx
@@ -385,13 +385,15 @@ export function Chat({
     return target?.kind === 'anchor' && target.viewStateKey === key
   }
 
-  const onScrollUpdate = (target: EventTarget) => {
+  const onScrollUpdate = (target: EventTarget, isListMount?: boolean) => {
     const scroller = target as HTMLDivElement
     scrollerRef.current = scroller
 
     // Any move has to happen before the scroll position is read below, so what the rest of this
-    // reports is where the list actually ends up rather than where it passed through.
-    if (lastSeenConversationRef.current !== refreshToken) {
+    // reports is where the list actually ends up rather than where it passed through. A list that
+    // has just mounted counts as arriving at its conversation however many times it happens: the
+    // mount pins to the bottom, and nothing else here would put the viewport back.
+    if (isListMount || lastSeenConversationRef.current !== refreshToken) {
       lastSeenConversationRef.current = refreshToken
       pendingScrollRef.current = undefined
       if (viewStateKey !== undefined) {

--- a/client/messaging/chat.tsx
+++ b/client/messaging/chat.tsx
@@ -46,7 +46,18 @@ type PendingScrollTarget =
   /** The unread divider, wherever it sat when the move was started. */
   | { kind: 'unreadLine'; unreadLineTime: number }
   /** The reading position the user left the conversation at, saved under `viewStateKey`. */
-  | { kind: 'anchor'; viewStateKey: string; anchor: ChatViewAnchor }
+  | {
+      kind: 'anchor'
+      viewStateKey: string
+      anchor: ChatViewAnchor
+      /**
+       * Which loaded window the move was started against. A different one means the replacement
+       * the move was waiting on has arrived.
+       */
+      windowGenAtStart: number | undefined
+      /** Whether a load has been seen in flight since the move was started. */
+      sawLoading: boolean
+    }
 
 /**
  * A move the list can't make yet because it's waiting on history the list doesn't hold. It carries
@@ -262,14 +273,17 @@ export function Chat({
     loading,
     hasMoreHistory,
     hasNewerMessages,
+    windowGeneration,
     refreshToken,
     viewStateKey,
   } = listProps
 
   /**
    * Starts moving the list to the position the user left this conversation at, if they left one
-   * behind. A position the loaded window doesn't reach becomes a pending move, which the owner is
-   * expected to fetch a window for and which lands once that window arrives.
+   * behind. Only a position that lies before the loaded window becomes a pending move: it takes a
+   * replacement window that the owner is expected to ask for, and it lands once that window
+   * arrives. Everything else is settled here and now, since the bottom is where the list already
+   * is.
    */
   const startAnchorRestore = (scroller: HTMLDivElement, key: string) => {
     const anchor = chatViewAnchorStore.get(key)
@@ -278,19 +292,35 @@ export function Chat({
     }
 
     const placement = findChatViewPlacement(messages, anchor)
-    if (
-      placement.kind === 'message' &&
+    if (placement.kind === 'message') {
       scrollToAnchoredMessage(scroller, placement.messageId, placement.offsetPx)
-    ) {
+      return
+    }
+    if (placement.kind === 'bottom') {
       return
     }
 
     pendingScrollRef.current = {
       refreshToken,
-      target: { kind: 'anchor', viewStateKey: key, anchor },
+      target: {
+        kind: 'anchor',
+        viewStateKey: key,
+        anchor,
+        windowGenAtStart: windowGeneration,
+        sawLoading: false,
+      },
     }
   }
 
+  /**
+   * Carries a move that couldn't be made when it was started as far as the list now allows.
+   *
+   * A move waiting on a replacement window only ever gives up on something a committed render has
+   * shown it: the window generation changing, or a load it watched start and then finish. "Nothing
+   * is loading" on its own can't be trusted, because this runs from scroll updates as well as from
+   * renders, and a scroll update between a commit and the request it triggers reads the loading
+   * flag a render behind — as idle, when the request is about to be made.
+   */
   const applyPendingScroll = (scroller: HTMLDivElement) => {
     const pending = pendingScrollRef.current
     if (!pending) {
@@ -302,8 +332,9 @@ export function Chat({
       return
     }
 
-    if (pending.target.kind === 'unreadLine') {
-      if (pending.target.unreadLineTime !== unreadLineTime) {
+    const target = pending.target
+    if (target.kind === 'unreadLine') {
+      if (target.unreadLineTime !== unreadLineTime) {
         // Where the divider sits changed out from under the move.
         pendingScrollRef.current = undefined
         return
@@ -321,14 +352,31 @@ export function Chat({
       return
     }
 
-    const placement = findChatViewPlacement(messages, pending.target.anchor)
-    const placed =
+    const placement = findChatViewPlacement(messages, target.anchor)
+    if (
       placement.kind === 'message' &&
       scrollToAnchoredMessage(scroller, placement.messageId, placement.offsetPx)
-    if (placed || !loading) {
-      // Either the list has reached the saved position, or nothing that could hold it is still on
-      // its way and the list keeps the position it was given by default: the newest messages.
+    ) {
       pendingScrollRef.current = undefined
+      return
+    }
+
+    if (windowGeneration !== target.windowGenAtStart) {
+      // A replacement window arrived and still can't hold the saved position, so the newest
+      // messages are as close to it as this conversation gets.
+      pendingScrollRef.current = undefined
+      scroller.scrollTop = scroller.scrollHeight
+      return
+    }
+
+    if (target.sawLoading && !loading) {
+      // A request went out and came back without replacing the window, so nothing more is coming.
+      pendingScrollRef.current = undefined
+      return
+    }
+
+    if (loading) {
+      target.sawLoading = true
     }
   }
 

--- a/client/messaging/chat.tsx
+++ b/client/messaging/chat.tsx
@@ -212,8 +212,11 @@ export interface ChatProps {
   /** If true, prevents mentions and usernames from being interactable. Defaults to false. */
   disallowMentionInteraction?: boolean
   /**
-   * Called when the user's scrolled-to-bottom state changes. Message lists mount pinned to the
-   * bottom, so owners should assume at-bottom initially.
+   * Called with the at-bottom state the viewport settles in when the list arrives at a
+   * conversation, and again whenever that state changes. The arrival report fires during the
+   * commit that mounts or re-targets the list, before owners' effects run; when a move to a saved
+   * reading position is pending, the report waits for the move to settle instead, so what's
+   * reported is where the user actually ends up.
    */
   onAtBottomChange?: (atBottom: boolean) => void
   /**
@@ -256,8 +259,11 @@ export function Chat({
   const [isScrolledUp, setIsScrolledUp] = useState<boolean>(false)
   const [showJumpToBottom, setShowJumpToBottom] = useState<boolean>(false)
   const [showUnreadBanner, setShowUnreadBanner] = useState<boolean>(false)
-  // Message lists mount pinned to the bottom, matching how `MessageList` initially scrolls.
-  const wasAtBottomRef = useRef(true)
+  // The last at-bottom state reported through `onAtBottomChange`, so only changes are reported.
+  // Undefined while nothing has been reported for the current conversation, which makes the first
+  // settled update report unconditionally: the owner has no other way to learn where the viewport
+  // actually ended up.
+  const wasAtBottomRef = useRef<boolean | undefined>(undefined)
   const scrollerRef = useRef<HTMLDivElement | null>(null)
   // Set while the list is waiting for what it needs to reach a position to come into the loaded
   // window, so it can move there once it does.
@@ -447,6 +453,7 @@ export function Chat({
     if (isListMount || lastSeenConversationRef.current !== refreshToken) {
       lastSeenConversationRef.current = refreshToken
       pendingScrollRef.current = undefined
+      wasAtBottomRef.current = undefined
       if (viewStateKey !== undefined) {
         startAnchorRestore(scroller, viewStateKey)
       }

--- a/client/messaging/chat.tsx
+++ b/client/messaging/chat.tsx
@@ -11,6 +11,12 @@ import { ElevatedButton } from '../material/button'
 import { buttonReset } from '../material/button-reset'
 import { MenuItem, MenuItemProps } from '../material/menu/item'
 import { MenuItemSymbol, MenuItemType } from '../material/menu/menu-item-symbol'
+import {
+  ChatViewAnchor,
+  chatViewAnchorStore,
+  findChatViewPlacement,
+  scrollToAnchoredMessage,
+} from '../messaging/chat-view-anchor'
 import { UNREAD_LINE_SELECTOR } from '../messaging/common-message-layout'
 import { MessageInput, MessageInputHandle, MessageInputProps } from '../messaging/message-input'
 import { MessageList, MessageListProps } from '../messaging/message-list'
@@ -35,12 +41,22 @@ const JUMP_TO_BOTTOM_THRESHOLD_SCREENS = 1.5
 /** How much room to leave above the unread divider when jumping to it, in pixels. */
 const UNREAD_LINE_SCROLL_MARGIN_PX = 8
 
-/** An in-progress hunt for the unread divider, waiting on history the list doesn't hold yet. */
-interface UnreadLineSeek {
-  /** Identifies the conversation the seek was started in. */
+/** A place in a conversation the list is on its way to. */
+type PendingScrollTarget =
+  /** The unread divider, wherever it sat when the move was started. */
+  | { kind: 'unreadLine'; unreadLineTime: number }
+  /** The reading position the user left the conversation at, saved under `viewStateKey`. */
+  | { kind: 'anchor'; viewStateKey: string; anchor: ChatViewAnchor }
+
+/**
+ * A move the list can't make yet because it's waiting on history the list doesn't hold. It carries
+ * what it was started for, so it can't outlive the conversation (or the divider position) it was
+ * aimed at.
+ */
+interface PendingScroll {
+  /** Identifies the conversation the move was started in. */
   refreshToken: unknown
-  /** Where the divider sat when the seek was started. */
-  unreadLineTime: number
+  target: PendingScrollTarget
 }
 
 function findUnreadLine(scroller: HTMLElement): HTMLElement | null {
@@ -155,7 +171,7 @@ const overlayTransition: Transition = {
 
 export interface ChatProps {
   className?: string
-  listProps: Omit<MessageListProps, 'onScrollUpdate'>
+  listProps: Omit<MessageListProps, 'onScrollUpdate' | 'isRestorePending'>
   inputProps: Omit<MessageInputProps, 'showDivider'>
   /**
    * Optional header component which will be rendered on top of the message list. This is useful if
@@ -226,10 +242,12 @@ export function Chat({
   // Message lists mount pinned to the bottom, matching how `MessageList` initially scrolls.
   const wasAtBottomRef = useRef(true)
   const scrollerRef = useRef<HTMLDivElement | null>(null)
-  // Set while we're waiting for the unread divider to come into the loaded window, so we can jump
-  // to it once it does. It carries what it was started for, so a seek can't outlive the
-  // conversation (or the divider position) it was aimed at.
-  const seekRef = useRef<UnreadLineSeek | undefined>(undefined)
+  // Set while the list is waiting for what it needs to reach a position to come into the loaded
+  // window, so it can move there once it does.
+  const pendingScrollRef = useRef<PendingScroll | undefined>(undefined)
+  // The conversation the last scroll update was for, so the first update after a switch can start
+  // that conversation's restore before anything else reads the scroll position.
+  const lastSeenConversationRef = useRef<unknown>(undefined)
   // The divider the user has already had in view. The banner is a one-shot prompt for a divider
   // they haven't laid eyes on yet — once it's been on screen, scrolling back down doesn't
   // resurface the banner. Carries what it was recorded for, so a conversation switch or a newly
@@ -238,18 +256,114 @@ export function Chat({
     undefined,
   )
 
-  const { unreadLineTime, messages, loading, hasMoreHistory, hasNewerMessages, refreshToken } =
-    listProps
+  const {
+    unreadLineTime,
+    messages,
+    loading,
+    hasMoreHistory,
+    hasNewerMessages,
+    refreshToken,
+    viewStateKey,
+  } = listProps
+
+  /**
+   * Starts moving the list to the position the user left this conversation at, if they left one
+   * behind. A position the loaded window doesn't reach becomes a pending move, which the owner is
+   * expected to fetch a window for and which lands once that window arrives.
+   */
+  const startAnchorRestore = (scroller: HTMLDivElement, key: string) => {
+    const anchor = chatViewAnchorStore.get(key)
+    if (!anchor) {
+      return
+    }
+
+    const placement = findChatViewPlacement(messages, anchor)
+    if (
+      placement.kind === 'message' &&
+      scrollToAnchoredMessage(scroller, placement.messageId, placement.offsetPx)
+    ) {
+      return
+    }
+
+    pendingScrollRef.current = {
+      refreshToken,
+      target: { kind: 'anchor', viewStateKey: key, anchor },
+    }
+  }
+
+  const applyPendingScroll = (scroller: HTMLDivElement) => {
+    const pending = pendingScrollRef.current
+    if (!pending) {
+      return
+    }
+
+    if (pending.refreshToken !== refreshToken) {
+      pendingScrollRef.current = undefined
+      return
+    }
+
+    if (pending.target.kind === 'unreadLine') {
+      if (pending.target.unreadLineTime !== unreadLineTime) {
+        // Where the divider sits changed out from under the move.
+        pendingScrollRef.current = undefined
+        return
+      }
+
+      const unreadLine = findUnreadLine(scroller)
+      if (unreadLine) {
+        pendingScrollRef.current = undefined
+        scrollToUnreadLine(scroller, unreadLine)
+      } else if (!loading) {
+        // The window the move was waiting on has arrived and holds no divider, which means there
+        // was nothing unread to move to after all.
+        pendingScrollRef.current = undefined
+      }
+      return
+    }
+
+    const placement = findChatViewPlacement(messages, pending.target.anchor)
+    const placed =
+      placement.kind === 'message' &&
+      scrollToAnchoredMessage(scroller, placement.messageId, placement.offsetPx)
+    if (placed || !loading) {
+      // Either the list has reached the saved position, or nothing that could hold it is still on
+      // its way and the list keeps the position it was given by default: the newest messages.
+      pendingScrollRef.current = undefined
+    }
+  }
+
+  const isRestorePending = (key: string) => {
+    const target = pendingScrollRef.current?.target
+    return target?.kind === 'anchor' && target.viewStateKey === key
+  }
 
   const onScrollUpdate = (target: EventTarget) => {
     const scroller = target as HTMLDivElement
+    scrollerRef.current = scroller
+
+    // Any move has to happen before the scroll position is read below, so what the rest of this
+    // reports is where the list actually ends up rather than where it passed through.
+    if (lastSeenConversationRef.current !== refreshToken) {
+      lastSeenConversationRef.current = refreshToken
+      pendingScrollRef.current = undefined
+      if (viewStateKey !== undefined) {
+        startAnchorRestore(scroller, viewStateKey)
+      }
+    } else {
+      applyPendingScroll(scroller)
+    }
+
+    // A move that's still pending leaves the list wherever it was placed by default, which says
+    // nothing about whether the user has caught up with the conversation.
+    const restorePending = pendingScrollRef.current?.target.kind === 'anchor'
+
     const { scrollTop, scrollHeight, clientHeight } = scroller
 
     const newIsScrolledUp = scrollTop + clientHeight < scrollHeight
     setIsScrolledUp(newIsScrolledUp)
 
     const newAtBottom = !newIsScrolledUp
-    if (newAtBottom !== wasAtBottomRef.current) {
+    if (!restorePending && newAtBottom !== wasAtBottomRef.current) {
       wasAtBottomRef.current = newAtBottom
       onAtBottomChange?.(newAtBottom)
     }
@@ -257,26 +371,8 @@ export function Chat({
     const distanceFromBottom = scrollHeight - clientHeight - scrollTop
     setShowJumpToBottom(distanceFromBottom > clientHeight * JUMP_TO_BOTTOM_THRESHOLD_SCREENS)
 
-    scrollerRef.current = scroller
-
-    const unreadLine = findUnreadLine(scroller)
-
-    const seek = seekRef.current
-    if (seek) {
-      if (seek.refreshToken !== refreshToken || seek.unreadLineTime !== unreadLineTime) {
-        // The conversation, or where its divider sits, changed out from under the seek.
-        seekRef.current = undefined
-      } else if (unreadLine) {
-        seekRef.current = undefined
-        scrollToUnreadLine(scroller, unreadLine)
-      } else if (!loading) {
-        // The window the seek was waiting on has arrived and holds no divider, which means there
-        // was nothing unread to move to after all.
-        seekRef.current = undefined
-      }
-    }
-
     // Rects are read after the scrolling above, so the banner reflects where the divider ended up.
+    const unreadLine = findUnreadLine(scroller)
     let newShowUnreadBanner = false
     if (unreadLineTime !== undefined) {
       if (unreadLine) {
@@ -340,9 +436,12 @@ export function Chat({
     }
 
     if (onSeekToUnread) {
-      // The divider is above the loaded window: ask for a window that contains it, and let the seek
-      // do the scrolling once it renders.
-      seekRef.current = { refreshToken, unreadLineTime }
+      // The divider is above the loaded window: ask for a window that contains it, and let the
+      // pending move do the scrolling once it renders.
+      pendingScrollRef.current = {
+        refreshToken,
+        target: { kind: 'unreadLine', unreadLineTime },
+      }
       onSeekToUnread()
     }
   }
@@ -385,7 +484,11 @@ export function Chat({
           {header}
           {backgroundContent}
           <MessageListContainer>
-            <StyledMessageList {...listProps} onScrollUpdate={onScrollUpdate} />
+            <StyledMessageList
+              {...listProps}
+              onScrollUpdate={onScrollUpdate}
+              isRestorePending={isRestorePending}
+            />
             <AnimatePresence>
               {showUnreadBanner && unreadLineTime !== undefined ? (
                 <UnreadBannerButton

--- a/client/messaging/chat.tsx
+++ b/client/messaging/chat.tsx
@@ -51,12 +51,18 @@ type PendingScrollTarget =
       viewStateKey: string
       anchor: ChatViewAnchor
       /**
-       * Which loaded window the move was started against. A different one means the replacement
-       * the move was waiting on has arrived.
+       * Which loaded window the current wait was started against. A different one means the
+       * replacement the move was waiting on has arrived.
        */
       windowGenAtStart: number | undefined
-      /** Whether a load has been seen in flight since the move was started. */
+      /** Whether a load has been seen in flight since the current wait was started. */
       sawLoading: boolean
+      /**
+       * Scroll height the last attempt at the position was made against, if one has been made. The
+       * list can't land any closer until its content changes, so further attempts wait for that
+       * rather than fighting whatever scrolling the user does in the meantime.
+       */
+      attemptedScrollHeight: number | undefined
     }
 
 /**
@@ -280,10 +286,11 @@ export function Chat({
 
   /**
    * Starts moving the list to the position the user left this conversation at, if they left one
-   * behind. Only a position that lies before the loaded window becomes a pending move: it takes a
-   * replacement window that the owner is expected to ask for, and it lands once that window
-   * arrives. Everything else is settled here and now, since the bottom is where the list already
-   * is.
+   * behind. A move becomes pending when reaching the position takes messages the window doesn't
+   * hold: the position lies before the window, so a replacement one the owner is expected to ask
+   * for has to arrive first, or the window ends too few messages below the position for the
+   * viewport to sit at it, so a page of newer messages has to be appended. Everything else is
+   * settled here and now, since the bottom is where the list already is.
    */
   const startAnchorRestore = (scroller: HTMLDivElement, key: string) => {
     const anchor = chatViewAnchorStore.get(key)
@@ -292,12 +299,22 @@ export function Chat({
     }
 
     const placement = findChatViewPlacement(messages, anchor)
-    if (placement.kind === 'message') {
-      scrollToAnchoredMessage(scroller, placement.messageId, placement.offsetPx)
-      return
-    }
     if (placement.kind === 'bottom') {
       return
+    }
+
+    let attemptedScrollHeight: number | undefined
+    if (placement.kind === 'message') {
+      const result = scrollToAnchoredMessage(scroller, placement.messageId, placement.offsetPx)
+      if (result !== 'clamped') {
+        return
+      }
+      if (!hasNewerMessages) {
+        // The bottom of the window is the newest message there is, so a viewport that stopped above
+        // the position is as close to it as the conversation gets.
+        return
+      }
+      attemptedScrollHeight = scroller.scrollHeight
     }
 
     pendingScrollRef.current = {
@@ -308,6 +325,7 @@ export function Chat({
         anchor,
         windowGenAtStart: windowGeneration,
         sawLoading: false,
+        attemptedScrollHeight,
       },
     }
   }
@@ -319,7 +337,13 @@ export function Chat({
    * shown it: the window generation changing, or a load it watched start and then finish. "Nothing
    * is loading" on its own can't be trusted, because this runs from scroll updates as well as from
    * renders, and a scroll update between a commit and the request it triggers reads the loading
-   * flag a render behind — as idle, when the request is about to be made.
+   * flag a render behind — as idle, when the request is about to be made. A generation change to a
+   * window with no messages in it doesn't count as that replacement arriving either: it's the gap
+   * before one, so the move re-arms against the new generation and keeps waiting.
+   *
+   * A move that found its position but couldn't reach it waits on something else entirely: the
+   * content growing, since re-running the same attempt against the same content can only land where
+   * it already did.
    */
   const applyPendingScroll = (scroller: HTMLDivElement) => {
     const pending = pendingScrollRef.current
@@ -353,20 +377,47 @@ export function Chat({
     }
 
     const placement = findChatViewPlacement(messages, target.anchor)
-    if (
-      placement.kind === 'message' &&
-      scrollToAnchoredMessage(scroller, placement.messageId, placement.offsetPx)
-    ) {
-      pendingScrollRef.current = undefined
-      return
+    if (placement.kind === 'message') {
+      if (scroller.scrollHeight === target.attemptedScrollHeight) {
+        // The list holds exactly what the last attempt was made against, so trying again would land
+        // in the same place while dragging the viewport away from wherever the user has scrolled.
+        return
+      }
+
+      const result = scrollToAnchoredMessage(scroller, placement.messageId, placement.offsetPx)
+      if (result === 'clamped' && hasNewerMessages) {
+        // The window ends too few messages below the position for the viewport to sit at it. The
+        // bottom edge of the list is in view in that state and asks for the page that fixes it, so
+        // the move stays armed to finish once that page lands, waiting now on this window growing
+        // rather than on the one it was originally aimed at.
+        target.windowGenAtStart = windowGeneration
+        target.sawLoading = false
+        target.attemptedScrollHeight = scroller.scrollHeight
+        return
+      }
+      if (result !== 'missing') {
+        // The viewport is either at the position, or stopped short of it with the newest messages
+        // already loaded, which is as close as the conversation goes.
+        pendingScrollRef.current = undefined
+        return
+      }
     }
 
     if (windowGeneration !== target.windowGenAtStart) {
-      // A replacement window arrived and still can't hold the saved position, so the newest
-      // messages are as close to it as this conversation gets.
-      pendingScrollRef.current = undefined
-      scroller.scrollTop = scroller.scrollHeight
-      return
+      if (messages.some(isServerOriginMessage)) {
+        // A replacement window arrived and still can't hold the saved position, so the newest
+        // messages are as close to it as this conversation gets.
+        pendingScrollRef.current = undefined
+        scroller.scrollTop = scroller.scrollHeight
+        return
+      }
+
+      // The generation moved but left no content behind: the window was cleared to make way for a
+      // replacement that hasn't arrived yet, not a replacement that failed to cover the position.
+      // The wait carries over to whatever window fills it, so re-arm against this generation and
+      // fall through to the loading latch below in case a request is already in flight this render.
+      target.windowGenAtStart = windowGeneration
+      target.sawLoading = false
     }
 
     if (target.sawLoading && !loading) {

--- a/client/messaging/common-message-layout.tsx
+++ b/client/messaging/common-message-layout.tsx
@@ -161,6 +161,7 @@ export function TextMessage({ msgId, userId, selfUserId, time, text, testId }: T
     <>
       <TimestampMessageLayout
         time={time}
+        msgId={msgId}
         active={contextMenuPopoverProps.open}
         highlighted={isHighlighted}
         onContextMenu={onContextMenu}
@@ -232,7 +233,7 @@ export const BlockedMessage = React.memo<{
 
   return (
     <>
-      <TimestampMessageLayout time={props.time} highlighted={false}>
+      <TimestampMessageLayout time={props.time} msgId={props.msgId} highlighted={false}>
         <BlockedText>{t('messaging.blockedMessage', 'Blocked message')}</BlockedText>
         <BlockedDivider>&mdash;</BlockedDivider>
         <ShowHideLink onClick={() => setShow(!show)}>

--- a/client/messaging/message-layout.tsx
+++ b/client/messaging/message-layout.tsx
@@ -112,6 +112,11 @@ const MessageContainer = styled.div<{ $active?: boolean; $highlighted?: boolean 
 
 interface TimestampMessageLayoutProps {
   time: number
+  /**
+   * Id of the message being rendered. Surfaces that restore a reading position locate messages in
+   * the DOM by it, so leaving it out makes a message impossible to anchor to.
+   */
+  msgId?: string
   active?: boolean
   highlighted?: boolean
   className?: string
@@ -128,6 +133,7 @@ export const TimestampMessageLayout = (props: TimestampMessageLayoutProps) => {
       className={props.className}
       role='document'
       onContextMenu={props.onContextMenu}
+      data-message-id={props.msgId}
       data-testid={props.testId}>
       <MessageTimestamp time={props.time} />
       {props.children}

--- a/client/messaging/message-list.tsx
+++ b/client/messaging/message-list.tsx
@@ -262,9 +262,13 @@ export interface MessageListProps {
   refreshToken?: unknown
   /**
    * Callback whenever the scroll position or scroll height has been updated (debounced to
-   * animation frames).
+   * animation frames). `isListMount` marks the update that follows the list mounting and pinning
+   * itself to the bottom: a mount always starts there, so anyone who wants the viewport somewhere
+   * else has to hear about every one of them. Mounts aren't in one-to-one correspondence with
+   * conversations — a remount that reuses the owner's state (as development StrictMode does) would
+   * otherwise pin to the bottom with nobody left to place the viewport again.
    */
-  onScrollUpdate?: (scrollTarget: EventTarget) => void
+  onScrollUpdate?: (scrollTarget: EventTarget, isListMount?: boolean) => void
   onLoadMoreMessages?: () => void
   onLoadNewerMessages?: () => void
   /**
@@ -361,9 +365,7 @@ export class MessageList extends React.Component<MessageListProps> {
     if (scrollable) {
       scrollable.scrollTop = scrollable.scrollHeight
 
-      if (this.props.onScrollUpdate) {
-        this.props.onScrollUpdate(scrollable)
-      }
+      this.props.onScrollUpdate?.(scrollable, true)
     }
   }
 

--- a/client/messaging/message-list.tsx
+++ b/client/messaging/message-list.tsx
@@ -149,6 +149,8 @@ interface PureMessageListProps {
   MessageComponent?: MessageComponentType
   unreadLineTime?: number
   hasMoreHistory?: boolean
+  /** Whether more history is currently being requested for this list. */
+  loading?: boolean
 }
 
 function PureMessageList({
@@ -157,12 +159,19 @@ function PureMessageList({
   MessageComponent,
   unreadLineTime,
   hasMoreHistory,
+  loading,
 }: PureMessageListProps) {
   const { t } = useTranslation()
   const selfUserId = useSelfUser()!.id
   const blocks = useAppSelector(s => s.relationships.blocks)
 
   if (messages.length < 1) {
+    if (loading) {
+      // A loader (rendered by the surrounding infinite scroll list) is already telling the user
+      // messages are on their way; showing empty state text at the same time would read as a
+      // contradiction.
+      return undefined
+    }
     return showEmptyState ? (
       <EmptyList>{t('common.lists.empty', 'Nothing to see here')}</EmptyList>
     ) : undefined
@@ -463,6 +472,7 @@ export class MessageList extends React.Component<MessageListProps> {
             MessageComponent={MessageComponent}
             unreadLineTime={unreadLineTime}
             hasMoreHistory={hasMoreHistory}
+            loading={loading}
           />
         </InfiniteScrollList>
       </Scrollable>

--- a/client/messaging/message-list.tsx
+++ b/client/messaging/message-list.tsx
@@ -11,6 +11,7 @@ import { animationFrameHandler } from '../material/animation-frame-handler'
 import { useAppSelector } from '../redux-hooks'
 import { selectableTextContainer } from '../styles/text-selection'
 import { bodyLarge } from '../styles/typography'
+import { captureChatViewAnchor, chatViewAnchorStore } from './chat-view-anchor'
 import {
   BlockedMessage,
   NewDayMessage,
@@ -272,6 +273,18 @@ export interface MessageListProps {
    * than this.
    */
   unreadLineTime?: number
+  /**
+   * Key identifying the conversation being displayed, under which the reading position the user
+   * leaves it at is saved. Surfaces whose chat is only meaningful for as long as it's on screen
+   * (lobby chat, say) leave this unset, which turns saving off entirely.
+   */
+  viewStateKey?: string
+  /**
+   * Whether the list is still on its way to the saved reading position for the given key rather
+   * than showing it. Reading a position out of the DOM while that's true would overwrite the saved
+   * one with a position the user never chose.
+   */
+  isRestorePending?: (viewStateKey: string) => boolean
 }
 
 interface MessageListSnapshot {
@@ -293,9 +306,44 @@ export class MessageList extends React.Component<MessageListProps> {
 
   override componentWillUnmount() {
     this.onScroll.cancel()
+
+    if (this.props.viewStateKey !== undefined) {
+      this.saveViewState(this.props.viewStateKey, this.props.messages)
+    }
   }
 
-  override getSnapshotBeforeUpdate() {
+  /**
+   * Records where the user is reading in a conversation, so returning to it can pick up there.
+   * Being at the bottom is the position message lists open at anyway, so it's stored as the absence
+   * of an entry.
+   */
+  private saveViewState(viewStateKey: string, messages: ReadonlyArray<SbMessage>) {
+    const scrollable = this.scrollableRef.current
+    if (!scrollable || this.props.isRestorePending?.(viewStateKey)) {
+      return
+    }
+
+    const atBottom =
+      scrollable.scrollTop + scrollable.clientHeight + AUTOSCROLL_LEEWAY_PX >=
+      scrollable.scrollHeight
+    const anchor = atBottom ? undefined : captureChatViewAnchor(scrollable, messages)
+
+    if (anchor) {
+      chatViewAnchorStore.set(viewStateKey, anchor)
+    } else {
+      chatViewAnchorStore.delete(viewStateKey)
+    }
+  }
+
+  override getSnapshotBeforeUpdate(prevProps: MessageListProps) {
+    const prevViewStateKey = prevProps.viewStateKey
+    if (prevViewStateKey !== undefined && prevViewStateKey !== this.props.viewStateKey) {
+      // The DOM still holds the conversation that's being swapped out, so this is both the last
+      // chance to read where the user was in it and the only one where the incoming conversation's
+      // content can't have clamped the scroll position first.
+      this.saveViewState(prevViewStateKey, prevProps.messages)
+    }
+
     if (!this.scrollableRef.current) {
       return { wasAtBottom: true, lastScrollTop: 0, lastScrollHeight: 0 }
     }
@@ -325,7 +373,24 @@ export class MessageList extends React.Component<MessageListProps> {
     snapshot: MessageListSnapshot,
   ) {
     const scrollable = this.scrollableRef.current
-    if (!scrollable || scrollable.scrollHeight === snapshot.lastScrollHeight) {
+    if (!scrollable) {
+      return
+    }
+
+    if (
+      this.props.viewStateKey !== undefined &&
+      prevProps.viewStateKey !== this.props.viewStateKey
+    ) {
+      // A different conversation's messages have taken this one's place, so nothing of the old
+      // viewport carries over and the list starts at the bottom exactly like a fresh mount does.
+      // Owners that want it somewhere else move it from the scroll update below, which still runs
+      // before anything is painted.
+      scrollable.scrollTop = scrollable.scrollHeight
+      this.props.onScrollUpdate?.(scrollable)
+      return
+    }
+
+    if (scrollable.scrollHeight === snapshot.lastScrollHeight) {
       return
     }
 

--- a/client/whispers/action-creators.ts
+++ b/client/whispers/action-creators.ts
@@ -248,10 +248,13 @@ export function jumpToPresent(
   }
 }
 
-export function activateWhisperSession(target: SbUserId): ActivateWhisperSession {
+export function activateWhisperSession(
+  target: SbUserId,
+  atBottom: boolean,
+): ActivateWhisperSession {
   return {
     type: '@whispers/activateWhisperSession',
-    payload: { target },
+    payload: { target, atBottom },
   }
 }
 

--- a/client/whispers/action-creators.ts
+++ b/client/whispers/action-creators.ts
@@ -248,13 +248,10 @@ export function jumpToPresent(
   }
 }
 
-export function activateWhisperSession(
-  target: SbUserId,
-  atBottom: boolean,
-): ActivateWhisperSession {
+export function activateWhisperSession(target: SbUserId): ActivateWhisperSession {
   return {
     type: '@whispers/activateWhisperSession',
-    payload: { target, atBottom },
+    payload: { target },
   }
 }
 

--- a/client/whispers/actions.ts
+++ b/client/whispers/actions.ts
@@ -155,18 +155,15 @@ export interface ResetMessageWindow {
 
 /**
  * Activate a particular whisper session. This is a purely client-side action which marks the
- * session as "active", and removes the unread indicator if there is one.
+ * session as "active", and removes the unread indicator if there is one. The message list reports
+ * the at-bottom state it opened in (`UpdateSessionAtBottom`) ahead of this being dispatched, so
+ * the reducer reads the current flag to tell an open at the newest messages from one restoring a
+ * position further back.
  */
 export interface ActivateWhisperSession {
   type: '@whispers/activateWhisperSession'
   payload: {
     target: SbUserId
-    /**
-     * Whether the message list is opening at the newest messages. It isn't when the view is being
-     * restored to a position further back, which means the user hasn't necessarily caught up with
-     * the conversation just by opening it.
-     */
-    atBottom: boolean
   }
 }
 
@@ -182,7 +179,7 @@ export interface DeactivateWhisperSession {
 }
 
 /**
- * Update whether an activated whisper session's message list is scrolled to the bottom. This is a
+ * Update whether a viewed whisper session's message list is scrolled to the bottom. This is a
  * purely client-side action; the reducer uses it to trim message history down to the same cap
  * applied to inactive sessions, since removing old messages while pinned to the bottom is
  * invisible to the user (auto-scroll keeps the view at the newest message).

--- a/client/whispers/actions.ts
+++ b/client/whispers/actions.ts
@@ -161,6 +161,12 @@ export interface ActivateWhisperSession {
   type: '@whispers/activateWhisperSession'
   payload: {
     target: SbUserId
+    /**
+     * Whether the message list is opening at the newest messages. It isn't when the view is being
+     * restored to a position further back, which means the user hasn't necessarily caught up with
+     * the conversation just by opening it.
+     */
+    atBottom: boolean
   }
 }
 

--- a/client/whispers/whisper-reducer.test.ts
+++ b/client/whispers/whisper-reducer.test.ts
@@ -170,10 +170,10 @@ function resetMessageWindowAction(): WhisperActions {
   }
 }
 
-function activateSessionAction(atBottom: boolean): WhisperActions {
+function activateSessionAction(): WhisperActions {
   return {
     type: '@whispers/activateWhisperSession',
-    payload: { target: TARGET_ID, atBottom },
+    payload: { target: TARGET_ID },
   }
 }
 
@@ -633,9 +633,9 @@ describe('client/whispers/whisper-reducer', () => {
 
   describe('@whispers/activateWhisperSession', () => {
     test('freezes the divider at the read position when the session has unread messages', () => {
-      const state = makeState({ unread: true, lastReadTime: 100 })
+      const state = makeState({ unread: true, lastReadTime: 100, atBottom: true })
 
-      const result = whisperReducer(state, activateSessionAction(true))
+      const result = whisperReducer(state, activateSessionAction())
 
       const session = sessionOf(result)
       expect(session.unreadLineTime).toBe(100)
@@ -643,17 +643,17 @@ describe('client/whispers/whisper-reducer', () => {
       expect(session.activated).toBe(true)
     })
 
-    test('records the at-bottom state the view is opening in', () => {
-      const state = makeState()
-
-      expect(sessionOf(whisperReducer(state, activateSessionAction(true))).atBottom).toBe(true)
-      expect(sessionOf(whisperReducer(state, activateSessionAction(false))).atBottom).toBe(false)
+    test('leaves the at-bottom state the view reported in place', () => {
+      expect(
+        sessionOf(whisperReducer(makeState({ atBottom: true }), activateSessionAction())).atBottom,
+      ).toBe(true)
+      expect(sessionOf(whisperReducer(makeState(), activateSessionAction())).atBottom).toBe(false)
     })
 
     test('consumes a divider the read position has passed when opening at the bottom', () => {
-      const state = makeState({ lastReadTime: 200, unreadLineTime: 100 })
+      const state = makeState({ lastReadTime: 200, unreadLineTime: 100, atBottom: true })
 
-      const result = whisperReducer(state, activateSessionAction(true))
+      const result = whisperReducer(state, activateSessionAction())
 
       expect(sessionOf(result).unreadLineTime).toBeUndefined()
     })
@@ -661,23 +661,23 @@ describe('client/whispers/whisper-reducer', () => {
     test('keeps a divider the read position has passed when opening away from the bottom', () => {
       const state = makeState({ lastReadTime: 200, unreadLineTime: 100 })
 
-      const result = whisperReducer(state, activateSessionAction(false))
+      const result = whisperReducer(state, activateSessionAction())
 
       expect(sessionOf(result).unreadLineTime).toBe(100)
     })
 
     test('keeps a divider the read position has not passed', () => {
-      const state = makeState({ lastReadTime: 100, unreadLineTime: 100 })
+      const state = makeState({ lastReadTime: 100, unreadLineTime: 100, atBottom: true })
 
-      const result = whisperReducer(state, activateSessionAction(true))
+      const result = whisperReducer(state, activateSessionAction())
 
       expect(sessionOf(result).unreadLineTime).toBe(100)
     })
 
     test('keeps a divider frozen by this activation', () => {
-      const state = makeState({ unread: true, lastReadTime: 100 })
+      const state = makeState({ unread: true, lastReadTime: 100, atBottom: true })
 
-      const result = whisperReducer(state, activateSessionAction(true))
+      const result = whisperReducer(state, activateSessionAction())
 
       expect(sessionOf(result).unreadLineTime).toBe(100)
     })

--- a/client/whispers/whisper-reducer.test.ts
+++ b/client/whispers/whisper-reducer.test.ts
@@ -170,6 +170,13 @@ function resetMessageWindowAction(): WhisperActions {
   }
 }
 
+function activateSessionAction(atBottom: boolean): WhisperActions {
+  return {
+    type: '@whispers/activateWhisperSession',
+    payload: { target: TARGET_ID, atBottom },
+  }
+}
+
 function deactivateSessionAction(): WhisperActions {
   return {
     type: '@whispers/deactivateWhisperSession',
@@ -624,7 +631,98 @@ describe('client/whispers/whisper-reducer', () => {
     })
   })
 
+  describe('@whispers/activateWhisperSession', () => {
+    test('freezes the divider at the read position when the session has unread messages', () => {
+      const state = makeState({ unread: true, lastReadTime: 100 })
+
+      const result = whisperReducer(state, activateSessionAction(true))
+
+      const session = sessionOf(result)
+      expect(session.unreadLineTime).toBe(100)
+      expect(session.hasUnread).toBe(false)
+      expect(session.activated).toBe(true)
+    })
+
+    test('records the at-bottom state the view is opening in', () => {
+      const state = makeState()
+
+      expect(sessionOf(whisperReducer(state, activateSessionAction(true))).atBottom).toBe(true)
+      expect(sessionOf(whisperReducer(state, activateSessionAction(false))).atBottom).toBe(false)
+    })
+
+    test('consumes a divider the read position has passed when opening at the bottom', () => {
+      const state = makeState({ lastReadTime: 200, unreadLineTime: 100 })
+
+      const result = whisperReducer(state, activateSessionAction(true))
+
+      expect(sessionOf(result).unreadLineTime).toBeUndefined()
+    })
+
+    test('keeps a divider the read position has passed when opening away from the bottom', () => {
+      const state = makeState({ lastReadTime: 200, unreadLineTime: 100 })
+
+      const result = whisperReducer(state, activateSessionAction(false))
+
+      expect(sessionOf(result).unreadLineTime).toBe(100)
+    })
+
+    test('keeps a divider the read position has not passed', () => {
+      const state = makeState({ lastReadTime: 100, unreadLineTime: 100 })
+
+      const result = whisperReducer(state, activateSessionAction(true))
+
+      expect(sessionOf(result).unreadLineTime).toBe(100)
+    })
+
+    test('keeps a divider frozen by this activation', () => {
+      const state = makeState({ unread: true, lastReadTime: 100 })
+
+      const result = whisperReducer(state, activateSessionAction(true))
+
+      expect(sessionOf(result).unreadLineTime).toBe(100)
+    })
+  })
+
   describe('@whispers/deactivateWhisperSession', () => {
+    test('consumes a divider the read position has passed when left at the bottom', () => {
+      const state = makeState({
+        activated: true,
+        atBottom: true,
+        lastReadTime: 200,
+        unreadLineTime: 100,
+      })
+
+      const result = whisperReducer(state, deactivateSessionAction())
+
+      expect(sessionOf(result).unreadLineTime).toBeUndefined()
+    })
+
+    test('keeps a divider the read position has passed when left away from the bottom', () => {
+      const state = makeState({
+        activated: true,
+        atBottom: false,
+        lastReadTime: 200,
+        unreadLineTime: 100,
+      })
+
+      const result = whisperReducer(state, deactivateSessionAction())
+
+      expect(sessionOf(result).unreadLineTime).toBe(100)
+    })
+
+    test('keeps a divider the read position has not passed', () => {
+      const state = makeState({
+        activated: true,
+        atBottom: true,
+        lastReadTime: 100,
+        unreadLineTime: 100,
+      })
+
+      const result = whisperReducer(state, deactivateSessionAction())
+
+      expect(sessionOf(result).unreadLineTime).toBe(100)
+    })
+
     test('drops a detached window entirely', () => {
       const messages = Array.from({ length: 200 }, (_, i) => textMessage(i + 1))
       const state = makeState({

--- a/client/whispers/whisper-reducer.ts
+++ b/client/whispers/whisper-reducer.ts
@@ -393,7 +393,7 @@ export default immerKeyedReducer(DEFAULT_STATE, {
   },
 
   ['@whispers/activateWhisperSession'](state, action) {
-    const { target } = action.payload
+    const { target, atBottom } = action.payload
     if (!state.byId.has(target)) {
       return
     }
@@ -402,7 +402,7 @@ export default immerKeyedReducer(DEFAULT_STATE, {
 
     // Freeze the unread divider at the read position before clearing the unread flag, so the
     // divider marks where the user left off instead of where the read position ends up after the
-    // eager mark-read this activation triggers.
+    // eager mark-read opening at the newest messages triggers.
     if (
       session.hasUnread &&
       session.unreadLineTime === undefined &&
@@ -411,9 +411,20 @@ export default immerKeyedReducer(DEFAULT_STATE, {
       session.unreadLineTime = session.lastReadTime
     }
 
+    // A divider the read position has already moved past outlives that only for as long as the
+    // view keeps returning to where the user stopped reading; opening at the newest messages means
+    // they're caught up and the divider has served its purpose.
+    if (
+      atBottom &&
+      session.unreadLineTime !== undefined &&
+      session.lastReadTime !== undefined &&
+      session.lastReadTime > session.unreadLineTime
+    ) {
+      session.unreadLineTime = undefined
+    }
+
     session.activated = true
-    // Message lists mount pinned to the bottom.
-    session.atBottom = true
+    session.atBottom = atBottom
     session.hasUnread = false
   },
 
@@ -424,6 +435,7 @@ export default immerKeyedReducer(DEFAULT_STATE, {
     }
 
     const session = state.byId.get(target)!
+    const leftAtBottom = session.atBottom
 
     if (session.hasNewer) {
       // Keeping a window that sits mid-history would put the user back where they were reading with
@@ -439,11 +451,14 @@ export default immerKeyedReducer(DEFAULT_STATE, {
 
     session.activated = false
     session.atBottom = false
-    // The unread divider is only consumed once the read position has actually moved past it — a
-    // deactivation where the user never read anything new (including the mount/cleanup/remount
-    // cycle React's StrictMode runs in development) leaves the still-unread divider in place for
-    // the next visit.
+    // The unread divider is only consumed once the read position has actually moved past it *and*
+    // the user was looking at the newest messages when they left. A deactivation where they never
+    // read anything new (including the mount/cleanup/remount cycle React's StrictMode runs in
+    // development) leaves the still-unread divider in place, and so does one from the middle of the
+    // backlog, where the read position running ahead is an artifact of having passed the bottom on
+    // the way in rather than of having caught up.
     if (
+      leftAtBottom &&
       session.unreadLineTime !== undefined &&
       session.lastReadTime !== undefined &&
       session.lastReadTime > session.unreadLineTime

--- a/client/whispers/whisper-reducer.ts
+++ b/client/whispers/whisper-reducer.ts
@@ -393,12 +393,18 @@ export default immerKeyedReducer(DEFAULT_STATE, {
   },
 
   ['@whispers/activateWhisperSession'](state, action) {
-    const { target, atBottom } = action.payload
+    const { target } = action.payload
     if (!state.byId.has(target)) {
       return
     }
 
     const session = state.byId.get(target)!
+
+    // Whether the view is opening at the newest messages. The view reports where its viewport
+    // settles (`updateSessionAtBottom`) ahead of this dispatch, so the current flag reflects this
+    // activation's viewport; a view still on its way back to a saved reading position hasn't
+    // reported yet and counts as away from the bottom, which is where it's headed.
+    const atBottom = session.atBottom
 
     // Freeze the unread divider at the read position before clearing the unread flag, so the
     // divider marks where the user left off instead of where the read position ends up after the
@@ -424,7 +430,6 @@ export default immerKeyedReducer(DEFAULT_STATE, {
     }
 
     session.activated = true
-    session.atBottom = atBottom
     session.hasUnread = false
   },
 

--- a/client/whispers/whisper.tsx
+++ b/client/whispers/whisper.tsx
@@ -122,7 +122,7 @@ export function ConnectedWhisper({
 
   const onActivate = useEffectEvent(() => {
     const anchor = chatViewAnchorStore.get(viewStateKey)
-    dispatch(activateWhisperSession(targetId, anchor === undefined))
+    dispatch(activateWhisperSession(targetId))
 
     if (anchor && anchorNeedsFetch(whisperSession?.messages ?? [], anchor)) {
       // Getting back to where the user was reading takes a window the client doesn't hold, so that

--- a/client/whispers/whisper.tsx
+++ b/client/whispers/whisper.tsx
@@ -1,9 +1,10 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useEffectEvent, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 import { SbUserId } from '../../common/users/sb-user-id'
 import { useSelfUser } from '../auth/auth-utils'
 import { Chat } from '../messaging/chat'
+import { anchorNeedsFetch, chatViewAnchorStore } from '../messaging/chat-view-anchor'
 import { flushLastRead } from '../messaging/last-read'
 import { isServerOriginMessage } from '../messaging/message-records'
 import { push, replace } from '../navigation/routing'
@@ -101,9 +102,51 @@ export function ConnectedWhisper({
     }
   }, [isClosingWhisper])
 
+  const showMessageLoadError = (err: Error) => {
+    // TODO(tec27): This would probably be better to show at the position the message loading
+    // failed in the message list (and offer a button to retry)
+    snackbarController.showSnackbar(
+      t('whispers.errors.loadingHistory', {
+        defaultValue: 'Error loading message history: {{errorMessage}}',
+        errorMessage: err.message,
+      }),
+      DURATION_LONG,
+    )
+  }
+
+  const [isLoadingHistory, setIsLoadingHistory] = useState(false)
+  const [isLoadingNewer, setIsLoadingNewer] = useState(false)
+
+  const viewStateKey = `whisper.${targetId}`
+
+  const onActivate = useEffectEvent(() => {
+    const anchor = chatViewAnchorStore.get(viewStateKey)
+    dispatch(activateWhisperSession(targetId, anchor === undefined))
+
+    if (anchor && anchorNeedsFetch(whisperSession?.messages ?? [], anchor)) {
+      // Getting back to where the user was reading takes a window the client doesn't hold, so that
+      // window is this activation's history request instead of the newest page the list would
+      // otherwise ask for.
+      dispatch(
+        getMessagesAround(targetId, MESSAGES_LIMIT, anchor.sentTime, {
+          onStart: () => {
+            setIsLoadingHistory(true)
+          },
+          onSuccess: () => {
+            setIsLoadingHistory(false)
+          },
+          onError: err => {
+            setIsLoadingHistory(false)
+            showMessageLoadError(err)
+          },
+        }),
+      )
+    }
+  })
+
   useEffect(() => {
     if (isSessionOpen) {
-      dispatch(activateWhisperSession(targetId))
+      onActivate()
     } else if (!isClosingWhisper) {
       dispatch(
         startWhisperSessionById(targetId, {
@@ -152,21 +195,6 @@ export function ConnectedWhisper({
   useEffect(() => () => flushLastRead(getWhisperLastReadKey(targetId)), [targetId])
 
   const unreadLineTime = whisperSession?.unreadLineTime
-
-  const showMessageLoadError = (err: Error) => {
-    // TODO(tec27): This would probably be better to show at the position the message loading
-    // failed in the message list (and offer a button to retry)
-    snackbarController.showSnackbar(
-      t('whispers.errors.loadingHistory', {
-        defaultValue: 'Error loading message history: {{errorMessage}}',
-        errorMessage: err.message,
-      }),
-      DURATION_LONG,
-    )
-  }
-
-  const [isLoadingHistory, setIsLoadingHistory] = useState(false)
-  const [isLoadingNewer, setIsLoadingNewer] = useState(false)
 
   const onLoadMoreMessages = useStableCallback(() => {
     setIsLoadingHistory(true)
@@ -276,13 +304,14 @@ export function ConnectedWhisper({
           hasNewerMessages: whisperSession.hasNewer,
           windowGeneration: whisperSession.windowGen,
           refreshToken: targetId,
+          viewStateKey,
           onLoadMoreMessages,
           onLoadNewerMessages,
           unreadLineTime,
         }}
         inputProps={{
           onSendChatMessage,
-          storageKey: `whisper.${targetId}`,
+          storageKey: viewStateKey,
         }}
         onAtBottomChange={onAtBottomChange}
         onJumpToPresent={onJumpToPresent}

--- a/client/whispers/whisper.tsx
+++ b/client/whispers/whisper.tsx
@@ -25,6 +25,7 @@ import {
   getWhisperLastReadKey,
   jumpToPresent,
   markWhisperRead,
+  resetMessageWindow,
   sendMessage,
   startWhisperSessionById,
   updateSessionAtBottom,
@@ -126,7 +127,11 @@ export function ConnectedWhisper({
     if (anchor && anchorNeedsFetch(whisperSession?.messages ?? [], anchor)) {
       // Getting back to where the user was reading takes a window the client doesn't hold, so that
       // window is this activation's history request instead of the newest page the list would
-      // otherwise ask for.
+      // otherwise ask for. Whatever window is still loaded doesn't contain the position either and
+      // is about to be replaced anyway, so it's dropped up front rather than left on screen: leaving
+      // it in place would show the user a spot they weren't (its bottom) only to yank them away once
+      // the requested window lands, whereas an empty window renders as loading for that same wait.
+      dispatch(resetMessageWindow(targetId))
       dispatch(
         getMessagesAround(targetId, MESSAGES_LIMIT, anchor.sentTime, {
           onStart: () => {

--- a/server/lib/chat/chat-models.ts
+++ b/server/lib/chat/chat-models.ts
@@ -487,7 +487,8 @@ export async function addMessageToChannel<T extends ChatMessageData>(
 /**
  * Where to start a page of message history from, and in which direction to read: `newest` gets
  * the most recent page with no time bound, `before`/`after` get a page strictly older/newer than
- * `date`, and `around` gets messages from both sides of `date` (inclusive on the newer side).
+ * `date`, and `around` gets messages from both sides of `date`, weighted toward the newer side
+ * (inclusive on the newer side).
  */
 export type HistoryCursor = { kind: 'newest' } | { kind: 'before' | 'after' | 'around'; date: Date }
 
@@ -571,7 +572,10 @@ export async function getMessagesForChannel(
       }
 
       case 'around': {
-        const beforeLimit = Math.floor(limit / 2)
+        // An around window is used to place the message at `date` near the top of a viewport, so
+        // most of the window belongs to what renders below it: too little content below the
+        // target leaves the viewport unable to scroll down to the position.
+        const beforeLimit = Math.floor(limit / 3)
         const afterLimit = limit - beforeLimit
         // `is_before` lets the two halves be told apart in JS without comparing timestamps
         // against `cursor.date` there (the DB's microsecond-precision `sent` loses precision when

--- a/server/lib/whispers/whisper-models.ts
+++ b/server/lib/whispers/whisper-models.ts
@@ -306,7 +306,10 @@ export async function getMessagesForWhisperSession(
       }
 
       case 'around': {
-        const beforeLimit = Math.floor(limit / 2)
+        // An around window is used to place the message at `date` near the top of a viewport, so
+        // most of the window belongs to what renders below it: too little content below the
+        // target leaves the viewport unable to scroll down to the position.
+        const beforeLimit = Math.floor(limit / 3)
         const afterLimit = limit - beforeLimit
         // `is_before` lets the two halves be told apart in JS without comparing timestamps
         // against `cursor.date` there (the DB's microsecond-precision `sent` loses precision when


### PR DESCRIPTION
Returning to a channel or whisper now picks up where the user left off instead of always pinning to the newest messages.

- Reading positions are content anchors (`{messageId, sentTime, offsetPx}`) captured once from the DOM as a conversation is left (pre-commit on a conversation switch, `componentWillUnmount` on route exits), stored per place in the shared view-state LRU with a 45-minute TTL. Leaving at the bottom stores nothing — the bottom is the default.
- Restoring into an anchor the loaded window still holds is a direct scroll; an anchor past the deactivation trim fetches one `aroundTime` window (the detachable-window machinery from #1443) and positions when it lands. A deleted anchor message falls back to the first message at or after its time.
- Activation now carries `atBottom`, so restoring into scrollback no longer fires the eager mark-read — the read position only advances when the user actually reaches the bottom.
- The unread divider is consumed at deactivation only when the user left at the bottom; left mid-backlog it survives alongside the saved position, and an already-passed divider outlives the ack only while a fresh anchor exists.
- Pending restores only give up on observed state changes (window generation, a load seen starting and finishing) — never on a loading flag read from a stale render closure. List mounts always re-enter the restore path, which keeps development StrictMode's simulated remounts from clobbering a placed viewport.

Lobby chat is unaffected (no view-state key). Live-verified in the dev client: exact in-window and fetch-around restores (single `aroundTime`, no duplicate initial fetch, no premature mark-read), divider survival/consumption both ways, whisper parity including the fresh-mount path.