### PR TITLE
Mark each player's result in the games list and fix assorted UI nits.

### DIFF
--- a/client/games/game-list-entry.tsx
+++ b/client/games/game-list-entry.tsx
@@ -12,7 +12,7 @@ import { Tooltip } from '../material/tooltip'
 import { useCurrentMinuteMs } from '../react/date-hooks'
 import { useAppSelector } from '../redux-hooks'
 import { bodyMedium, singleLine, titleMedium, titleSmall } from '../styles/typography'
-import { GamePlayersDisplay, getOrderedTeams, useGamePlayerNames } from './game-players-display'
+import { GamePlayersDisplay } from './game-players-display'
 
 // The row's cells respond to the `game-list-rows` container established around the scrolling list
 // in `GameListView` and the replay library (its inline size tracks the actual row width, unlike
@@ -299,6 +299,11 @@ export const SelectableRowContainer = styled.div<ButtonStateStyleProps & { $sele
 
 export interface GameListEntryProps {
   game: ReadonlyDeep<GameRecordJson>
+  /**
+   * Shows each row's result: as a leading Win/Loss column from `forUserId`'s perspective when one
+   * is given, otherwise as a marker beside every player's name, since without a perspective there
+   * is no single side a row-level label could honestly describe.
+   */
   showResult?: boolean
   forUserId?: SbUserId
   /**
@@ -327,7 +332,6 @@ export function GameListEntry({
 }: GameListEntryProps) {
   const { t } = useTranslation()
   const map = useAppSelector(s => s.maps.byId.get(game.mapId))
-  const nameById = useGamePlayerNames(game)
 
   const [buttonProps, rippleRef] = useButtonState({
     onClick: onClick ? () => onClick(game.id) : undefined,
@@ -336,69 +340,31 @@ export function GameListEntry({
 
   const { results } = game
 
-  // The side the result label refers to: `forUserId`'s side when one was given, otherwise
-  // whichever side `GamePlayersDisplay` lists first for this row — sharing its ordering logic
-  // keeps the label and the rendered player order from ever disagreeing. Outside of topVBottom,
-  // the two displayed columns are an alphabetical split of all players rather than real teams, so
-  // only the single first-listed player can honestly be labeled with one result. Left empty
-  // (rather than computed) when the result isn't even shown.
-  const orderedTeams = showResult
-    ? getOrderedTeams(game.config.teams, game.config.gameType, nameById, forUserId)
-    : []
-  const firstSide =
-    game.config.gameType === 'topVBottom'
-      ? (orderedTeams[0] ?? [])
-      : (orderedTeams[0]?.slice(0, 1) ?? [])
-
   // NOTE(2Pac): No need to memoize this under react-compiler; it re-derives only when its inputs
   // change.
   let result: ReconciledResult = 'unknown'
-  if (results) {
-    if (forUserId) {
-      for (const [userId, r] of results) {
-        if (userId === forUserId) {
-          result = r.result
-          break
-        }
-      }
-    } else {
-      // Team members' results agree in practice, so the first member with a reported entry is
-      // enough. A no-op loop over an empty `firstSide` when the result isn't shown.
-      for (const player of firstSide) {
-        if (player.isComputer) continue
-        const entry = results.find(([userId]) => userId === player.id)
-        if (entry) {
-          result = entry[1].result
-          break
-        }
-      }
-    }
+  if (showResult && forUserId && Array.isArray(results)) {
+    result = results.find(([userId]) => userId === forUserId)?.[1].result ?? 'unknown'
   }
 
   const gameType = getGameTypeLabel(game, t)
   const mapName = map?.name ?? t('game.mapName.unknown', 'Unknown map')
 
-  const resultForNames = firstSide
-    .map(player =>
-      player.isComputer
-        ? t('game.playerName.computer', 'Computer')
-        : (nameById.get(player.id) ?? t('game.playerName.unknown', 'Unknown player')),
-    )
-    .join(', ')
-
   const layoutProps: GameListEntryLayoutProps = {
-    leading: showResult ? (
-      <Tooltip
-        text={t('games.list.resultTooltip', {
-          defaultValue: 'Result for {{names}}',
-          names: resultForNames,
-        })}>
+    leading:
+      showResult && forUserId ? (
         <GameListEntryResult $result={spoilerFree ? 'unknown' : result}>
           {spoilerFree ? '—' : getResultLabel(result, t, true)}
         </GameListEntryResult>
-      </Tooltip>
-    ) : undefined,
-    players: <GamePlayersDisplay game={game} forUserId={forUserId} showTeamLabels={false} />,
+      ) : undefined,
+    players: (
+      <GamePlayersDisplay
+        game={game}
+        forUserId={forUserId}
+        showTeamLabels={false}
+        showPlayerResults={showResult && !forUserId && !spoilerFree}
+      />
+    ),
     relativeTime: <GameRelativeTime timestampMs={game.startTime} />,
     duration: spoilerFree || !game.gameLength ? '—' : getGameDurationString(game.gameLength),
     mapName,

--- a/client/games/game-list-view.tsx
+++ b/client/games/game-list-view.tsx
@@ -113,8 +113,9 @@ export interface GameListViewProps {
   /** Shows the game source (All/Ranked/Custom) filter chip and reads its URL param (games page only). */
   showSourceFilter?: boolean
   /**
-   * Shows each row's win/loss result. From `forUserId`'s perspective when given (match history);
-   * otherwise from whichever side of the matchup is listed first (games page, league games).
+   * Shows each row's result: as a leading Win/Loss column from `forUserId`'s perspective when one
+   * is given, otherwise as a marker beside every player's name, since without a perspective there
+   * is no single side a row-level label could honestly describe.
    */
   showResult?: boolean
   /** Whose perspective results and the side panel roster are shown from (match history only). */

--- a/client/games/game-list.tsx
+++ b/client/games/game-list.tsx
@@ -41,6 +41,7 @@ const GameEntriesRoot = styled.div`
 const StyledLiveGameEntry = styled(LiveGameEntry)`
   ${elevationPlus1};
   ${containerStyles(ContainerLevel.Low)};
+  border-radius: 4px;
 `
 
 const GamesListQuery = graphql(/* GraphQL */ `

--- a/client/games/game-players-display.tsx
+++ b/client/games/game-players-display.tsx
@@ -42,33 +42,19 @@ function areUsersEqual(a: ReadonlyArray<SbUser>, b: ReadonlyArray<SbUser>): bool
   return true
 }
 
-/**
- * Resolves the display names (from the users store) of every human player in a game, keyed by
- * their user ID. Computer players are never present in the result.
- */
-export function useGamePlayerNames(
-  game: ReadonlyDeep<GameRecordJson>,
-): ReadonlyMap<SbUserId, string> {
-  const players = useAppSelector(usePlayersSelector(game), areUsersEqual)
-  return new Map(players.map(p => [p.id, p.name]))
-}
-
 // TODO(2Pac): Handle game types which can have more than two teams
 /**
- * Orders a game's teams the same way they're shown in `GamePlayersDisplay`, so a row's rendered
- * player order and anything derived from "the first-listed side" (e.g. a result label) can never
- * diverge.
+ * Orders a game's teams for display.
  *
  * For `topVBottom`, the two teams are ordered with `forUserId`'s team first (falling back to
  * alphabetical by first player name when absent or when there's no `forUserId`), then each team's
  * own members are sorted alphabetically. Otherwise, every player is flattened into one alphabetical
- * ordering (`forUserId` first) and split into two roughly-even sides by alternating players into
- * them — the "first side" here is the even-indexed half of that single sorted list, not a real team.
+ * ordering (`forUserId` first) and dealt alternately into two columns.
  *
  * Players with no resolved name (absent from `nameById`, e.g. computer players) sort last within
  * whatever grouping they fall into.
  */
-export function getOrderedTeams(
+function getOrderedTeams(
   teams: ReadonlyArray<ReadonlyArray<GameConfigPlayer>>,
   gameType: GameType,
   nameById: ReadonlyMap<SbUserId, string>,
@@ -195,6 +181,7 @@ export function GamePlayersDisplay({
   forUserId,
   showTeamLabels = true,
   showTeamResults = false,
+  showPlayerResults = false,
   interactiveNames = false,
   className,
 }: {
@@ -203,6 +190,12 @@ export function GamePlayersDisplay({
   showTeamLabels?: boolean
   /** When true, each displayed column's overline gains a win/loss result, colored accordingly. */
   showTeamResults?: boolean
+  /**
+   * When true, each human player's own reconciled result renders as a compact marker beside their
+   * name. Unlike `showTeamResults` this needs no per-column reduction, so it's honest for every
+   * game type, including free-for-all splits and columns with mixed outcomes.
+   */
+  showPlayerResults?: boolean
   /**
    * When true, human players' names render as store-connected, interactive usernames (clicking
    * opens the profile overlay, right-clicking opens the user context menu) instead of plain text.
@@ -226,14 +219,15 @@ export function GamePlayersDisplay({
   }, [results])
 
   const toDisplayPlayer = (player: GameConfigPlayer): PlayerTeamsDisplayPlayer => {
-    const result = player.isComputer ? undefined : resultsById.get(player.id)
+    const playerResult = player.isComputer ? undefined : resultsById.get(player.id)
     return {
-      race: result?.race ?? player.race,
+      race: playerResult?.race ?? player.race,
       isRandom: player.race === 'r',
       name: player.isComputer
         ? t('game.playerName.computer', 'Computer')
         : (nameById.get(player.id) ?? t('game.playerName.unknown', 'Unknown player')),
       userId: interactiveNames && !player.isComputer ? player.id : undefined,
+      result: showPlayerResults ? playerResult?.result : undefined,
     }
   }
 

--- a/client/games/game-record-side-panel.tsx
+++ b/client/games/game-record-side-panel.tsx
@@ -130,10 +130,12 @@ function GameRecordSidePanelContent({
       {!map ? <GameSidePanelTitle>{mapName}</GameSidePanelTitle> : null}
 
       <GameSidePanelSection>
+        {/* The column overline holds either the team name or its result; both at once read as
+            noise, so team names only fill in while spoiler-free hides the results. */}
         <GamePlayersDisplay
           game={game}
           forUserId={forUserId}
-          showTeamLabels={true}
+          showTeamLabels={spoilerFree}
           showTeamResults={!spoilerFree}
           interactiveNames={true}
         />

--- a/client/games/game-record-side-panel.tsx
+++ b/client/games/game-record-side-panel.tsx
@@ -130,12 +130,13 @@ function GameRecordSidePanelContent({
       {!map ? <GameSidePanelTitle>{mapName}</GameSidePanelTitle> : null}
 
       <GameSidePanelSection>
-        {/* The column overline holds either the team name or its result; both at once read as
-            noise, so team names only fill in while spoiler-free hides the results. */}
+        {/* Team names are always requested so a column whose result can't be reduced to one
+            outcome (a disputed game, a computer player) still gets an overline; a resolved result
+            replaces the name rather than joining it, so the overline never reads "Top · Win". */}
         <GamePlayersDisplay
           game={game}
           forUserId={forUserId}
-          showTeamLabels={spoilerFree}
+          showTeamLabels={true}
           showTeamResults={!spoilerFree}
           interactiveNames={true}
         />

--- a/client/games/player-teams-display.tsx
+++ b/client/games/player-teams-display.tsx
@@ -1,10 +1,10 @@
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
-import { getResultLabel, ReconciledResult } from '../../common/games/results'
+import { getResultLabel, getResultShortLabel, ReconciledResult } from '../../common/games/results'
 import { RaceChar } from '../../common/races'
 import { SbUserId } from '../../common/users/sb-user-id'
 import { RaceIcon } from '../lobbies/race-icon'
-import { labelMedium, singleLine, titleSmall } from '../styles/typography'
+import { labelMedium, labelSmall, singleLine, titleSmall } from '../styles/typography'
 import { ConnectedUsername } from '../users/connected-username'
 
 const PlayerTeamsRoot = styled.div`
@@ -50,6 +50,37 @@ const PlayerRowContainer = styled.div`
 
   display: flex;
   align-items: center;
+`
+
+const PlayerResultChip = styled.span<{ $result: ReconciledResult }>`
+  ${labelSmall};
+  /*
+    Sized by its label rather than fixed, since some locales abbreviate results to several
+    characters (e.g. Russian) instead of one letter.
+  */
+  min-width: 16px;
+  padding: 0 3px;
+  height: 16px;
+  margin-right: 6px;
+  flex-shrink: 0;
+
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+
+  border-radius: 4px;
+  font-weight: 700;
+  color: ${props => {
+    switch (props.$result) {
+      case 'win':
+        return 'var(--theme-positive)'
+      case 'loss':
+        return 'var(--theme-negative)'
+      default:
+        return 'var(--theme-on-surface-variant)'
+    }
+  }};
+  background: color-mix(in srgb, currentColor 16%, transparent);
 `
 
 const PlayerRowName = styled.span<{ $dimmed?: boolean }>`
@@ -127,6 +158,11 @@ export interface PlayerTeamsDisplayPlayer {
    * files) should only set this for users known to exist.
    */
   userId?: SbUserId
+  /**
+   * The player's own reconciled result. Anything other than `'unknown'` renders as a compact
+   * win/loss/draw marker ahead of the race icon.
+   */
+  result?: ReconciledResult
 }
 
 /**
@@ -169,6 +205,15 @@ export function PlayerTeamsDisplay({
             ) : null}
             {team.map((player, playerIndex) => (
               <PlayerRowContainer key={`player-${playerIndex}`}>
+                {player.result && player.result !== 'unknown' ? (
+                  <PlayerResultChip
+                    $result={player.result}
+                    role='img'
+                    aria-label={getResultLabel(player.result, t)}
+                    title={getResultLabel(player.result, t)}>
+                    {getResultShortLabel(player.result, t)}
+                  </PlayerResultChip>
+                ) : null}
                 <PlayerRace race={player.race} isRandom={player.isRandom} />
                 {player.userId !== undefined ? (
                   <PlayerRowConnectedName userId={player.userId} />

--- a/client/games/player-teams-display.tsx
+++ b/client/games/player-teams-display.tsx
@@ -178,7 +178,10 @@ export function PlayerTeamsDisplay({
 }: {
   teams: ReadonlyArray<ReadonlyArray<PlayerTeamsDisplayPlayer>>
   teamLabels?: ReadonlyArray<string>
-  /** One reconciled result per team, aligned by index with `teams`. */
+  /**
+   * One reconciled result per team, aligned by index with `teams`. A team's result takes the
+   * place of its label in the column overline; the label only shows for teams without one.
+   */
   teamResults?: ReadonlyArray<ReconciledResult>
   className?: string
 }) {
@@ -189,20 +192,20 @@ export function PlayerTeamsDisplay({
       {teams.map((team, teamIndex) => {
         const label = teamLabels?.[teamIndex]
         const result = teamResults?.[teamIndex]
+        let overline: React.ReactNode
+        if (result) {
+          overline = (
+            <PlayerTeamOverlineResult $result={result}>
+              {getResultLabel(result, t)}
+            </PlayerTeamOverlineResult>
+          )
+        } else if (label) {
+          overline = label
+        }
 
         return (
           <PlayerTeamColumn key={`team-${teamIndex}`}>
-            {label || result ? (
-              <PlayerTeamOverline>
-                {label}
-                {label && result ? ' · ' : null}
-                {result ? (
-                  <PlayerTeamOverlineResult $result={result}>
-                    {getResultLabel(result, t)}
-                  </PlayerTeamOverlineResult>
-                ) : null}
-              </PlayerTeamOverline>
-            ) : null}
+            {overline ? <PlayerTeamOverline>{overline}</PlayerTeamOverline> : null}
             {team.map((player, playerIndex) => (
               <PlayerRowContainer key={`player-${playerIndex}`}>
                 {player.result && player.result !== 'unknown' ? (

--- a/client/settings/settings-content.tsx
+++ b/client/settings/settings-content.tsx
@@ -208,6 +208,12 @@ const CloseButton = styled(IconButton)`
 `
 
 const LabeledCloseButton = styled.div`
+  /*
+    Stays put while the settings body scrolls beneath it. The offset matches ContentContainer's
+    padding so the button sticks exactly where it starts.
+  */
+  position: sticky;
+  top: 16px;
   ${labelSmall};
   display: flex;
   flex-direction: column;

--- a/client/twitch/devonly/live-streams-test.tsx
+++ b/client/twitch/devonly/live-streams-test.tsx
@@ -13,6 +13,7 @@ import {
   ViewerCountPill,
 } from '../live-indicators'
 import { FeaturedLiveStreamEntry } from '../live-stream-entry'
+import { LiveStreamsGrid } from '../live-streams-page'
 
 /** Builds a gradient placeholder thumbnail as a data URI (no remote images in dev). */
 function thumb(from: string, to: string) {
@@ -164,20 +165,14 @@ export function LiveStreamsTest() {
       </LobbySlotRow>
 
       <SectionTitle>Live page grid</SectionTitle>
-      <PageGrid>
+      <LiveStreamsGrid>
         {mockEntries.map((query, i) => (
           <FeaturedLiveStreamEntry key={i} query={query} />
         ))}
-      </PageGrid>
+      </LiveStreamsGrid>
     </Root>
   )
 }
-
-const PageGrid = styled.div`
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
-  gap: 16px;
-`
 
 const LobbySlotRow = styled.div`
   ${titleSmall};

--- a/client/twitch/live-streams-page.tsx
+++ b/client/twitch/live-streams-page.tsx
@@ -29,7 +29,8 @@ const PageHeader = styled.div`
   margin-bottom: 24px;
 `
 
-const Grid = styled.div`
+/** The featured-entry grid of the live streams page. */
+export const LiveStreamsGrid = styled.div`
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
   /*
@@ -63,11 +64,11 @@ export function LiveStreamsPage() {
       <Content>
         <PageHeader>{t('twitch.liveStreams.pageTitle', 'Live streams')}</PageHeader>
         {sorted.length > 0 ? (
-          <Grid>
+          <LiveStreamsGrid>
             {sorted.map(stream => (
               <FeaturedLiveStreamEntry key={stream.twitchLogin} query={stream} />
             ))}
-          </Grid>
+          </LiveStreamsGrid>
         ) : (
           <EmptyText>
             {t('twitch.liveStreams.empty', 'No one is streaming StarCraft right now.')}

--- a/client/twitch/live-streams-page.tsx
+++ b/client/twitch/live-streams-page.tsx
@@ -32,7 +32,15 @@ const PageHeader = styled.div`
 const Grid = styled.div`
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
-  gap: 16px;
+  /*
+    Each FeaturedLiveStreamEntry pads itself (10px top/sides, 12px bottom) as room for its
+    thumbnail's hover outline, which would otherwise inset the thumbnails from the page title
+    above and the content edge. Bleeding the grid into that padding keeps the thumbnails flush
+    with the title, and the reduced gap accounts for the padding already separating neighbouring
+    entries.
+  */
+  margin: -10px -10px 0;
+  gap: 4px;
 `
 
 const EmptyText = styled.div`

--- a/client/users/user-profile-overlay.tsx
+++ b/client/users/user-profile-overlay.tsx
@@ -82,6 +82,11 @@ export function ConnectedUserProfileOverlay({
 
 const PopoverContents = styled.div`
   min-width: 256px;
+  /*
+    Caps the overlay so single-line content (e.g. a live stream's title) truncates instead of
+    stretching the card toward the viewport edge.
+  */
+  max-width: 360px;
   min-height: 200px;
   padding: 16px 16px 8px;
 

--- a/common/games/results.ts
+++ b/common/games/results.ts
@@ -53,6 +53,24 @@ export function getResultLabel(
   return assertUnreachable(result)
 }
 
+/**
+ * A one-letter form of `getResultLabel` for compact per-player markers. Empty for `'unknown'`,
+ * which has no marker.
+ */
+export function getResultShortLabel(result: ReconciledResult, t: TFunction): string {
+  if (result === 'win') {
+    return t('game.results.winShort', 'W')
+  } else if (result === 'loss') {
+    return t('game.results.lossShort', 'L')
+  } else if (result === 'draw') {
+    return t('game.results.drawShort', 'D')
+  } else if (result === 'unknown') {
+    return ''
+  }
+
+  return assertUnreachable(result)
+}
+
 export interface ReconciledPlayerResult {
   result: ReconciledResult
   race: AssignedRaceChar

--- a/server/public/locales/en/global.json
+++ b/server/public/locales/en/global.json
@@ -624,6 +624,7 @@
     },
     "results": {
       "draw": "Draw",
+      "drawShort": "D",
       "loss": "Loss",
       "lossShort": "L",
       "unknown": "Unknown",
@@ -803,7 +804,6 @@
     },
     "list": {
       "noMatchingGames": "No matching games.",
-      "resultTooltip": "Result for {{names}}",
       "retrievingError": "There was an error retrieving the games."
     },
     "liveGames": {

--- a/server/public/locales/es/global.json
+++ b/server/public/locales/es/global.json
@@ -627,6 +627,7 @@
     },
     "results": {
       "draw": "Empate",
+      "drawShort": "E",
       "loss": "Derrota",
       "lossShort": "D",
       "unknown": "Desconocido",
@@ -806,7 +807,6 @@
     },
     "list": {
       "noMatchingGames": "No hay partidas que coincidan.",
-      "resultTooltip": "Resultado de {{names}}",
       "retrievingError": "Hubo un error al obtener las partidas."
     },
     "liveGames": {

--- a/server/public/locales/ko/global.json
+++ b/server/public/locales/ko/global.json
@@ -621,6 +621,7 @@
     },
     "results": {
       "draw": "무승부",
+      "drawShort": "D",
       "loss": "패배",
       "lossShort": "L",
       "unknown": "언노운",
@@ -800,7 +801,6 @@
     },
     "list": {
       "noMatchingGames": "일치하는 게임이 없습니다.",
-      "resultTooltip": "{{names}}의 결과",
       "retrievingError": "게임을 불러오는 중 오류가 발생했습니다."
     },
     "liveGames": {

--- a/server/public/locales/ru/global.json
+++ b/server/public/locales/ru/global.json
@@ -630,6 +630,7 @@
     },
     "results": {
       "draw": "Ничья",
+      "drawShort": "Нич.",
       "loss": "Поражение",
       "lossShort": "Пор.",
       "unknown": "Неизвестно",
@@ -809,7 +810,6 @@
     },
     "list": {
       "noMatchingGames": "Нет подходящих игр.",
-      "resultTooltip": "Результат: {{names}}",
       "retrievingError": "Произошла ошибка при получении игр."
     },
     "liveGames": {

--- a/server/public/locales/zh-Hans/global.json
+++ b/server/public/locales/zh-Hans/global.json
@@ -621,6 +621,7 @@
     },
     "results": {
       "draw": "平局",
+      "drawShort": "平",
       "loss": "失败",
       "lossShort": "败",
       "unknown": "不明",
@@ -800,7 +801,6 @@
     },
     "list": {
       "noMatchingGames": "没有匹配的游戏。",
-      "resultTooltip": "{{names}}的结果",
       "retrievingError": "获取游戏时出错。"
     },
     "liveGames": {


### PR DESCRIPTION
Triage of a batch of UI issues:

- **Games page / league games result column**: the row-level Win/Loss referred to whichever side sorted first, which was unreadable without the tooltip. Replaced with a per-player W/L chip beside each name (honest for every game type, including FFA and mixed columns). Match history keeps the leading column since its perspective is the profile's user. Spoiler-free hides the chips.
- **Side panel Top/Bottom labels**: shown only while spoiler-free hides the per-team results, so the overline never reads `Top · Win`. Mini match history and the replay inspector are untouched.
- **Live game cards on `/games`**: 4px radius, matching the same cards on the home page.
- **User profile overlay**: `max-width: 360px` so a long stream title truncates instead of stretching the popover.
- **Live streams page**: the grid bleeds into the entries' own 10px padding (room for the hover outline) so thumbnails align with the page title; gap reduced accordingly. The home page hero card is unaffected.
- **Settings / channel settings close button**: sticky, so it stays in place while the body scrolls.

Verified in the dev web client: chips render on `/games` and toggle off with spoiler-free; match history still shows the leading column with no chips; the side panel overline flips between `Win`/`Loss` and `Top`/`Bottom` with spoiler-free; the profile overlay computes `max-width: 360px`; the settings close button stays at the same viewport position after scrolling the body. The live game card radius and streams grid could not be exercised live (no live games or streams in dev).
