### PR TITLE
Size the accept countdown strip from seconds per cell, not a fixed cell count.

### DIFF
--- a/client/matchmaking/accept-match-dialog.tsx
+++ b/client/matchmaking/accept-match-dialog.tsx
@@ -25,11 +25,11 @@ const ENTER = 'Enter'
 const ENTER_NUMPAD = 'NumpadEnter'
 
 /**
- * How many cells the accept countdown strip is divided into. Chosen so each cell covers a whole
- * number of seconds of the accept window (3s at the standard 30s), keeping the per-second melt
- * notches evenly sized across every cell.
+ * How many seconds of the accept window each cell of the countdown strip covers. The strip gets
+ * however many cells the window needs at this size, so the per-second melt notches (a third of a
+ * cell each) stay the same size however long the window is.
  */
-const TIMER_CELL_COUNT = 10
+const TIMER_CELL_SECONDS = 3
 /**
  * How often the countdown re-renders. The cells melt in per-second notches, but a fast tick keeps
  * the notch (and the waiting-state drain bar) landing close to the true second boundary.
@@ -296,20 +296,20 @@ function AcceptingStateView({ close }: { close: () => void }) {
   const acceptedPlayers = foundMatch?.acceptedPlayers ?? 0
 
   if (!hasAccepted) {
+    const cellCount = Math.max(1, Math.round(acceptTimeTotal / (TIMER_CELL_SECONDS * 1000)))
     // Quantized to whole seconds so the leading cell melts in discrete notches that land exactly
     // on the ticks (and thus stay in sync with the flash and the tick sounds), rather than
-    // draining smoothly between them.
-    const cellValue = ((secondsLeft * 1000) / acceptTimeTotal) * TIMER_CELL_COUNT
+    // draining smoothly between them. Multiplied out before dividing so the value is exact on the
+    // ticks where it lands on a cell boundary; rounding error there would ceil to the wrong cell.
+    const cellValue = (secondsLeft * 1000 * cellCount) / acceptTimeTotal
     const leadIndex = Math.ceil(cellValue) - 1
     // The flash accompanies a cell that just lost a notch but survived. On ticks where a cell
     // dies instead, its collapse animation is the only accent — flashing the next cell at the
     // same moment would have two cells animating at once.
-    const prevCellValue = (((secondsLeft + 1) * 1000) / acceptTimeTotal) * TIMER_CELL_COUNT
+    const prevCellValue = ((secondsLeft + 1) * 1000 * cellCount) / acceptTimeTotal
     const flashIndex =
-      Math.ceil(prevCellValue) - 1 === leadIndex && prevCellValue <= TIMER_CELL_COUNT
-        ? leadIndex
-        : -1
-    const timerCells = Array.from(range(0, TIMER_CELL_COUNT), i => {
+      Math.ceil(prevCellValue) - 1 === leadIndex && prevCellValue <= cellCount ? leadIndex : -1
+    const timerCells = Array.from(range(0, cellCount), i => {
       const fill = Math.max(0, Math.min(1, cellValue - i))
       const lit = fill > 0
 

--- a/client/matchmaking/devonly/match-dialogs-test.tsx
+++ b/client/matchmaking/devonly/match-dialogs-test.tsx
@@ -19,7 +19,6 @@ import { CheckBox } from '../../material/check-box'
 import { NumberTextField } from '../../material/number-text-field'
 import { SelectOption } from '../../material/select/option'
 import { Select } from '../../material/select/select'
-import { useStableCallback } from '../../react/state-hooks'
 import { useAppDispatch } from '../../redux-hooks'
 import { BodyMedium } from '../../styles/typography'
 import { closeAcceptMatchDialog, openAcceptMatchDialog } from '../action-creators'
@@ -50,9 +49,10 @@ export function MatchDialogsTest() {
   const [acceptedPlayers, setAcceptedPlayers] = useState(0)
   const [hasAccepted, setHasAccepted] = useState(false)
   const [showProvisioningStatus, setShowProvisioningStatus] = useState(false)
+  const [acceptWindowSecs, setAcceptWindowSecs] = useState(MATCHMAKING_ACCEPT_MATCH_TIME_MS / 1000)
   const [autoCloseSecs, setAutoCloseSecs] = useState(10)
 
-  const showAcceptDialog = useStableCallback(() => {
+  const showAcceptDialog = () => {
     store.set(currentSearchInfoAtom, {
       searchedTypes: new Map<MatchmakingType, RaceChar>([[matchmakingType, 'r']]),
       startTime: window.performance.now(),
@@ -61,21 +61,28 @@ export function MatchDialogsTest() {
       matchmakingType,
       numPlayers,
       acceptStart: window.performance.now(),
-      acceptTimeTotalMillis: MATCHMAKING_ACCEPT_MATCH_TIME_MS,
+      acceptTimeTotalMillis: acceptWindowSecs * 1000,
       acceptedPlayers,
       hasAccepted,
     })
     dispatch(openAcceptMatchDialog())
 
-    // The dialog is modal with no close button (the real flow closes it from server events), so
-    // close it and reset the fake state automatically after a bit
+    // Mirrors what the server does when the window runs out: the match goes away while the
+    // search continues, which puts the dialog into its returning-to-queue state until it closes
+    // itself. The final clear covers the case where the dialog was dismissed before then.
     setTimeout(() => {
-      clearMatchmakingState(store)
-      dispatch(closeAcceptMatchDialog())
-    }, autoCloseSecs * 1000)
-  })
+      store.set(foundMatchAtom, undefined)
+    }, acceptWindowSecs * 1000)
+    setTimeout(
+      () => {
+        clearMatchmakingState(store)
+        dispatch(closeAcceptMatchDialog())
+      },
+      acceptWindowSecs * 1000 + 6000,
+    )
+  }
 
-  const showLaunchingDialog = useStableCallback((type: MatchmakingType | undefined) => {
+  const showLaunchingDialog = (type: MatchmakingType | undefined) => {
     store.set(matchLaunchingAtom, true)
     store.set(launchingMatchmakingTypeAtom, type)
     store.set(
@@ -89,14 +96,16 @@ export function MatchDialogsTest() {
       store.set(gameLoadingStatusAtom, undefined)
       dispatch(closeDialog(DialogType.LaunchingGame))
     }, autoCloseSecs * 1000)
-  })
+  }
 
   return (
     <div>
       <ControlsCard>
         <BodyMedium>
-          The accept-match and launching-game dialogs are modal without a close button, so they
-          auto-close after the configured number of seconds.
+          The accept-match dialog runs its full lifecycle: the countdown runs for the configured
+          accept window, then the match dissolves and the dialog shows its returning-to-queue state
+          before closing itself. The launching dialog has no close button, so it auto-closes after
+          the configured number of seconds.
         </BodyMedium>
         <Select
           value={matchmakingType}
@@ -136,7 +145,13 @@ export function MatchDialogsTest() {
           }
         />
         <NumberTextField
-          label='Auto-close after (seconds)'
+          label='Accept window (seconds)'
+          floatingLabel={true}
+          value={acceptWindowSecs}
+          onChange={setAcceptWindowSecs}
+        />
+        <NumberTextField
+          label='Auto-close launching dialog after (seconds)'
           floatingLabel={true}
           value={autoCloseSecs}
           onChange={setAutoCloseSecs}


### PR DESCRIPTION
## Problem

The accept dialog's countdown strip hardcoded 10 cells, tuned so each covered 3s of the 30s window and melted in three visible per-second notches. Raising the window to 60s (7a41eafc1) silently made each cell cover 6s: a notch shrank to ~1.6px / 0.12 opacity and a cell only died every six seconds, so the strip barely moved.

## Change

- `accept-match-dialog.tsx`: `TIMER_CELL_COUNT = 10` → `TIMER_CELL_SECONDS = 3`, with the count derived from the match's `acceptTimeTotalMillis` at render time (20 cells at 60s). The per-cell melt, flash, and death cadence are untouched. The cell value multiplies before dividing so ticks that land on a cell boundary are exact.
- `devonly/match-dialogs-test.tsx`: new "Accept window (seconds)" field so 30s and 60s can be compared side by side. The accept dialog now runs its real lifecycle (window expires → match dissolves → returning-to-queue state → self-close) instead of being force-closed after 10s, which only ever showed the first ten seconds. Stale "no close button" copy fixed; `useStableCallback` dropped.

## Verification

- Lint, typecheck, `client/matchmaking` unit tests pass.
- Simulated every tick of the 60s window: each second is exactly one flash or one cell death (never both, never neither), and notch sizes match the 30s values (scaleY 1 → 0.82 → 0.63, opacity 1 → 0.77 → 0.53).
- Measured in the dev page: 20 cells of 10×18px, 276px strip + 35px numeral inside the 352px dialog content; flash/death cadence as designed; low-time red pulse at 0:05; expiry into the returning-to-queue state and self-close.

Eyeball it at `/dev/matchmaking/match-dialogs` with the window at 60 and 30. If 20 cells read too dense, cell width/gap (10px/4px) is the knob; raising `TIMER_CELL_SECONDS` shrinks the notches again.
