### PR TITLE
Persist chat and whisper message drafts across reload via localStorage.

### DIFF
--- a/client/messaging/draft-storage.test.ts
+++ b/client/messaging/draft-storage.test.ts
@@ -1,0 +1,216 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { makeSbUserId } from '../../common/users/sb-user-id'
+import {
+  DRAFT_WRITE_COALESCE_MS,
+  MAX_STORED_DRAFTS,
+  StoredDraftsMap,
+  flushDraftWrite,
+  getStoredDraft,
+  resetDraftStorageForTesting,
+  resolveInitialDraftValue,
+  scheduleDraftWrite,
+  withDraftUpdate,
+} from './draft-storage'
+
+const USER_ID = makeSbUserId(1)
+
+describe('messaging/draft-storage', () => {
+  describe('withDraftUpdate', () => {
+    test('adds a new entry with the given text and savedAt', () => {
+      const result = withDraftUpdate({}, 'chat.1', 'hello', 100)
+
+      expect(result).toEqual({ 'chat.1': { text: 'hello', savedAt: 100 } })
+    })
+
+    test('overwrites an existing entry for the same key', () => {
+      const drafts: StoredDraftsMap = { 'chat.1': { text: 'hello', savedAt: 100 } }
+
+      const result = withDraftUpdate(drafts, 'chat.1', 'hello there', 200)
+
+      expect(result).toEqual({ 'chat.1': { text: 'hello there', savedAt: 200 } })
+    })
+
+    test('leaves other entries untouched', () => {
+      const drafts: StoredDraftsMap = {
+        'chat.1': { text: 'first', savedAt: 100 },
+        'whisper.2': { text: 'second', savedAt: 150 },
+      }
+
+      const result = withDraftUpdate(drafts, 'chat.1', 'updated', 300)
+
+      expect(result).toEqual({
+        'chat.1': { text: 'updated', savedAt: 300 },
+        'whisper.2': { text: 'second', savedAt: 150 },
+      })
+    })
+
+    test('removes the entry when text is empty, rather than storing an empty string', () => {
+      const drafts: StoredDraftsMap = { 'chat.1': { text: 'hello', savedAt: 100 } }
+
+      const result = withDraftUpdate(drafts, 'chat.1', '', 200)
+
+      expect(result).toEqual({})
+    })
+
+    test('an empty update for a key with no existing entry is a no-op', () => {
+      const drafts: StoredDraftsMap = { 'whisper.2': { text: 'second', savedAt: 150 } }
+
+      const result = withDraftUpdate(drafts, 'chat.1', '', 200)
+
+      expect(result).toEqual({ 'whisper.2': { text: 'second', savedAt: 150 } })
+    })
+
+    test('drops other stray empty entries encountered while updating', () => {
+      // Empty entries should never be written by `withDraftUpdate` itself, but defend against
+      // them anyway (e.g. a value written by a future/older format).
+      const drafts: StoredDraftsMap = {
+        'chat.1': { text: '', savedAt: 100 },
+        'whisper.2': { text: 'kept', savedAt: 150 },
+      }
+
+      const result = withDraftUpdate(drafts, 'chat.3', 'new', 200)
+
+      expect(result).toEqual({
+        'whisper.2': { text: 'kept', savedAt: 150 },
+        'chat.3': { text: 'new', savedAt: 200 },
+      })
+    })
+
+    test('does not evict anything when at or under the cap', () => {
+      const drafts: StoredDraftsMap = {}
+      for (let i = 0; i < MAX_STORED_DRAFTS - 1; i++) {
+        drafts[`chat.${i}`] = { text: `text ${i}`, savedAt: i }
+      }
+
+      const result = withDraftUpdate(drafts, 'chat.new', 'new text', MAX_STORED_DRAFTS)
+
+      expect(Object.keys(result)).toHaveLength(MAX_STORED_DRAFTS)
+    })
+
+    test('evicts the oldest entries by savedAt once the cap is exceeded', () => {
+      const drafts: StoredDraftsMap = {}
+      for (let i = 0; i < MAX_STORED_DRAFTS; i++) {
+        drafts[`chat.${i}`] = { text: `text ${i}`, savedAt: i }
+      }
+
+      // chat.0 has the oldest savedAt (0), so adding one more entry should evict it.
+      const result = withDraftUpdate(drafts, 'chat.new', 'new text', MAX_STORED_DRAFTS)
+
+      expect(Object.keys(result)).toHaveLength(MAX_STORED_DRAFTS)
+      expect(result['chat.0']).toBeUndefined()
+      expect(result['chat.1']).toEqual({ text: 'text 1', savedAt: 1 })
+      expect(result['chat.new']).toEqual({ text: 'new text', savedAt: MAX_STORED_DRAFTS })
+    })
+  })
+
+  describe('resolveInitialDraftValue', () => {
+    test('returns the in-session value when present', () => {
+      expect(resolveInitialDraftValue('in session', 'stored', 'default')).toBe('in session')
+    })
+
+    test('falls back to the stored value when there is no in-session value', () => {
+      expect(resolveInitialDraftValue(undefined, 'stored', 'default')).toBe('stored')
+    })
+
+    test('falls back to the default when neither in-session nor stored values are present', () => {
+      expect(resolveInitialDraftValue(undefined, undefined, 'default')).toBe('default')
+    })
+
+    test('prefers the in-session value over the stored value when both are present', () => {
+      expect(resolveInitialDraftValue('in session', 'stored', 'default')).toBe('in session')
+    })
+  })
+
+  describe('scheduleDraftWrite / flushDraftWrite / getStoredDraft', () => {
+    beforeEach(() => {
+      vi.useFakeTimers()
+      resetDraftStorageForTesting()
+      localStorage.clear()
+    })
+
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    test('does not persist anything before the coalescing window elapses', () => {
+      scheduleDraftWrite(USER_ID, 'chat.1', 'hello')
+
+      vi.advanceTimersByTime(DRAFT_WRITE_COALESCE_MS - 1)
+
+      expect(getStoredDraft(USER_ID, 'chat.1')).toBeUndefined()
+    })
+
+    test('persists the text once the coalescing window elapses', () => {
+      scheduleDraftWrite(USER_ID, 'chat.1', 'hello')
+
+      vi.advanceTimersByTime(DRAFT_WRITE_COALESCE_MS)
+
+      expect(getStoredDraft(USER_ID, 'chat.1')).toBe('hello')
+    })
+
+    test('rapid updates within the window coalesce into a single write of the newest text', () => {
+      scheduleDraftWrite(USER_ID, 'chat.1', 'h')
+      vi.advanceTimersByTime(DRAFT_WRITE_COALESCE_MS / 2)
+      scheduleDraftWrite(USER_ID, 'chat.1', 'he')
+      vi.advanceTimersByTime(DRAFT_WRITE_COALESCE_MS / 2)
+      scheduleDraftWrite(USER_ID, 'chat.1', 'hel')
+
+      // The first two schedules should have been superseded rather than each writing in turn.
+      vi.advanceTimersByTime(DRAFT_WRITE_COALESCE_MS)
+
+      expect(getStoredDraft(USER_ID, 'chat.1')).toBe('hel')
+    })
+
+    test('flushDraftWrite persists immediately and cancels the pending timer', () => {
+      scheduleDraftWrite(USER_ID, 'chat.1', 'hello')
+
+      flushDraftWrite(USER_ID, 'chat.1')
+
+      expect(getStoredDraft(USER_ID, 'chat.1')).toBe('hello')
+
+      // Nothing further should happen when the original timer would have fired.
+      vi.advanceTimersByTime(DRAFT_WRITE_COALESCE_MS)
+      expect(getStoredDraft(USER_ID, 'chat.1')).toBe('hello')
+    })
+
+    test('flushDraftWrite with nothing pending is a no-op', () => {
+      expect(() => flushDraftWrite(USER_ID, 'chat.never-scheduled')).not.toThrow()
+      expect(getStoredDraft(USER_ID, 'chat.never-scheduled')).toBeUndefined()
+    })
+
+    test('scheduling an empty text deletes a previously persisted draft', () => {
+      scheduleDraftWrite(USER_ID, 'chat.1', 'hello')
+      vi.advanceTimersByTime(DRAFT_WRITE_COALESCE_MS)
+      expect(getStoredDraft(USER_ID, 'chat.1')).toBe('hello')
+
+      scheduleDraftWrite(USER_ID, 'chat.1', '')
+      vi.advanceTimersByTime(DRAFT_WRITE_COALESCE_MS)
+
+      expect(getStoredDraft(USER_ID, 'chat.1')).toBeUndefined()
+    })
+
+    test('independent keys coalesce separately', () => {
+      scheduleDraftWrite(USER_ID, 'chat.1', 'first')
+      vi.advanceTimersByTime(DRAFT_WRITE_COALESCE_MS / 2)
+      scheduleDraftWrite(USER_ID, 'whisper.2', 'second')
+
+      vi.advanceTimersByTime(DRAFT_WRITE_COALESCE_MS / 2)
+      expect(getStoredDraft(USER_ID, 'chat.1')).toBe('first')
+      expect(getStoredDraft(USER_ID, 'whisper.2')).toBeUndefined()
+
+      vi.advanceTimersByTime(DRAFT_WRITE_COALESCE_MS / 2)
+      expect(getStoredDraft(USER_ID, 'whisper.2')).toBe('second')
+    })
+
+    test('drafts for different users are stored independently', () => {
+      const otherUser = makeSbUserId(2)
+
+      scheduleDraftWrite(USER_ID, 'chat.1', 'mine')
+      scheduleDraftWrite(otherUser, 'chat.1', 'theirs')
+      vi.advanceTimersByTime(DRAFT_WRITE_COALESCE_MS)
+
+      expect(getStoredDraft(USER_ID, 'chat.1')).toBe('mine')
+      expect(getStoredDraft(otherUser, 'chat.1')).toBe('theirs')
+    })
+  })
+})

--- a/client/messaging/draft-storage.ts
+++ b/client/messaging/draft-storage.ts
@@ -1,0 +1,164 @@
+import { getErrorStack } from '../../common/errors'
+import { SbUserId } from '../../common/users/sb-user-id'
+import logger from '../logging/logger'
+
+/**
+ * How long to wait after the last update to a conversation's draft before persisting it to
+ * `localStorage`. Keystrokes arriving faster than this get folded into a single write, so a burst
+ * of typing costs at most one write per window rather than one per keystroke.
+ */
+export const DRAFT_WRITE_COALESCE_MS = 300
+
+/** The maximum number of conversations' worth of drafts kept per user in durable storage. */
+export const MAX_STORED_DRAFTS = 50
+
+export interface StoredDraft {
+  text: string
+  savedAt: number
+}
+
+/** A user's drafts, keyed by the same per-place storage key used for the in-session draft map. */
+export type StoredDraftsMap = Record<string, StoredDraft>
+
+function draftsStorageKey(userId: SbUserId): string {
+  return `${userId}|chatDrafts`
+}
+
+function readDraftsMap(userId: SbUserId): StoredDraftsMap {
+  try {
+    const json = localStorage.getItem(draftsStorageKey(userId))
+    if (json === null) {
+      return {}
+    }
+
+    const parsed = JSON.parse(json)
+    return parsed && typeof parsed === 'object' ? parsed : {}
+  } catch (err) {
+    logger.error(`error reading chat drafts: ${getErrorStack(err)}`)
+    return {}
+  }
+}
+
+function writeDraftsMap(userId: SbUserId, drafts: StoredDraftsMap): void {
+  try {
+    localStorage.setItem(draftsStorageKey(userId), JSON.stringify(drafts))
+  } catch (err) {
+    logger.error(`error writing chat drafts: ${getErrorStack(err)}`)
+  }
+}
+
+/**
+ * Returns a copy of `drafts` with `key`'s entry set to `{ text, savedAt }`, or removed if `text`
+ * is empty (an empty draft is never stored, whether it's new or clearing an existing one). Any
+ * other empty entries are dropped as well, and the result is capped to `MAX_STORED_DRAFTS` places,
+ * evicting the entries with the oldest `savedAt` first.
+ */
+export function withDraftUpdate(
+  drafts: StoredDraftsMap,
+  key: string,
+  text: string,
+  savedAt: number,
+): StoredDraftsMap {
+  const next: StoredDraftsMap = {}
+  for (const [k, v] of Object.entries(drafts)) {
+    if (k !== key && v.text) {
+      next[k] = v
+    }
+  }
+  if (text) {
+    next[key] = { text, savedAt }
+  }
+
+  const entries = Object.entries(next)
+  if (entries.length <= MAX_STORED_DRAFTS) {
+    return next
+  }
+
+  entries.sort((a, b) => b[1].savedAt - a[1].savedAt)
+  return Object.fromEntries(entries.slice(0, MAX_STORED_DRAFTS))
+}
+
+/**
+ * Resolves the initial value a conversation's message input should hydrate with: the in-session
+ * value (if this conversation was already visited earlier in the session) takes precedence over
+ * the durable copy from a previous session, which takes precedence over the default.
+ */
+export function resolveInitialDraftValue(
+  inSessionValue: string | undefined,
+  storedValue: string | undefined,
+  defaultValue: string,
+): string {
+  return inSessionValue ?? storedValue ?? defaultValue
+}
+
+/** Reads the durably-stored draft text for `userId`/`key`, or `undefined` if none is stored. */
+export function getStoredDraft(userId: SbUserId, key: string): string | undefined {
+  return readDraftsMap(userId)[key]?.text
+}
+
+interface PendingWrite {
+  userId: SbUserId
+  key: string
+  text: string
+  timer: ReturnType<typeof setTimeout>
+}
+
+const pendingWrites = new Map<string, PendingWrite>()
+
+function pendingWriteKey(userId: SbUserId, key: string): string {
+  return `${userId}|${key}`
+}
+
+function commitWrite(pending: PendingWrite): void {
+  const drafts = readDraftsMap(pending.userId)
+  const updated = withDraftUpdate(drafts, pending.key, pending.text, Date.now())
+  writeDraftsMap(pending.userId, updated)
+}
+
+/**
+ * Schedules `text` to be persisted as the draft for `userId`/`key`, coalescing rapid updates (e.g.
+ * a burst of keystrokes) into a single write `DRAFT_WRITE_COALESCE_MS` after the last one. An
+ * empty `text` removes the stored draft rather than persisting an empty string.
+ */
+export function scheduleDraftWrite(userId: SbUserId, key: string, text: string): void {
+  const pendingKey = pendingWriteKey(userId, key)
+  const existing = pendingWrites.get(pendingKey)
+  if (existing) {
+    clearTimeout(existing.timer)
+  }
+
+  const timer = setTimeout(() => {
+    const pending = pendingWrites.get(pendingKey)
+    if (pending) {
+      pendingWrites.delete(pendingKey)
+      commitWrite(pending)
+    }
+  }, DRAFT_WRITE_COALESCE_MS)
+
+  pendingWrites.set(pendingKey, { userId, key, text, timer })
+}
+
+/**
+ * Immediately persists a pending draft write scheduled for `userId`/`key` by `scheduleDraftWrite`,
+ * cancelling its timer. Meant to be called when a conversation's input is about to go away
+ * (unmount, app close) so a keystroke that landed just before that isn't lost.
+ */
+export function flushDraftWrite(userId: SbUserId, key: string): void {
+  const pendingKey = pendingWriteKey(userId, key)
+  const pending = pendingWrites.get(pendingKey)
+  if (!pending) {
+    return
+  }
+
+  clearTimeout(pending.timer)
+  pendingWrites.delete(pendingKey)
+  commitWrite(pending)
+}
+
+/** Clears all pending draft writes without persisting them. Only for use in tests. */
+export function resetDraftStorageForTesting(): void {
+  for (const pending of pendingWrites.values()) {
+    clearTimeout(pending.timer)
+  }
+  pendingWrites.clear()
+}

--- a/client/messaging/message-input.tsx
+++ b/client/messaging/message-input.tsx
@@ -29,6 +29,12 @@ import { Popover, useElemAnchorPosition, usePopoverController } from '../materia
 import { TextField } from '../material/text-field'
 import { useStableCallback } from '../react/state-hooks'
 import { useAppDispatch, useAppSelector } from '../redux-hooks'
+import {
+  flushDraftWrite,
+  getStoredDraft,
+  resolveInitialDraftValue,
+  scheduleDraftWrite,
+} from './draft-storage'
 import { getUnicodeEmojiEntries } from './emoji-data'
 import { EmotePickerButton } from './emote-picker'
 import {
@@ -107,35 +113,78 @@ const EmoteSuggestionIcon = styled.span`
   text-align: center;
 `
 
-/** A Map to store the message input contents for each chat instance. */
+/**
+ * A Map to store the message input contents for each chat instance for the current browsing
+ * session, keyed the same way as the durable per-user copy in `draft-storage.ts`. This is the fast
+ * path for switching between conversations already visited this session; `draft-storage.ts` is
+ * what survives a reload or app restart.
+ */
 const messageInputMap = new Map<string, string>()
 
 function useStorageSyncedState(
   defaultInitialValue: string,
-  key?: string,
+  userId?: SbUserId,
+  storageKey?: string,
 ): [value: string, setValue: (value: SetStateAction<string>) => void] {
-  const [value, setValue] = useState<string>(() =>
-    key ? (messageInputMap.get(key) ?? defaultInitialValue) : defaultInitialValue,
-  )
+  const memKey =
+    userId !== undefined && storageKey !== undefined ? `${userId}-${storageKey}` : undefined
+
+  const [value, setValue] = useState<string>(() => {
+    if (!memKey || userId === undefined || storageKey === undefined) {
+      return defaultInitialValue
+    }
+    return resolveInitialDraftValue(
+      messageInputMap.get(memKey),
+      getStoredDraft(userId, storageKey),
+      defaultInitialValue,
+    )
+  })
+
   const syncedSetValue = useCallback(
-    (value: SetStateAction<string>) => {
-      if (typeof value === 'string') {
-        setValue(value)
-        if (key) {
-          messageInputMap.set(key, value)
+    (update: SetStateAction<string>) => {
+      const applyUpdate = (newValue: string) => {
+        if (memKey) {
+          if (newValue) {
+            messageInputMap.set(memKey, newValue)
+          } else {
+            messageInputMap.delete(memKey)
+          }
         }
+        if (userId !== undefined && storageKey !== undefined) {
+          scheduleDraftWrite(userId, storageKey, newValue)
+        }
+      }
+
+      if (typeof update === 'string') {
+        setValue(update)
+        applyUpdate(update)
       } else {
         setValue(prev => {
-          const newValue = value(prev)
-          if (key) {
-            messageInputMap.set(key, newValue)
-          }
+          const newValue = update(prev)
+          applyUpdate(newValue)
           return newValue
         })
       }
     },
-    [key],
+    [memKey, userId, storageKey],
   )
+
+  useEffect(() => {
+    if (userId === undefined || storageKey === undefined) {
+      return undefined
+    }
+
+    // Flush rather than let the coalescing window run out on its own, so a keystroke that landed
+    // just before the conversation goes away (component unmount) or the app closes/reloads
+    // (beforeunload) isn't lost.
+    const flush = () => flushDraftWrite(userId, storageKey)
+    window.addEventListener('beforeunload', flush)
+    return () => {
+      window.removeEventListener('beforeunload', flush)
+      flush()
+    }
+  }, [userId, storageKey])
+
   return [value, syncedSetValue]
 }
 
@@ -145,10 +194,11 @@ export interface MessageInputProps {
   maxRows?: number
   onSendChatMessage: (msg: string) => void
   /**
-   * A key to store the current message input contents under (in a global Map). If provided, the
-   * previous message input contents will be restored when the component is mounted (so the key
-   * should uniquely identify the type + instance of the chat container). The key is prefixed with
-   * the user's ID to handle user changing their account.
+   * A key to store the current message input contents under, both in-session and (per-user) in
+   * `localStorage`. If provided, the previous message input contents will be restored when the
+   * component is mounted, surviving a reload or app restart (so the key should uniquely identify
+   * the type + instance of the chat container). The key is scoped to the user's ID to handle the
+   * user changing their account.
    */
   storageKey?: string
   /**
@@ -186,8 +236,7 @@ export const MessageInput = React.forwardRef<MessageInputHandle, MessageInputPro
     const dispatch = useAppDispatch()
     const user = useSelfUser()
     const chatRestriction = useAppSelector(s => s.auth.self?.restrictions.get(RestrictionKind.Chat))
-    const combinedStorageKey = user && storageKey ? `${user.id}-${storageKey}` : undefined
-    const [message, setMessage] = useStorageSyncedState('', combinedStorageKey)
+    const [message, setMessage] = useStorageSyncedState('', user?.id, storageKey)
     const inputRef = useRef<HTMLInputElement>(null)
     const [containerElem, setContainerElem] = useState<HTMLDivElement | null>(null)
 


### PR DESCRIPTION
Unsent message input already survived conversation switches in-session; it now also survives a reload or app restart.

One localStorage entry per user (`{userId}|chatDrafts`) keyed by the existing per-place storage keys. Keystroke bursts coalesce into a single write (300ms trailing edge), flushed on unmount and `beforeunload`; sending or clearing deletes the entry rather than storing an empty string. Entries are pruned on write (empties dropped, capped at 50 places, oldest first). Lobby chat stays draft-free as before.

Live-verified: a typed draft survives a full reload and is restored into the input; clearing it removes the stored entry.