### PR TITLE
Add shareable links to individual chat messages

### DIFF
--- a/client/chat/action-creators.ts
+++ b/client/chat/action-creators.ts
@@ -544,7 +544,7 @@ export function getMessagesAroundMessage(
 
     const promise = fetchJson<GetChannelHistoryServerResponse>(
       apiUrl`chat/${channelId}/messages2?limit=${limit}&aroundMessageId=${messageId}`,
-      { method: 'GET' },
+      { method: 'GET', signal: spec.signal },
     )
     dispatch({
       type: '@chat/loadMessagesAroundBegin',

--- a/client/chat/action-creators.ts
+++ b/client/chat/action-creators.ts
@@ -47,6 +47,7 @@ import {
   ResetMessageWindow,
   UpdateChannelAtBottom,
 } from './actions'
+import { urlForChannel } from './channel-url'
 import { newestServerOriginTime, oldestServerOriginTime } from './chat-reducer'
 
 export function getJoinedChannels(spec: RequestHandlingSpec<void>): ThunkAction {
@@ -508,6 +509,56 @@ export function getMessagesAround(
   }
 }
 
+/**
+ * Loads a window of messages centered on a particular message, replacing whatever is currently
+ * loaded for the channel. This is how the client reaches a message named by a link, which can sit
+ * anywhere in the channel's history. The caller is expected to handle errors: a message the server
+ * can't find in the channel (it never existed there, or has been deleted) fails the request.
+ */
+export function getMessagesAroundMessage(
+  channelId: SbChannelId,
+  limit: number,
+  messageId: string,
+  spec: RequestHandlingSpec<void>,
+): ThunkAction {
+  return abortableThunk(spec, async (dispatch, getStore) => {
+    const {
+      chat: { idToMessages },
+    } = getStore()
+    const channelMessages = idToMessages.get(channelId)
+    if (!channelMessages) {
+      return
+    }
+
+    const knownNewest = Math.max(
+      newestServerOriginTime(channelMessages.messages) ?? -Infinity,
+      channelMessages.detachedNewestTime ?? -Infinity,
+    )
+    const params = {
+      channelId,
+      limit,
+      aroundMessageId: messageId,
+      windowGen: channelMessages.windowGen,
+      knownNewestTime: knownNewest === -Infinity ? undefined : knownNewest,
+    }
+
+    const promise = fetchJson<GetChannelHistoryServerResponse>(
+      apiUrl`chat/${channelId}/messages2?limit=${limit}&aroundMessageId=${messageId}`,
+      { method: 'GET' },
+    )
+    dispatch({
+      type: '@chat/loadMessagesAroundBegin',
+      payload: params,
+    })
+    dispatch({
+      type: '@chat/loadMessagesAround',
+      payload: promise,
+      meta: params,
+    })
+    await promise
+  })
+}
+
 export function resetMessageWindow(channelId: SbChannelId): ResetMessageWindow {
   return {
     type: '@chat/resetMessageWindow',
@@ -780,7 +831,14 @@ export function updateChannelAtBottom(
 }
 
 export function navigateToChannel(channelId: SbChannelId, channelName: string) {
-  push(urlPath`/chat/${channelId}/${channelName}`)
+  const path = urlForChannel(channelId, channelName)
+  // Arriving at a channel that's already on screen (joining it from its own info page) keeps
+  // whatever the URL carries about this channel, such as a message the user followed a link to.
+  // Coming from anywhere else, the search belongs to the page being left behind.
+  const search = window.location.pathname.startsWith(urlPath`/chat/${channelId}/`)
+    ? window.location.search
+    : ''
+  push(path + search)
 }
 
 /**
@@ -789,5 +847,7 @@ export function navigateToChannel(channelId: SbChannelId, channelName: string) {
  * for their channel ID.
  */
 export function correctChannelNameForChat(channelId: SbChannelId, channelName: string) {
-  replace(urlPath`/chat/${channelId}/${channelName}`)
+  // The correction is only about the name segment: the rest of the URL still describes what the
+  // user asked for, and dropping it would undo a message link before the page could act on it.
+  replace(urlForChannel(channelId, channelName) + window.location.search)
 }

--- a/client/chat/action-creators.ts
+++ b/client/chat/action-creators.ts
@@ -674,8 +674,14 @@ const channelsBatchRequester = new MicrotaskBatchRequester<SbChannelId>(
 export function getBatchChannelInfo(channelId: SbChannelId): ThunkAction {
   return (dispatch, getState) => {
     const {
-      chat: { idToBasicInfo, idToDetailedInfo },
+      chat: { idToBasicInfo, idToDetailedInfo, deletedChannels, privateChannels },
     } = getState()
+
+    // The server would just report the same thing again for either of these, so re-requesting
+    // them on every mount of a name for the channel would only add load for no new information.
+    if (deletedChannels.has(channelId) || privateChannels.has(channelId)) {
+      return
+    }
 
     if (!idToBasicInfo.has(channelId) || !idToDetailedInfo.has(channelId)) {
       channelsBatchRequester.request(dispatch, channelId)

--- a/client/chat/actions.ts
+++ b/client/chat/actions.ts
@@ -262,7 +262,10 @@ export interface LoadMessagesAroundBegin {
   payload: {
     channelId: SbChannelId
     limit: number
-    aroundTime: number
+    /** The time the window was asked for around, when the request named a time. */
+    aroundTime?: number
+    /** The message the window was asked for around, when the request named a message. */
+    aroundMessageId?: string
     windowGen: number
     /**
      * The newest server-recorded message time (epoch ms) this client knew existed when the request
@@ -276,9 +279,9 @@ export interface LoadMessagesAroundBegin {
 }
 
 /**
- * Loads a window of up to `limit` messages in a chat channel centered on a particular time. The
- * result replaces whatever was loaded for the channel, since the fetched range doesn't have to
- * touch it.
+ * Loads a window of up to `limit` messages in a chat channel centered on a particular point in its
+ * history, named either by time or by one of its messages. The result replaces whatever was loaded
+ * for the channel, since the fetched range doesn't have to touch it.
  */
 export interface LoadMessagesAround {
   type: '@chat/loadMessagesAround'
@@ -286,7 +289,10 @@ export interface LoadMessagesAround {
   meta: {
     channelId: SbChannelId
     limit: number
-    aroundTime: number
+    /** The time the window was asked for around, when the request named a time. */
+    aroundTime?: number
+    /** The message the window was asked for around, when the request named a message. */
+    aroundMessageId?: string
     windowGen: number
     /**
      * The newest server-recorded message time (epoch ms) this client knew existed when the request
@@ -304,7 +310,10 @@ export interface LoadMessagesAroundFailure extends BaseFetchFailure<'@chat/loadM
   meta: {
     channelId: SbChannelId
     limit: number
-    aroundTime: number
+    /** The time the window was asked for around, when the request named a time. */
+    aroundTime?: number
+    /** The message the window was asked for around, when the request named a message. */
+    aroundMessageId?: string
     windowGen: number
     /**
      * The newest server-recorded message time (epoch ms) this client knew existed when the request

--- a/client/chat/channel-menu-items.tsx
+++ b/client/chat/channel-menu-items.tsx
@@ -1,18 +1,22 @@
 import { useContext, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { appendToMultimap } from '../../common/data-structures/maps'
+import { getErrorStack } from '../../common/errors'
 import { useHasAnyPermission } from '../admin/admin-permissions'
 import { openDialog } from '../dialogs/action-creators'
 import { DialogType } from '../dialogs/dialog-type'
-import { DestructiveMenuItem } from '../material/menu/item'
+import logger from '../logging/logger'
+import { DestructiveMenuItem, MenuItem } from '../material/menu/item'
 import {
   MenuItemCategory as MessageMenuItemCategory,
   MessageMenuProps,
 } from '../messaging/message-context-menu'
+import { getServerOrigin } from '../network/server-url'
 import { useAppDispatch, useAppSelector } from '../redux-hooks'
 import { MenuItemCategory, UserMenuProps } from '../users/user-context-menu'
 import { getChatUserProfile } from './action-creators'
 import { ChannelContext } from './channel-context'
+import { urlForChannelMessage } from './channel-url'
 
 export function ChannelUserMenu({ userId, items, onMenuClose, MenuComponent }: UserMenuProps) {
   const { t } = useTranslation()
@@ -131,9 +135,25 @@ export function ChannelMessageMenu({
   const { t } = useTranslation()
   const dispatch = useAppDispatch()
   const { channelId } = useContext(ChannelContext)
+  const channelName = useAppSelector(s => s.chat.idToBasicInfo.get(channelId)?.name)
   const isServerModerator = useHasAnyPermission('moderateChatChannels')
 
   const menuItems = new Map(items)
+  appendToMultimap(
+    menuItems,
+    MessageMenuItemCategory.General,
+    <MenuItem
+      key='copy-message-link'
+      text={t('chat.messageMenu.copyMessageLink', 'Copy message link')}
+      onClick={() => {
+        navigator.clipboard
+          .writeText(getServerOrigin() + urlForChannelMessage(channelId, channelName, messageId))
+          .catch(err => logger.error(`Error writing to clipboard: ${getErrorStack(err)}`))
+        onMenuClose()
+      }}
+    />,
+  )
+
   if (isServerModerator) {
     appendToMultimap(
       menuItems,

--- a/client/chat/channel-message-link.tsx
+++ b/client/chat/channel-message-link.tsx
@@ -1,0 +1,42 @@
+import { useTranslation } from 'react-i18next'
+import { SbChannelId } from '../../common/chat'
+import { ExternalLink, isShieldBatteryUrl } from '../navigation/external-link'
+import { channelMessageFromUrl, ChannelMessageLinkTarget } from './channel-url'
+import { ConnectedChannelName } from './connected-channel-name'
+
+/**
+ * Returns the channel and message embedded in a chat message link, or undefined if the link isn't
+ * a ShieldBattery channel message link (an external URL, or a ShieldBattery URL for something
+ * other than a channel message).
+ */
+export function channelMessageFromMessageLink(href: string): ChannelMessageLinkTarget | undefined {
+  let url: URL
+  try {
+    url = new URL(href)
+  } catch {
+    return undefined
+  }
+
+  return isShieldBatteryUrl(url) ? channelMessageFromUrl(url) : undefined
+}
+
+/**
+ * Renders a chat message link (minted by "Copy message link", see `channel-menu-items.tsx`) as an
+ * in-app link labeled with the channel it points at, e.g. "#some-channel › message", rather than
+ * the raw URL. The URL is intentionally not shown as text -- it still lives on the rendered
+ * anchor's `href`, so "Copy link" in the message context menu (which reads the clicked element's
+ * closest anchor's `href`) and ctrl/shift-click to open in a new window both still work on it.
+ */
+export function ChannelMessageLink({ href, channelId }: { href: string; channelId: SbChannelId }) {
+  const { t } = useTranslation()
+
+  return (
+    <ExternalLink href={href}>
+      <ConnectedChannelName channelId={channelId} interactive={false} />
+      {/* Non-breaking spaces keep the label from wrapping between its parts, while an over-long
+          channel name can still break mid-word the way any other over-long word in the message does. */}
+      {'\u00A0›\u00A0'}
+      {t('chat.messageLink.label', 'message')}
+    </ExternalLink>
+  )
+}

--- a/client/chat/channel-message-link.tsx
+++ b/client/chat/channel-message-link.tsx
@@ -1,5 +1,7 @@
 import { useTranslation } from 'react-i18next'
+import styled from 'styled-components'
 import { SbChannelId } from '../../common/chat'
+import { MaterialIcon } from '../icons/material/material-icon'
 import { ExternalLink, isShieldBatteryUrl } from '../navigation/external-link'
 import { channelMessageFromUrl, ChannelMessageLinkTarget } from './channel-url'
 import { ConnectedChannelName } from './connected-channel-name'
@@ -20,23 +22,76 @@ export function channelMessageFromMessageLink(href: string): ChannelMessageLinkT
   return isShieldBatteryUrl(url) ? channelMessageFromUrl(url) : undefined
 }
 
+// Message rows render inside a fixed 20px line box (see `TimestampMessageLayout` in
+// `client/messaging/message-layout.tsx`), so the chip is exactly that tall and top-aligned to sit
+// inside the line without growing it. `inline-flex` makes it an atomic inline that wraps as one
+// unit rather than splitting across lines; `max-width: 100%` combined with the ellipsized channel
+// name below keeps an over-long name from overflowing the message list horizontally instead of
+// wrapping. The link color itself comes from the global `a:link`/`a:hover` rules (see
+// `client/styles/global.ts`), so the chip still reads as a link -- only their underline needs
+// overriding, since this chip conveys its link-ness through its background instead.
+//
+// The message container's hanging indent (72px of padding pulled back with a negative
+// `text-indent`) is meant for the message text only; `text-indent` inherits, and on the chip's
+// flex items it would subtract from each item's intrinsic width and collapse them to nothing, so
+// the chip resets it.
+const ChipLink = styled(ExternalLink)`
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  max-width: 100%;
+  height: 20px;
+  padding: 0 6px 0 4px;
+  vertical-align: top;
+  text-indent: 0;
+
+  border-radius: 4px;
+  background-color: var(--theme-container-high);
+  text-decoration: none;
+
+  &:hover {
+    background-color: var(--theme-container-highest);
+    text-decoration: none;
+  }
+`
+
+const ChipIcon = styled(MaterialIcon)`
+  flex-shrink: 0;
+`
+
+// The only shrinkable chip child: an over-long channel name ellipsizes instead of pushing the chip
+// wider than the available line.
+const ChannelName = styled(ConnectedChannelName)`
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`
+
+const Separator = styled.span`
+  flex-shrink: 0;
+`
+
+const Label = styled.span`
+  flex-shrink: 0;
+`
+
 /**
  * Renders a chat message link (minted by "Copy message link", see `channel-menu-items.tsx`) as an
- * in-app link labeled with the channel it points at, e.g. "#some-channel › message", rather than
- * the raw URL. The URL is intentionally not shown as text -- it still lives on the rendered
- * anchor's `href`, so "Copy link" in the message context menu (which reads the clicked element's
- * closest anchor's `href`) and ctrl/shift-click to open in a new window both still work on it.
+ * in-app chip -- an icon, the channel it points at, and "message" -- rather than the raw URL. The
+ * URL is intentionally not shown as text -- it still lives on the rendered anchor's `href`, so
+ * "Copy link" in the message context menu (which reads the clicked element's closest anchor's
+ * `href`) and ctrl/shift-click to open in a new window both still work on it.
  */
 export function ChannelMessageLink({ href, channelId }: { href: string; channelId: SbChannelId }) {
   const { t } = useTranslation()
 
   return (
-    <ExternalLink href={href}>
-      <ConnectedChannelName channelId={channelId} interactive={false} />
-      {/* Non-breaking spaces keep the label from wrapping between its parts, while an over-long
-          channel name can still break mid-word the way any other over-long word in the message does. */}
-      {'\u00A0›\u00A0'}
-      {t('chat.messageLink.label', 'message')}
-    </ExternalLink>
+    <ChipLink href={href}>
+      <ChipIcon icon='chat' size={16} />
+      <ChannelName channelId={channelId} interactive={false} />
+      <Separator>›</Separator>
+      <Label>{t('chat.messageLink.label', 'message')}</Label>
+    </ChipLink>
   )
 }

--- a/client/chat/channel-url.test.ts
+++ b/client/chat/channel-url.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test } from 'vitest'
 import { makeSbChannelId } from '../../common/chat'
-import { MESSAGE_LINK_PARAM, urlForChannel, urlForChannelMessage } from './channel-url'
+import {
+  channelMessageFromUrl,
+  MESSAGE_LINK_PARAM,
+  urlForChannel,
+  urlForChannelMessage,
+} from './channel-url'
 
 const CHANNEL_ID = makeSbChannelId(7)
 const MESSAGE_ID = '9b2e8d0e-5f3a-4a2b-8c1d-6f5e4d3c2b1a'
@@ -39,6 +44,60 @@ describe('chat/channel-url', () => {
       const search = new URLSearchParams(url.substring(url.indexOf('?')))
 
       expect(search.get(MESSAGE_LINK_PARAM)).toBe(MESSAGE_ID)
+    })
+  })
+
+  describe('channelMessageFromUrl', () => {
+    test('round-trips a URL built by urlForChannelMessage', () => {
+      const path = urlForChannelMessage(CHANNEL_ID, 'ShieldBattery', MESSAGE_ID)
+      const url = new URL(path, 'https://example.org')
+
+      expect(channelMessageFromUrl(url)).toEqual({ channelId: CHANNEL_ID, messageId: MESSAGE_ID })
+    })
+
+    test('ignores the channel name segment', () => {
+      const url = new URL(
+        `/chat/7/some-other-name?${MESSAGE_LINK_PARAM}=${MESSAGE_ID}`,
+        'https://example.org',
+      )
+
+      expect(channelMessageFromUrl(url)).toEqual({ channelId: CHANNEL_ID, messageId: MESSAGE_ID })
+    })
+
+    test('ignores the placeholder channel name segment', () => {
+      const url = new URL(`/chat/7/_?${MESSAGE_LINK_PARAM}=${MESSAGE_ID}`, 'https://example.org')
+
+      expect(channelMessageFromUrl(url)).toEqual({ channelId: CHANNEL_ID, messageId: MESSAGE_ID })
+    })
+
+    test('rejects a non-chat path', () => {
+      const url = new URL(`/lobbies/7?${MESSAGE_LINK_PARAM}=${MESSAGE_ID}`, 'https://example.org')
+
+      expect(channelMessageFromUrl(url)).toBeUndefined()
+    })
+
+    test('rejects a non-numeric channel id', () => {
+      const url = new URL(
+        `/chat/not-a-number/ShieldBattery?${MESSAGE_LINK_PARAM}=${MESSAGE_ID}`,
+        'https://example.org',
+      )
+
+      expect(channelMessageFromUrl(url)).toBeUndefined()
+    })
+
+    test('rejects a missing message param', () => {
+      const url = new URL('/chat/7/ShieldBattery', 'https://example.org')
+
+      expect(channelMessageFromUrl(url)).toBeUndefined()
+    })
+
+    test('rejects a non-UUID message param', () => {
+      const url = new URL(
+        `/chat/7/ShieldBattery?${MESSAGE_LINK_PARAM}=not-a-uuid`,
+        'https://example.org',
+      )
+
+      expect(channelMessageFromUrl(url)).toBeUndefined()
     })
   })
 })

--- a/client/chat/channel-url.test.ts
+++ b/client/chat/channel-url.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from 'vitest'
+import { makeSbChannelId } from '../../common/chat'
+import { MESSAGE_LINK_PARAM, urlForChannel, urlForChannelMessage } from './channel-url'
+
+const CHANNEL_ID = makeSbChannelId(7)
+const MESSAGE_ID = '9b2e8d0e-5f3a-4a2b-8c1d-6f5e4d3c2b1a'
+
+describe('chat/channel-url', () => {
+  describe('urlForChannel', () => {
+    test('builds a channel URL', () => {
+      expect(urlForChannel(CHANNEL_ID, 'ShieldBattery')).toBe('/chat/7/ShieldBattery')
+    })
+
+    test('encodes the channel name', () => {
+      expect(urlForChannel(CHANNEL_ID, 'cool guys/gals')).toBe('/chat/7/cool%20guys%2Fgals')
+    })
+
+    test('uses a placeholder name when the name is unknown', () => {
+      expect(urlForChannel(CHANNEL_ID, undefined)).toBe('/chat/7/_')
+      expect(urlForChannel(CHANNEL_ID, '')).toBe('/chat/7/_')
+    })
+  })
+
+  describe('urlForChannelMessage', () => {
+    test('adds the message to the channel URL', () => {
+      expect(urlForChannelMessage(CHANNEL_ID, 'ShieldBattery', MESSAGE_ID)).toBe(
+        `/chat/7/ShieldBattery?${MESSAGE_LINK_PARAM}=${MESSAGE_ID}`,
+      )
+    })
+
+    test('encodes the message id', () => {
+      expect(urlForChannelMessage(CHANNEL_ID, 'ShieldBattery', 'a b&c')).toBe(
+        `/chat/7/ShieldBattery?${MESSAGE_LINK_PARAM}=a+b%26c`,
+      )
+    })
+
+    test('reads back through URLSearchParams', () => {
+      const url = urlForChannelMessage(CHANNEL_ID, 'ShieldBattery', MESSAGE_ID)
+      const search = new URLSearchParams(url.substring(url.indexOf('?')))
+
+      expect(search.get(MESSAGE_LINK_PARAM)).toBe(MESSAGE_ID)
+    })
+  })
+})

--- a/client/chat/channel-url.ts
+++ b/client/chat/channel-url.ts
@@ -1,4 +1,4 @@
-import { SbChannelId } from '../../common/chat'
+import { makeSbChannelId, SbChannelId } from '../../common/chat'
 import { urlPath } from '../../common/urls'
 
 /**
@@ -30,4 +30,40 @@ export function urlForChannelMessage(
 ): string {
   const params = new URLSearchParams({ [MESSAGE_LINK_PARAM]: messageId })
   return `${urlForChannel(channelId, channelName)}?${params}`
+}
+
+/** Matches a UUID's `8-4-4-4-12` hex layout, case-insensitively. */
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+/** A channel message link's target: the channel it's in and the message it points at. */
+export interface ChannelMessageLinkTarget {
+  channelId: SbChannelId
+  messageId: string
+}
+
+/**
+ * Returns the channel and message a channel message link points at, or undefined if `url` isn't
+ * one: its pathname must be `/chat/<channelId>/<name>` (the name segment is ignored — the id is
+ * authoritative, and a stale or placeholder name gets corrected in place once the channel page
+ * loads the real one), and it must carry a {@link MESSAGE_LINK_PARAM} search param that looks like
+ * a UUID. Doesn't check the URL's origin; callers that only want ShieldBattery's own links (as
+ * opposed to some other site that happens to have a `/chat/...` path) must check that themselves.
+ */
+export function channelMessageFromUrl(url: URL): ChannelMessageLinkTarget | undefined {
+  const segments = url.pathname.split('/').filter(segment => segment.length > 0)
+  if (segments.length < 2 || segments[0] !== 'chat' || !/^\d+$/.test(segments[1])) {
+    return undefined
+  }
+
+  const channelId = Number(segments[1])
+  if (!Number.isSafeInteger(channelId) || channelId <= 0) {
+    return undefined
+  }
+
+  const messageId = url.searchParams.get(MESSAGE_LINK_PARAM)
+  if (!messageId || !UUID_PATTERN.test(messageId)) {
+    return undefined
+  }
+
+  return { channelId: makeSbChannelId(channelId), messageId }
 }

--- a/client/chat/channel-url.ts
+++ b/client/chat/channel-url.ts
@@ -1,0 +1,33 @@
+import { SbChannelId } from '../../common/chat'
+import { urlPath } from '../../common/urls'
+
+/**
+ * Stand-in for a channel's name in its URL when the name isn't known. The route needs something in
+ * that segment, and the name is corrected in place once the channel's info is available.
+ */
+const UNKNOWN_CHANNEL_NAME = '_'
+
+/**
+ * Name of the query param that points a channel URL at one particular message in the channel.
+ * Reading and writing it must go through this name so a link and the page that consumes it can't
+ * disagree.
+ */
+export const MESSAGE_LINK_PARAM = 'm'
+
+/** Returns the URL for a chat channel. */
+export function urlForChannel(channelId: SbChannelId, channelName: string | undefined): string {
+  return urlPath`/chat/${channelId}/${channelName || UNKNOWN_CHANNEL_NAME}`
+}
+
+/**
+ * Returns the URL for a chat channel that points at one of its messages. Opening it moves the
+ * message list to that message, wherever in the channel's history it sits.
+ */
+export function urlForChannelMessage(
+  channelId: SbChannelId,
+  channelName: string | undefined,
+  messageId: string,
+): string {
+  const params = new URLSearchParams({ [MESSAGE_LINK_PARAM]: messageId })
+  return `${urlForChannel(channelId, channelName)}?${params}`
+}

--- a/client/chat/channel.tsx
+++ b/client/chat/channel.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useEffectEvent, useMemo, useState } from 'react'
+import React, { useEffect, useEffectEvent, useMemo, useRef, useState } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 import {
@@ -15,11 +15,14 @@ import { anchorNeedsFetch, chatViewAnchorStore } from '../messaging/chat-view-an
 import { flushLastRead } from '../messaging/last-read'
 import { MAX_MENTIONED_USERS } from '../messaging/message-input'
 import { MessageComponentProps } from '../messaging/message-list'
+import { useLocationSearchParam } from '../navigation/router-hooks'
 import { push } from '../navigation/routing'
 import { isFetchError } from '../network/fetch-errors'
 import { LoadingDotsArea } from '../progress/dots'
 import { usePrevious, useStableCallback } from '../react/state-hooks'
 import { useAppDispatch, useAppSelector } from '../redux-hooks'
+import { DURATION_LONG } from '../snackbars/snackbar-durations'
+import { useSnackbarController } from '../snackbars/snackbar-overlay'
 import { CenteredContentContainer } from '../styles/centered-container'
 import { bodyLarge, titleLarge } from '../styles/typography'
 import { areUserEntriesEqual, useUserEntriesSelector } from '../users/user-entries'
@@ -31,6 +34,7 @@ import {
   getChannelLastReadKey,
   getMessageHistory,
   getMessagesAround,
+  getMessagesAroundMessage,
   getNewerMessages,
   jumpToPresent,
   leaveChannelWithConfirmation,
@@ -45,6 +49,7 @@ import { CHANNEL_HEADER_HEIGHT, ChannelHeader } from './channel-header'
 import { ConnectedChannelInfoCard } from './channel-info-card'
 import { ChannelMessageMenu, ChannelUserMenu } from './channel-menu-items'
 import { ConnectedChannelSettings } from './channel-settings/channel-settings'
+import { MESSAGE_LINK_PARAM } from './channel-url'
 import { UserList } from './channel-user-list'
 import {
   BanUserMessage,
@@ -170,6 +175,11 @@ export function ConnectedChatChannel({
   const isAtBottom = useAppSelector(s => s.chat.atBottomChannels.has(channelId))
   const unreadLineTime = useAppSelector(s => s.chat.idToUnreadLineTime.get(channelId))
   const isWindowFocused = useWindowFocus()
+  const snackbarController = useSnackbarController()
+  const { t } = useTranslation()
+  // A message named by a link the user followed here. It's consumed rather than kept: once the list
+  // has acted on it the param goes away, so reloading the page afterwards is an ordinary visit.
+  const [linkedMessageId, setLinkedMessageId] = useLocationSearchParam(MESSAGE_LINK_PARAM)
 
   // NOTE(2Pac): When user types the single @ character in chat, we show the ten most recent
   // chatters in the channel as an option to mention.
@@ -265,6 +275,12 @@ export function ConnectedChatChannel({
     const anchor = chatViewAnchorStore.get(viewStateKey)
     dispatch(activateChannel(channelId))
 
+    if (linkedMessageId) {
+      // A link names the window this activation needs, which the effect below requests. The
+      // position the user left behind is where they were, not where they just asked to go.
+      return
+    }
+
     if (anchor && anchorNeedsFetch(channelMessages?.messages ?? [], anchor)) {
       // Getting back to where the user was reading takes a window the client doesn't hold, so that
       // window is this activation's history request instead of the newest page the list would
@@ -286,6 +302,85 @@ export function ConnectedChatChannel({
       dispatch(deactivateChannel(channelId))
     }
   }, [isInChannel, channelId, dispatch])
+
+  const onLinkedMessage = useEffectEvent((messageId: string, signal: AbortSignal) => {
+    // The window that's loaded doesn't hold the message; the request below replaces it with one that
+    // does, showing the current messages under a loading indicator until it lands. The window isn't
+    // dropped up front: an abandoned request (the user leaving, or a development remount) would
+    // otherwise leave it empty with nothing to refill it.
+    dispatch(
+      getMessagesAroundMessage(channelId, MESSAGES_LIMIT, messageId, {
+        signal,
+        onSuccess: () => {},
+        onError: err => {
+          if (isFetchError(err) && err.code === ChatServiceErrorCode.MessageNotFound) {
+            snackbarController.showSnackbar(
+              t(
+                'chat.errors.messageNotFound',
+                "That message couldn't be found. It may have been deleted.",
+              ),
+              DURATION_LONG,
+            )
+          } else {
+            snackbarController.showSnackbar(
+              t('chat.errors.loadingHistory', {
+                defaultValue: 'Error loading message history: {{errorMessage}}',
+                errorMessage: err.message,
+              }),
+              DURATION_LONG,
+            )
+          }
+
+          // The window was dropped to make room for one that can't be had, so the channel goes back
+          // to the newest messages rather than being left empty.
+          setLinkedMessageId('')
+          dispatch(jumpToPresent(channelId, MESSAGES_LIMIT))
+        },
+      }),
+    )
+  })
+
+  // Holds the request for the window a linked message sits in, so it's made once for a given link
+  // and abandoned only when the link or channel changes — not on the message updates that settling
+  // the channel's own window brings.
+  const linkFetchRef = useRef<AbortController | undefined>(undefined)
+  useEffect(() => {
+    return () => {
+      linkFetchRef.current?.abort()
+      linkFetchRef.current = undefined
+    }
+  }, [channelId, linkedMessageId])
+
+  // A link into a channel is reached by loading the window its message sits in, but only once the
+  // channel's own window has settled. A message already loaded there is placed by the list with no
+  // fetch at all; a fetch made before the entry even exists, or against the empty window a channel
+  // starts with, would either be dropped or race the channel's initial load. So this waits for the
+  // window to hold messages (or to have run out of history) and to be idle, then loads around the
+  // message if it isn't already on screen. The reading position the user left behind gives way to
+  // it: a link names where they just asked to go.
+  useEffect(() => {
+    if (!isInChannel || !linkedMessageId || !channelMessages || linkFetchRef.current) {
+      return
+    }
+    if (channelMessages.messages.some(m => m.id === linkedMessageId)) {
+      return
+    }
+    if (channelMessages.loadingHistory) {
+      return
+    }
+    if (channelMessages.messages.length === 0 && channelMessages.hasHistory) {
+      return
+    }
+
+    const abortController = new AbortController()
+    linkFetchRef.current = abortController
+    onLinkedMessage(linkedMessageId, abortController.signal)
+  }, [isInChannel, channelId, linkedMessageId, channelMessages])
+
+  const onLinkedMessageSettled = () => {
+    // However the move came out, the link has been acted on and shouldn't move the list again.
+    setLinkedMessageId('')
+  }
 
   // The newest server-recorded message time: client-only messages (e.g. the self-join banner) are
   // stamped with the local clock, so they can't be reported as a read position.
@@ -376,6 +471,8 @@ export function ConnectedChatChannel({
               mentionableUsers,
               baseMentionableUsers,
             }}
+            linkedMessageId={linkedMessageId || undefined}
+            onLinkedMessageSettled={onLinkedMessageSettled}
             onAtBottomChange={onAtBottomChange}
             onJumpToPresent={onJumpToPresent}
             onSeekToUnread={onSeekToUnread}

--- a/client/chat/chat-reducer.test.ts
+++ b/client/chat/chat-reducer.test.ts
@@ -6,6 +6,7 @@ import {
   ChatMessage,
   ChatMessageEvent,
   ClientChatMessageType,
+  GetBatchedChannelInfosResponse,
   GetChannelHistoryServerResponse,
   InitialChannelData,
   SbChannelId,
@@ -101,6 +102,7 @@ function makeState(
     atBottomChannels: new Set(overrides.atBottom ? [CHANNEL_ID] : []),
     unreadChannels: new Set(overrides.unread ? [CHANNEL_ID] : []),
     deletedChannels: new Set(),
+    privateChannels: new Set(),
     idToLastReadTime: new Map(
       overrides.lastReadTime !== undefined ? [[CHANNEL_ID, overrides.lastReadTime]] : [],
     ),
@@ -474,6 +476,57 @@ describe('client/chat/chat-reducer', () => {
       const result = chatReducer(state, getJoinedChannelsAction(initialChannelData()))
 
       expect(result.idToLatestMentionTime.has(CHANNEL_ID)).toBe(false)
+    })
+  })
+
+  describe('@chat/getBatchChannelInfo', () => {
+    const PRIVATE_CHANNEL_ID = makeSbChannelId(2)
+
+    function getBatchChannelInfoAction(
+      payload: Partial<GetBatchedChannelInfosResponse> = {},
+    ): ChatActions {
+      return {
+        type: '@chat/getBatchChannelInfo',
+        payload: {
+          channelInfos: [],
+          detailedChannelInfos: [],
+          joinedChannelInfos: [],
+          deletedChannels: [],
+          privateChannels: [],
+          ...payload,
+        },
+      }
+    }
+
+    test('adds ids the server reports as private to privateChannels', () => {
+      const state = makeState()
+
+      const result = chatReducer(
+        state,
+        getBatchChannelInfoAction({ privateChannels: [PRIVATE_CHANNEL_ID] }),
+      )
+
+      expect(result.privateChannels.has(PRIVATE_CHANNEL_ID)).toBe(true)
+    })
+
+    test('clears an id from privateChannels once its basic info arrives', () => {
+      const state = makeState()
+      const withPrivate = chatReducer(
+        state,
+        getBatchChannelInfoAction({ privateChannels: [PRIVATE_CHANNEL_ID] }),
+      )
+
+      const result = chatReducer(
+        withPrivate,
+        getBatchChannelInfoAction({
+          channelInfos: [
+            { id: PRIVATE_CHANNEL_ID, name: 'now-visible', private: false, official: false },
+          ],
+        }),
+      )
+
+      expect(result.privateChannels.has(PRIVATE_CHANNEL_ID)).toBe(false)
+      expect(result.idToBasicInfo.get(PRIVATE_CHANNEL_ID)?.name).toBe('now-visible')
     })
   })
 

--- a/client/chat/chat-reducer.test.ts
+++ b/client/chat/chat-reducer.test.ts
@@ -528,6 +528,30 @@ describe('client/chat/chat-reducer', () => {
       expect(result.privateChannels.has(PRIVATE_CHANNEL_ID)).toBe(false)
       expect(result.idToBasicInfo.get(PRIVATE_CHANNEL_ID)?.name).toBe('now-visible')
     })
+
+    test('clears an id from privateChannels when the channel is joined', () => {
+      const state = makeState()
+      const withPrivate = chatReducer(
+        state,
+        getBatchChannelInfoAction({ privateChannels: [PRIVATE_CHANNEL_ID] }),
+      )
+
+      expect(withPrivate.privateChannels.has(PRIVATE_CHANNEL_ID)).toBe(true)
+
+      const data = initialChannelData()
+      const result = chatReducer(
+        withPrivate,
+        getJoinedChannelsAction({
+          ...data,
+          channelInfo: { ...data.channelInfo, id: PRIVATE_CHANNEL_ID },
+          detailedChannelInfo: { ...data.detailedChannelInfo, id: PRIVATE_CHANNEL_ID },
+          joinedChannelInfo: { ...data.joinedChannelInfo, id: PRIVATE_CHANNEL_ID },
+        }),
+      )
+
+      expect(result.privateChannels.has(PRIVATE_CHANNEL_ID)).toBe(false)
+      expect(result.idToBasicInfo.get(PRIVATE_CHANNEL_ID)).toBeDefined()
+    })
   })
 
   describe('@chat/updateMessage', () => {

--- a/client/chat/chat-reducer.ts
+++ b/client/chat/chat-reducer.ts
@@ -558,9 +558,7 @@ function initChannel(state: ChatState, channelId: SbChannelId, data: InitialChan
     carriedClientMessages: [],
   }
   state.joinedChannels.add(channelId)
-  state.idToBasicInfo.set(channelId, channelInfo)
-  state.idToDetailedInfo.set(channelId, detailedChannelInfo)
-  state.idToJoinedInfo.set(channelId, joinedChannelInfo)
+  updateChannelInfos(state, [channelInfo], [detailedChannelInfo], [joinedChannelInfo])
   initChannelUsers(state, channelId)
   state.idToMessages.set(channelId, messagesState)
   state.idToUserProfiles.set(channelId, new Map())

--- a/client/chat/chat-reducer.ts
+++ b/client/chat/chat-reducer.ts
@@ -98,6 +98,12 @@ export interface ChatState {
   /** A set of channel IDs saved in various chat messages that no longer exist. */
   deletedChannels: Set<SbChannelId>
   /**
+   * Channels known to exist whose info the server withheld because they're private and the user
+   * isn't a member. An id leaves this set as soon as its info arrives (e.g. after the user is
+   * invited and joins).
+   */
+  privateChannels: Set<SbChannelId>
+  /**
    * A map of channel ID -> the client's view of the server-recorded read position (epoch ms).
    * Seeded from the server at init, and advanced optimistically whenever the client reports a
    * mark-read for the channel.
@@ -134,6 +140,7 @@ const DEFAULT_CHAT_STATE: Immutable<ChatState> = {
   atBottomChannels: new Set(),
   unreadChannels: new Set(),
   deletedChannels: new Set(),
+  privateChannels: new Set(),
   idToLastReadTime: new Map(),
   idToLatestMentionTime: new Map(),
   idToUnreadLineTime: new Map(),
@@ -489,6 +496,7 @@ function updateChannelInfos(
   for (const channel of basicChannelInfos) {
     state.idToBasicInfo.set(channel.id, channel)
     state.deletedChannels.delete(channel.id)
+    state.privateChannels.delete(channel.id)
   }
   for (const channel of detailedChannelInfos) {
     state.idToDetailedInfo.set(channel.id, channel)
@@ -501,6 +509,12 @@ function updateChannelInfos(
 function updateDeletedChannels(state: ChatState, deletedChannels: SbChannelId[]) {
   for (const channelId of deletedChannels) {
     state.deletedChannels.add(channelId)
+  }
+}
+
+function updatePrivateChannels(state: ChatState, privateChannels: SbChannelId[]) {
+  for (const channelId of privateChannels) {
+    state.privateChannels.add(channelId)
   }
 }
 
@@ -1016,11 +1030,17 @@ export default immerKeyedReducer(DEFAULT_CHAT_STATE, {
       return
     }
 
-    const { channelInfos, detailedChannelInfos, joinedChannelInfos, deletedChannels } =
-      action.payload
+    const {
+      channelInfos,
+      detailedChannelInfos,
+      joinedChannelInfos,
+      deletedChannels,
+      privateChannels,
+    } = action.payload
 
     updateChannelInfos(state, channelInfos, detailedChannelInfos, joinedChannelInfos)
     updateDeletedChannels(state, deletedChannels)
+    updatePrivateChannels(state, privateChannels)
   },
 
   ['@chat/searchChannels'](state, action) {

--- a/client/chat/chat-reducer.ts
+++ b/client/chat/chat-reducer.ts
@@ -1016,9 +1016,11 @@ export default immerKeyedReducer(DEFAULT_CHAT_STATE, {
       return
     }
 
-    const { channelInfos, detailedChannelInfos, joinedChannelInfos } = action.payload
+    const { channelInfos, detailedChannelInfos, joinedChannelInfos, deletedChannels } =
+      action.payload
 
     updateChannelInfos(state, channelInfos, detailedChannelInfos, joinedChannelInfos)
+    updateDeletedChannels(state, deletedChannels)
   },
 
   ['@chat/searchChannels'](state, action) {

--- a/client/chat/connected-channel-name.tsx
+++ b/client/chat/connected-channel-name.tsx
@@ -39,7 +39,10 @@ export interface ConnectedChannelNameProps {
 
 /**
  * A component which, given a channel ID, displays a clickable channel name, which displays channel
- * info when clicked.
+ * info when clicked. Renders one of three non-name placeholders instead when there's no name to
+ * show: a loading skeleton while the channel's info hasn't arrived yet, "#deleted-channel" for an
+ * id that no longer names any channel, and "#private-channel" for a private channel the viewer
+ * isn't a member of (the server withholds its name from non-members).
  */
 export function ConnectedChannelName({
   className,
@@ -50,12 +53,13 @@ export function ConnectedChannelName({
   const dispatch = useAppDispatch()
   const basicChannelInfo = useAppSelector(s => s.chat.idToBasicInfo.get(channelId))
   const isChannelDeleted = useAppSelector(s => s.chat.deletedChannels.has(channelId))
+  const isChannelPrivate = useAppSelector(s => s.chat.privateChannels.has(channelId))
 
   useEffect(() => {
-    if (!isChannelDeleted) {
+    if (!isChannelDeleted && !isChannelPrivate) {
       dispatch(getBatchChannelInfo(channelId))
     }
-  }, [dispatch, channelId, isChannelDeleted])
+  }, [dispatch, channelId, isChannelDeleted, isChannelPrivate])
 
   const [anchor, anchorX, anchorY, refreshAnchorPos] = useRefAnchorPosition('right', 'top')
   const [channelInfoCardOpen, openChannelInfoCard, closeChannelInfoCard] = usePopoverController({
@@ -70,7 +74,15 @@ export function ConnectedChannelName({
   }
 
   if (isChannelDeleted) {
-    return <span>#{t('chat.channelName.deletedChannel', 'deleted-channel')}</span>
+    return (
+      <span className={className}>#{t('chat.channelName.deletedChannel', 'deleted-channel')}</span>
+    )
+  }
+
+  if (isChannelPrivate) {
+    return (
+      <span className={className}>#{t('chat.channelName.privateChannel', 'private-channel')}</span>
+    )
   }
 
   return (

--- a/client/chat/connected-channel-name.tsx
+++ b/client/chat/connected-channel-name.tsx
@@ -42,7 +42,9 @@ export interface ConnectedChannelNameProps {
  * info when clicked. Renders one of three non-name placeholders instead when there's no name to
  * show: a loading skeleton while the channel's info hasn't arrived yet, "#deleted-channel" for an
  * id that no longer names any channel, and "#private-channel" for a private channel the viewer
- * isn't a member of (the server withholds its name from non-members).
+ * isn't a member of and whose name the client doesn't already know (the server withholds the name
+ * of a private channel from non-members, but the client can still have learned it separately, e.g.
+ * from a mention in already-loaded message history).
  */
 export function ConnectedChannelName({
   className,
@@ -79,7 +81,7 @@ export function ConnectedChannelName({
     )
   }
 
-  if (isChannelPrivate) {
+  if (isChannelPrivate && !basicChannelInfo) {
     return (
       <span className={className}>#{t('chat.channelName.privateChannel', 'private-channel')}</span>
     )

--- a/client/messaging/__snapshots__/common-message-layout.test.tsx.snap
+++ b/client/messaging/__snapshots__/common-message-layout.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`client/messaging/common-message-layout/TextMessage > message as a norma
   data-testid="message-container"
 >
   <div
-    class="sc-jvDgNt jfqicU"
+    class="sc-jvDgNt kzcowL"
     data-message-id="MESSAGE_ID"
     role="document"
   >
@@ -62,7 +62,7 @@ exports[`client/messaging/common-message-layout/TextMessage > message mixing emo
   data-testid="message-container"
 >
   <div
-    class="sc-jvDgNt jfqicU"
+    class="sc-jvDgNt kzcowL"
     data-message-id="MESSAGE_ID"
     role="document"
   >
@@ -124,7 +124,7 @@ exports[`client/messaging/common-message-layout/TextMessage > message with a lin
   data-testid="message-container"
 >
   <div
-    class="sc-jvDgNt jfqicU"
+    class="sc-jvDgNt kzcowL"
     data-message-id="MESSAGE_ID"
     role="document"
   >
@@ -188,7 +188,7 @@ exports[`client/messaging/common-message-layout/TextMessage > message with a lin
   data-testid="message-container"
 >
   <div
-    class="sc-jvDgNt jfqicU"
+    class="sc-jvDgNt kzcowL"
     data-message-id="MESSAGE_ID"
     role="document"
   >
@@ -265,7 +265,7 @@ exports[`client/messaging/common-message-layout/TextMessage > message with a lin
   data-testid="message-container"
 >
   <div
-    class="sc-jvDgNt jfqicU"
+    class="sc-jvDgNt kzcowL"
     data-message-id="MESSAGE_ID"
     role="document"
   >
@@ -357,7 +357,7 @@ exports[`client/messaging/common-message-layout/TextMessage > message with a men
   data-testid="message-container"
 >
   <div
-    class="sc-jvDgNt jfqicU"
+    class="sc-jvDgNt kzcowL"
     data-message-id="MESSAGE_ID"
     role="document"
   >
@@ -427,7 +427,7 @@ exports[`client/messaging/common-message-layout/TextMessage > message with a men
   data-testid="message-container"
 >
   <div
-    class="sc-jvDgNt jfqicU"
+    class="sc-jvDgNt kzcowL"
     data-message-id="MESSAGE_ID"
     role="document"
   >
@@ -503,7 +503,7 @@ exports[`client/messaging/common-message-layout/TextMessage > message with a men
   data-testid="message-container"
 >
   <div
-    class="sc-jvDgNt jfqicU"
+    class="sc-jvDgNt kzcowL"
     data-message-id="MESSAGE_ID"
     role="document"
   >
@@ -588,7 +588,7 @@ exports[`client/messaging/common-message-layout/TextMessage > message with a men
   data-testid="message-container"
 >
   <div
-    class="sc-jvDgNt TFjef"
+    class="sc-jvDgNt bWKAqk"
     data-message-id="MESSAGE_ID"
     role="document"
   >
@@ -658,7 +658,7 @@ exports[`client/messaging/common-message-layout/TextMessage > message with only 
   data-testid="message-container"
 >
   <div
-    class="sc-jvDgNt jfqicU"
+    class="sc-jvDgNt kzcowL"
     data-message-id="MESSAGE_ID"
     role="document"
   >
@@ -725,7 +725,7 @@ exports[`client/messaging/common-message-layout/TextMessage > message with too m
   data-testid="message-container"
 >
   <div
-    class="sc-jvDgNt jfqicU"
+    class="sc-jvDgNt kzcowL"
     data-message-id="MESSAGE_ID"
     role="document"
   >

--- a/client/messaging/__snapshots__/common-message-layout.test.tsx.snap
+++ b/client/messaging/__snapshots__/common-message-layout.test.tsx.snap
@@ -5,51 +5,51 @@ exports[`client/messaging/common-message-layout/TextMessage > message as a norma
   data-testid="message-container"
 >
   <div
-    class="sc-jvDgNt kzcowL"
+    class="sc-hKOsxR lmgodX"
     data-message-id="MESSAGE_ID"
     role="document"
   >
     <div
-      class="sc-ikrMhg iRLQJB sc-hjIEjD cGTiYu"
+      class="sc-kZvNah kkIpz sc-iXWgTX bBIaqX"
       tabindex="0"
     >
       <span
-        class="sc-bRBteW kFvymL"
+        class="sc-hZoehQ btvgwO"
       >
         <i
           aria-hidden="true"
-          class="sc-jhbick fENxjz"
+          class="sc-jmvSDW hNLerz"
         >
           [
         </i>
         12:00 AM
         <i
           aria-hidden="true"
-          class="sc-jhbick fENxjz"
+          class="sc-jmvSDW hNLerz"
         >
           ] 
         </i>
       </span>
     </div>
     <span
-      class="sc-gHmoSK kRelkX sc-cVdwKd kHdooS"
+      class="sc-jvDgNt dEyFgr sc-fylCKh hhpGLA"
       tabindex="0"
     >
       <span
         aria-label="Username loading…"
-        class="sc-djMJHV upVlS"
+        class="sc-edvVIM kwhisI"
       >
                    
       </span>
     </span>
     <i
       aria-hidden="true"
-      class="sc-jhbick fENxjz"
+      class="sc-jmvSDW hNLerz"
     >
       : 
     </i>
     <span
-      class="sc-kIBtVG heMaNB"
+      class="sc-gerFA dEeYPb"
     >
       This is test message
     </span>
@@ -62,55 +62,55 @@ exports[`client/messaging/common-message-layout/TextMessage > message mixing emo
   data-testid="message-container"
 >
   <div
-    class="sc-jvDgNt kzcowL"
+    class="sc-hKOsxR lmgodX"
     data-message-id="MESSAGE_ID"
     role="document"
   >
     <div
-      class="sc-ikrMhg iRLQJB sc-hjIEjD cGTiYu"
+      class="sc-kZvNah kkIpz sc-iXWgTX bBIaqX"
       tabindex="0"
     >
       <span
-        class="sc-bRBteW kFvymL"
+        class="sc-hZoehQ btvgwO"
       >
         <i
           aria-hidden="true"
-          class="sc-jhbick fENxjz"
+          class="sc-jmvSDW hNLerz"
         >
           [
         </i>
         12:00 AM
         <i
           aria-hidden="true"
-          class="sc-jhbick fENxjz"
+          class="sc-jmvSDW hNLerz"
         >
           ] 
         </i>
       </span>
     </div>
     <span
-      class="sc-gHmoSK kRelkX sc-cVdwKd kHdooS"
+      class="sc-jvDgNt dEyFgr sc-fylCKh hhpGLA"
       tabindex="0"
     >
       <span
         aria-label="Username loading…"
-        class="sc-djMJHV upVlS"
+        class="sc-edvVIM kwhisI"
       >
                    
       </span>
     </span>
     <i
       aria-hidden="true"
-      class="sc-jhbick fENxjz"
+      class="sc-jmvSDW hNLerz"
     >
       : 
     </i>
     <span
-      class="sc-kIBtVG heMaNB"
+      class="sc-gerFA dEeYPb"
     >
       nice game 
       <span
-        class="sc-bGxLfG fVtgOC"
+        class="sc-IAGWt fONgRe"
       >
         🔥
       </span>
@@ -124,51 +124,51 @@ exports[`client/messaging/common-message-layout/TextMessage > message with a lin
   data-testid="message-container"
 >
   <div
-    class="sc-jvDgNt kzcowL"
+    class="sc-hKOsxR lmgodX"
     data-message-id="MESSAGE_ID"
     role="document"
   >
     <div
-      class="sc-ikrMhg iRLQJB sc-hjIEjD cGTiYu"
+      class="sc-kZvNah kkIpz sc-iXWgTX bBIaqX"
       tabindex="0"
     >
       <span
-        class="sc-bRBteW kFvymL"
+        class="sc-hZoehQ btvgwO"
       >
         <i
           aria-hidden="true"
-          class="sc-jhbick fENxjz"
+          class="sc-jmvSDW hNLerz"
         >
           [
         </i>
         12:00 AM
         <i
           aria-hidden="true"
-          class="sc-jhbick fENxjz"
+          class="sc-jmvSDW hNLerz"
         >
           ] 
         </i>
       </span>
     </div>
     <span
-      class="sc-gHmoSK kRelkX sc-cVdwKd kHdooS"
+      class="sc-jvDgNt dEyFgr sc-fylCKh hhpGLA"
       tabindex="0"
     >
       <span
         aria-label="Username loading…"
-        class="sc-djMJHV upVlS"
+        class="sc-edvVIM kwhisI"
       >
                    
       </span>
     </span>
     <i
       aria-hidden="true"
-      class="sc-jhbick fENxjz"
+      class="sc-jmvSDW hNLerz"
     >
       : 
     </i>
     <span
-      class="sc-kIBtVG heMaNB"
+      class="sc-gerFA dEeYPb"
     >
       here is a link 
       <a
@@ -188,51 +188,51 @@ exports[`client/messaging/common-message-layout/TextMessage > message with a lin
   data-testid="message-container"
 >
   <div
-    class="sc-jvDgNt kzcowL"
+    class="sc-hKOsxR lmgodX"
     data-message-id="MESSAGE_ID"
     role="document"
   >
     <div
-      class="sc-ikrMhg iRLQJB sc-hjIEjD cGTiYu"
+      class="sc-kZvNah kkIpz sc-iXWgTX bBIaqX"
       tabindex="0"
     >
       <span
-        class="sc-bRBteW kFvymL"
+        class="sc-hZoehQ btvgwO"
       >
         <i
           aria-hidden="true"
-          class="sc-jhbick fENxjz"
+          class="sc-jmvSDW hNLerz"
         >
           [
         </i>
         12:00 AM
         <i
           aria-hidden="true"
-          class="sc-jhbick fENxjz"
+          class="sc-jmvSDW hNLerz"
         >
           ] 
         </i>
       </span>
     </div>
     <span
-      class="sc-gHmoSK kRelkX sc-cVdwKd kHdooS"
+      class="sc-jvDgNt dEyFgr sc-fylCKh hhpGLA"
       tabindex="0"
     >
       <span
         aria-label="Username loading…"
-        class="sc-djMJHV upVlS"
+        class="sc-edvVIM kwhisI"
       >
                    
       </span>
     </span>
     <i
       aria-hidden="true"
-      class="sc-jhbick fENxjz"
+      class="sc-jmvSDW hNLerz"
     >
       : 
     </i>
     <span
-      class="sc-kIBtVG heMaNB"
+      class="sc-gerFA dEeYPb"
     >
       <a
         href="http://www.example.com"
@@ -244,13 +244,13 @@ exports[`client/messaging/common-message-layout/TextMessage > message with a lin
        go here
        
       <span
-        class="sc-gHmoSK kRelkX sc-kubIlH dmKybX"
+        class="sc-jvDgNt dEyFgr sc-ciUawz ghjPtB"
         tabindex="0"
       >
         @
         <span
           aria-label="Username loading…"
-          class="sc-djMJHV upVlS"
+          class="sc-edvVIM kwhisI"
         >
                      
         </span>
@@ -265,62 +265,62 @@ exports[`client/messaging/common-message-layout/TextMessage > message with a lin
   data-testid="message-container"
 >
   <div
-    class="sc-jvDgNt kzcowL"
+    class="sc-hKOsxR lmgodX"
     data-message-id="MESSAGE_ID"
     role="document"
   >
     <div
-      class="sc-ikrMhg iRLQJB sc-hjIEjD cGTiYu"
+      class="sc-kZvNah kkIpz sc-iXWgTX bBIaqX"
       tabindex="0"
     >
       <span
-        class="sc-bRBteW kFvymL"
+        class="sc-hZoehQ btvgwO"
       >
         <i
           aria-hidden="true"
-          class="sc-jhbick fENxjz"
+          class="sc-jmvSDW hNLerz"
         >
           [
         </i>
         12:00 AM
         <i
           aria-hidden="true"
-          class="sc-jhbick fENxjz"
+          class="sc-jmvSDW hNLerz"
         >
           ] 
         </i>
       </span>
     </div>
     <span
-      class="sc-gHmoSK kRelkX sc-cVdwKd kHdooS"
+      class="sc-jvDgNt dEyFgr sc-fylCKh hhpGLA"
       tabindex="0"
     >
       <span
         aria-label="Username loading…"
-        class="sc-djMJHV upVlS"
+        class="sc-edvVIM kwhisI"
       >
                    
       </span>
     </span>
     <i
       aria-hidden="true"
-      class="sc-jhbick fENxjz"
+      class="sc-jmvSDW hNLerz"
     >
       : 
     </i>
     <span
-      class="sc-kIBtVG heMaNB"
+      class="sc-gerFA dEeYPb"
     >
       hey
        
       <span
-        class="sc-gHmoSK kRelkX sc-kubIlH dmKybX"
+        class="sc-jvDgNt dEyFgr sc-ciUawz ghjPtB"
         tabindex="0"
       >
         @
         <span
           aria-label="Username loading…"
-          class="sc-djMJHV upVlS"
+          class="sc-edvVIM kwhisI"
         >
                      
         </span>
@@ -336,13 +336,13 @@ exports[`client/messaging/common-message-layout/TextMessage > message with a lin
        go here
        
       <span
-        class="sc-gHmoSK kRelkX sc-kubIlH dmKybX"
+        class="sc-jvDgNt dEyFgr sc-ciUawz ghjPtB"
         tabindex="0"
       >
         @
         <span
           aria-label="Username loading…"
-          class="sc-djMJHV upVlS"
+          class="sc-edvVIM kwhisI"
         >
                      
         </span>
@@ -357,62 +357,62 @@ exports[`client/messaging/common-message-layout/TextMessage > message with a men
   data-testid="message-container"
 >
   <div
-    class="sc-jvDgNt kzcowL"
+    class="sc-hKOsxR lmgodX"
     data-message-id="MESSAGE_ID"
     role="document"
   >
     <div
-      class="sc-ikrMhg iRLQJB sc-hjIEjD cGTiYu"
+      class="sc-kZvNah kkIpz sc-iXWgTX bBIaqX"
       tabindex="0"
     >
       <span
-        class="sc-bRBteW kFvymL"
+        class="sc-hZoehQ btvgwO"
       >
         <i
           aria-hidden="true"
-          class="sc-jhbick fENxjz"
+          class="sc-jmvSDW hNLerz"
         >
           [
         </i>
         12:00 AM
         <i
           aria-hidden="true"
-          class="sc-jhbick fENxjz"
+          class="sc-jmvSDW hNLerz"
         >
           ] 
         </i>
       </span>
     </div>
     <span
-      class="sc-gHmoSK kRelkX sc-cVdwKd kHdooS"
+      class="sc-jvDgNt dEyFgr sc-fylCKh hhpGLA"
       tabindex="0"
     >
       <span
         aria-label="Username loading…"
-        class="sc-djMJHV upVlS"
+        class="sc-edvVIM kwhisI"
       >
                    
       </span>
     </span>
     <i
       aria-hidden="true"
-      class="sc-jhbick fENxjz"
+      class="sc-jmvSDW hNLerz"
     >
       : 
     </i>
     <span
-      class="sc-kIBtVG heMaNB"
+      class="sc-gerFA dEeYPb"
     >
       hey
        
       <span
-        class="sc-gHmoSK kRelkX sc-kubIlH dmKybX"
+        class="sc-jvDgNt dEyFgr sc-ciUawz ghjPtB"
         tabindex="0"
       >
         @
         <span
           aria-label="Username loading…"
-          class="sc-djMJHV upVlS"
+          class="sc-edvVIM kwhisI"
         >
                      
         </span>
@@ -427,60 +427,60 @@ exports[`client/messaging/common-message-layout/TextMessage > message with a men
   data-testid="message-container"
 >
   <div
-    class="sc-jvDgNt kzcowL"
+    class="sc-hKOsxR lmgodX"
     data-message-id="MESSAGE_ID"
     role="document"
   >
     <div
-      class="sc-ikrMhg iRLQJB sc-hjIEjD cGTiYu"
+      class="sc-kZvNah kkIpz sc-iXWgTX bBIaqX"
       tabindex="0"
     >
       <span
-        class="sc-bRBteW kFvymL"
+        class="sc-hZoehQ btvgwO"
       >
         <i
           aria-hidden="true"
-          class="sc-jhbick fENxjz"
+          class="sc-jmvSDW hNLerz"
         >
           [
         </i>
         12:00 AM
         <i
           aria-hidden="true"
-          class="sc-jhbick fENxjz"
+          class="sc-jmvSDW hNLerz"
         >
           ] 
         </i>
       </span>
     </div>
     <span
-      class="sc-gHmoSK kRelkX sc-cVdwKd kHdooS"
+      class="sc-jvDgNt dEyFgr sc-fylCKh hhpGLA"
       tabindex="0"
     >
       <span
         aria-label="Username loading…"
-        class="sc-djMJHV upVlS"
+        class="sc-edvVIM kwhisI"
       >
                    
       </span>
     </span>
     <i
       aria-hidden="true"
-      class="sc-jhbick fENxjz"
+      class="sc-jmvSDW hNLerz"
     >
       : 
     </i>
     <span
-      class="sc-kIBtVG heMaNB"
+      class="sc-gerFA dEeYPb"
     >
       <span
-        class="sc-gHmoSK kRelkX sc-kubIlH dmKybX"
+        class="sc-jvDgNt dEyFgr sc-ciUawz ghjPtB"
         tabindex="0"
       >
         @
         <span
           aria-label="Username loading…"
-          class="sc-djMJHV upVlS"
+          class="sc-edvVIM kwhisI"
         >
                      
         </span>
@@ -503,51 +503,51 @@ exports[`client/messaging/common-message-layout/TextMessage > message with a men
   data-testid="message-container"
 >
   <div
-    class="sc-jvDgNt kzcowL"
+    class="sc-hKOsxR lmgodX"
     data-message-id="MESSAGE_ID"
     role="document"
   >
     <div
-      class="sc-ikrMhg iRLQJB sc-hjIEjD cGTiYu"
+      class="sc-kZvNah kkIpz sc-iXWgTX bBIaqX"
       tabindex="0"
     >
       <span
-        class="sc-bRBteW kFvymL"
+        class="sc-hZoehQ btvgwO"
       >
         <i
           aria-hidden="true"
-          class="sc-jhbick fENxjz"
+          class="sc-jmvSDW hNLerz"
         >
           [
         </i>
         12:00 AM
         <i
           aria-hidden="true"
-          class="sc-jhbick fENxjz"
+          class="sc-jmvSDW hNLerz"
         >
           ] 
         </i>
       </span>
     </div>
     <span
-      class="sc-gHmoSK kRelkX sc-cVdwKd kHdooS"
+      class="sc-jvDgNt dEyFgr sc-fylCKh hhpGLA"
       tabindex="0"
     >
       <span
         aria-label="Username loading…"
-        class="sc-djMJHV upVlS"
+        class="sc-edvVIM kwhisI"
       >
                    
       </span>
     </span>
     <i
       aria-hidden="true"
-      class="sc-jhbick fENxjz"
+      class="sc-jmvSDW hNLerz"
     >
       : 
     </i>
     <span
-      class="sc-kIBtVG heMaNB"
+      class="sc-gerFA dEeYPb"
     >
       <a
         href="http://www.example.com"
@@ -559,13 +559,13 @@ exports[`client/messaging/common-message-layout/TextMessage > message with a men
        go here
        
       <span
-        class="sc-gHmoSK kRelkX sc-kubIlH dmKybX"
+        class="sc-jvDgNt dEyFgr sc-ciUawz ghjPtB"
         tabindex="0"
       >
         @
         <span
           aria-label="Username loading…"
-          class="sc-djMJHV upVlS"
+          class="sc-edvVIM kwhisI"
         >
                      
         </span>
@@ -588,62 +588,62 @@ exports[`client/messaging/common-message-layout/TextMessage > message with a men
   data-testid="message-container"
 >
   <div
-    class="sc-jvDgNt bWKAqk"
+    class="sc-hKOsxR KylBo"
     data-message-id="MESSAGE_ID"
     role="document"
   >
     <div
-      class="sc-ikrMhg iRLQJB sc-hjIEjD cGTiYu"
+      class="sc-kZvNah kkIpz sc-iXWgTX bBIaqX"
       tabindex="0"
     >
       <span
-        class="sc-bRBteW kFvymL"
+        class="sc-hZoehQ btvgwO"
       >
         <i
           aria-hidden="true"
-          class="sc-jhbick fENxjz"
+          class="sc-jmvSDW hNLerz"
         >
           [
         </i>
         12:00 AM
         <i
           aria-hidden="true"
-          class="sc-jhbick fENxjz"
+          class="sc-jmvSDW hNLerz"
         >
           ] 
         </i>
       </span>
     </div>
     <span
-      class="sc-gHmoSK kRelkX sc-cVdwKd kHdooS"
+      class="sc-jvDgNt dEyFgr sc-fylCKh hhpGLA"
       tabindex="0"
     >
       <span
         aria-label="Username loading…"
-        class="sc-djMJHV upVlS"
+        class="sc-edvVIM kwhisI"
       >
                    
       </span>
     </span>
     <i
       aria-hidden="true"
-      class="sc-jhbick fENxjz"
+      class="sc-jmvSDW hNLerz"
     >
       : 
     </i>
     <span
-      class="sc-kIBtVG heMaNB"
+      class="sc-gerFA dEeYPb"
     >
       Hey
        
       <span
-        class="sc-gHmoSK kRelkX sc-kubIlH dmKybX"
+        class="sc-jvDgNt dEyFgr sc-ciUawz ghjPtB"
         tabindex="0"
       >
         @
         <span
           aria-label="Username loading…"
-          class="sc-djMJHV upVlS"
+          class="sc-edvVIM kwhisI"
         >
                      
         </span>
@@ -658,60 +658,60 @@ exports[`client/messaging/common-message-layout/TextMessage > message with only 
   data-testid="message-container"
 >
   <div
-    class="sc-jvDgNt kzcowL"
+    class="sc-hKOsxR lmgodX"
     data-message-id="MESSAGE_ID"
     role="document"
   >
     <div
-      class="sc-ikrMhg iRLQJB sc-hjIEjD cGTiYu"
+      class="sc-kZvNah kkIpz sc-iXWgTX bBIaqX"
       tabindex="0"
     >
       <span
-        class="sc-bRBteW kFvymL"
+        class="sc-hZoehQ btvgwO"
       >
         <i
           aria-hidden="true"
-          class="sc-jhbick fENxjz"
+          class="sc-jmvSDW hNLerz"
         >
           [
         </i>
         12:00 AM
         <i
           aria-hidden="true"
-          class="sc-jhbick fENxjz"
+          class="sc-jmvSDW hNLerz"
         >
           ] 
         </i>
       </span>
     </div>
     <span
-      class="sc-gHmoSK kRelkX sc-cVdwKd kHdooS"
+      class="sc-jvDgNt dEyFgr sc-fylCKh hhpGLA"
       tabindex="0"
     >
       <span
         aria-label="Username loading…"
-        class="sc-djMJHV upVlS"
+        class="sc-edvVIM kwhisI"
       >
                    
       </span>
     </span>
     <i
       aria-hidden="true"
-      class="sc-jhbick fENxjz"
+      class="sc-jmvSDW hNLerz"
     >
       : 
     </i>
     <span
-      class="sc-kIBtVG heMaNB"
+      class="sc-gerFA dEeYPb"
     >
       <span
-        class="sc-bGxLfG gtOLJR"
+        class="sc-IAGWt chiZeR"
       >
         🔥🔥
       </span>
        
       <span
-        class="sc-bGxLfG gtOLJR"
+        class="sc-IAGWt chiZeR"
       >
         🎉
       </span>
@@ -725,54 +725,54 @@ exports[`client/messaging/common-message-layout/TextMessage > message with too m
   data-testid="message-container"
 >
   <div
-    class="sc-jvDgNt kzcowL"
+    class="sc-hKOsxR lmgodX"
     data-message-id="MESSAGE_ID"
     role="document"
   >
     <div
-      class="sc-ikrMhg iRLQJB sc-hjIEjD cGTiYu"
+      class="sc-kZvNah kkIpz sc-iXWgTX bBIaqX"
       tabindex="0"
     >
       <span
-        class="sc-bRBteW kFvymL"
+        class="sc-hZoehQ btvgwO"
       >
         <i
           aria-hidden="true"
-          class="sc-jhbick fENxjz"
+          class="sc-jmvSDW hNLerz"
         >
           [
         </i>
         12:00 AM
         <i
           aria-hidden="true"
-          class="sc-jhbick fENxjz"
+          class="sc-jmvSDW hNLerz"
         >
           ] 
         </i>
       </span>
     </div>
     <span
-      class="sc-gHmoSK kRelkX sc-cVdwKd kHdooS"
+      class="sc-jvDgNt dEyFgr sc-fylCKh hhpGLA"
       tabindex="0"
     >
       <span
         aria-label="Username loading…"
-        class="sc-djMJHV upVlS"
+        class="sc-edvVIM kwhisI"
       >
                    
       </span>
     </span>
     <i
       aria-hidden="true"
-      class="sc-jhbick fENxjz"
+      class="sc-jmvSDW hNLerz"
     >
       : 
     </i>
     <span
-      class="sc-kIBtVG heMaNB"
+      class="sc-gerFA dEeYPb"
     >
       <span
-        class="sc-bGxLfG fVtgOC"
+        class="sc-IAGWt fONgRe"
       >
         😀😀😀😀😀😀😀😀😀😀😀
       </span>

--- a/client/messaging/chat-context.tsx
+++ b/client/messaging/chat-context.tsx
@@ -12,6 +12,12 @@ export interface ChatContextValue {
   MessageMenu: MessageMenuComponent
   /** If true, prevents mentions and usernames from being interactable. Defaults to false. */
   disallowMentionInteraction?: boolean
+  /**
+   * Id of the message the list has just been sent to by a link, if any. It's highlighted so the
+   * user can tell which of the messages around it they came for; the highlight is dropped (and
+   * fades out) a short while after the list arrives.
+   */
+  linkedMessageId?: string
 }
 
 export const ChatContext = React.createContext<ChatContextValue>({

--- a/client/messaging/chat.tsx
+++ b/client/messaging/chat.tsx
@@ -1,7 +1,7 @@
 import { AnimatePresence, Transition, Variants } from 'motion/react'
 import * as m from 'motion/react-m'
 import * as React from 'react'
-import { useContext, useRef, useState } from 'react'
+import { useContext, useEffect, useEffectEvent, useLayoutEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 import { Merge, Simplify } from 'type-fest'
@@ -14,6 +14,7 @@ import { MenuItemSymbol, MenuItemType } from '../material/menu/menu-item-symbol'
 import {
   ChatViewAnchor,
   chatViewAnchorStore,
+  ChatViewPlacement,
   findChatViewPlacement,
   scrollToAnchoredMessage,
 } from '../messaging/chat-view-anchor'
@@ -60,44 +61,74 @@ const MAX_CLAMPED_RESTORE_ATTEMPTS = 4
  */
 const SCROLL_MATCH_TOLERANCE_PX = 1
 
+/**
+ * How far below the top of the viewport, as a fraction of its height, a message the list was sent
+ * to by a link is placed. Room above it puts the message among what led up to it rather than at the
+ * very edge of the view, while keeping most of what follows on screen.
+ */
+const LINKED_MESSAGE_VIEWPORT_FRACTION = 0.25
+
+/** How long a message the list was sent to by a link stays highlighted after the list arrives. */
+const LINKED_MESSAGE_FLASH_MS = 2000
+
+/** How a move to a message named by a link came out. */
+export type LinkedMessageOutcome =
+  /** The viewport sits at the message. */
+  | 'placed'
+  /** The conversation turned out not to hold the message, so there was nowhere to move to. */
+  | 'missing'
+  /** The user took the viewport over before the move could be made. */
+  | 'cancelled'
+
+/**
+ * What a move waiting on a window the list doesn't hold has seen so far. A move only ever gives up
+ * on something a committed render has shown it, which is what these record.
+ */
+interface PendingWindowWait {
+  /**
+   * Which loaded window the current wait was started against. A different one means the
+   * replacement the move was waiting on has arrived.
+   */
+  windowGenAtStart: number | undefined
+  /** Whether a load has been seen in flight since the current wait was started. */
+  sawLoading: boolean
+}
+
+/** How far a move aimed at one particular message has got in reaching it. */
+interface PendingMessageProgress extends PendingWindowWait {
+  /**
+   * Scroll height the last attempt at the position was made against, if one has been made. The
+   * list can't land any closer until its content changes, so further attempts wait for that
+   * rather than fighting whatever scrolling the user does in the meantime.
+   */
+  attemptedScrollHeight: number | undefined
+  /**
+   * How many times the move has stopped short of the position and armed itself to try again
+   * once more messages arrive below it.
+   */
+  clampedAttempts: number
+}
+
 /** A place in a conversation the list is on its way to. */
 type PendingScrollTarget =
   /** The unread divider, wherever it sat when the move was started. */
-  | {
-      kind: 'unreadLine'
-      unreadLineTime: number
-      /**
-       * Which loaded window the current wait was started against. A different one means the
-       * replacement the move was waiting on has arrived.
-       */
-      windowGenAtStart: number | undefined
-      /** Whether a load has been seen in flight since the current wait was started. */
-      sawLoading: boolean
-    }
+  | ({ kind: 'unreadLine'; unreadLineTime: number } & PendingWindowWait)
   /** The reading position the user left the conversation at, saved under `viewStateKey`. */
-  | {
-      kind: 'anchor'
-      viewStateKey: string
-      anchor: ChatViewAnchor
-      /**
-       * Which loaded window the current wait was started against. A different one means the
-       * replacement the move was waiting on has arrived.
-       */
-      windowGenAtStart: number | undefined
-      /** Whether a load has been seen in flight since the current wait was started. */
-      sawLoading: boolean
-      /**
-       * Scroll height the last attempt at the position was made against, if one has been made. The
-       * list can't land any closer until its content changes, so further attempts wait for that
-       * rather than fighting whatever scrolling the user does in the meantime.
-       */
-      attemptedScrollHeight: number | undefined
-      /**
-       * How many times the move has stopped short of the position and armed itself to try again
-       * once more messages arrive below it.
-       */
-      clampedAttempts: number
-    }
+  | ({ kind: 'anchor'; viewStateKey: string; anchor: ChatViewAnchor } & PendingMessageProgress)
+  /** The message a link the user followed into the conversation names. */
+  | ({ kind: 'message'; messageId: string } & PendingMessageProgress)
+
+/** A move aimed at a particular message, whichever named it. */
+type PendingMessageTarget = Extract<PendingScrollTarget, { kind: 'anchor' | 'message' }>
+
+/** What a move waiting on a replacement window has to go on after a particular render. */
+type PendingWaitResult =
+  /** Nothing that bears on the move has happened yet, so it stays armed. */
+  | 'waiting'
+  /** A replacement window arrived, and it isn't one the move can be made in. */
+  | 'windowReplaced'
+  /** The request the move was waiting on came back without replacing the window. */
+  | 'requestFinished'
 
 /**
  * A move the list can't make yet because it's waiting on history the list doesn't hold. It carries
@@ -246,6 +277,19 @@ export interface ChatProps {
   /** If true, prevents mentions and usernames from being interactable. Defaults to false. */
   disallowMentionInteraction?: boolean
   /**
+   * A message in this conversation the list should move to and highlight, if the user has followed
+   * a link to one. The list places it as soon as the loaded window holds it, so a message that
+   * takes a window the client doesn't hold is reached by setting this and loading that window; the
+   * two can happen in either order.
+   */
+  linkedMessageId?: string
+  /**
+   * Called once with how a move started for `linkedMessageId` came out. Owners are expected to stop
+   * asking for that message at this point, whatever the outcome: the link has been acted on, and
+   * only a fresh one should move the list again.
+   */
+  onLinkedMessageSettled?: (messageId: string, outcome: LinkedMessageOutcome) => void
+  /**
    * Called with the at-bottom state the viewport settles in when the list arrives at a
    * conversation, and again whenever that state changes. The arrival report fires during the
    * commit that mounts or re-targets the list, before owners' effects run; when a move to a saved
@@ -284,6 +328,8 @@ export function Chat({
   UserMenu,
   MessageMenu = DefaultMessageMenu,
   disallowMentionInteraction: disallowUserInteraction,
+  linkedMessageId,
+  onLinkedMessageSettled,
   onAtBottomChange,
   onJumpToPresent,
   onSeekToUnread,
@@ -315,6 +361,17 @@ export function Chat({
   const seenLineRef = useRef<{ refreshToken: unknown; unreadLineTime: number } | undefined>(
     undefined,
   )
+  // The message the list has arrived at by way of a link, and the conversation it was reached in.
+  // Highlighting it is what tells the user which of the messages on screen they came for.
+  const [linkFlash, setLinkFlash] = useState<
+    { refreshToken: unknown; messageId: string } | undefined
+  >(undefined)
+  // The move started for the link the list is currently acting on. It outlives the move itself, so
+  // a list that mounts again can re-run the move without reporting a second outcome for it, and so
+  // a link to the same message that arrives later counts as a new move.
+  const linkJumpRef = useRef<
+    { refreshToken: unknown; messageId: string; settled: boolean } | undefined
+  >(undefined)
 
   const {
     unreadLineTime,
@@ -377,19 +434,100 @@ export function Chat({
   }
 
   /**
+   * Where a message a link names sits in the loaded window, if the window holds it. It's placed a
+   * fixed way down the viewport rather than at its very top, so the messages that led up to it
+   * stay readable.
+   */
+  const findLinkedMessagePlacement = (
+    scroller: HTMLDivElement,
+    messageId: string,
+  ): ChatViewPlacement => {
+    if (!messages.some(msg => msg.id === messageId)) {
+      return { kind: 'fetch' }
+    }
+
+    return {
+      kind: 'message',
+      messageId,
+      offsetPx: Math.round(scroller.clientHeight * LINKED_MESSAGE_VIEWPORT_FRACTION),
+    }
+  }
+
+  /**
+   * Records what the current render shows a move that's waiting on a window the list doesn't hold,
+   * and says what the move has to go on.
+   *
+   * Such a move only ever gives up on something a committed render has shown it: the window
+   * generation changing, or a load it watched start and then finish. "Nothing is loading" on its
+   * own can't be trusted, because this runs from scroll updates as well as from renders, and a
+   * scroll update between a commit and the request it triggers reads the loading flag a render
+   * behind — as idle, when the request is about to be made. A generation change to a window with no
+   * messages in it doesn't count as the replacement arriving either: it's the gap before one, so
+   * the wait re-arms against the new generation and carries over to whatever fills it.
+   */
+  const advancePendingWait = (wait: PendingWindowWait): PendingWaitResult => {
+    if (windowGeneration !== wait.windowGenAtStart) {
+      if (messages.some(isServerOriginMessage)) {
+        return 'windowReplaced'
+      }
+
+      wait.windowGenAtStart = windowGeneration
+      wait.sawLoading = false
+    }
+
+    if (wait.sawLoading && !loading) {
+      return 'requestFinished'
+    }
+    if (loading) {
+      wait.sawLoading = true
+    }
+
+    return 'waiting'
+  }
+
+  /**
+   * Highlights the message the list has just arrived at by way of a link. The highlight is dropped
+   * again a moment later, and belongs to the conversation it was started in.
+   */
+  const startLinkedMessageFlash = (messageId: string) => {
+    setLinkFlash({ refreshToken, messageId })
+  }
+
+  /**
+   * Tells the owner how the move started for a link came out, at most once per move. A list that
+   * mounts again runs the move over so the viewport still lands on the message, but the outcome of
+   * that move has already been reported.
+   */
+  const reportLinkedMessage = (messageId: string, outcome: LinkedMessageOutcome) => {
+    if (outcome === 'placed') {
+      startLinkedMessageFlash(messageId)
+    }
+
+    const jump = linkJumpRef.current
+    if (jump !== undefined && jump.refreshToken === refreshToken && jump.messageId === messageId) {
+      if (jump.settled) {
+        return
+      }
+      jump.settled = true
+    }
+
+    onLinkedMessageSettled?.(messageId, outcome)
+  }
+
+  /** Ends a move aimed at a particular message, whether it reached the message or gave up on it. */
+  const endMessageMove = (target: PendingMessageTarget, outcome: LinkedMessageOutcome) => {
+    pendingScrollRef.current = undefined
+    if (target.kind === 'message') {
+      reportLinkedMessage(target.messageId, outcome)
+    }
+  }
+
+  /**
    * Carries a move that couldn't be made when it was started as far as the list now allows.
    *
-   * A move waiting on a replacement window only ever gives up on something a committed render has
-   * shown it: the window generation changing, or a load it watched start and then finish. "Nothing
-   * is loading" on its own can't be trusted, because this runs from scroll updates as well as from
-   * renders, and a scroll update between a commit and the request it triggers reads the loading
-   * flag a render behind — as idle, when the request is about to be made. A generation change to a
-   * window with no messages in it doesn't count as that replacement arriving either: it's the gap
-   * before one, so the move re-arms against the new generation and keeps waiting.
-   *
-   * A move that found its position but couldn't reach it waits on something else entirely: the
-   * content growing, since re-running the same attempt against the same content can only land where
-   * it already did.
+   * A move that found its position but couldn't reach it waits on the content growing, since
+   * re-running the same attempt against the same content can only land where it already did.
+   * Everything else waits on a window the list doesn't hold yet (see `advancePendingWait`).
    */
   const applyPendingScroll = (scroller: HTMLDivElement) => {
     const pending = pendingScrollRef.current
@@ -417,30 +555,18 @@ export function Chat({
         return
       }
 
-      if (windowGeneration !== target.windowGenAtStart) {
-        if (messages.some(isServerOriginMessage)) {
-          // The replacement window arrived and holds no divider, which means there was nothing
-          // unread to move to after all.
-          pendingScrollRef.current = undefined
-          return
-        }
-
-        // The generation moved but left no content behind: the window was cleared to make way for a
-        // replacement that hasn't arrived yet. The wait carries over to whatever window fills it.
-        target.windowGenAtStart = windowGeneration
-        target.sawLoading = false
-      }
-
-      if (target.sawLoading && !loading) {
-        // A request went out and came back without turning up a divider, so nothing more is coming.
+      // A replacement window that turned up no divider means there was nothing unread to move to
+      // after all, and a request that came back without one means nothing more is coming.
+      if (advancePendingWait(target) !== 'waiting') {
         pendingScrollRef.current = undefined
-      } else if (loading) {
-        target.sawLoading = true
       }
       return
     }
 
-    const placement = findChatViewPlacement(messages, target.anchor)
+    const placement =
+      target.kind === 'anchor'
+        ? findChatViewPlacement(messages, target.anchor)
+        : findLinkedMessagePlacement(scroller, target.messageId)
     if (placement.kind === 'message') {
       if (scroller.scrollHeight === target.attemptedScrollHeight) {
         // The list holds exactly what the last attempt was made against, so trying again would land
@@ -448,7 +574,7 @@ export function Chat({
         if (!hasNewerMessages) {
           // Nothing will be added below it either, so where the last attempt left the viewport is
           // as close to the position as this conversation gets.
-          pendingScrollRef.current = undefined
+          endMessageMove(target, 'placed')
         }
         return
       }
@@ -473,41 +599,75 @@ export function Chat({
         // The viewport is either at the position, or as close to it as the list will get: the
         // newest messages are loaded, or the pages that kept arriving below never brought the
         // position within reach.
-        pendingScrollRef.current = undefined
+        endMessageMove(target, 'placed')
+        return
+      }
+      if (target.kind === 'message') {
+        // The window holds the message but nothing in the list renders it, and waiting on a window
+        // that has already arrived would leave the move armed forever.
+        endMessageMove(target, 'missing')
         return
       }
     }
 
-    if (windowGeneration !== target.windowGenAtStart) {
-      if (messages.some(isServerOriginMessage)) {
-        // A replacement window arrived and still can't hold the saved position, so the newest
-        // messages are as close to it as this conversation gets.
-        pendingScrollRef.current = undefined
-        scroller.scrollTop = scroller.scrollHeight
-        return
-      }
-
-      // The generation moved but left no content behind: the window was cleared to make way for a
-      // replacement that hasn't arrived yet, not a replacement that failed to cover the position.
-      // The wait carries over to whatever window fills it, so re-arm against this generation and
-      // fall through to the loading latch below in case a request is already in flight this render.
-      target.windowGenAtStart = windowGeneration
-      target.sawLoading = false
-    }
-
-    if (target.sawLoading && !loading) {
-      // A request went out and came back without replacing the window, so nothing more is coming.
-      pendingScrollRef.current = undefined
+    const waitResult = advancePendingWait(target)
+    if (waitResult === 'waiting') {
       return
     }
 
-    if (loading) {
-      target.sawLoading = true
+    if (target.kind === 'anchor' && waitResult === 'windowReplaced') {
+      // A replacement window arrived and still can't hold the saved position, so the newest
+      // messages are as close to it as this conversation gets.
+      scroller.scrollTop = scroller.scrollHeight
     }
+    endMessageMove(target, 'missing')
   }
+
+  /**
+   * Starts moving the list to a message a link names. A message the loaded window already holds is
+   * reached here and now; otherwise the move becomes pending until a window that holds it arrives,
+   * which the owner is expected to ask for.
+   */
+  const startLinkedMessageJump = (scroller: HTMLDivElement, messageId: string) => {
+    const jump = linkJumpRef.current
+    if (jump === undefined || jump.refreshToken !== refreshToken || jump.messageId !== messageId) {
+      linkJumpRef.current = { refreshToken, messageId, settled: false }
+    }
+
+    pendingScrollRef.current = {
+      refreshToken,
+      target: {
+        kind: 'message',
+        messageId,
+        windowGenAtStart: windowGeneration,
+        sawLoading: false,
+        attemptedScrollHeight: undefined,
+        clampedAttempts: 0,
+      },
+    }
+    applyPendingScroll(scroller)
+  }
+
+  // The highlight on a linked message marks the moment the list arrives at it, not a state the
+  // message stays in.
+  useEffect(() => {
+    if (!linkFlash) {
+      return undefined
+    }
+
+    const timeout = setTimeout(() => {
+      setLinkFlash(undefined)
+    }, LINKED_MESSAGE_FLASH_MS)
+    return () => clearTimeout(timeout)
+  }, [linkFlash])
 
   const isRestorePending = (key: string) => {
     const target = pendingScrollRef.current?.target
+    if (target?.kind === 'message') {
+      // A move to a linked message leaves the list somewhere the user didn't pick just as much as a
+      // move to a saved reading position does.
+      return viewStateKey === key
+    }
     return target?.kind === 'anchor' && target.viewStateKey === key
   }
 
@@ -522,6 +682,7 @@ export function Chat({
       reason === 'scroll' &&
       lastScrollTopRef.current !== undefined &&
       Math.abs(scroller.scrollTop - lastScrollTopRef.current) > SCROLL_MATCH_TOLERANCE_PX
+    const pendingTarget = pendingScrollRef.current?.target
 
     // Any move has to happen before the scroll position is read below, so what the rest of this
     // reports is where the list actually ends up rather than where it passed through. A list that
@@ -532,20 +693,31 @@ export function Chat({
       pendingScrollRef.current = undefined
       wasAtBottomRef.current = undefined
       lastScrollTopRef.current = undefined
-      if (viewStateKey !== undefined) {
+      if (linkedMessageId) {
+        // A link names the one place in the conversation the user asked for, which outranks both
+        // the position they left behind and the divider.
+        startLinkedMessageJump(scroller, linkedMessageId)
+      } else if (viewStateKey !== undefined) {
         startAnchorRestore(scroller, viewStateKey)
       }
-    } else if (userScrolled && pendingScrollRef.current?.target.kind === 'anchor') {
+    } else if (
+      userScrolled &&
+      (pendingTarget?.kind === 'anchor' || pendingTarget?.kind === 'message')
+    ) {
       // Where the user has scrolled to says more about where they want to be than a reading
-      // position they left behind does.
+      // position they left behind, or a message they followed a link to, does.
       pendingScrollRef.current = undefined
+      if (pendingTarget.kind === 'message') {
+        reportLinkedMessage(pendingTarget.messageId, 'cancelled')
+      }
     } else {
       applyPendingScroll(scroller)
     }
 
     // A move that's still pending leaves the list wherever it was placed by default, which says
     // nothing about whether the user has caught up with the conversation.
-    const restorePending = pendingScrollRef.current?.target.kind === 'anchor'
+    const pendingKind = pendingScrollRef.current?.target.kind
+    const restorePending = pendingKind === 'anchor' || pendingKind === 'message'
 
     const { scrollTop, scrollHeight, clientHeight } = scroller
     // Where the moves above left the list, so the scroll events they cause can be told apart from
@@ -591,6 +763,60 @@ export function Chat({
     }
     setShowUnreadBanner(newShowUnreadBanner)
   }
+
+  // A link into the conversation that's already on screen changes nothing about the list's content,
+  // so the list has no scroll update to report it in and the move is started from the prop instead.
+  // Arriving at a conversation starts it from the list's own arrival report, which runs first.
+  const startLinkedMessageJumpIfNeeded = useEffectEvent(
+    (messageId: string | undefined, conversation: unknown) => {
+      if (!messageId) {
+        // With no link left to act on, a later link to the same message is a move of its own rather
+        // than the one that has already been made.
+        linkJumpRef.current = undefined
+        return
+      }
+
+      const scroller = scrollerRef.current
+      if (!scroller) {
+        return
+      }
+
+      const jump = linkJumpRef.current
+      if (
+        jump !== undefined &&
+        jump.refreshToken === conversation &&
+        jump.messageId === messageId
+      ) {
+        return
+      }
+
+      startLinkedMessageJump(scroller, messageId)
+      // Arming the move from the prop skips the scroll update that arriving at a conversation places
+      // it from, so where the list ended up (at the bottom, or held above it while the move waits on
+      // a window) has to be reported here as that update would have. A content reason never reads as
+      // the user scrolling, and the move already ran, so this only reports the result.
+      onScrollUpdate(scroller, 'content')
+    },
+  )
+
+  useLayoutEffect(() => {
+    startLinkedMessageJumpIfNeeded(linkedMessageId, refreshToken)
+  }, [linkedMessageId, refreshToken])
+
+  // Re-drives a move toward a linked message when the loaded messages change. The list reports its
+  // own content updates only when they change its scroll height, so a conversation whose messages
+  // all fit the viewport would otherwise never tell the move that the one it's waiting for has
+  // arrived. This runs before the browser paints, so the message is in place by the time it shows.
+  const driveLinkedMessageJump = useEffectEvent(() => {
+    const scroller = scrollerRef.current
+    if (!scroller || pendingScrollRef.current?.target.kind !== 'message') {
+      return
+    }
+    onScrollUpdate(scroller, 'content')
+  })
+  useLayoutEffect(() => {
+    driveLinkedMessageJump()
+  }, [messages])
 
   const onJumpToBottomClick = () => {
     if (hasNewerMessages) {
@@ -661,6 +887,13 @@ export function Chat({
     onMenuClose()
   }
 
+  // A highlight is only ever shown in the conversation it was started in, so switching conversations
+  // never carries one into a list the user is looking at fresh.
+  const flashedMessageId =
+    linkFlash !== undefined && linkFlash.refreshToken === refreshToken
+      ? linkFlash.messageId
+      : undefined
+
   return (
     <BaseUserMenuItemsProvider
       items={
@@ -677,6 +910,7 @@ export function Chat({
           UserMenu,
           MessageMenu,
           disallowMentionInteraction: disallowUserInteraction,
+          linkedMessageId: flashedMessageId,
         }}>
         <MessagesAndInput className={className}>
           {header}

--- a/client/messaging/common-message-layout.test.tsx
+++ b/client/messaging/common-message-layout.test.tsx
@@ -148,7 +148,10 @@ describe('client/messaging/common-message-layout/TextMessage', () => {
         `https://shieldbattery.net/chat/1/some-channel?m=${CHANNEL_MESSAGE_ID}`,
       )
       expect(link.textContent).not.toContain('shieldbattery.net')
-      expect(link.textContent).toContain(' › message')
+      expect(link.textContent).not.toContain('https://')
+      // MaterialIcon renders its icon name as text content ('chat'), so this checks for the
+      // translated label rather than asserting exact equality on the chip's full text.
+      expect(link.textContent).toContain('message')
     })
 
     test('a same-origin chat URL without a valid message param renders as a plain link', () => {

--- a/client/messaging/common-message-layout.test.tsx
+++ b/client/messaging/common-message-layout.test.tsx
@@ -136,4 +136,33 @@ describe('client/messaging/common-message-layout/TextMessage', () => {
     })
     expect(screen.queryByTestId('lobby-invite-card')).toBeNull()
   })
+
+  describe('channel message links', () => {
+    const CHANNEL_MESSAGE_ID = '9b2e8d0e-5f3a-4a2b-8c1d-6f5e4d3c2b1a'
+
+    test('a ShieldBattery channel message link renders as a channel/message label', () => {
+      doRender(`see this: https://shieldbattery.net/chat/1/some-channel?m=${CHANNEL_MESSAGE_ID}`)
+      const link = screen.getByRole('link')
+
+      expect(link.getAttribute('href')).toBe(
+        `https://shieldbattery.net/chat/1/some-channel?m=${CHANNEL_MESSAGE_ID}`,
+      )
+      expect(link.textContent).not.toContain('shieldbattery.net')
+      expect(link.textContent).toContain(' › message')
+    })
+
+    test('a same-origin chat URL without a valid message param renders as a plain link', () => {
+      doRender('https://shieldbattery.net/chat/1/some-channel')
+      const link = screen.getByRole('link')
+
+      expect(link.textContent).toBe('https://shieldbattery.net/chat/1/some-channel')
+    })
+
+    test('a foreign-origin chat-shaped URL renders as a plain link', () => {
+      doRender(`https://example.com/chat/1/x?m=${CHANNEL_MESSAGE_ID}`)
+      const link = screen.getByRole('link')
+
+      expect(link.textContent).toBe(`https://example.com/chat/1/x?m=${CHANNEL_MESSAGE_ID}`)
+    })
+  })
 })

--- a/client/messaging/common-message-layout.tsx
+++ b/client/messaging/common-message-layout.tsx
@@ -8,6 +8,7 @@ import { matchLinks } from '../../common/text/links'
 import { countEmojisIn, matchUnicodeEmojis } from '../../common/text/unicode-emojis'
 import { matchUserMentionsMarkup } from '../../common/text/user-mentions'
 import { makeSbUserId, SbUserId } from '../../common/users/sb-user-id'
+import { channelMessageFromMessageLink, ChannelMessageLink } from '../chat/channel-message-link'
 import { ConnectedChannelName } from '../chat/connected-channel-name'
 import { useContextMenu } from '../dom/use-context-menu'
 import { TransInterpolation } from '../i18n/i18next'
@@ -185,11 +186,22 @@ export function TextMessage({ msgId, userId, selfUserId, time, text, testId }: T
         inviteLobbyId = lobbyIdFromMessageLink(match.text)
       }
 
-      parsedText.push(
-        <ExternalLink key={match.index} href={match.text}>
-          {match.text}
-        </ExternalLink>,
-      )
+      const channelMessage = channelMessageFromMessageLink(match.text)
+      if (channelMessage) {
+        parsedText.push(
+          <ChannelMessageLink
+            key={match.index}
+            href={match.text}
+            channelId={channelMessage.channelId}
+          />,
+        )
+      } else {
+        parsedText.push(
+          <ExternalLink key={match.index} href={match.text}>
+            {match.text}
+          </ExternalLink>,
+        )
+      }
     } else if (match.type === 'unicodeEmoji') {
       parsedText.push(
         <UnicodeEmoji key={match.index} $jumbo={jumboEmoji}>

--- a/client/messaging/message-layout.tsx
+++ b/client/messaging/message-layout.tsx
@@ -1,8 +1,10 @@
 import * as React from 'react'
+import { useContext } from 'react'
 import styled, { css } from 'styled-components'
 import { longTimestamp, shortTimestamp } from '../i18n/date-formats'
 import { Tooltip } from '../material/tooltip'
 import { bodyMedium, labelMedium, titleSmall } from '../styles/typography'
+import { ChatContext } from './chat-context'
 
 /** Hidden separators that only show up in copy+paste. */
 export const Separator = styled.i.attrs({ 'aria-hidden': true })`
@@ -59,7 +61,18 @@ const messageContainerBase = css`
   line-height: 20px;
 `
 
-const MessageContainer = styled.div<{ $active?: boolean; $highlighted?: boolean }>`
+/**
+ * How long the highlight on a message the list was sent to takes to fade back into the
+ * conversation once it's dropped. Slow enough to read as the highlight receding rather than the
+ * message changing.
+ */
+const LINKED_FADE_DURATION = '1s'
+
+const MessageContainer = styled.div<{
+  $active?: boolean
+  $highlighted?: boolean
+  $linked?: boolean
+}>`
   ${messageContainerBase};
   ${bodyMedium};
 
@@ -67,6 +80,28 @@ const MessageContainer = styled.div<{ $active?: boolean; $highlighted?: boolean 
 
   line-height: 20px;
   text-indent: -72px;
+  /**
+    Gives the highlight layer below a stacking context of its own to sit at the bottom of, so it
+    paints above this element's own hover/mention background but below its text.
+  */
+  isolation: isolate;
+
+  /**
+    The highlight on a message the list was sent to is a layer of its own rather than another
+    background color, so it can fade out on its own without dragging the hover and mention
+    backgrounds into the transition.
+  */
+  &::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    z-index: -1;
+
+    background-color: rgb(from var(--theme-primary) r g b / 0.24);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity ${LINKED_FADE_DURATION} linear;
+  }
 
   ${props => {
     if (!props.$highlighted) {
@@ -84,6 +119,31 @@ const MessageContainer = styled.div<{ $active?: boolean; $highlighted?: boolean 
         bottom: 0;
         width: 2px;
         background-color: var(--color-amber90);
+      }
+
+      /** Leaves the mention's edge showing through the layer painted over it. */
+      &::after {
+        left: 2px;
+      }
+    `
+  }}
+
+  ${props => {
+    if (!props.$linked) {
+      return ''
+    }
+
+    return css`
+      &::after {
+        /**
+          A message that mentions the user keeps the mention's edge: which messages are for them
+          says more than how they got to this one.
+        */
+        ${props.$highlighted ? '' : 'border-left: 2px solid var(--theme-primary);'}
+
+        opacity: 1;
+        /** Arriving at a message is immediate; only leaving it fades. */
+        transition: none;
       }
     `
   }}
@@ -126,10 +186,13 @@ interface TimestampMessageLayoutProps {
 }
 
 export const TimestampMessageLayout = (props: TimestampMessageLayoutProps) => {
+  const { linkedMessageId } = useContext(ChatContext)
+
   return (
     <MessageContainer
       $active={props.active}
       $highlighted={props.highlighted}
+      $linked={props.msgId !== undefined && props.msgId === linkedMessageId}
       className={props.className}
       role='document'
       onContextMenu={props.onContextMenu}

--- a/client/whispers/action-creators.ts
+++ b/client/whispers/action-creators.ts
@@ -301,5 +301,7 @@ export function navigateToWhisper(targetId: SbUserId, targetName: string, transi
  * for their user ID.
  */
 export function correctUsernameForWhisper(userId: SbUserId, username: string) {
-  replace(urlPath`/whispers/${userId}/${username}`)
+  // The correction is only about the name segment: the rest of the URL still describes what the
+  // user asked for, so it survives being sent to the canonical name.
+  replace(urlPath`/whispers/${userId}/${username}` + window.location.search)
 }

--- a/common/chat.ts
+++ b/common/chat.ts
@@ -709,6 +709,11 @@ export interface GetBatchedChannelInfosResponse {
   channelInfos: BasicChannelInfo[]
   detailedChannelInfos: DetailedChannelInfo[]
   joinedChannelInfos: JoinedChannelInfo[]
+  /**
+   * Requested channel IDs that name no existing channel (deleted, or never existed), so a client
+   * can stop treating them as still loading.
+   */
+  deletedChannels: SbChannelId[]
 }
 
 /**

--- a/common/chat.ts
+++ b/common/chat.ts
@@ -714,6 +714,12 @@ export interface GetBatchedChannelInfosResponse {
    * can stop treating them as still loading.
    */
   deletedChannels: SbChannelId[]
+  /**
+   * Requested channel IDs that exist but are private and the requester isn't a member of. Nothing
+   * about them is returned beyond the id, so a client can show a generic private-channel label
+   * instead of waiting for a name.
+   */
+  privateChannels: SbChannelId[]
 }
 
 /**

--- a/common/chat.ts
+++ b/common/chat.ts
@@ -37,6 +37,7 @@ export enum ChatServiceErrorCode {
   InappropriateImage = 'InappropriateImage',
   MaximumJoinedChannels = 'MaximumJoinedChannels',
   MaximumOwnedChannels = 'MaximumOwnedChannels',
+  MessageNotFound = 'MessageNotFound',
   NoInitialChannelData = 'NoChannelData',
   NotEnoughPermissions = 'NotEnoughPermissions',
   NotInChannel = 'NotInChannel',

--- a/server/lib/chat/chat-api.ts
+++ b/server/lib/chat/chat-api.ts
@@ -207,6 +207,7 @@ function convertChatServiceError(err: unknown) {
 
   switch (err.code) {
     case ChatServiceErrorCode.ChannelNotFound:
+    case ChatServiceErrorCode.MessageNotFound:
     case ChatServiceErrorCode.NotInChannel:
     case ChatServiceErrorCode.TargetNotBanned:
     case ChatServiceErrorCode.TargetNotInChannel:
@@ -366,19 +367,21 @@ export class ChatApi {
   async getChannelHistory(ctx: RouterContext): Promise<GetChannelHistoryServerResponse> {
     const channelId = getValidatedChannelId(ctx)
     const {
-      query: { limit, beforeTime, afterTime, aroundTime },
+      query: { limit, beforeTime, afterTime, aroundTime, aroundMessageId },
     } = validateRequest(ctx, {
       query: Joi.object<{
         limit: number
         beforeTime?: number
         afterTime?: number
         aroundTime?: number
+        aroundMessageId?: string
       }>({
         limit: Joi.number().min(1).max(100),
         beforeTime: joiTimestampMillis().min(-1),
         afterTime: joiTimestampMillis().min(0),
         aroundTime: joiTimestampMillis().min(0),
-      }).oxor('beforeTime', 'afterTime', 'aroundTime'),
+        aroundMessageId: Joi.string().uuid(),
+      }).oxor('beforeTime', 'afterTime', 'aroundTime', 'aroundMessageId'),
     })
 
     return await this.chatService.getChannelHistory({
@@ -388,6 +391,7 @@ export class ChatApi {
       beforeTime,
       afterTime,
       aroundTime,
+      aroundMessageId,
     })
   }
 

--- a/server/lib/chat/chat-models.ts
+++ b/server/lib/chat/chat-models.ts
@@ -649,6 +649,28 @@ export async function deleteChannelMessage(
   }
 }
 
+/**
+ * Returns when a channel message was sent, or `undefined` if it doesn't exist in the channel
+ * (deleted, never existed, or belongs to a different channel).
+ */
+export async function getChannelMessageSentTime(
+  channelId: SbChannelId,
+  messageId: string,
+  withClient?: DbClient,
+): Promise<Date | undefined> {
+  const { client, done } = await db(withClient)
+  try {
+    const result = await client.query<{ sent: Date }>(sql`
+      SELECT sent
+      FROM channel_messages
+      WHERE id = ${messageId} AND channel_id = ${channelId};
+    `)
+    return result.rows[0]?.sent
+  } finally {
+    done()
+  }
+}
+
 export interface LeaveChannelResult {
   /**
    * Whether the user's channel membership was actually removed. `false` when they were no longer

--- a/server/lib/chat/chat-service.test.ts
+++ b/server/lib/chat/chat-service.test.ts
@@ -1997,6 +1997,7 @@ describe('chat/chat-service', () => {
         detailedChannelInfos: [],
         joinedChannelInfos: [],
         deletedChannels: [],
+        privateChannels: [],
       })
     })
 
@@ -2013,6 +2014,7 @@ describe('chat/chat-service', () => {
         detailedChannelInfos: [shieldBatteryDetailedInfo, testDetailedInfo],
         joinedChannelInfos: [shieldBatteryJoinedInfo, testJoinedInfo],
         deletedChannels: [],
+        privateChannels: [],
       })
     })
 
@@ -2030,6 +2032,7 @@ describe('chat/chat-service', () => {
         detailedChannelInfos: [shieldBatteryDetailedInfo],
         joinedChannelInfos: [shieldBatteryJoinedInfo],
         deletedChannels: [DELETED_ID],
+        privateChannels: [],
       })
     })
 
@@ -2041,17 +2044,18 @@ describe('chat/chat-service', () => {
         ])
       })
 
-      test("doesn't return detailed and joined channel infos for private channels", async () => {
+      test("doesn't return channel, detailed, or joined info for private channels the user isn't in", async () => {
         const result = await chatService.getChannelInfos(
           [shieldBatteryChannel.id, testChannel.id],
           user1.id,
         )
 
         expect(result).toEqual({
-          channelInfos: [shieldBatteryBasicInfo, { ...testBasicInfo, private: true }],
+          channelInfos: [shieldBatteryBasicInfo],
           detailedChannelInfos: [shieldBatteryDetailedInfo],
           joinedChannelInfos: [shieldBatteryJoinedInfo],
           deletedChannels: [],
+          privateChannels: [testChannel.id],
         })
       })
 
@@ -2076,6 +2080,7 @@ describe('chat/chat-service', () => {
           ],
           joinedChannelInfos: [shieldBatteryJoinedInfo, testJoinedInfo],
           deletedChannels: [],
+          privateChannels: [],
         })
       })
     })

--- a/server/lib/chat/chat-service.test.ts
+++ b/server/lib/chat/chat-service.test.ts
@@ -7,6 +7,7 @@ import {
   ChannelModerationAction,
   ChannelPermissions,
   ChannelPreferences,
+  ChatServiceErrorCode,
   DetailedChannelInfo,
   GetChannelHistoryServerResponse,
   JoinedChannelInfo,
@@ -52,6 +53,7 @@ import {
   getChannelBans,
   getChannelInfo,
   getChannelInfos,
+  getChannelMessageSentTime,
   getChannelsForUser,
   getMessagesForChannel,
   getUnreadChannelInfo,
@@ -143,6 +145,7 @@ vi.mock('./chat-models', async () => {
     getMessagesForChannel: vi
       .fn()
       .mockResolvedValue({ messages: [], hasMoreBefore: false, hasMoreAfter: false }),
+    getChannelMessageSentTime: vi.fn(),
     deleteChannelMessage: vi.fn(),
     removeUserFromChannel: vi.fn(),
     updateUserPreferences: vi.fn(),
@@ -2407,6 +2410,37 @@ describe('chat/chat-service', () => {
           kind: 'around',
           date: new Date(3000),
         })
+      })
+
+      test('uses an around cursor at the message time when aroundMessageId is given', async () => {
+        const messageId = 'MESSAGE_ID'
+        asMockedFunction(getChannelMessageSentTime).mockResolvedValue(new Date(3000))
+
+        await chatService.getChannelHistory({
+          channelId: testChannel.id,
+          userId: user1.id,
+          limit: 50,
+          aroundMessageId: messageId,
+        })
+
+        expect(getChannelMessageSentTime).toHaveBeenCalledWith(testChannel.id, messageId)
+        expect(getMessagesForChannel).toHaveBeenCalledWith(testChannel.id, 50, {
+          kind: 'around',
+          date: new Date(3000),
+        })
+      })
+
+      test('throws MessageNotFound when aroundMessageId names no message in the channel', async () => {
+        asMockedFunction(getChannelMessageSentTime).mockResolvedValue(undefined)
+
+        await expect(
+          chatService.getChannelHistory({
+            channelId: testChannel.id,
+            userId: user1.id,
+            limit: 50,
+            aroundMessageId: 'MESSAGE_ID',
+          }),
+        ).rejects.toMatchObject({ code: ChatServiceErrorCode.MessageNotFound })
       })
     })
   })

--- a/server/lib/chat/chat-service.test.ts
+++ b/server/lib/chat/chat-service.test.ts
@@ -1996,6 +1996,7 @@ describe('chat/chat-service', () => {
         channelInfos: [],
         detailedChannelInfos: [],
         joinedChannelInfos: [],
+        deletedChannels: [],
       })
     })
 
@@ -2011,6 +2012,24 @@ describe('chat/chat-service', () => {
         channelInfos: [shieldBatteryBasicInfo, testBasicInfo],
         detailedChannelInfos: [shieldBatteryDetailedInfo, testDetailedInfo],
         joinedChannelInfos: [shieldBatteryJoinedInfo, testJoinedInfo],
+        deletedChannels: [],
+      })
+    })
+
+    test('returns requested ids that name no existing channel as deleted', async () => {
+      const DELETED_ID = makeSbChannelId(999)
+      asMockedFunction(getChannelInfos).mockResolvedValue([shieldBatteryChannel])
+
+      const result = await chatService.getChannelInfos(
+        [shieldBatteryChannel.id, DELETED_ID],
+        user1.id,
+      )
+
+      expect(result).toEqual({
+        channelInfos: [shieldBatteryBasicInfo],
+        detailedChannelInfos: [shieldBatteryDetailedInfo],
+        joinedChannelInfos: [shieldBatteryJoinedInfo],
+        deletedChannels: [DELETED_ID],
       })
     })
 
@@ -2032,6 +2051,7 @@ describe('chat/chat-service', () => {
           channelInfos: [shieldBatteryBasicInfo, { ...testBasicInfo, private: true }],
           detailedChannelInfos: [shieldBatteryDetailedInfo],
           joinedChannelInfos: [shieldBatteryJoinedInfo],
+          deletedChannels: [],
         })
       })
 
@@ -2055,6 +2075,7 @@ describe('chat/chat-service', () => {
             { ...testDetailedInfo, userCount: testChannel.userCount },
           ],
           joinedChannelInfos: [shieldBatteryJoinedInfo, testJoinedInfo],
+          deletedChannels: [],
         })
       })
     })

--- a/server/lib/chat/chat-service.ts
+++ b/server/lib/chat/chat-service.ts
@@ -5,6 +5,7 @@ import { singleton } from 'tsyringe'
 import { assertUnreachable } from '../../../common/assert-unreachable'
 import swallowNonBuiltins from '../../../common/async/swallow-non-builtins'
 import {
+  BasicChannelInfo,
   CHANNEL_BADGE_HEIGHT,
   CHANNEL_BADGE_WIDTH,
   CHANNEL_BANNER_HEIGHT,
@@ -903,14 +904,20 @@ export default class ChatService {
     ])
 
     const userJoinedChannelsSet = new global.Set(userChannelEntries.map(e => e.channelId))
+    const visibleChannelInfos: BasicChannelInfo[] = []
     const detailedChannelInfos: DetailedChannelInfo[] = []
     const joinedChannelInfos: JoinedChannelInfo[] = []
+    const privateChannels: SbChannelId[] = []
 
     for (const channel of channelInfos) {
       if (channel.private && !userJoinedChannelsSet.has(channel.id)) {
+        // A private channel's info (including its name) is only for its members; a non-member
+        // gets nothing about it beyond confirmation that the id belongs to a private channel.
+        privateChannels.push(channel.id)
         continue
       }
 
+      visibleChannelInfos.push(toBasicChannelInfo(channel))
       detailedChannelInfos.push(toDetailedChannelInfo(channel))
       joinedChannelInfos.push(toJoinedChannelInfo(channel))
     }
@@ -926,10 +933,11 @@ export default class ChatService {
           )
 
     return {
-      channelInfos: channelInfos.map(channel => toBasicChannelInfo(channel)),
+      channelInfos: visibleChannelInfos,
       detailedChannelInfos,
       joinedChannelInfos,
       deletedChannels,
+      privateChannels,
     }
   }
 

--- a/server/lib/chat/chat-service.ts
+++ b/server/lib/chat/chat-service.ts
@@ -915,10 +915,21 @@ export default class ChatService {
       joinedChannelInfos.push(toJoinedChannelInfo(channel))
     }
 
+    const deletedChannels =
+      channelIds.length === channelInfos.length
+        ? []
+        : Array.from(
+            subtract(
+              new global.Set(channelIds),
+              channelInfos.map(c => c.id),
+            ),
+          )
+
     return {
       channelInfos: channelInfos.map(channel => toBasicChannelInfo(channel)),
       detailedChannelInfos,
       joinedChannelInfos,
+      deletedChannels,
     }
   }
 

--- a/server/lib/chat/chat-service.ts
+++ b/server/lib/chat/chat-service.ts
@@ -77,6 +77,7 @@ import {
   getChannelBans,
   getChannelInfo,
   getChannelInfos,
+  getChannelMessageSentTime,
   getChannelsForUser,
   getMessagesForChannel,
   getUnreadChannelInfo,
@@ -965,6 +966,7 @@ export default class ChatService {
     beforeTime,
     afterTime,
     aroundTime,
+    aroundMessageId,
     isAdmin,
   }: {
     channelId: SbChannelId
@@ -973,6 +975,7 @@ export default class ChatService {
     beforeTime?: number
     afterTime?: number
     aroundTime?: number
+    aroundMessageId?: string
     isAdmin?: boolean
   }): Promise<GetChannelHistoryServerResponse> {
     const isUserInChannel = Boolean(await getUserChannelEntryForUser(userId, channelId))
@@ -991,6 +994,15 @@ export default class ChatService {
       cursor = { kind: 'after', date: new Date(afterTime) }
     } else if (aroundTime !== undefined && aroundTime >= 0) {
       cursor = { kind: 'around', date: new Date(aroundTime) }
+    } else if (aroundMessageId !== undefined) {
+      const sentTime = await getChannelMessageSentTime(channelId, aroundMessageId)
+      if (sentTime === undefined) {
+        throw new ChatServiceError(
+          ChatServiceErrorCode.MessageNotFound,
+          'Message not found in this channel',
+        )
+      }
+      cursor = { kind: 'around', date: sentTime }
     }
 
     const {

--- a/server/public/locales/en/global.json
+++ b/server/public/locales/en/global.json
@@ -359,6 +359,10 @@
       "errorMessage": "Error deleting message",
       "successMessage": "Message deleted"
     },
+    "errors": {
+      "loadingHistory": "Error loading message history: {{errorMessage}}",
+      "messageNotFound": "That message couldn't be found. It may have been deleted."
+    },
     "joinChannel": {
       "bannedError": "You are banned from #{{channelName}}",
       "genericError": "An error occurred while joining #{{channelName}}",
@@ -390,6 +394,7 @@
       "selfJoinChannel": "You joined <2><0></0></2>"
     },
     "messageMenu": {
+      "copyMessageLink": "Copy message link",
       "deleteMessage": "Delete message"
     },
     "navEntry": {

--- a/server/public/locales/en/global.json
+++ b/server/public/locales/en/global.json
@@ -393,6 +393,9 @@
       "newChannelOwner": "<0><0></0></0> is the new owner of the channel",
       "selfJoinChannel": "You joined <2><0></0></2>"
     },
+    "messageLink": {
+      "label": "message"
+    },
     "messageMenu": {
       "copyMessageLink": "Copy message link",
       "deleteMessage": "Delete message"

--- a/server/public/locales/en/global.json
+++ b/server/public/locales/en/global.json
@@ -285,7 +285,8 @@
       "kickAction": "Kick {{user}}"
     },
     "channelName": {
-      "deletedChannel": "deleted-channel"
+      "deletedChannel": "deleted-channel",
+      "privateChannel": "private-channel"
     },
     "channelSettings": {
       "bannedUsers": {


### PR DESCRIPTION
Item 6 (the last unbuilt item) of the scroll-restoration / chat-parity roadmap: links that point at one message in a channel.

## What this does

- A channel URL can carry a message id as `?m=<id>`. Opening one activates the channel, loads the window the message sits in (fetching around it when it isn't already loaded), scrolls the message about a quarter of the way down the viewport, and highlights it for ~2s before the highlight fades.
- The message context menu gains **Copy message link**, which writes `<origin>/chat/<id>/<name>?m=<messageId>` to the clipboard.
- The `?m` param is consumed once the move settles (a reload mid-jump re-jumps; afterward it's an ordinary visit). Precedence at a channel: link → saved reading position → unread line → bottom.
- A not-found / deleted target shows a snackbar and drops back to the newest messages.

## Server

`GET .../messages2` gains an `aroundMessageId` cursor, mutually exclusive with the time cursors via the existing `.oxor`. It resolves the id to its sent time (new `getChannelMessageSentTime` model) and reuses the around-window query. An id that names no message in the channel throws the new `ChatServiceErrorCode.MessageNotFound`, mapped to 404.

## Client

- New `PendingScrollTarget` kind `message` in the shared `Chat`, sharing the saved-position move's window-wait, clamp, and generation handling (the shared logic is extracted rather than duplicated). A linked move settles exactly once — placed, missing, or cancelled by a user scroll.
- A short channel whose content fits the viewport never changes its scroll height as messages load, so the list emits no content scroll-update; a layout effect re-drives a pending linked move on message changes to cover that case.
- URL name-correction for channels and whispers now preserves the query string, so a link's message id survives the canonical-name redirect.

## Scope

Whisper message links are intentionally not built: only the two participants could open one, and no UI mints them. The changes are additive and can be mirrored to whispers later.

## Verification

- `pnpm run typecheck`, `pnpm run lint`, and the full unit suite (2518 tests) pass; `gen-translations` run.
- Live-verified in the browser client against a stable seeded channel and a fresh join: deep link from another view (one around-fetch, detached window, placed at ~25%), already-loaded link (no fetch, flash holds then fades over 1s), join-from-link into a short channel (settles, mark-read fires), not-found id (404 → snackbar → jump to present), same-channel link updates the at-bottom state, leave-and-return after a jump restores the saved position, and copy-link round-trips through the clipboard.