### PR TITLE
Refuse whispers between users where either has blocked the other.

### DIFF
--- a/client/whispers/whisper.tsx
+++ b/client/whispers/whisper.tsx
@@ -2,12 +2,14 @@ import { useEffect, useEffectEvent } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 import { SbUserId } from '../../common/users/sb-user-id'
+import { isWhisperServiceErrorCode, whisperServiceErrorToString } from '../../common/whispers'
 import { useSelfUser } from '../auth/auth-utils'
 import { Chat } from '../messaging/chat'
 import { anchorNeedsFetch, chatViewAnchorStore } from '../messaging/chat-view-anchor'
 import { flushLastRead } from '../messaging/last-read'
 import { isServerOriginMessage } from '../messaging/message-records'
 import { push, replace } from '../navigation/routing'
+import { isFetchError } from '../network/fetch-errors'
 import LoadingIndicator from '../progress/dots'
 import { usePrevious, useStableCallback } from '../react/state-hooks'
 import { useAppDispatch, useAppSelector } from '../redux-hooks'
@@ -251,10 +253,14 @@ export function ConnectedWhisper({
         onError: err => {
           // TODO(tec27): Offer a retry for the same message content? Display it in the message list
           // ala Discord?
+          const errorMessage =
+            isFetchError(err) && isWhisperServiceErrorCode(err.code ?? '')
+              ? whisperServiceErrorToString(err.code, t)
+              : err.message
           snackbarController.showSnackbar(
             t('whispers.errors.sendingMessage', {
               defaultValue: 'Error sending message: {{errorMessage}}',
-              errorMessage: err.message,
+              errorMessage,
             }),
             DURATION_LONG,
           )

--- a/common/whispers.ts
+++ b/common/whispers.ts
@@ -111,12 +111,14 @@ export enum WhisperServiceErrorCode {
   NoSelfMessaging = 'noSelfMessaging',
   InvalidGetSessionHistoryAction = 'invalidGetSessionHistoryAction',
   UserChatRestricted = 'userChatRestricted',
+  BlockedByUser = 'blockedByUser',
+  UserBlocked = 'userBlocked',
 }
 
 const ALL_WHISPER_SERVICE_ERROR_CODES: ReadonlyArray<WhisperServiceErrorCode> =
   Object.values(WhisperServiceErrorCode)
 
-function isWhisperServiceErrorCode(code: string): code is WhisperServiceErrorCode {
+export function isWhisperServiceErrorCode(code: string): code is WhisperServiceErrorCode {
   return ALL_WHISPER_SERVICE_ERROR_CODES.includes(code as WhisperServiceErrorCode)
 }
 
@@ -140,6 +142,10 @@ export function whisperServiceErrorToString(
           'whispers.errors.userChatRestricted',
           'You are currently restricted from sending chat messages',
         )
+      case WhisperServiceErrorCode.BlockedByUser:
+        return t('whispers.errors.blockedByUser', 'You have been blocked by this user')
+      case WhisperServiceErrorCode.UserBlocked:
+        return t('whispers.errors.userBlocked', 'You have blocked this user')
       default:
         return assertUnreachable(code)
     }

--- a/server/lib/users/user-relationship-service.test.ts
+++ b/server/lib/users/user-relationship-service.test.ts
@@ -349,9 +349,33 @@ vi.mock('./user-relationship-models', () => {
       return result
     }),
 
-    isUserBlockedBy: vi.fn(async (userId: SbUserId, potentialBlocker: SbUserId) => {
-      const blockerSummary = fakeDb.get(potentialBlocker)
-      return blockerSummary?.blocks?.some(r => r.toId === userId) ?? false
+    getRelationshipsForUsers: vi.fn(async (userA: SbUserId, userB: SbUserId) => {
+      const aSummary = fakeDb.get(userA) ?? createSummary()
+      const bSummary = fakeDb.get(userB) ?? createSummary()
+
+      const aBlock = aSummary.blocks.find(r => r.toId === userB)
+      const bBlock = bSummary.blocks.find(r => r.toId === userA)
+      if (aBlock || bBlock) {
+        // Blocks override any other relationships that may exist (note that in the actual DB those
+        // relationships can't actually exist, since it's a single row)
+        return [aBlock, bBlock].filter(r => !!r)
+      }
+
+      const result: UserRelationship[] = []
+      const aRelationship =
+        aSummary.friends.find(r => r.toId === userB) ??
+        aSummary.outgoingRequests.find(r => r.toId === userB)
+      if (aRelationship) {
+        result.push(aRelationship)
+      }
+      const bRelationship =
+        bSummary.friends.find(r => r.toId === userA) ??
+        bSummary.outgoingRequests.find(r => r.toId === userA)
+      if (bRelationship) {
+        result.push(bRelationship)
+      }
+
+      return result
     }),
   }
 })
@@ -1138,6 +1162,36 @@ describe('users/user-relationship-service', () => {
       expect(client1.publish).not.toHaveBeenCalledWith(getFriendActivityStatusPath(OTHER), {
         userId: OTHER,
         status: FriendActivityStatus.Offline,
+      })
+    })
+  })
+
+  describe('getBlocksBetween', () => {
+    const USER = makeSbUserId(1)
+    const OTHER = makeSbUserId(2)
+
+    test('reports a block made by the first user', async () => {
+      await userRelationshipService.blockUser(USER, OTHER)
+
+      expect(await userRelationshipService.getBlocksBetween(USER, OTHER)).toEqual({
+        aBlocksB: true,
+        bBlocksA: false,
+      })
+    })
+
+    test('reports a block made by the second user', async () => {
+      await userRelationshipService.blockUser(OTHER, USER)
+
+      expect(await userRelationshipService.getBlocksBetween(USER, OTHER)).toEqual({
+        aBlocksB: false,
+        bBlocksA: true,
+      })
+    })
+
+    test('reports no blocks between unrelated users', async () => {
+      expect(await userRelationshipService.getBlocksBetween(USER, OTHER)).toEqual({
+        aBlocksB: false,
+        bBlocksA: false,
       })
     })
   })

--- a/server/lib/users/user-relationship-service.ts
+++ b/server/lib/users/user-relationship-service.ts
@@ -424,9 +424,22 @@ export class UserRelationshipService {
     return await getRelationshipSummaryForUser(userId)
   }
 
-  /** Returns whether the given user with `userId` is blocked by `potentialBlocker`. */
-  async isUserBlockedBy(userId: SbUserId, potentialBlocker: SbUserId): Promise<boolean> {
-    const relationships = await getRelationshipsForUsers(userId, potentialBlocker)
-    return relationships.some(r => r.kind === UserRelationshipKind.Block && r.toId === userId)
+  /**
+   * Returns which of two users has blocked the other, if either has. Both directions are stored in
+   * a single row, so this costs one query regardless of which side is being checked.
+   */
+  async getBlocksBetween(
+    userA: SbUserId,
+    userB: SbUserId,
+  ): Promise<{ aBlocksB: boolean; bBlocksA: boolean }> {
+    const relationships = await getRelationshipsForUsers(userA, userB)
+    return {
+      aBlocksB: relationships.some(
+        r => r.kind === UserRelationshipKind.Block && r.fromId === userA && r.toId === userB,
+      ),
+      bBlocksA: relationships.some(
+        r => r.kind === UserRelationshipKind.Block && r.fromId === userB && r.toId === userA,
+      ),
+    }
   }
 }

--- a/server/lib/whispers/whisper-api.ts
+++ b/server/lib/whispers/whisper-api.ts
@@ -71,6 +71,8 @@ const convertWhisperServiceErrors = makeErrorConverterMiddleware(err => {
       throw asHttpError(400, err)
     case WhisperServiceErrorCode.NoSelfMessaging:
     case WhisperServiceErrorCode.UserChatRestricted:
+    case WhisperServiceErrorCode.BlockedByUser:
+    case WhisperServiceErrorCode.UserBlocked:
       throw asHttpError(403, err)
     default:
       assertUnreachable(err.code)

--- a/server/lib/whispers/whisper-service.test.ts
+++ b/server/lib/whispers/whisper-service.test.ts
@@ -3,7 +3,9 @@ import { beforeEach, describe, expect, test, vi } from 'vitest'
 import { asMockedFunction } from '../../../common/testing/mocks'
 import { SbUser } from '../../../common/users/sb-user'
 import { SbUserId } from '../../../common/users/sb-user-id'
+import { WhisperMessageType, WhisperServiceErrorCode } from '../../../common/whispers'
 import { RestrictionService } from '../users/restriction-service'
+import { UserRelationshipService } from '../users/user-relationship-service'
 import { RequestSessionLookup } from '../websockets/session-lookup'
 import { UserSocketsManager } from '../websockets/socket-groups'
 import {
@@ -13,13 +15,19 @@ import {
 } from '../websockets/testing/websockets'
 import { TypedPublisher } from '../websockets/typed-publisher'
 import {
+  addMessageToWhisper,
   getMessagesForWhisperSession,
   getUnreadWhisperTargets,
   getWhisperSessionsForUser,
   startWhisperSession,
+  startWhisperSessionsBothDirections,
   updateLastReadTime,
 } from './whisper-models'
-import WhisperService, { getSessionPath, getWhisperUserPath } from './whisper-service'
+import WhisperService, {
+  getSessionPath,
+  getWhisperUserPath,
+  WhisperServiceError,
+} from './whisper-service'
 
 const { user1, user2, user3 } = vi.hoisted(() => ({
   user1: { id: 1 as SbUserId, name: 'USER_NAME_1', created: 1577836800000 } as SbUser,
@@ -37,6 +45,7 @@ vi.mock('../users/user-model', () => {
     findUsersById: vi.fn().mockImplementation(async (ids: ReadonlyArray<SbUserId>) => {
       return ids.map(id => USERS_BY_ID.get(id)).filter(u => !!u)
     }),
+    findUsersByName: vi.fn().mockResolvedValue([]),
   }
 })
 
@@ -45,6 +54,7 @@ vi.mock('../chat/chat-models', async () => {
     await vi.importActual<typeof import('../chat/chat-models')>('../chat/chat-models')
   return {
     getChannelInfos: vi.fn().mockResolvedValue([]),
+    findChannelsByName: vi.fn().mockResolvedValue([]),
     toBasicChannelInfo: originalModule.toBasicChannelInfo,
   }
 })
@@ -66,6 +76,10 @@ const mockRestrictionService = {
   isRestricted: vi.fn().mockResolvedValue(false),
 } as any as RestrictionService
 
+const mockUserRelationshipService = {
+  getBlocksBetween: vi.fn().mockResolvedValue({ aBlocksB: false, bBlocksA: false }),
+} as any as UserRelationshipService
+
 describe('whispers/whisper-service', () => {
   let nydus: NydusServer
   let whisperService: WhisperService
@@ -83,7 +97,12 @@ describe('whispers/whisper-service', () => {
     const userSocketsManager = new UserSocketsManager(nydus, sessionLookup, async () => {})
     const publisher = new TypedPublisher(nydus)
 
-    whisperService = new WhisperService(publisher, userSocketsManager, mockRestrictionService)
+    whisperService = new WhisperService(
+      publisher,
+      userSocketsManager,
+      mockRestrictionService,
+      mockUserRelationshipService,
+    )
     connector = new NydusConnector(nydus, sessionLookup)
 
     connector.connectClient(user1, 'USER1_CLIENT_ID')
@@ -156,6 +175,75 @@ describe('whispers/whisper-service', () => {
           // sits one millisecond before that.
           { targetId: user3.id, lastReadTime: user3StartDate.getTime() - 1 },
         ],
+      })
+    })
+  })
+
+  describe('sendWhisperMessage', () => {
+    const getBlocksBetweenMock = asMockedFunction(mockUserRelationshipService.getBlocksBetween)
+    const addMessageToWhisperMock = asMockedFunction(addMessageToWhisper)
+
+    beforeEach(() => {
+      getBlocksBetweenMock.mockResolvedValue({ aBlocksB: false, bBlocksA: false })
+    })
+
+    test('throws and stores nothing when the target has blocked the sender', async () => {
+      getBlocksBetweenMock.mockResolvedValue({ aBlocksB: false, bBlocksA: true })
+
+      const sendPromise = whisperService.sendWhisperMessage(user1.id, user2.id, 'hi')
+      await expect(sendPromise).rejects.toBeInstanceOf(WhisperServiceError)
+      await expect(sendPromise).rejects.toMatchObject({
+        code: WhisperServiceErrorCode.BlockedByUser,
+      })
+
+      expect(startWhisperSessionsBothDirections).not.toHaveBeenCalled()
+      expect(addMessageToWhisperMock).not.toHaveBeenCalled()
+    })
+
+    test('throws and stores nothing when the sender has blocked the target', async () => {
+      getBlocksBetweenMock.mockResolvedValue({ aBlocksB: true, bBlocksA: false })
+
+      const sendPromise = whisperService.sendWhisperMessage(user1.id, user2.id, 'hi')
+      await expect(sendPromise).rejects.toBeInstanceOf(WhisperServiceError)
+      await expect(sendPromise).rejects.toMatchObject({
+        code: WhisperServiceErrorCode.UserBlocked,
+      })
+
+      expect(startWhisperSessionsBothDirections).not.toHaveBeenCalled()
+      expect(addMessageToWhisperMock).not.toHaveBeenCalled()
+    })
+
+    test('stores and publishes the message when neither user has blocked the other', async () => {
+      const sent = new Date('2023-03-12T00:00:00.000Z')
+      addMessageToWhisperMock.mockResolvedValue({
+        id: 'MESSAGE_ID',
+        from: user1.id,
+        to: user2.id,
+        sent,
+        data: { type: WhisperMessageType.TextMessage, text: 'hi' },
+      })
+
+      await whisperService.sendWhisperMessage(user1.id, user2.id, 'hi')
+
+      expect(addMessageToWhisperMock).toHaveBeenCalledWith(user1.id, user2.id, {
+        type: WhisperMessageType.TextMessage,
+        text: 'hi',
+        mentions: undefined,
+        channelMentions: undefined,
+      })
+      expect(nydus.publish).toHaveBeenCalledWith(getSessionPath(user1.id, user2.id), {
+        action: 'message',
+        message: {
+          id: 'MESSAGE_ID',
+          type: WhisperMessageType.TextMessage,
+          from: user1.id,
+          to: user2.id,
+          time: sent.getTime(),
+          text: 'hi',
+        },
+        users: [user1, user2],
+        mentions: [],
+        channelMentions: [],
       })
     })
   })

--- a/server/lib/whispers/whisper-service.ts
+++ b/server/lib/whispers/whisper-service.ts
@@ -23,6 +23,7 @@ import filterChatMessage from '../messaging/filter-chat-message'
 import { processMessageContents } from '../messaging/process-chat-message'
 import { RestrictionService } from '../users/restriction-service'
 import { findUserById, findUsersById } from '../users/user-model'
+import { UserRelationshipService } from '../users/user-relationship-service'
 import { UserSocketsGroup, UserSocketsManager } from '../websockets/socket-groups'
 import { TypedPublisher } from '../websockets/typed-publisher'
 import {
@@ -71,6 +72,7 @@ export default class WhisperService {
     private publisher: TypedPublisher<WhisperEvent | WhisperUserEvent>,
     private userSocketsManager: UserSocketsManager,
     private restrictionService: RestrictionService,
+    private userRelationshipService: UserRelationshipService,
   ) {
     userSocketsManager
       .on('newUser', userSockets => {
@@ -179,6 +181,23 @@ export default class WhisperService {
       throw new WhisperServiceError(
         WhisperServiceErrorCode.UserChatRestricted,
         'User is chat restricted',
+      )
+    }
+
+    // When either user has blocked the other, no message is stored and no session row is created
+    // in either direction, so a block keeps the blocked user out of the blocker's whisper list
+    // entirely rather than just muting them client-side.
+    const { aBlocksB: senderBlocksTarget, bBlocksA: targetBlocksSender } =
+      await this.userRelationshipService.getBlocksBetween(userId, targetUser)
+    if (targetBlocksSender) {
+      throw new WhisperServiceError(
+        WhisperServiceErrorCode.BlockedByUser,
+        'You have been blocked by this user',
+      )
+    } else if (senderBlocksTarget) {
+      throw new WhisperServiceError(
+        WhisperServiceErrorCode.UserBlocked,
+        'You have blocked this user',
       )
     }
 

--- a/server/public/locales/en/global.json
+++ b/server/public/locales/en/global.json
@@ -2306,6 +2306,7 @@
       "usernameRequired": "Enter a username"
     },
     "errors": {
+      "blockedByUser": "You have been blocked by this user",
       "cantWhisperYourself": "You can't whisper with yourself.",
       "invalidAction": "Must have an active whisper session with a user to retrieve message history",
       "loadingHistory": "Error loading message history: {{errorMessage}}",
@@ -2313,6 +2314,7 @@
       "openSession": "Error opening whisper to user: {{errorMessage}}",
       "sendingMessage": "Error sending message: {{errorMessage}}",
       "unknownError": "Unknown error",
+      "userBlocked": "You have blocked this user",
       "userChatRestricted": "You are currently restricted from sending chat messages",
       "userNotFound": "User not found"
     },


### PR DESCRIPTION
## Summary

The whisper service didn't enforce blocks: a blocked user's whisper was stored, created a session on the blocker's side, and showed up as unread there. Only the client suppressed the sound and tray for blocked senders (and hid the "Whisper" context-menu item for users you blocked).

- `WhisperService.sendWhisperMessage` now checks the block relationship in both directions before anything is stored, via a new `UserRelationshipService.getBlocksBetween(a, b)` (one query; both directions live in the same `user_relationships` row). The unused `isUserBlockedBy` is removed.
- Two new `WhisperServiceErrorCode`s, both mapped to 403: `BlockedByUser` (the target blocked the sender → "You have been blocked by this user") and `UserBlocked` (the sender blocked the target → "You have blocked this user"). An explicit error rather than a silent drop, matching what friend requests already tell users via `UserRelationshipServiceErrorCode.BlockedByUser`.
- No session row and no message is created on either side when the check fails, so a blocked user never appears in the blocker's whisper list or unread state. `startWhisperSession` is deliberately untouched: opening a tab is harmless, delivery is what the block governs.
- The client's send-error snackbar localizes recognized whisper error codes (`isWhisperServiceErrorCode` is now exported) instead of echoing the raw server message.

## Verification

- `pnpm run typecheck`, `pnpm run lint`, and vitest for `server/lib/whispers`, `server/lib/users/user-relationship-service.test.ts`, `client/whispers` (6 new tests: `getBlocksBetween` in each direction and with no block; `sendWhisperMessage` rejecting with each code without touching the session/message models, and storing + publishing when neither user has blocked the other).
- Live in two browser sessions against the dev server: after claude-1 blocked claude-2 through the API, a whisper from claude-2 got 403 with the "You have been blocked by this user" snackbar, and one from claude-1 got 403 with "You have blocked this user"; the whisper message count in the DB didn't change. After unblocking, the next whisper was delivered and showed up on the other side.
