### PR TITLE
Persist chat reading positions and dividers across reloads.

### DIFF
--- a/client/auth/action-creators.ts
+++ b/client/auth/action-creators.ts
@@ -13,6 +13,7 @@ import { DialogType } from '../dialogs/dialog-type'
 import { dispatch, type ThunkAction } from '../dispatch-registry'
 import { maybeChangeLanguageLocally } from '../i18n/action-creators'
 import logger from '../logging/logger'
+import { clearViewState } from '../navigation/view-state-store'
 import { RequestHandlingSpec, abortableThunk } from '../network/abortable-thunk'
 import {
   CREDENTIAL_STORAGE,
@@ -129,6 +130,9 @@ export function logOut(spec: RequestHandlingSpec): ThunkAction {
     dispatch({ type: '@auth/logOut' })
     CREDENTIAL_STORAGE.store(undefined)
     clearSessionRefresh()
+    // Reading positions and scroll offsets belong to the account that produced them; the next one
+    // to sign in on this client must not land in them.
+    clearViewState()
   })
 }
 

--- a/client/chat/action-creators.ts
+++ b/client/chat/action-creators.ts
@@ -31,6 +31,7 @@ import { DialogType } from '../dialogs/dialog-type'
 import { ThunkAction } from '../dispatch-registry'
 import i18n from '../i18n/i18next'
 import logger from '../logging/logger'
+import { saveStoredChatRestore } from '../messaging/chat-restore-storage'
 import { reportLastRead } from '../messaging/last-read'
 import { push, replace } from '../navigation/routing'
 import { RequestHandlingSpec, abortableThunk } from '../network/abortable-thunk'
@@ -66,6 +67,14 @@ export function getJoinedChannels(spec: RequestHandlingSpec<void>): ThunkAction 
 /** The `reportLastRead`/`flushLastRead` coalescing key for a channel's read position. */
 export function getChannelLastReadKey(channelId: SbChannelId): string {
   return `channel-${channelId}`
+}
+
+/**
+ * The key a channel's per-conversation view state — the reading position it was left at, the draft
+ * typed into it — is stored under.
+ */
+export function getChannelViewStateKey(channelId: SbChannelId): string {
+  return `chat.${channelId}`
 }
 
 /**
@@ -755,10 +764,39 @@ export function unbanUser(
   })
 }
 
-export function activateChannel(channelId: SbChannelId): ActivateChannel {
+export function activateChannel(
+  channelId: SbChannelId,
+  restoredUnreadLineTime?: number,
+): ActivateChannel {
   return {
     type: '@chat/activateChannel',
-    payload: { channelId },
+    payload: { channelId, restoredUnreadLineTime },
+  }
+}
+
+/**
+ * Copies where the user was reading in a channel into durable per-user storage, so returning to it
+ * after a reload or an app restart picks up in the same place. The position it copies is the one
+ * the message list records as it goes away, so this belongs after that: on the channel's teardown,
+ * or once the list has saved for a page that's unloading. Nobody signed in means nowhere to store
+ * it.
+ */
+export function persistChannelRestorePosition(channelId: SbChannelId): ThunkAction {
+  return (_dispatch, getStore) => {
+    const { auth, chat } = getStore()
+    const selfId = auth.self?.user.id
+    // Without the channel having been open, holding no position in memory means it was never
+    // looked at rather than that it was left at the newest messages, and clearing what an earlier
+    // session stored on the strength of that would throw away a position nothing has replaced.
+    if (selfId === undefined || !chat.activatedChannels.has(channelId)) {
+      return
+    }
+
+    saveStoredChatRestore(
+      selfId,
+      getChannelViewStateKey(channelId),
+      chat.idToUnreadLineTime.get(channelId),
+    )
   }
 }
 

--- a/client/chat/actions.ts
+++ b/client/chat/actions.ts
@@ -401,6 +401,12 @@ export interface ActivateChannel {
   type: '@chat/activateChannel'
   payload: {
     channelId: SbChannelId
+    /**
+     * An unread divider carried over from a previous session, restored alongside the reading
+     * position it was saved with. Only used when this session has no divider of its own for the
+     * channel.
+     */
+    restoredUnreadLineTime?: number
   }
 }
 

--- a/client/chat/channel.tsx
+++ b/client/chat/channel.tsx
@@ -10,6 +10,10 @@ import {
 } from '../../common/chat'
 import { SbUserId } from '../../common/users/sb-user-id'
 import { Chat } from '../messaging/chat'
+import {
+  getStoredRestoreUnreadLineTime,
+  hydrateStoredChatAnchor,
+} from '../messaging/chat-restore-storage'
 import { anchorNeedsFetch, chatViewAnchorStore } from '../messaging/chat-view-anchor'
 import { flushLastRead } from '../messaging/last-read'
 import { MAX_MENTIONED_USERS } from '../messaging/message-input'
@@ -28,12 +32,14 @@ import {
   deactivateChannel,
   getChannelInfo,
   getChannelLastReadKey,
+  getChannelViewStateKey,
   getMessageHistory,
   getMessagesAround,
   getNewerMessages,
   jumpToPresent,
   leaveChannelWithConfirmation,
   markChannelRead,
+  persistChannelRestorePosition,
   resetMessageWindow,
   retrieveUserList,
   sendMessage,
@@ -168,6 +174,7 @@ export function ConnectedChatChannel({
   const isActivated = useAppSelector(s => s.chat.activatedChannels.has(channelId))
   const isAtBottom = useAppSelector(s => s.chat.atBottomChannels.has(channelId))
   const unreadLineTime = useAppSelector(s => s.chat.idToUnreadLineTime.get(channelId))
+  const selfUserId = useAppSelector(s => s.auth.self?.user.id)
 
   // NOTE(2Pac): When user types the single @ character in chat, we show the ten most recent
   // chatters in the channel as an option to mention.
@@ -255,13 +262,19 @@ export function ConnectedChatChannel({
     }
   }, [isLeavingChannel])
 
-  const viewStateKey = `chat.${channelId}`
+  const viewStateKey = getChannelViewStateKey(channelId)
 
   const onActivate = useEffectEvent(() => {
     dispatch(retrieveUserList(channelId))
 
+    // A position saved before a reload or restart has to be back in memory before the read below
+    // decides how the channel opens, and the divider that was saved with it comes along so the two
+    // are restored together.
+    hydrateStoredChatAnchor(selfUserId, viewStateKey)
+    const restoredUnreadLineTime = getStoredRestoreUnreadLineTime(selfUserId, viewStateKey)
+
     const anchor = chatViewAnchorStore.get(viewStateKey)
-    dispatch(activateChannel(channelId))
+    dispatch(activateChannel(channelId, restoredUnreadLineTime))
 
     if (anchor && anchorNeedsFetch(channelMessages?.messages ?? [], anchor)) {
       // Getting back to where the user was reading takes a window the client doesn't hold, so that
@@ -281,6 +294,9 @@ export function ConnectedChatChannel({
     }
 
     return () => {
+      // The durable copy is taken before deactivating, which is free to consume the divider that
+      // belongs with the position being stored.
+      dispatch(persistChannelRestorePosition(channelId))
       dispatch(deactivateChannel(channelId))
     }
   }, [isInChannel, channelId, dispatch])
@@ -359,6 +375,9 @@ export function ConnectedChatChannel({
               windowGeneration: channelMessages?.windowGen,
               refreshToken: channelId,
               viewStateKey,
+              onViewStateSavedOnUnload: () => {
+                dispatch(persistChannelRestorePosition(channelId))
+              },
               MessageComponent: ChannelMessage,
               onLoadMoreMessages,
               onLoadNewerMessages,

--- a/client/chat/chat-reducer.test.ts
+++ b/client/chat/chat-reducer.test.ts
@@ -245,10 +245,10 @@ function resetMessageWindowAction(): ChatActions {
   }
 }
 
-function activateChannelAction(): ChatActions {
+function activateChannelAction(restoredUnreadLineTime?: number): ChatActions {
   return {
     type: '@chat/activateChannel',
-    payload: { channelId: CHANNEL_ID },
+    payload: { channelId: CHANNEL_ID, restoredUnreadLineTime },
   }
 }
 
@@ -948,6 +948,38 @@ describe('client/chat/chat-reducer', () => {
       const result = chatReducer(state, activateChannelAction())
 
       expect(result.idToUnreadLineTime.get(CHANNEL_ID)).toBe(100)
+    })
+
+    test('takes a restored divider when the channel has none', () => {
+      const state = makeState({ lastReadTime: 300 })
+
+      const result = chatReducer(state, activateChannelAction(100))
+
+      expect(result.idToUnreadLineTime.get(CHANNEL_ID)).toBe(100)
+    })
+
+    test('keeps the divider it already has over a restored one', () => {
+      const state = makeState({ lastReadTime: 300, unreadLineTime: 200 })
+
+      const result = chatReducer(state, activateChannelAction(100))
+
+      expect(result.idToUnreadLineTime.get(CHANNEL_ID)).toBe(200)
+    })
+
+    test('a restored divider takes the place of the one this activation would freeze', () => {
+      const state = makeState({ unread: true, lastReadTime: 300 })
+
+      const result = chatReducer(state, activateChannelAction(100))
+
+      expect(result.idToUnreadLineTime.get(CHANNEL_ID)).toBe(100)
+    })
+
+    test('a restored divider the read position has passed is consumed at the bottom', () => {
+      const state = makeState({ lastReadTime: 300, atBottom: true })
+
+      const result = chatReducer(state, activateChannelAction(100))
+
+      expect(result.idToUnreadLineTime.has(CHANNEL_ID)).toBe(false)
     })
   })
 

--- a/client/chat/chat-reducer.ts
+++ b/client/chat/chat-reducer.ts
@@ -994,13 +994,20 @@ export default immerKeyedReducer(DEFAULT_CHAT_STATE, {
   },
 
   ['@chat/activateChannel'](state, action) {
-    const { channelId } = action.payload
+    const { channelId, restoredUnreadLineTime } = action.payload
 
     // Whether the view is opening at the newest messages. The view reports where its viewport
     // settles (`updateChannelAtBottom`) ahead of this dispatch, so the current flag reflects this
     // activation's viewport; a view still on its way back to a saved reading position hasn't
     // reported yet and counts as away from the bottom, which is where it's headed.
     const atBottom = state.atBottomChannels.has(channelId)
+
+    // A divider from a previous session stands in for one this session never had a chance to
+    // freeze. It goes in ahead of everything else that looks at the divider, so the rules for
+    // freezing and consuming it treat it no differently from one frozen here.
+    if (restoredUnreadLineTime !== undefined && !state.idToUnreadLineTime.has(channelId)) {
+      state.idToUnreadLineTime.set(channelId, restoredUnreadLineTime)
+    }
 
     // Freeze the unread divider at the read position before clearing the unread flag, so the
     // divider marks where the user left off instead of where the read position ends up after the

--- a/client/games/use-game-list-search.test.tsx
+++ b/client/games/use-game-list-search.test.tsx
@@ -1,7 +1,7 @@
 import { act, renderHook } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import type { GameRecordJson } from '../../common/games/games'
-import { resetViewStateForTesting } from '../navigation/view-state-store'
+import { clearViewState } from '../navigation/view-state-store'
 import { GameListSearchPage, useGameListSearch } from './use-game-list-search'
 
 // The hook only reads `useHistoryEntryKey` from router-hooks, so that's all this mocks. The test
@@ -57,7 +57,7 @@ describe('client/games/use-game-list-search', () => {
   beforeEach(() => {
     currentEntryKey = undefined
     fakeGamesById.clear()
-    resetViewStateForTesting()
+    clearViewState()
   })
 
   afterEach(() => {

--- a/client/messaging/chat-restore-storage.test.ts
+++ b/client/messaging/chat-restore-storage.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, test } from 'vitest'
+import {
+  getFreshStoredRestore,
+  MAX_STORED_RESTORE_PLACES,
+  resolveRestoreHydration,
+  StoredChatRestore,
+  StoredChatRestoreMap,
+  withRestoreUpdate,
+} from './chat-restore-storage'
+import { CHAT_ANCHOR_MAX_AGE_MS, ChatViewAnchor } from './chat-view-anchor'
+
+const NOW = 10_000_000
+
+function anchor(messageId = 'a'): ChatViewAnchor {
+  return { messageId, sentTime: 500, offsetPx: -12 }
+}
+
+function stored(overrides: Partial<StoredChatRestore> = {}): StoredChatRestore {
+  return { anchor: anchor(), savedAt: NOW, ...overrides }
+}
+
+describe('messaging/chat-restore-storage/withRestoreUpdate', () => {
+  test('adds a new entry with the given savedAt', () => {
+    const result = withRestoreUpdate({}, 'chat.1', { anchor: anchor() }, NOW)
+
+    expect(result).toEqual({ 'chat.1': { anchor: anchor(), savedAt: NOW } })
+  })
+
+  test('stores the divider alongside the position', () => {
+    const result = withRestoreUpdate({}, 'chat.1', { anchor: anchor(), unreadLineTime: 400 }, NOW)
+
+    expect(result).toEqual({
+      'chat.1': { anchor: anchor(), unreadLineTime: 400, savedAt: NOW },
+    })
+  })
+
+  test('overwrites an existing entry for the same key', () => {
+    const positions: StoredChatRestoreMap = {
+      'chat.1': stored({ anchor: anchor('old'), unreadLineTime: 100, savedAt: NOW - 1000 }),
+    }
+
+    const result = withRestoreUpdate(positions, 'chat.1', { anchor: anchor('new') }, NOW)
+
+    expect(result).toEqual({ 'chat.1': { anchor: anchor('new'), savedAt: NOW } })
+  })
+
+  test('leaves other entries untouched', () => {
+    const positions: StoredChatRestoreMap = {
+      'whisper.2': stored({ anchor: anchor('other'), savedAt: NOW - 1000 }),
+    }
+
+    const result = withRestoreUpdate(positions, 'chat.1', { anchor: anchor() }, NOW)
+
+    expect(result).toEqual({
+      'whisper.2': { anchor: anchor('other'), savedAt: NOW - 1000 },
+      'chat.1': { anchor: anchor(), savedAt: NOW },
+    })
+  })
+
+  test('removes the entry when there is no position to store', () => {
+    const positions: StoredChatRestoreMap = { 'chat.1': stored() }
+
+    const result = withRestoreUpdate(positions, 'chat.1', undefined, NOW)
+
+    expect(result).toEqual({})
+  })
+
+  test('removing an entry that was never stored is a no-op', () => {
+    const positions: StoredChatRestoreMap = { 'whisper.2': stored({ savedAt: NOW - 1000 }) }
+
+    const result = withRestoreUpdate(positions, 'chat.1', undefined, NOW)
+
+    expect(result).toEqual({ 'whisper.2': { anchor: anchor(), savedAt: NOW - 1000 } })
+  })
+
+  test('prunes entries that have outlived a reading position', () => {
+    const positions: StoredChatRestoreMap = {
+      'chat.2': stored({ savedAt: NOW - CHAT_ANCHOR_MAX_AGE_MS - 1 }),
+      'chat.3': stored({ savedAt: NOW - CHAT_ANCHOR_MAX_AGE_MS }),
+    }
+
+    const result = withRestoreUpdate(positions, 'chat.1', { anchor: anchor() }, NOW)
+
+    expect(Object.keys(result).sort()).toEqual(['chat.1', 'chat.3'])
+  })
+
+  test('drops stray entries that carry no position', () => {
+    const positions = {
+      'chat.2': { savedAt: NOW } as StoredChatRestore,
+      'chat.3': stored(),
+    }
+
+    const result = withRestoreUpdate(positions, 'chat.1', { anchor: anchor() }, NOW)
+
+    expect(Object.keys(result).sort()).toEqual(['chat.1', 'chat.3'])
+  })
+
+  test('caps the stored places, evicting the ones saved longest ago', () => {
+    const positions: StoredChatRestoreMap = {}
+    for (let i = 0; i < MAX_STORED_RESTORE_PLACES; i++) {
+      positions[`chat.${i}`] = stored({ savedAt: NOW - (MAX_STORED_RESTORE_PLACES - i) })
+    }
+
+    const result = withRestoreUpdate(positions, 'chat.new', { anchor: anchor() }, NOW)
+
+    expect(Object.keys(result).length).toBe(MAX_STORED_RESTORE_PLACES)
+    expect(result['chat.new']).toBeDefined()
+    // `chat.0` had the oldest savedAt of the entries that were already there.
+    expect(result['chat.0']).toBeUndefined()
+    expect(result['chat.1']).toBeDefined()
+  })
+
+  test('leaves a map at exactly the cap alone', () => {
+    const positions: StoredChatRestoreMap = {}
+    for (let i = 0; i < MAX_STORED_RESTORE_PLACES - 1; i++) {
+      positions[`chat.${i}`] = stored({ savedAt: NOW - 1 })
+    }
+
+    const result = withRestoreUpdate(positions, 'chat.new', { anchor: anchor() }, NOW)
+
+    expect(Object.keys(result).length).toBe(MAX_STORED_RESTORE_PLACES)
+  })
+})
+
+describe('messaging/chat-restore-storage/getFreshStoredRestore', () => {
+  test('returns an entry that is still worth returning to', () => {
+    const positions: StoredChatRestoreMap = { 'chat.1': stored({ unreadLineTime: 400 }) }
+
+    expect(getFreshStoredRestore(positions, 'chat.1', NOW)).toEqual({
+      anchor: anchor(),
+      unreadLineTime: 400,
+      savedAt: NOW,
+    })
+  })
+
+  test('returns nothing for a key that has no entry', () => {
+    expect(getFreshStoredRestore({}, 'chat.1', NOW)).toBeUndefined()
+  })
+
+  test('returns nothing for an entry that carries no position', () => {
+    const positions = { 'chat.1': { savedAt: NOW } as StoredChatRestore }
+
+    expect(getFreshStoredRestore(positions, 'chat.1', NOW)).toBeUndefined()
+  })
+
+  test('returns nothing for an entry that has outlived a reading position', () => {
+    const positions: StoredChatRestoreMap = {
+      'chat.1': stored({ savedAt: NOW - CHAT_ANCHOR_MAX_AGE_MS - 1 }),
+    }
+
+    expect(getFreshStoredRestore(positions, 'chat.1', NOW)).toBeUndefined()
+  })
+
+  test('returns an entry saved exactly a reading position ago', () => {
+    const positions: StoredChatRestoreMap = {
+      'chat.1': stored({ savedAt: NOW - CHAT_ANCHOR_MAX_AGE_MS }),
+    }
+
+    expect(getFreshStoredRestore(positions, 'chat.1', NOW)).toBeDefined()
+  })
+})
+
+describe('messaging/chat-restore-storage/resolveRestoreHydration', () => {
+  test('brings back a stored position when this session holds none', () => {
+    expect(resolveRestoreHydration(undefined, stored())).toEqual(anchor())
+  })
+
+  test('leaves a position this session already holds alone', () => {
+    expect(
+      resolveRestoreHydration(anchor('in-session'), stored({ anchor: anchor('durable') })),
+    ).toEqual(undefined)
+  })
+
+  test('brings back nothing when there is nothing stored to bring back', () => {
+    expect(resolveRestoreHydration(undefined, undefined)).toBeUndefined()
+  })
+})

--- a/client/messaging/chat-restore-storage.ts
+++ b/client/messaging/chat-restore-storage.ts
@@ -1,0 +1,174 @@
+import { getErrorStack } from '../../common/errors'
+import { SbUserId } from '../../common/users/sb-user-id'
+import logger from '../logging/logger'
+import { CHAT_ANCHOR_MAX_AGE_MS, ChatViewAnchor, chatViewAnchorStore } from './chat-view-anchor'
+
+/**
+ * The maximum number of conversations' worth of reading positions kept per user in durable
+ * storage. Only conversations left away from their newest messages take up a slot, so this reaches
+ * much further back than the number of conversations a session touches.
+ */
+export const MAX_STORED_RESTORE_PLACES = 20
+
+/** A conversation's reading position, as it survives a reload or an app restart. */
+export interface StoredChatRestore {
+  anchor: ChatViewAnchor
+  /**
+   * The unread divider the user hadn't caught up with, if there was one. It's only ever stored
+   * next to a position: a divider the read position has already passed is consumed the moment its
+   * conversation opens at the newest messages, so one with no position to return to would be gone
+   * before it could be seen.
+   */
+  unreadLineTime?: number
+  savedAt: number
+}
+
+/**
+ * A user's stored reading positions, keyed by the same per-place key the in-memory store and the
+ * message input's drafts use.
+ */
+export type StoredChatRestoreMap = Record<string, StoredChatRestore>
+
+function restoreStorageKey(userId: SbUserId): string {
+  return `${userId}|chatRestore`
+}
+
+function readRestoreMap(userId: SbUserId): StoredChatRestoreMap {
+  try {
+    const json = localStorage.getItem(restoreStorageKey(userId))
+    if (json === null) {
+      return {}
+    }
+
+    const parsed = JSON.parse(json)
+    return parsed && typeof parsed === 'object' ? parsed : {}
+  } catch (err) {
+    logger.error(`error reading chat reading positions: ${getErrorStack(err)}`)
+    return {}
+  }
+}
+
+function writeRestoreMap(userId: SbUserId, positions: StoredChatRestoreMap): void {
+  try {
+    localStorage.setItem(restoreStorageKey(userId), JSON.stringify(positions))
+  } catch (err) {
+    logger.error(`error writing chat reading positions: ${getErrorStack(err)}`)
+  }
+}
+
+/**
+ * Returns a copy of `positions` with `key`'s entry set to `entry`, or removed when there's nothing
+ * to store for it (a conversation left at its newest messages opens there anyway). Entries that
+ * have outlived a reading position's usefulness are dropped along the way, as are any that carry
+ * no position at all, and the result is capped to `MAX_STORED_RESTORE_PLACES` conversations,
+ * evicting the ones saved longest ago first.
+ */
+export function withRestoreUpdate(
+  positions: StoredChatRestoreMap,
+  key: string,
+  entry: Omit<StoredChatRestore, 'savedAt'> | undefined,
+  savedAt: number,
+): StoredChatRestoreMap {
+  const next: StoredChatRestoreMap = {}
+  for (const [k, v] of Object.entries(positions)) {
+    if (k !== key && v?.anchor && savedAt - v.savedAt <= CHAT_ANCHOR_MAX_AGE_MS) {
+      next[k] = v
+    }
+  }
+  if (entry) {
+    next[key] = { ...entry, savedAt }
+  }
+
+  const entries = Object.entries(next)
+  if (entries.length <= MAX_STORED_RESTORE_PLACES) {
+    return next
+  }
+
+  entries.sort((a, b) => b[1].savedAt - a[1].savedAt)
+  return Object.fromEntries(entries.slice(0, MAX_STORED_RESTORE_PLACES))
+}
+
+/**
+ * Returns `key`'s stored entry if it's still worth returning to: it has to carry a position, and
+ * it stops naming a place worth going back to once it has outlived a reading position's lifetime,
+ * exactly as the in-memory store treats its own entries.
+ */
+export function getFreshStoredRestore(
+  positions: StoredChatRestoreMap,
+  key: string,
+  now: number,
+): StoredChatRestore | undefined {
+  const stored = positions[key]
+  if (!stored?.anchor || now - stored.savedAt > CHAT_ANCHOR_MAX_AGE_MS) {
+    return undefined
+  }
+
+  return stored
+}
+
+/**
+ * Decides which reading position opening a conversation should use: the one this session already
+ * holds, if any, otherwise the durably-stored one. Returns the position to bring back into memory,
+ * or nothing when memory is already ahead (its position is from this session and so the newer of
+ * the two) or when there's nothing stored worth restoring.
+ */
+export function resolveRestoreHydration(
+  inMemoryAnchor: ChatViewAnchor | undefined,
+  stored: StoredChatRestore | undefined,
+): ChatViewAnchor | undefined {
+  return inMemoryAnchor === undefined ? stored?.anchor : undefined
+}
+
+/**
+ * Copies a conversation's current in-memory reading position into durable storage for `userId`,
+ * along with the unread divider the user hadn't caught up with. A conversation holding no position
+ * in memory — one left at its newest messages — has its stored entry removed instead. The position
+ * this reads is the one the message list records as it goes away, so this belongs after that: on
+ * the conversation's own teardown, or once the list has saved for a page that's unloading.
+ */
+export function saveStoredChatRestore(
+  userId: SbUserId,
+  placeKey: string,
+  unreadLineTime: number | undefined,
+): void {
+  const anchor = chatViewAnchorStore.get(placeKey)
+  const entry = anchor ? { anchor, unreadLineTime } : undefined
+
+  writeRestoreMap(userId, withRestoreUpdate(readRestoreMap(userId), placeKey, entry, Date.now()))
+}
+
+/**
+ * Brings a conversation's durably-stored reading position into the in-memory store, unless this
+ * session is already holding one for it. Everything that goes looking for a position calls this
+ * first, so it has to be safe to repeat: once memory holds a position, further calls change
+ * nothing. Nobody signed in means there's no store to read from.
+ */
+export function hydrateStoredChatAnchor(userId: SbUserId | undefined, placeKey: string): void {
+  if (userId === undefined) {
+    return
+  }
+
+  const anchor = resolveRestoreHydration(
+    chatViewAnchorStore.get(placeKey),
+    getFreshStoredRestore(readRestoreMap(userId), placeKey, Date.now()),
+  )
+  if (anchor) {
+    chatViewAnchorStore.set(placeKey, anchor)
+  }
+}
+
+/**
+ * The unread divider stored alongside a conversation's durable reading position, for an activation
+ * to bring back together with it. A divider without a position to return to would be consumed as
+ * soon as the conversation opened, which is why the two are only ever stored together.
+ */
+export function getStoredRestoreUnreadLineTime(
+  userId: SbUserId | undefined,
+  placeKey: string,
+): number | undefined {
+  if (userId === undefined) {
+    return undefined
+  }
+
+  return getFreshStoredRestore(readRestoreMap(userId), placeKey, Date.now())?.unreadLineTime
+}

--- a/client/messaging/chat-view-anchor.ts
+++ b/client/messaging/chat-view-anchor.ts
@@ -4,9 +4,10 @@ import { isServerOriginMessage, SbMessage } from './message-records'
 /**
  * How long a saved reading position stays usable. A place in a conversation keeps its meaning
  * longer than a list's scroll offset does, but not indefinitely: coming back much later, the newest
- * messages are the interesting ones.
+ * messages are the interesting ones. Durable copies of a position expire on the same schedule, so
+ * that surviving a reload doesn't make a position outlive its usefulness.
  */
-const ANCHOR_MAX_AGE_MS = 45 * 60 * 1000
+export const CHAT_ANCHOR_MAX_AGE_MS = 45 * 60 * 1000
 
 /** Attribute carrying a message's id on the element that renders it. */
 export const MESSAGE_ID_ATTRIBUTE = 'data-message-id'
@@ -33,7 +34,7 @@ export interface ChatViewAnchor {
  * needs no restoring: message lists open there anyway.
  */
 export const chatViewAnchorStore = createViewStateStore<ChatViewAnchor>('chat-anchor', {
-  maxAgeMs: ANCHOR_MAX_AGE_MS,
+  maxAgeMs: CHAT_ANCHOR_MAX_AGE_MS,
 })
 
 /**

--- a/client/messaging/chat.tsx
+++ b/client/messaging/chat.tsx
@@ -11,6 +11,7 @@ import { ElevatedButton } from '../material/button'
 import { buttonReset } from '../material/button-reset'
 import { MenuItem, MenuItemProps } from '../material/menu/item'
 import { MenuItemSymbol, MenuItemType } from '../material/menu/menu-item-symbol'
+import { hydrateStoredChatAnchor } from '../messaging/chat-restore-storage'
 import {
   ChatViewAnchor,
   chatViewAnchorStore,
@@ -26,7 +27,7 @@ import {
   ScrollUpdateReason,
 } from '../messaging/message-list'
 import { isServerOriginMessage } from '../messaging/message-records'
-import { useAppDispatch } from '../redux-hooks'
+import { useAppDispatch, useAppSelector } from '../redux-hooks'
 import { labelMedium } from '../styles/typography'
 import {
   BaseUserMenuItemsProvider,
@@ -290,6 +291,7 @@ export function Chat({
 }: ChatProps) {
   const { t } = useTranslation()
   const dispatch = useAppDispatch()
+  const selfUserId = useAppSelector(s => s.auth.self?.user.id)
   const [isScrolledUp, setIsScrolledUp] = useState<boolean>(false)
   const [showJumpToBottom, setShowJumpToBottom] = useState<boolean>(false)
   const [showUnreadBanner, setShowUnreadBanner] = useState<boolean>(false)
@@ -336,6 +338,11 @@ export function Chat({
    * settled here and now, since the bottom is where the list already is.
    */
   const startAnchorRestore = (scroller: HTMLDivElement, key: string) => {
+    // The list asks where it should be sitting the moment it mounts, ahead of the conversation's
+    // own activation, so a position that outlived a reload has to be brought back here to be found
+    // at all.
+    hydrateStoredChatAnchor(selfUserId, key)
+
     const anchor = chatViewAnchorStore.get(key)
     if (!anchor) {
       return

--- a/client/messaging/message-list.tsx
+++ b/client/messaging/message-list.tsx
@@ -322,6 +322,13 @@ export interface MessageListProps {
    * one with a position the user never chose.
    */
   isRestorePending?: (viewStateKey: string) => boolean
+  /**
+   * Called when the page is going away, right after the list has recorded where the user was
+   * reading in the conversation it's showing. The saves made on unmount and on switching
+   * conversations get no such callback: whoever owns the conversation sees those in its own
+   * teardown, which runs after the list's, whereas an unloading page tears nothing down.
+   */
+  onViewStateSavedOnUnload?: () => void
 }
 
 interface MessageListSnapshot {
@@ -341,8 +348,18 @@ export class MessageList extends React.Component<MessageListProps> {
     }
   })
 
+  private onBeforeUnload = () => {
+    if (this.props.viewStateKey === undefined) {
+      return
+    }
+
+    this.saveViewState(this.props.viewStateKey, this.props.messages)
+    this.props.onViewStateSavedOnUnload?.()
+  }
+
   override componentWillUnmount() {
     this.onScroll.cancel()
+    window.removeEventListener('beforeunload', this.onBeforeUnload)
 
     if (this.props.viewStateKey !== undefined) {
       this.saveViewState(this.props.viewStateKey, this.props.messages)
@@ -391,6 +408,10 @@ export class MessageList extends React.Component<MessageListProps> {
   }
 
   override componentDidMount() {
+    // A page that unloads never unmounts anything, so the reading position it would have saved on
+    // the way out has to be taken here instead.
+    window.addEventListener('beforeunload', this.onBeforeUnload)
+
     const scrollable = this.scrollableRef.current
     if (scrollable) {
       scrollable.scrollTop = scrollable.scrollHeight

--- a/client/navigation/view-state-store.test.ts
+++ b/client/navigation/view-state-store.test.ts
@@ -1,10 +1,10 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest'
-import { createViewStateStore, resetViewStateForTesting } from './view-state-store'
+import { clearViewState, createViewStateStore } from './view-state-store'
 
 describe('view-state-store', () => {
   beforeEach(() => {
     vi.useFakeTimers()
-    resetViewStateForTesting()
+    clearViewState()
   })
 
   test('get returns undefined for a missing key', () => {

--- a/client/navigation/view-state-store.ts
+++ b/client/navigation/view-state-store.ts
@@ -77,7 +77,11 @@ export function createViewStateStore<T>(
   }
 }
 
-/** Removes all stored entries across every namespace. Only for use in tests. */
-export function resetViewStateForTesting(): void {
+/**
+ * Removes all stored entries across every namespace. Everything kept here belongs to whoever is
+ * signed in — where they were reading, how far down a list they had scrolled — so it all stops
+ * being meaningful at once when that changes. Also used to isolate tests from each other.
+ */
+export function clearViewState(): void {
   entries.clear()
 }

--- a/client/whispers/action-creators.ts
+++ b/client/whispers/action-creators.ts
@@ -9,6 +9,7 @@ import {
 } from '../../common/whispers'
 import { ThunkAction } from '../dispatch-registry'
 import logger from '../logging/logger'
+import { saveStoredChatRestore } from '../messaging/chat-restore-storage'
 import { reportLastRead } from '../messaging/last-read'
 import { push, replace } from '../navigation/routing'
 import { RequestHandlingSpec, abortableThunk } from '../network/abortable-thunk'
@@ -38,6 +39,14 @@ export function getWhisperSessions(spec: RequestHandlingSpec<void>): ThunkAction
 /** The `reportLastRead`/`flushLastRead` coalescing key for a whisper conversation's read position. */
 export function getWhisperLastReadKey(targetId: SbUserId): string {
   return `whisper-${targetId}`
+}
+
+/**
+ * The key a whisper conversation's per-conversation view state — the reading position it was left
+ * at, the draft typed into it — is stored under.
+ */
+export function getWhisperViewStateKey(targetId: SbUserId): string {
+  return `whisper.${targetId}`
 }
 
 /**
@@ -270,10 +279,36 @@ export function jumpToPresent(
   }
 }
 
-export function activateWhisperSession(target: SbUserId): ActivateWhisperSession {
+export function activateWhisperSession(
+  target: SbUserId,
+  restoredUnreadLineTime?: number,
+): ActivateWhisperSession {
   return {
     type: '@whispers/activateWhisperSession',
-    payload: { target },
+    payload: { target, restoredUnreadLineTime },
+  }
+}
+
+/**
+ * Copies where the user was reading in a whisper conversation into durable per-user storage, so
+ * returning to it after a reload or an app restart picks up in the same place. The position it
+ * copies is the one the message list records as it goes away, so this belongs after that: on the
+ * conversation's teardown, or once the list has saved for a page that's unloading. Nobody signed
+ * in means nowhere to store it.
+ */
+export function persistWhisperRestorePosition(target: SbUserId): ThunkAction {
+  return (_dispatch, getStore) => {
+    const { auth, whispers } = getStore()
+    const selfId = auth.self?.user.id
+    const session = whispers.byId.get(target)
+    // Without the conversation having been open, holding no position in memory means it was never
+    // looked at rather than that it was left at the newest messages, and clearing what an earlier
+    // session stored on the strength of that would throw away a position nothing has replaced.
+    if (selfId === undefined || !session?.activated) {
+      return
+    }
+
+    saveStoredChatRestore(selfId, getWhisperViewStateKey(target), session.unreadLineTime)
   }
 }
 

--- a/client/whispers/actions.ts
+++ b/client/whispers/actions.ts
@@ -217,6 +217,12 @@ export interface ActivateWhisperSession {
   type: '@whispers/activateWhisperSession'
   payload: {
     target: SbUserId
+    /**
+     * An unread divider carried over from a previous session, restored alongside the reading
+     * position it was saved with. Only used when this session has no divider of its own for the
+     * conversation.
+     */
+    restoredUnreadLineTime?: number
   }
 }
 

--- a/client/whispers/whisper-reducer.test.ts
+++ b/client/whispers/whisper-reducer.test.ts
@@ -206,10 +206,10 @@ function resetMessageWindowAction(): WhisperActions {
   }
 }
 
-function activateSessionAction(): WhisperActions {
+function activateSessionAction(restoredUnreadLineTime?: number): WhisperActions {
   return {
     type: '@whispers/activateWhisperSession',
-    payload: { target: TARGET_ID },
+    payload: { target: TARGET_ID, restoredUnreadLineTime },
   }
 }
 
@@ -739,6 +739,38 @@ describe('client/whispers/whisper-reducer', () => {
       const result = whisperReducer(state, activateSessionAction())
 
       expect(sessionOf(result).unreadLineTime).toBe(100)
+    })
+
+    test('takes a restored divider when the session has none', () => {
+      const state = makeState({ lastReadTime: 300 })
+
+      const result = whisperReducer(state, activateSessionAction(100))
+
+      expect(sessionOf(result).unreadLineTime).toBe(100)
+    })
+
+    test('keeps the divider it already has over a restored one', () => {
+      const state = makeState({ lastReadTime: 300, unreadLineTime: 200 })
+
+      const result = whisperReducer(state, activateSessionAction(100))
+
+      expect(sessionOf(result).unreadLineTime).toBe(200)
+    })
+
+    test('a restored divider takes the place of the one this activation would freeze', () => {
+      const state = makeState({ unread: true, lastReadTime: 300 })
+
+      const result = whisperReducer(state, activateSessionAction(100))
+
+      expect(sessionOf(result).unreadLineTime).toBe(100)
+    })
+
+    test('a restored divider the read position has passed is consumed at the bottom', () => {
+      const state = makeState({ lastReadTime: 300, atBottom: true })
+
+      const result = whisperReducer(state, activateSessionAction(100))
+
+      expect(sessionOf(result).unreadLineTime).toBeUndefined()
     })
   })
 

--- a/client/whispers/whisper-reducer.ts
+++ b/client/whispers/whisper-reducer.ts
@@ -458,7 +458,7 @@ export default immerKeyedReducer(DEFAULT_STATE, {
   },
 
   ['@whispers/activateWhisperSession'](state, action) {
-    const { target } = action.payload
+    const { target, restoredUnreadLineTime } = action.payload
     if (!state.byId.has(target)) {
       return
     }
@@ -470,6 +470,13 @@ export default immerKeyedReducer(DEFAULT_STATE, {
     // activation's viewport; a view still on its way back to a saved reading position hasn't
     // reported yet and counts as away from the bottom, which is where it's headed.
     const atBottom = session.atBottom
+
+    // A divider from a previous session stands in for one this session never had a chance to
+    // freeze. It goes in ahead of everything else that looks at the divider, so the rules for
+    // freezing and consuming it treat it no differently from one frozen here.
+    if (restoredUnreadLineTime !== undefined && session.unreadLineTime === undefined) {
+      session.unreadLineTime = restoredUnreadLineTime
+    }
 
     // Freeze the unread divider at the read position before clearing the unread flag, so the
     // divider marks where the user left off instead of where the read position ends up after the

--- a/client/whispers/whisper.tsx
+++ b/client/whispers/whisper.tsx
@@ -4,6 +4,10 @@ import styled from 'styled-components'
 import { SbUserId } from '../../common/users/sb-user-id'
 import { useSelfUser } from '../auth/auth-utils'
 import { Chat } from '../messaging/chat'
+import {
+  getStoredRestoreUnreadLineTime,
+  hydrateStoredChatAnchor,
+} from '../messaging/chat-restore-storage'
 import { anchorNeedsFetch, chatViewAnchorStore } from '../messaging/chat-view-anchor'
 import { flushLastRead } from '../messaging/last-read'
 import { isServerOriginMessage } from '../messaging/message-records'
@@ -23,8 +27,10 @@ import {
   getMessagesAround,
   getNewerMessages,
   getWhisperLastReadKey,
+  getWhisperViewStateKey,
   jumpToPresent,
   markWhisperRead,
+  persistWhisperRestorePosition,
   resetMessageWindow,
   sendMessage,
   startWhisperSessionById,
@@ -115,11 +121,17 @@ export function ConnectedWhisper({
     )
   }
 
-  const viewStateKey = `whisper.${targetId}`
+  const viewStateKey = getWhisperViewStateKey(targetId)
 
   const onActivate = useEffectEvent(() => {
+    // A position saved before a reload or restart has to be back in memory before the read below
+    // decides how the conversation opens, and the divider that was saved with it comes along so
+    // the two are restored together.
+    hydrateStoredChatAnchor(selfUser.id, viewStateKey)
+    const restoredUnreadLineTime = getStoredRestoreUnreadLineTime(selfUser.id, viewStateKey)
+
     const anchor = chatViewAnchorStore.get(viewStateKey)
-    dispatch(activateWhisperSession(targetId))
+    dispatch(activateWhisperSession(targetId, restoredUnreadLineTime))
 
     if (anchor && anchorNeedsFetch(whisperSession?.messages ?? [], anchor)) {
       // Getting back to where the user was reading takes a window the client doesn't hold, so that
@@ -170,6 +182,9 @@ export function ConnectedWhisper({
     }
 
     return () => {
+      // The durable copy is taken before deactivating, which is free to consume the divider that
+      // belongs with the position being stored.
+      dispatch(persistWhisperRestorePosition(targetId))
       dispatch(deactivateWhisperSession(targetId))
     }
   }, [isSessionOpen, targetId, dispatch])
@@ -283,6 +298,9 @@ export function ConnectedWhisper({
           windowGeneration: whisperSession.windowGen,
           refreshToken: targetId,
           viewStateKey,
+          onViewStateSavedOnUnload: () => {
+            dispatch(persistWhisperRestorePosition(targetId))
+          },
           onLoadMoreMessages,
           onLoadNewerMessages,
           unreadLineTime,


### PR DESCRIPTION
Stacked on #1445. Makes the reading-position restore survive a reload or app restart.

- One localStorage entry per user (`{userId}|chatRestore`) maps place keys to `{anchor, unreadLineTime?, savedAt}`, written when a conversation is left and on `beforeunload` (the message list owns the unload save and calls back after recording, avoiding listener-ordering assumptions). Same 45-minute TTL as the in-memory store, capped at 20 places, oldest evicted.
- A conversation left at the bottom deletes its entry; an entry is never written without an anchor — a divider alone would be consumed the moment its conversation opened.
- Hydration is idempotent and happens both where the list first asks for its position (layout phase) and in activation (passive phase); the restored divider rides the activate action and obeys the same freeze/consume rules as one frozen in-session.
- The persist thunks bail unless the place is actually activated, so a cold load cannot wipe the entry it is about to restore. Logging out clears the in-memory view state so another account cannot inherit positions.

Live-verified: reload mid-backlog restores the exact anchor and the divider (with the server read position already past it) via a single `aroundTime`; catching up and reloading pins to the bottom with the entry removed.