### PR TITLE
Hold the chat read position while the app window is unfocused.

### DIFF
--- a/client/chat/actions.ts
+++ b/client/chat/actions.ts
@@ -457,7 +457,11 @@ export interface InitChannel {
 export interface UpdateJoin {
   type: '@chat/updateJoin'
   payload: ChatJoinEvent
-  meta: { channelId: SbChannelId }
+  meta: {
+    channelId: SbChannelId
+    /** Whether the app window was focused when this arrived. See `UpdateMessage`. */
+    windowFocused: boolean
+  }
 }
 
 /**
@@ -466,7 +470,11 @@ export interface UpdateJoin {
 export interface UpdateLeave {
   type: '@chat/updateLeave'
   payload: ChatLeaveEvent
-  meta: { channelId: SbChannelId }
+  meta: {
+    channelId: SbChannelId
+    /** Whether the app window was focused when this arrived. See `UpdateMessage`. */
+    windowFocused: boolean
+  }
 }
 
 /**
@@ -483,7 +491,11 @@ export interface UpdateLeaveSelf {
 export interface UpdateKick {
   type: '@chat/updateKick'
   payload: ChatKickEvent
-  meta: { channelId: SbChannelId }
+  meta: {
+    channelId: SbChannelId
+    /** Whether the app window was focused when this arrived. See `UpdateMessage`. */
+    windowFocused: boolean
+  }
 }
 
 /**
@@ -500,7 +512,11 @@ export interface UpdateKickSelf {
 export interface UpdateBan {
   type: '@chat/updateBan'
   payload: ChatBanEvent
-  meta: { channelId: SbChannelId }
+  meta: {
+    channelId: SbChannelId
+    /** Whether the app window was focused when this arrived. See `UpdateMessage`. */
+    windowFocused: boolean
+  }
 }
 
 /**
@@ -517,7 +533,11 @@ export interface UpdateBanSelf {
 export interface UpdateChannelOwner {
   type: '@chat/ownerChanged'
   payload: ChatOwnerChangedEvent
-  meta: { channelId: SbChannelId }
+  meta: {
+    channelId: SbChannelId
+    /** Whether the app window was focused when this arrived. See `UpdateMessage`. */
+    windowFocused: boolean
+  }
 }
 
 /**
@@ -532,6 +552,12 @@ export interface UpdateMessage {
      * Whether the message mentions the current user and wasn't sent by someone they've blocked.
      */
     mentionsSelf: boolean
+    /**
+     * Whether the app window was focused when the message arrived. A message landing in an
+     * unfocused window can't have been seen no matter where the channel's view is scrolled, so the
+     * reducer counts it as unread regardless.
+     */
+    windowFocused: boolean
   }
 }
 

--- a/client/chat/channel.tsx
+++ b/client/chat/channel.tsx
@@ -9,6 +9,7 @@ import {
   isServerChatMessage,
 } from '../../common/chat'
 import { SbUserId } from '../../common/users/sb-user-id'
+import { useWindowFocus } from '../dom/window-focus'
 import { Chat } from '../messaging/chat'
 import { anchorNeedsFetch, chatViewAnchorStore } from '../messaging/chat-view-anchor'
 import { flushLastRead } from '../messaging/last-read'
@@ -168,6 +169,7 @@ export function ConnectedChatChannel({
   const isActivated = useAppSelector(s => s.chat.activatedChannels.has(channelId))
   const isAtBottom = useAppSelector(s => s.chat.atBottomChannels.has(channelId))
   const unreadLineTime = useAppSelector(s => s.chat.idToUnreadLineTime.get(channelId))
+  const isWindowFocused = useWindowFocus()
 
   // NOTE(2Pac): When user types the single @ character in chat, we show the ten most recent
   // chatters in the channel as an option to mention.
@@ -298,14 +300,18 @@ export function ConnectedChatChannel({
     }
   }
 
-  // Reports the read position whenever the channel is both open and scrolled to the bottom, so
-  // arriving at a channel already at the bottom (or scrolling back down to it) reports the newest
-  // message just as much as a message arriving while already there does.
+  // Reports the read position whenever the channel is open, scrolled to the bottom, and the app
+  // window is focused, so arriving at a channel already at the bottom (or scrolling back down to
+  // it) reports the newest message just as much as a message arriving while already there does.
+  // The read position never advances while the window is unfocused: messages landing in a channel
+  // that's open and at the bottom while the user is off in another window stay unread until they
+  // come back, at which point this re-runs and reports the newest one. Refocusing with nothing new
+  // to report costs no request — the coalescer drops a position it has already sent.
   useEffect(() => {
-    if (isActivated && isAtBottom && newestMessageTime !== undefined) {
+    if (isActivated && isAtBottom && isWindowFocused && newestMessageTime !== undefined) {
       dispatch(markChannelRead(channelId, newestMessageTime))
     }
-  }, [isActivated, isAtBottom, newestMessageTime, channelId, dispatch])
+  }, [isActivated, isAtBottom, isWindowFocused, newestMessageTime, channelId, dispatch])
 
   useEffect(() => () => flushLastRead(getChannelLastReadKey(channelId)), [channelId])
 

--- a/client/chat/chat-reducer.test.ts
+++ b/client/chat/chat-reducer.test.ts
@@ -155,7 +155,11 @@ function getJoinedChannelsAction(data: InitialChannelData): ChatActions {
   }
 }
 
-function updateMessageAction(time: number, mentionsSelf: boolean): ChatActions {
+function updateMessageAction(
+  time: number,
+  mentionsSelf: boolean,
+  windowFocused = true,
+): ChatActions {
   const payload: ChatMessageEvent = {
     action: 'message2',
     message: textMessage(time),
@@ -166,7 +170,7 @@ function updateMessageAction(time: number, mentionsSelf: boolean): ChatActions {
   return {
     type: '@chat/updateMessage',
     payload,
-    meta: { channelId: CHANNEL_ID, mentionsSelf },
+    meta: { channelId: CHANNEL_ID, mentionsSelf, windowFocused },
   }
 }
 
@@ -338,10 +342,9 @@ describe('client/chat/chat-reducer', () => {
       expect(result.idToUnreadLineTime.get(CHANNEL_ID)).toBe(250)
     })
 
-    test('leaves the unread flag and divider untouched for an activated channel', () => {
+    test('leaves the divider untouched for an activated channel', () => {
       const state = makeState({
         activated: true,
-        unread: true,
         lastReadTime: 100,
         unreadLineTime: 150,
         messages: [textMessage(100)],
@@ -349,11 +352,53 @@ describe('client/chat/chat-reducer', () => {
 
       const result = chatReducer(state, updateLastReadTimeAction(200))
 
-      expect(result.unreadChannels.has(CHANNEL_ID)).toBe(true)
       expect(result.idToUnreadLineTime.get(CHANNEL_ID)).toBe(150)
       // The read position itself still advances even while activated, since this is also the path
       // this session's own optimistic mark-read reports take.
       expect(result.idToLastReadTime.get(CHANNEL_ID)).toBe(200)
+    })
+
+    test('clears an activated channel flag once the position covers the newest message', () => {
+      const state = makeState({
+        activated: true,
+        unread: true,
+        lastReadTime: 50,
+        unreadLineTime: 50,
+        messages: [textMessage(100)],
+      })
+
+      const result = chatReducer(state, updateLastReadTimeAction(100))
+
+      expect(result.unreadChannels.has(CHANNEL_ID)).toBe(false)
+      expect(result.idToUnreadLineTime.get(CHANNEL_ID)).toBe(50)
+    })
+
+    test('keeps an activated channel flag while the position is behind the newest message', () => {
+      const state = makeState({
+        activated: true,
+        unread: true,
+        lastReadTime: 50,
+        messages: [textMessage(100)],
+      })
+
+      const result = chatReducer(state, updateLastReadTimeAction(99))
+
+      expect(result.unreadChannels.has(CHANNEL_ID)).toBe(true)
+    })
+
+    test('keeps the flag when a detached present has run past what the position covers', () => {
+      const state = makeState({
+        activated: true,
+        unread: true,
+        lastReadTime: 50,
+        hasNewer: true,
+        detachedNewestTime: 200,
+        messages: [textMessage(100)],
+      })
+
+      const result = chatReducer(state, updateLastReadTimeAction(100))
+
+      expect(result.unreadChannels.has(CHANNEL_ID)).toBe(true)
     })
   })
 
@@ -494,6 +539,50 @@ describe('client/chat/chat-reducer', () => {
       const result = chatReducer(state, updateMessageAction(1000, false))
 
       expect(windowOf(result).messages.length).toBe(150)
+    })
+
+    test('a message arriving at the bottom of an unfocused window counts as unseen', () => {
+      const state = makeState({ activated: true, atBottom: true, lastReadTime: 100 })
+
+      const result = chatReducer(state, updateMessageAction(200, false, false))
+
+      expect(result.unreadChannels.has(CHANNEL_ID)).toBe(true)
+      expect(result.idToUnreadLineTime.get(CHANNEL_ID)).toBe(100)
+    })
+
+    test('a message arriving at the bottom of a focused window counts as seen', () => {
+      const state = makeState({ activated: true, atBottom: true, lastReadTime: 100 })
+
+      const result = chatReducer(state, updateMessageAction(200, false, true))
+
+      expect(result.unreadChannels.has(CHANNEL_ID)).toBe(false)
+      expect(result.idToUnreadLineTime.has(CHANNEL_ID)).toBe(false)
+    })
+
+    test('a message arriving while scrolled up in an unfocused window raises both', () => {
+      const state = makeState({ activated: true, atBottom: false, lastReadTime: 100 })
+
+      const result = chatReducer(state, updateMessageAction(200, false, false))
+
+      expect(result.unreadChannels.has(CHANNEL_ID)).toBe(true)
+      expect(result.idToUnreadLineTime.get(CHANNEL_ID)).toBe(100)
+    })
+
+    test('a message arriving while scrolled up in a focused window only freezes the divider', () => {
+      const state = makeState({ activated: true, atBottom: false, lastReadTime: 100 })
+
+      const result = chatReducer(state, updateMessageAction(200, false, true))
+
+      expect(result.unreadChannels.has(CHANNEL_ID)).toBe(false)
+      expect(result.idToUnreadLineTime.get(CHANNEL_ID)).toBe(100)
+    })
+
+    test('a message arriving in a channel that is not being viewed raises the unread flag', () => {
+      const state = makeState({ activated: false, lastReadTime: 100 })
+
+      const result = chatReducer(state, updateMessageAction(200, false, true))
+
+      expect(result.unreadChannels.has(CHANNEL_ID)).toBe(true)
     })
   })
 

--- a/client/chat/chat-reducer.ts
+++ b/client/chat/chat-reducer.ts
@@ -167,6 +167,7 @@ function removeUserFromChannel(
   state: ChatState,
   channelId: SbChannelId,
   userId: SbUserId,
+  arrival: LiveArrival,
   newOwnerId?: SbUserId,
   reason?: ChannelModerationAction,
 ) {
@@ -194,7 +195,7 @@ function removeUserFromChannel(
     messageType = ClientChatMessageType.BanUser
   }
 
-  updateMessages(state, channelId, true, m => {
+  updateMessages(state, channelId, arrival, m => {
     m.push({
       id: nanoid(),
       type: messageType,
@@ -206,11 +207,16 @@ function removeUserFromChannel(
   })
 
   if (newOwnerId) {
-    setChannelOwner(state, channelId, newOwnerId)
+    setChannelOwner(state, channelId, newOwnerId, arrival)
   }
 }
 
-function setChannelOwner(state: ChatState, channelId: SbChannelId, newOwnerId: SbUserId) {
+function setChannelOwner(
+  state: ChatState,
+  channelId: SbChannelId,
+  newOwnerId: SbUserId,
+  arrival: LiveArrival,
+) {
   const joinedChannelInfo = state.idToJoinedInfo.get(channelId)
   if (!joinedChannelInfo) {
     return
@@ -218,7 +224,7 @@ function setChannelOwner(state: ChatState, channelId: SbChannelId, newOwnerId: S
 
   joinedChannelInfo.ownerId = newOwnerId
 
-  updateMessages(state, channelId, true, m => {
+  updateMessages(state, channelId, arrival, m => {
     m.push({
       id: nanoid(),
       type: ClientChatMessageType.NewChannelOwner,
@@ -295,26 +301,27 @@ function dedupeAgainst(incoming: ChatMessage[], existing: readonly ChatMessage[]
 
 /**
  * Records that a message the user hasn't seen has arrived in a channel: raises the unread flag and,
- * where applicable, freezes the unread divider. Kept separate from `updateMessages` because a
- * message arriving while the loaded window is detached from the present isn't added to the window
- * at all, yet counts as unread exactly the same.
+ * where applicable, freezes the unread divider. Both mean the same thing — a message arrived that
+ * the user won't have seen — and an activated channel counts as seen only when its view sits at the
+ * bottom of a window attached to the present *and* the app window is focused, since a message that
+ * lands while the user is looking at something else can't have been read no matter where the list
+ * is scrolled. The divider freezes at the read position so it marks where the user left off instead
+ * of chasing the read position as it keeps advancing underneath it.
+ *
+ * Kept separate from `updateMessages` because a message arriving while the loaded window is
+ * detached from the present isn't added to the window at all, yet counts as unread exactly the same.
  */
-function markChannelUnread(state: ChatState, channelId: SbChannelId) {
+function markChannelUnread(state: ChatState, channelId: SbChannelId, windowFocused: boolean) {
   const isChannelActivated = state.activatedChannels.has(channelId)
 
-  if (!state.unreadChannels.has(channelId) && !isChannelActivated) {
+  if (!state.unreadChannels.has(channelId) && (!isChannelActivated || !windowFocused)) {
     state.unreadChannels.add(channelId)
   }
 
-  // The channel is being actively viewed, but the message still won't be seen right away: either
-  // the view is scrolled up, or the loaded window sits behind the present, where the bottom of the
-  // list isn't the newest message. Freeze the unread divider at the read position so it marks where
-  // the user left off instead of chasing the read position as the eager mark-read keeps advancing
-  // it.
   const isDetached = state.idToMessages.get(channelId)?.hasNewer ?? false
   if (
     isChannelActivated &&
-    (!state.atBottomChannels.has(channelId) || isDetached) &&
+    (!state.atBottomChannels.has(channelId) || isDetached || !windowFocused) &&
     !state.idToUnreadLineTime.has(channelId)
   ) {
     const lastReadTime = state.idToLastReadTime.get(channelId)
@@ -414,11 +421,22 @@ function dropMessageWindow(channelMessages: MessagesState) {
 }
 
 /**
+ * The conditions a message arrived under when it reached the channel live. Messages that reach a
+ * channel any other way (a page of history, a deletion) carry no arrival and do no unread
+ * bookkeeping: only something happening live can go unseen.
+ */
+interface LiveArrival {
+  /** Whether the app window was focused at the moment the message arrived. */
+  windowFocused: boolean
+}
+
+/**
  * Update the messages field for a channel, keeping the `hasUnread` flag in proper sync.
  *
  * @param state The complete chat state which holds all of the channels.
  * @param channelId The ID of the channel in which to update the messages.
- * @param makeUnread A boolean flag indicating whether to mark a channel as having unread messages.
+ * @param arrival The conditions a live message arrived under, or `undefined` when this isn't a live
+ *   arrival and so nothing can have gone unread.
  * @param updateFn A function which performs the update operation on the messages field. It may
  *   mutate the passed-in array in place (e.g. via `push`) and must return the array to use as the
  *   new messages value.
@@ -426,7 +444,7 @@ function dropMessageWindow(channelMessages: MessagesState) {
 function updateMessages(
   state: ChatState,
   channelId: SbChannelId,
-  makeUnread: boolean,
+  arrival: LiveArrival | undefined,
   updateFn: (messages: ChatMessage[]) => ChatMessage[],
 ) {
   const channelMessages = state.idToMessages.get(channelId)
@@ -455,8 +473,8 @@ function updateMessages(
     sliced = true
   }
 
-  if (makeUnread) {
-    markChannelUnread(state, channelId)
+  if (arrival) {
+    markChannelUnread(state, channelId, arrival.windowFocused)
   }
 
   channelMessages.hasHistory = channelMessages.hasHistory || sliced
@@ -548,14 +566,14 @@ function initChannel(state: ChatState, channelId: SbChannelId, data: InitialChan
   }
 
   // Seeds the unread badge from the server's recorded read position, so it survives a restart
-  // instead of resetting to "read" until the next message arrives. A channel the user is currently
-  // viewing is never marked unread, matching how a live message never marks an activated channel
-  // unread either.
+  // instead of resetting to "read" until the next message arrives. The seed only concerns channels
+  // that aren't on screen: an activated channel's flag is driven by what arrives live and what the
+  // view reads, both of which know things this seed doesn't.
   if (hasUnread && !state.activatedChannels.has(channelId)) {
     state.unreadChannels.add(channelId)
   }
 
-  updateMessages(state, channelId, false, m => {
+  updateMessages(state, channelId, undefined, m => {
     m.push({
       id: nanoid(),
       type: ClientChatMessageType.SelfJoinChannel,
@@ -586,7 +604,7 @@ export default immerKeyedReducer(DEFAULT_CHAT_STATE, {
 
   ['@chat/updateJoin'](state, action) {
     const { user, message } = action.payload
-    const { channelId } = action.meta
+    const { channelId, windowFocused } = action.meta
 
     const channelUsers = state.idToUsers.get(channelId)
     const detailedChannelInfo = state.idToDetailedInfo.get(channelId)
@@ -597,7 +615,7 @@ export default immerKeyedReducer(DEFAULT_CHAT_STATE, {
     channelUsers.active.add(user.id)
     detailedChannelInfo.userCount += 1
 
-    updateMessages(state, channelId, true, m => {
+    updateMessages(state, channelId, { windowFocused }, m => {
       m.push(message)
       return m
     })
@@ -605,9 +623,9 @@ export default immerKeyedReducer(DEFAULT_CHAT_STATE, {
 
   ['@chat/updateLeave'](state, action) {
     const { userId, newOwnerId } = action.payload
-    const { channelId } = action.meta
+    const { channelId, windowFocused } = action.meta
 
-    removeUserFromChannel(state, channelId, userId, newOwnerId)
+    removeUserFromChannel(state, channelId, userId, { windowFocused }, newOwnerId)
   },
 
   ['@chat/updateLeaveSelf'](state, action) {
@@ -618,9 +636,16 @@ export default immerKeyedReducer(DEFAULT_CHAT_STATE, {
 
   ['@chat/updateKick'](state, action) {
     const { targetId, newOwnerId } = action.payload
-    const { channelId } = action.meta
+    const { channelId, windowFocused } = action.meta
 
-    removeUserFromChannel(state, channelId, targetId, newOwnerId, ChannelModerationAction.Kick)
+    removeUserFromChannel(
+      state,
+      channelId,
+      targetId,
+      { windowFocused },
+      newOwnerId,
+      ChannelModerationAction.Kick,
+    )
   },
 
   ['@chat/updateKickSelf'](state, action) {
@@ -631,9 +656,16 @@ export default immerKeyedReducer(DEFAULT_CHAT_STATE, {
 
   ['@chat/updateBan'](state, action) {
     const { targetId, newOwnerId } = action.payload
-    const { channelId } = action.meta
+    const { channelId, windowFocused } = action.meta
 
-    removeUserFromChannel(state, channelId, targetId, newOwnerId, ChannelModerationAction.Ban)
+    removeUserFromChannel(
+      state,
+      channelId,
+      targetId,
+      { windowFocused },
+      newOwnerId,
+      ChannelModerationAction.Ban,
+    )
   },
 
   ['@chat/updateBanSelf'](state, action) {
@@ -644,14 +676,14 @@ export default immerKeyedReducer(DEFAULT_CHAT_STATE, {
 
   ['@chat/ownerChanged'](state, action) {
     const { newOwnerId } = action.payload
-    const { channelId } = action.meta
+    const { channelId, windowFocused } = action.meta
 
-    setChannelOwner(state, channelId, newOwnerId)
+    setChannelOwner(state, channelId, newOwnerId, { windowFocused })
   },
 
   ['@chat/updateMessage'](state, action) {
     const { message: newMessage, channelMentions } = action.payload
-    const { channelId, mentionsSelf } = action.meta
+    const { channelId, mentionsSelf, windowFocused } = action.meta
 
     const channelMessages = state.idToMessages.get(channelId)
     if (channelMessages?.hasNewer) {
@@ -662,9 +694,9 @@ export default immerKeyedReducer(DEFAULT_CHAT_STATE, {
         channelMessages.detachedNewestTime ?? -Infinity,
         newMessage.time,
       )
-      markChannelUnread(state, channelId)
+      markChannelUnread(state, channelId, windowFocused)
     } else {
-      updateMessages(state, channelId, true, m => {
+      updateMessages(state, channelId, { windowFocused }, m => {
         m.push(newMessage)
         return m
       })
@@ -754,7 +786,7 @@ export default immerKeyedReducer(DEFAULT_CHAT_STATE, {
 
     channelMessages.hasHistory = action.payload.hasMoreBefore
 
-    updateMessages(state, channelId, false, messages =>
+    updateMessages(state, channelId, undefined, messages =>
       dedupeAgainst(newMessages, messages).concat(messages),
     )
     // The older edge just moved (or, for a window left holding only carried messages by a prior
@@ -792,7 +824,7 @@ export default immerKeyedReducer(DEFAULT_CHAT_STATE, {
 
     const newMessages = action.payload.messages as ChatMessage[]
 
-    updateMessages(state, channelId, false, messages =>
+    updateMessages(state, channelId, undefined, messages =>
       messages.concat(dedupeAgainst(newMessages, messages)),
     )
     updateChannelInfos(state, action.payload.channelMentions)
@@ -916,7 +948,9 @@ export default immerKeyedReducer(DEFAULT_CHAT_STATE, {
     const { channelId } = action.meta
     const { messageId } = action.payload
 
-    updateMessages(state, channelId, false, messages => messages.filter(m => m.id !== messageId))
+    updateMessages(state, channelId, undefined, messages =>
+      messages.filter(m => m.id !== messageId),
+    )
   },
 
   ['@chat/retrieveUserListBegin'](state, action) {
@@ -1091,9 +1125,11 @@ export default immerKeyedReducer(DEFAULT_CHAT_STATE, {
   // This arrives both from this session's own optimistic mark-read reports (dispatched only while
   // the channel is activated) and from the socket handler relaying a mark-read made in one of the
   // user's other sessions (which can arrive for a channel this session isn't currently viewing).
-  // The unread flag and frozen divider are only re-evaluated in the latter case: an activated
-  // channel already has its unread flag cleared, and its divider is re-evaluated by
-  // `deactivateChannel` instead, so it must never move while the channel is being viewed here.
+  // The unread flag is re-evaluated either way: an activated channel can carry the flag, since a
+  // message arriving while the app window is unfocused counts as unread no matter what's on screen,
+  // and this is what lowers it once the read position covers that message. The frozen divider is
+  // only re-evaluated for a channel that isn't activated: while one is being viewed the divider has
+  // to hold still where it is, and `deactivateChannel` is what re-evaluates it.
   ['@chat/updateLastReadTime'](state, action) {
     const { channelId, lastReadTime } = action.payload
 
@@ -1103,13 +1139,21 @@ export default immerKeyedReducer(DEFAULT_CHAT_STATE, {
     }
     const effective = state.idToLastReadTime.get(channelId)!
 
-    if (!state.activatedChannels.has(channelId)) {
-      const messages = state.idToMessages.get(channelId)?.messages
-      const newestKnownTime = messages ? newestServerOriginTime(messages) : undefined
-      if (newestKnownTime === undefined || newestKnownTime <= effective) {
-        state.unreadChannels.delete(channelId)
-      }
+    // A detached window's present has run ahead of what's loaded, so the newest loaded message
+    // isn't the newest one known to exist. Clearing the flag against the loaded window alone would
+    // call the channel read on the strength of a position that only covers that window.
+    const channelMessages = state.idToMessages.get(channelId)
+    const knownTimes = [
+      channelMessages ? newestServerOriginTime(channelMessages.messages) : undefined,
+      channelMessages?.detachedNewestTime,
+    ].filter(t => t !== undefined)
+    const newestKnownTime = knownTimes.length ? Math.max(...knownTimes) : undefined
 
+    if (newestKnownTime === undefined || newestKnownTime <= effective) {
+      state.unreadChannels.delete(channelId)
+    }
+
+    if (!state.activatedChannels.has(channelId)) {
       const unreadLineTime = state.idToUnreadLineTime.get(channelId)
       if (unreadLineTime !== undefined && effective > unreadLineTime) {
         state.idToUnreadLineTime.delete(channelId)

--- a/client/chat/socket-handlers.ts
+++ b/client/chat/socket-handlers.ts
@@ -19,7 +19,7 @@ const eventToChatAction: EventToChatActionMap = {
     return {
       type: '@chat/updateJoin',
       payload: event,
-      meta: { channelId },
+      meta: { channelId, windowFocused: windowFocus.isFocused() },
     }
   },
 
@@ -45,7 +45,7 @@ const eventToChatAction: EventToChatActionMap = {
       dispatch({
         type: '@chat/updateLeave',
         payload: event,
-        meta: { channelId },
+        meta: { channelId, windowFocused: windowFocus.isFocused() },
       })
     }
   },
@@ -63,7 +63,7 @@ const eventToChatAction: EventToChatActionMap = {
       dispatch({
         type: '@chat/updateKick',
         payload: event,
-        meta: { channelId },
+        meta: { channelId, windowFocused: windowFocus.isFocused() },
       })
     }
   },
@@ -81,7 +81,7 @@ const eventToChatAction: EventToChatActionMap = {
       dispatch({
         type: '@chat/updateBan',
         payload: event,
-        meta: { channelId },
+        meta: { channelId, windowFocused: windowFocus.isFocused() },
       })
     }
   },
@@ -90,7 +90,7 @@ const eventToChatAction: EventToChatActionMap = {
     return {
       type: '@chat/ownerChanged',
       payload: event,
-      meta: { channelId },
+      meta: { channelId, windowFocused: windowFocus.isFocused() },
     }
   },
 
@@ -104,6 +104,7 @@ const eventToChatAction: EventToChatActionMap = {
 
       const isBlocked = blocks.has(event.message.from)
       const isUrgent = !isBlocked && event.mentions.some(m => m.id === auth.self!.user.id)
+      const windowFocused = windowFocus.isFocused()
       if (isUrgent) {
         // Mentions get the main process's transient attention treatment (urgent tray icon +
         // taskbar flash); regular messages reach it through the tracked unread state instead.
@@ -115,11 +116,11 @@ const eventToChatAction: EventToChatActionMap = {
       dispatch({
         type: '@chat/updateMessage',
         payload: event,
-        meta: { channelId, mentionsSelf: isUrgent },
+        meta: { channelId, mentionsSelf: isUrgent, windowFocused },
       })
 
       const isChannelActivated = activatedChannels.has(channelId)
-      if (isUrgent && (!isChannelActivated || !windowFocus.isFocused())) {
+      if (isUrgent && (!isChannelActivated || !windowFocused)) {
         audioManager.playSound(AvailableSound.MessageAlert)
       }
     }

--- a/client/whispers/actions.ts
+++ b/client/whispers/actions.ts
@@ -288,5 +288,11 @@ export interface WhisperMessageUpdate {
   meta: {
     /** The other user involved in this whisper (not the one logged in on this client). */
     target: SbUserId
+    /**
+     * Whether the app window was focused when the message arrived. A message landing in an
+     * unfocused window can't have been seen no matter where the session's view is scrolled, so the
+     * reducer counts it as unread regardless.
+     */
+    windowFocused: boolean
   }
 }

--- a/client/whispers/socket-handlers.ts
+++ b/client/whispers/socket-handlers.ts
@@ -43,6 +43,7 @@ const eventToAction: EventToActionMap = {
       }
 
       const isBlocked = blocks.has(event.message.from)
+      const windowFocused = windowFocus.isFocused()
       if (!isBlocked) {
         // Notify the main process of the new message, so it can display an appropriate notification
         ipcRenderer.send('chatNewMessage', {
@@ -55,7 +56,7 @@ const eventToAction: EventToActionMap = {
       dispatch({
         type: '@whispers/updateMessage',
         payload: event,
-        meta: { target },
+        meta: { target, windowFocused },
       })
 
       const session = whispersById.get(target)
@@ -63,7 +64,7 @@ const eventToAction: EventToActionMap = {
         return
       }
 
-      if (!isBlocked && (!session.activated || !windowFocus.isFocused())) {
+      if (!isBlocked && (!session.activated || !windowFocused)) {
         audioManager.playSound(AvailableSound.MessageAlert)
       }
     }

--- a/client/whispers/whisper-reducer.test.ts
+++ b/client/whispers/whisper-reducer.test.ts
@@ -185,7 +185,7 @@ function loadMessagesAroundAction(
   }
 }
 
-function updateMessageAction(time: number): WhisperActions {
+function updateMessageAction(time: number, windowFocused = true): WhisperActions {
   return {
     type: '@whispers/updateMessage',
     payload: {
@@ -195,7 +195,7 @@ function updateMessageAction(time: number): WhisperActions {
       mentions: [],
       channelMentions: [],
     },
-    meta: { target: TARGET_ID },
+    meta: { target: TARGET_ID, windowFocused },
   }
 }
 
@@ -287,10 +287,9 @@ describe('client/whispers/whisper-reducer', () => {
       expect(result.byId.get(TARGET_ID)!.unreadLineTime).toBe(250)
     })
 
-    test('leaves the unread flag and divider untouched for an activated session', () => {
+    test('leaves the divider untouched for an activated session', () => {
       const state = makeState({
         activated: true,
-        unread: true,
         lastReadTime: 100,
         unreadLineTime: 150,
         messages: [textMessage(100)],
@@ -299,11 +298,54 @@ describe('client/whispers/whisper-reducer', () => {
       const result = whisperReducer(state, updateLastReadTimeAction(200))
 
       const session = result.byId.get(TARGET_ID)!
-      expect(session.hasUnread).toBe(true)
       expect(session.unreadLineTime).toBe(150)
       // The read position itself still advances even while activated, since this is also the path
       // this session's own optimistic mark-read reports take.
       expect(session.lastReadTime).toBe(200)
+    })
+
+    test('clears an activated session flag once the position covers the newest message', () => {
+      const state = makeState({
+        activated: true,
+        unread: true,
+        lastReadTime: 50,
+        unreadLineTime: 50,
+        messages: [textMessage(100)],
+      })
+
+      const result = whisperReducer(state, updateLastReadTimeAction(100))
+
+      const session = sessionOf(result)
+      expect(session.hasUnread).toBe(false)
+      expect(session.unreadLineTime).toBe(50)
+    })
+
+    test('keeps an activated session flag while the position is behind the newest message', () => {
+      const state = makeState({
+        activated: true,
+        unread: true,
+        lastReadTime: 50,
+        messages: [textMessage(100)],
+      })
+
+      const result = whisperReducer(state, updateLastReadTimeAction(99))
+
+      expect(sessionOf(result).hasUnread).toBe(true)
+    })
+
+    test('keeps the flag when a detached present has run past what the position covers', () => {
+      const state = makeState({
+        activated: true,
+        unread: true,
+        lastReadTime: 50,
+        hasNewer: true,
+        detachedNewestTime: 200,
+        messages: [textMessage(100)],
+      })
+
+      const result = whisperReducer(state, updateLastReadTimeAction(100))
+
+      expect(sessionOf(result).hasUnread).toBe(true)
     })
   })
 
@@ -552,6 +594,54 @@ describe('client/whispers/whisper-reducer', () => {
       const result = whisperReducer(state, updateMessageAction(1000))
 
       expect(sessionOf(result).messages.length).toBe(150)
+    })
+
+    test('a message arriving at the bottom of an unfocused window counts as unseen', () => {
+      const state = makeState({ activated: true, atBottom: true, lastReadTime: 100 })
+
+      const result = whisperReducer(state, updateMessageAction(200, false))
+
+      const session = sessionOf(result)
+      expect(session.hasUnread).toBe(true)
+      expect(session.unreadLineTime).toBe(100)
+    })
+
+    test('a message arriving at the bottom of a focused window counts as seen', () => {
+      const state = makeState({ activated: true, atBottom: true, lastReadTime: 100 })
+
+      const result = whisperReducer(state, updateMessageAction(200, true))
+
+      const session = sessionOf(result)
+      expect(session.hasUnread).toBe(false)
+      expect(session.unreadLineTime).toBeUndefined()
+    })
+
+    test('a message arriving while scrolled up in an unfocused window raises both', () => {
+      const state = makeState({ activated: true, atBottom: false, lastReadTime: 100 })
+
+      const result = whisperReducer(state, updateMessageAction(200, false))
+
+      const session = sessionOf(result)
+      expect(session.hasUnread).toBe(true)
+      expect(session.unreadLineTime).toBe(100)
+    })
+
+    test('a message arriving while scrolled up in a focused window only freezes the divider', () => {
+      const state = makeState({ activated: true, atBottom: false, lastReadTime: 100 })
+
+      const result = whisperReducer(state, updateMessageAction(200, true))
+
+      const session = sessionOf(result)
+      expect(session.hasUnread).toBe(false)
+      expect(session.unreadLineTime).toBe(100)
+    })
+
+    test('a message arriving in a session that is not being viewed raises the unread flag', () => {
+      const state = makeState({ activated: false, lastReadTime: 100 })
+
+      const result = whisperReducer(state, updateMessageAction(200, true))
+
+      expect(sessionOf(result).hasUnread).toBe(true)
     })
   })
 

--- a/client/whispers/whisper-reducer.ts
+++ b/client/whispers/whisper-reducer.ts
@@ -130,23 +130,24 @@ function dedupeAgainst(
 
 /**
  * Records that a message the user hasn't seen has arrived in a whisper session: raises the unread
- * flag and, where applicable, freezes the unread divider. Kept separate from `updateMessages`
- * because a message arriving while the loaded window is detached from the present isn't added to
- * the window at all, yet counts as unread exactly the same.
+ * flag and, where applicable, freezes the unread divider. Both mean the same thing — a message
+ * arrived that the user won't have seen — and an activated session counts as seen only when its
+ * view sits at the bottom of a window attached to the present *and* the app window is focused,
+ * since a message that lands while the user is looking at something else can't have been read no
+ * matter where the list is scrolled. The divider freezes at the read position so it marks where the
+ * user left off instead of chasing the read position as it keeps advancing underneath it.
+ *
+ * Kept separate from `updateMessages` because a message arriving while the loaded window is
+ * detached from the present isn't added to the window at all, yet counts as unread exactly the same.
  */
-function markSessionUnread(session: WhisperSession) {
-  if (!session.hasUnread && !session.activated) {
+function markSessionUnread(session: WhisperSession, windowFocused: boolean) {
+  if (!session.hasUnread && (!session.activated || !windowFocused)) {
     session.hasUnread = true
   }
 
-  // The session is being actively viewed, but the message still won't be seen right away: either
-  // the view is scrolled up, or the loaded window sits behind the present, where the bottom of the
-  // list isn't the newest message. Freeze the unread divider at the read position so it marks where
-  // the user left off instead of chasing the read position as the eager mark-read keeps advancing
-  // it.
   if (
     session.activated &&
-    (!session.atBottom || session.hasNewer) &&
+    (!session.atBottom || session.hasNewer || !windowFocused) &&
     session.unreadLineTime === undefined &&
     session.lastReadTime !== undefined
   ) {
@@ -172,12 +173,24 @@ function dropMessageWindow(session: WhisperSession) {
 }
 
 /**
- * Update the messages field for a whisper, keeping the `hasUnread` flag in proper sync.
+ * The conditions a message arrived under when it reached the session live. Messages that reach a
+ * session any other way (a page of history) carry no arrival and do no unread bookkeeping: only
+ * something happening live can go unseen.
+ */
+interface LiveArrival {
+  /** Whether the app window was focused at the moment the message arrived. */
+  windowFocused: boolean
+}
+
+/**
+ * Update the messages field for a whisper, keeping the `hasUnread` flag in proper sync. `arrival`
+ * carries the conditions a live message arrived under, and is `undefined` when this isn't a live
+ * arrival and so nothing can have gone unread.
  */
 function updateMessages(
   state: WhisperState,
   target: SbUserId,
-  makeUnread: boolean,
+  arrival: LiveArrival | undefined,
   updateFn: (messages: CommonTextMessage[]) => CommonTextMessage[],
 ) {
   const session = state.byId.get(target)
@@ -202,8 +215,8 @@ function updateMessages(
     sliced = true
   }
 
-  if (makeUnread) {
-    markSessionUnread(session)
+  if (arrival) {
+    markSessionUnread(session, arrival.windowFocused)
   }
 
   session.hasHistory = session.hasHistory || sliced
@@ -222,9 +235,9 @@ export default immerKeyedReducer(DEFAULT_STATE, {
     }
 
     // Seeds the unread badge from the server's recorded read position, so it survives a restart
-    // instead of resetting to "read" until the next message arrives. A session the user is
-    // currently viewing is never marked unread, matching how a live message never marks an
-    // activated session unread either.
+    // instead of resetting to "read" until the next message arrives. The seed only concerns
+    // sessions that aren't on screen: an activated session's flag is driven by what arrives live
+    // and what the view reads, both of which know things this seed doesn't.
     for (const target of action.payload.unreadSessions ?? []) {
       const session = state.byId.get(target)
       if (session && !session.activated) {
@@ -261,7 +274,7 @@ export default immerKeyedReducer(DEFAULT_STATE, {
       payload: {
         message: { id, time, from, text },
       },
-      meta: { target },
+      meta: { target, windowFocused },
     },
   ) {
     const newMessage: CommonTextMessage = {
@@ -284,9 +297,9 @@ export default immerKeyedReducer(DEFAULT_STATE, {
         session.detachedNewestTime ?? -Infinity,
         newMessage.time,
       )
-      markSessionUnread(session)
+      markSessionUnread(session, windowFocused)
     } else {
-      updateMessages(state, target, true, m => {
+      updateMessages(state, target, { windowFocused }, m => {
         m.push(newMessage)
         return m
       })
@@ -322,7 +335,7 @@ export default immerKeyedReducer(DEFAULT_STATE, {
 
     session.hasHistory = action.payload.hasMoreBefore
 
-    updateMessages(state, target, false, messages =>
+    updateMessages(state, target, undefined, messages =>
       dedupeAgainst(newMessages, messages).concat(messages),
     )
   },
@@ -354,7 +367,7 @@ export default immerKeyedReducer(DEFAULT_STATE, {
 
     const newMessages = toTextMessages(action.payload.messages)
 
-    updateMessages(state, target, false, messages =>
+    updateMessages(state, target, undefined, messages =>
       messages.concat(dedupeAgainst(newMessages, messages)),
     )
 
@@ -579,10 +592,11 @@ export default immerKeyedReducer(DEFAULT_STATE, {
   // This arrives both from this session's own optimistic mark-read reports (dispatched only while
   // the session is activated) and from the socket handler relaying a mark-read made in one of the
   // user's other sessions (which can arrive for a session this session isn't currently viewing).
-  // The unread flag and frozen divider are only re-evaluated in the latter case: an activated
-  // session already has its unread flag cleared, and its divider is re-evaluated by
-  // `deactivateWhisperSession` instead, so it must never move while the session is being viewed
-  // here.
+  // The unread flag is re-evaluated either way: an activated session can carry the flag, since a
+  // message arriving while the app window is unfocused counts as unread no matter what's on screen,
+  // and this is what lowers it once the read position covers that message. The frozen divider is
+  // only re-evaluated for a session that isn't activated: while one is being viewed the divider has
+  // to hold still where it is, and `deactivateWhisperSession` is what re-evaluates it.
   ['@whispers/updateLastReadTime'](state, action) {
     const { targetId, lastReadTime } = action.payload
 
@@ -596,15 +610,25 @@ export default immerKeyedReducer(DEFAULT_STATE, {
     }
     const effective = session.lastReadTime!
 
-    if (!session.activated) {
-      const newestKnownTime = newestServerOriginTime(session.messages)
-      if (newestKnownTime === undefined || newestKnownTime <= effective) {
-        session.hasUnread = false
-      }
+    // A detached window's present has run ahead of what's loaded, so the newest loaded message
+    // isn't the newest one known to exist. Clearing the flag against the loaded window alone would
+    // call the session read on the strength of a position that only covers that window.
+    const knownTimes = [
+      newestServerOriginTime(session.messages),
+      session.detachedNewestTime,
+    ].filter(t => t !== undefined)
+    const newestKnownTime = knownTimes.length ? Math.max(...knownTimes) : undefined
 
-      if (session.unreadLineTime !== undefined && effective > session.unreadLineTime) {
-        session.unreadLineTime = undefined
-      }
+    if (newestKnownTime === undefined || newestKnownTime <= effective) {
+      session.hasUnread = false
+    }
+
+    if (
+      !session.activated &&
+      session.unreadLineTime !== undefined &&
+      effective > session.unreadLineTime
+    ) {
+      session.unreadLineTime = undefined
     }
   },
 

--- a/client/whispers/whisper.tsx
+++ b/client/whispers/whisper.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 import { SbUserId } from '../../common/users/sb-user-id'
 import { useSelfUser } from '../auth/auth-utils'
+import { useWindowFocus } from '../dom/window-focus'
 import { Chat } from '../messaging/chat'
 import { anchorNeedsFetch, chatViewAnchorStore } from '../messaging/chat-view-anchor'
 import { flushLastRead } from '../messaging/last-read'
@@ -80,6 +81,7 @@ export function ConnectedWhisper({
   const targetUser = useAppSelector(s => s.users.byId.get(targetId))
   const isSessionOpen = useAppSelector(s => s.whispers.sessions.has(targetId))
   const whisperSession = useAppSelector(s => s.whispers.byId.get(targetId))
+  const isWindowFocused = useWindowFocus()
 
   useEffect(() => {
     if (selfUser.id === targetId) {
@@ -187,14 +189,30 @@ export function ConnectedWhisper({
     }
   }
 
-  // Reports the read position whenever the session is both open and scrolled to the bottom, so
-  // arriving at a session already at the bottom (or scrolling back down to it) reports the newest
-  // message just as much as a message arriving while already there does.
+  // Reports the read position whenever the session is open, scrolled to the bottom, and the app
+  // window is focused, so arriving at a session already at the bottom (or scrolling back down to
+  // it) reports the newest message just as much as a message arriving while already there does.
+  // The read position never advances while the window is unfocused: messages landing in a session
+  // that's open and at the bottom while the user is off in another window stay unread until they
+  // come back, at which point this re-runs and reports the newest one. Refocusing with nothing new
+  // to report costs no request — the coalescer drops a position it has already sent.
   useEffect(() => {
-    if (whisperSession?.activated && whisperSession.atBottom && newestMessageTime !== undefined) {
+    if (
+      whisperSession?.activated &&
+      whisperSession.atBottom &&
+      isWindowFocused &&
+      newestMessageTime !== undefined
+    ) {
       dispatch(markWhisperRead(targetId, newestMessageTime))
     }
-  }, [whisperSession?.activated, whisperSession?.atBottom, newestMessageTime, targetId, dispatch])
+  }, [
+    whisperSession?.activated,
+    whisperSession?.atBottom,
+    isWindowFocused,
+    newestMessageTime,
+    targetId,
+    dispatch,
+  ])
 
   useEffect(() => () => flushLastRead(getWhisperLastReadKey(targetId)), [targetId])
 


### PR DESCRIPTION
## Summary

Mark-read reporting for channels and whispers now requires the app window to be focused, in addition to the conversation being open and scrolled to the bottom. Discord and Slack hold the ack the same way; for ShieldBattery it matters more, since alt-tabbed into StarCraft is the default state of a session and every message landing in the open channel was being auto-marked read.

- `channel.tsx` / `whisper.tsx`: the read-position effect is gated on `useWindowFocus()`. Refocusing re-runs it and reports the newest message; the coalescer in `last-read.ts` drops a position it has already sent, so refocusing with nothing new costs no request.
- Live-arrival actions (`@chat/updateMessage`, `updateJoin`, `updateLeave`, `updateKick`, `updateBan`, `ownerChanged`, `@whispers/updateMessage`) carry `windowFocused` in their meta, read once in the socket handlers (the same read the alert-sound check already used).
- Reducers treat an unfocused arrival as unseen even in the open conversation: the unread flag is raised (so the sidebar entry and tray icon reflect it) and the unread divider freezes at the read position. `updateMessages`' `makeUnread` boolean became `arrival: LiveArrival | undefined` so every live caller has to say what it knows.
- `updateLastReadTime` now clears the unread flag for activated conversations too (that is how the refocus report, or a read from another session, lowers it), comparing against the newest known message including a detached window's present. The frozen divider is still only re-evaluated for conversations that aren't being viewed.

## Verification

- `pnpm run typecheck`, `pnpm run lint`, and `vitest` for `client/chat`, `client/whispers`, `client/messaging` (246 tests, 18 added or rewritten for the new rules).
- Live, in two dev Electron clients. With the channel (and separately the whisper) open at the bottom on client 1 and the window blurred via a real Alt+Tab, a message from client 2 left `last_read_time` in the DB untouched for ~30s, added the channel to `unreadChannels` (whisper: `hasUnread`), and froze the divider at the previous read position. Refocusing client 1 sent the mark-read POST within milliseconds, advanced the read position to the new message, cleared the unread flag, and kept the divider in place.

Note for anyone repeating the live test: programmatic focus changes (AppActivate, SetForegroundWindow, a cross-process minimize, even the app's own `windowMinimize` IPC) never emit Electron's window `blur` on Windows and `isFocused()` stays true. Only real input like a SendKeys Alt+Tab blurs it.

## Not changed

The browser tracker maps focus to document visibility, so a visible but unfocused web tab still acks. Electron is the target; left as-is.
