### PR TITLE
Show friends as in a lobby, in the queue, or in a game.

### DIFF
--- a/client/active-game/socket-handlers.ts
+++ b/client/active-game/socket-handlers.ts
@@ -175,6 +175,41 @@ export default function ({
 
         doFetch()
       }
+
+      if (status.state === 'finished' || status.state === 'unknown') {
+        // The app reports `finished` when the game ended through the game-over handshake, and
+        // `unknown` when the process went away without one (a crash, the window being closed, a
+        // forced quit) or the game's config was cleared. Either way the game is over for this user,
+        // which is all the server tracks from this report (it drives friend presence), so both are
+        // reported as finished. Unlike the playing/error report above, a failure here never quits
+        // the game or clears its config: there's nothing left to abort.
+        let attempt = 0
+
+        const doFetch = () => {
+          attempt += 1
+          fetchJson(apiUrl`games/${status.id}/status`, {
+            method: 'put',
+            body: JSON.stringify({ status: stringToStatus('finished') }),
+            signal: AbortSignal.timeout(2000),
+          }).then(
+            () => {
+              logger.debug(`Reported game exit for ${status.id} to server`)
+            },
+            err => {
+              if (attempt < 3) {
+                setTimeout(doFetch, 500)
+              } else {
+                logger.error(
+                  `Failed to report game exit for ${status.id} to server after ` +
+                    `${attempt} attempts: ${err}`,
+                )
+              }
+            },
+          )
+        }
+
+        doFetch()
+      }
     })
     .on('activeGameReplaySaved', (_, gameId, path) => {
       jotaiStore.set(addRecentReplayPathAtom, { gameId, path })

--- a/client/chat/channel-user-list.tsx
+++ b/client/chat/channel-user-list.tsx
@@ -8,6 +8,7 @@ import { eatVirtuosoContext } from '../lists/eat-virtuoso-context'
 import { ChatContext } from '../messaging/chat-context'
 import { useMentionFilterClick } from '../messaging/mention-hooks'
 import { useAppSelector } from '../redux-hooks'
+import { FriendActivityStatusLine, NameBlock, NameLine } from '../social/friend-activity-status'
 import { labelMedium, singleLine, titleSmall } from '../styles/typography'
 import { LiveLabel } from '../twitch/live-indicators'
 import { useLiveUserIds } from '../twitch/live-state'
@@ -121,12 +122,6 @@ const UserListEntryItem = styled.div<UserListEntryItemProps>`
   }}
 `
 
-const UserListName = styled.span`
-  ${singleLine};
-  flex-grow: 1;
-  flex-shrink: 1;
-`
-
 interface UserListEntryProps {
   userId: SbUserId
   faded?: boolean
@@ -165,7 +160,10 @@ const ConnectedUserListEntry = React.memo<UserListEntryProps>(props => {
         onContextMenu={onContextMenu}>
         <StyledAvatar userId={props.userId} />
         {user ? (
-          <UserListName>{user.name}</UserListName>
+          <NameBlock>
+            <NameLine>{user.name}</NameLine>
+            <FriendActivityStatusLine userId={props.userId} />
+          </NameBlock>
         ) : (
           <LoadingName aria-label={t('common.loading.username', 'Username loading…')} />
         )}

--- a/client/messaging/__snapshots__/common-message-layout.test.tsx.snap
+++ b/client/messaging/__snapshots__/common-message-layout.test.tsx.snap
@@ -5,51 +5,51 @@ exports[`client/messaging/common-message-layout/TextMessage > message as a norma
   data-testid="message-container"
 >
   <div
-    class="sc-jvDgNt kzcowL"
+    class="sc-ewKWQi lczqpc"
     data-message-id="MESSAGE_ID"
     role="document"
   >
     <div
-      class="sc-ikrMhg iRLQJB sc-hjIEjD cGTiYu"
+      class="sc-ikrMhg iRLQJB sc-hZoehQ gpXEYv"
       tabindex="0"
     >
       <span
-        class="sc-bRBteW kFvymL"
+        class="sc-hKOsxR bpFDMS"
       >
         <i
           aria-hidden="true"
-          class="sc-jhbick fENxjz"
+          class="sc-iXWgTX cKQkDT"
         >
           [
         </i>
         12:00 AM
         <i
           aria-hidden="true"
-          class="sc-jhbick fENxjz"
+          class="sc-iXWgTX cKQkDT"
         >
           ] 
         </i>
       </span>
     </div>
     <span
-      class="sc-gHmoSK kRelkX sc-fylCKh hhpGLA"
+      class="sc-edvVIM BgKKj sc-iuKxBX dcHVMW"
       tabindex="0"
     >
       <span
         aria-label="Username loading…"
-        class="sc-djMJHV upVlS"
+        class="sc-jmvSDW kJMgdI"
       >
                    
       </span>
     </span>
     <i
       aria-hidden="true"
-      class="sc-jhbick fENxjz"
+      class="sc-iXWgTX cKQkDT"
     >
       : 
     </i>
     <span
-      class="sc-gerFA dEeYPb"
+      class="sc-dcDmxq joZYTb"
     >
       This is test message
     </span>
@@ -62,55 +62,55 @@ exports[`client/messaging/common-message-layout/TextMessage > message mixing emo
   data-testid="message-container"
 >
   <div
-    class="sc-jvDgNt kzcowL"
+    class="sc-ewKWQi lczqpc"
     data-message-id="MESSAGE_ID"
     role="document"
   >
     <div
-      class="sc-ikrMhg iRLQJB sc-hjIEjD cGTiYu"
+      class="sc-ikrMhg iRLQJB sc-hZoehQ gpXEYv"
       tabindex="0"
     >
       <span
-        class="sc-bRBteW kFvymL"
+        class="sc-hKOsxR bpFDMS"
       >
         <i
           aria-hidden="true"
-          class="sc-jhbick fENxjz"
+          class="sc-iXWgTX cKQkDT"
         >
           [
         </i>
         12:00 AM
         <i
           aria-hidden="true"
-          class="sc-jhbick fENxjz"
+          class="sc-iXWgTX cKQkDT"
         >
           ] 
         </i>
       </span>
     </div>
     <span
-      class="sc-gHmoSK kRelkX sc-fylCKh hhpGLA"
+      class="sc-edvVIM BgKKj sc-iuKxBX dcHVMW"
       tabindex="0"
     >
       <span
         aria-label="Username loading…"
-        class="sc-djMJHV upVlS"
+        class="sc-jmvSDW kJMgdI"
       >
                    
       </span>
     </span>
     <i
       aria-hidden="true"
-      class="sc-jhbick fENxjz"
+      class="sc-iXWgTX cKQkDT"
     >
       : 
     </i>
     <span
-      class="sc-gerFA dEeYPb"
+      class="sc-dcDmxq joZYTb"
     >
       nice game 
       <span
-        class="sc-IAGWt fONgRe"
+        class="sc-iucATu bAwULp"
       >
         🔥
       </span>
@@ -124,51 +124,51 @@ exports[`client/messaging/common-message-layout/TextMessage > message with a lin
   data-testid="message-container"
 >
   <div
-    class="sc-jvDgNt kzcowL"
+    class="sc-ewKWQi lczqpc"
     data-message-id="MESSAGE_ID"
     role="document"
   >
     <div
-      class="sc-ikrMhg iRLQJB sc-hjIEjD cGTiYu"
+      class="sc-ikrMhg iRLQJB sc-hZoehQ gpXEYv"
       tabindex="0"
     >
       <span
-        class="sc-bRBteW kFvymL"
+        class="sc-hKOsxR bpFDMS"
       >
         <i
           aria-hidden="true"
-          class="sc-jhbick fENxjz"
+          class="sc-iXWgTX cKQkDT"
         >
           [
         </i>
         12:00 AM
         <i
           aria-hidden="true"
-          class="sc-jhbick fENxjz"
+          class="sc-iXWgTX cKQkDT"
         >
           ] 
         </i>
       </span>
     </div>
     <span
-      class="sc-gHmoSK kRelkX sc-fylCKh hhpGLA"
+      class="sc-edvVIM BgKKj sc-iuKxBX dcHVMW"
       tabindex="0"
     >
       <span
         aria-label="Username loading…"
-        class="sc-djMJHV upVlS"
+        class="sc-jmvSDW kJMgdI"
       >
                    
       </span>
     </span>
     <i
       aria-hidden="true"
-      class="sc-jhbick fENxjz"
+      class="sc-iXWgTX cKQkDT"
     >
       : 
     </i>
     <span
-      class="sc-gerFA dEeYPb"
+      class="sc-dcDmxq joZYTb"
     >
       here is a link 
       <a
@@ -188,51 +188,51 @@ exports[`client/messaging/common-message-layout/TextMessage > message with a lin
   data-testid="message-container"
 >
   <div
-    class="sc-jvDgNt kzcowL"
+    class="sc-ewKWQi lczqpc"
     data-message-id="MESSAGE_ID"
     role="document"
   >
     <div
-      class="sc-ikrMhg iRLQJB sc-hjIEjD cGTiYu"
+      class="sc-ikrMhg iRLQJB sc-hZoehQ gpXEYv"
       tabindex="0"
     >
       <span
-        class="sc-bRBteW kFvymL"
+        class="sc-hKOsxR bpFDMS"
       >
         <i
           aria-hidden="true"
-          class="sc-jhbick fENxjz"
+          class="sc-iXWgTX cKQkDT"
         >
           [
         </i>
         12:00 AM
         <i
           aria-hidden="true"
-          class="sc-jhbick fENxjz"
+          class="sc-iXWgTX cKQkDT"
         >
           ] 
         </i>
       </span>
     </div>
     <span
-      class="sc-gHmoSK kRelkX sc-fylCKh hhpGLA"
+      class="sc-edvVIM BgKKj sc-iuKxBX dcHVMW"
       tabindex="0"
     >
       <span
         aria-label="Username loading…"
-        class="sc-djMJHV upVlS"
+        class="sc-jmvSDW kJMgdI"
       >
                    
       </span>
     </span>
     <i
       aria-hidden="true"
-      class="sc-jhbick fENxjz"
+      class="sc-iXWgTX cKQkDT"
     >
       : 
     </i>
     <span
-      class="sc-gerFA dEeYPb"
+      class="sc-dcDmxq joZYTb"
     >
       <a
         href="http://www.example.com"
@@ -244,13 +244,13 @@ exports[`client/messaging/common-message-layout/TextMessage > message with a lin
        go here
        
       <span
-        class="sc-gHmoSK kRelkX sc-ciUawz ghjPtB"
+        class="sc-edvVIM BgKKj sc-egVbnM hxTwgj"
         tabindex="0"
       >
         @
         <span
           aria-label="Username loading…"
-          class="sc-djMJHV upVlS"
+          class="sc-jmvSDW kJMgdI"
         >
                      
         </span>
@@ -265,62 +265,62 @@ exports[`client/messaging/common-message-layout/TextMessage > message with a lin
   data-testid="message-container"
 >
   <div
-    class="sc-jvDgNt kzcowL"
+    class="sc-ewKWQi lczqpc"
     data-message-id="MESSAGE_ID"
     role="document"
   >
     <div
-      class="sc-ikrMhg iRLQJB sc-hjIEjD cGTiYu"
+      class="sc-ikrMhg iRLQJB sc-hZoehQ gpXEYv"
       tabindex="0"
     >
       <span
-        class="sc-bRBteW kFvymL"
+        class="sc-hKOsxR bpFDMS"
       >
         <i
           aria-hidden="true"
-          class="sc-jhbick fENxjz"
+          class="sc-iXWgTX cKQkDT"
         >
           [
         </i>
         12:00 AM
         <i
           aria-hidden="true"
-          class="sc-jhbick fENxjz"
+          class="sc-iXWgTX cKQkDT"
         >
           ] 
         </i>
       </span>
     </div>
     <span
-      class="sc-gHmoSK kRelkX sc-fylCKh hhpGLA"
+      class="sc-edvVIM BgKKj sc-iuKxBX dcHVMW"
       tabindex="0"
     >
       <span
         aria-label="Username loading…"
-        class="sc-djMJHV upVlS"
+        class="sc-jmvSDW kJMgdI"
       >
                    
       </span>
     </span>
     <i
       aria-hidden="true"
-      class="sc-jhbick fENxjz"
+      class="sc-iXWgTX cKQkDT"
     >
       : 
     </i>
     <span
-      class="sc-gerFA dEeYPb"
+      class="sc-dcDmxq joZYTb"
     >
       hey
        
       <span
-        class="sc-gHmoSK kRelkX sc-ciUawz ghjPtB"
+        class="sc-edvVIM BgKKj sc-egVbnM hxTwgj"
         tabindex="0"
       >
         @
         <span
           aria-label="Username loading…"
-          class="sc-djMJHV upVlS"
+          class="sc-jmvSDW kJMgdI"
         >
                      
         </span>
@@ -336,13 +336,13 @@ exports[`client/messaging/common-message-layout/TextMessage > message with a lin
        go here
        
       <span
-        class="sc-gHmoSK kRelkX sc-ciUawz ghjPtB"
+        class="sc-edvVIM BgKKj sc-egVbnM hxTwgj"
         tabindex="0"
       >
         @
         <span
           aria-label="Username loading…"
-          class="sc-djMJHV upVlS"
+          class="sc-jmvSDW kJMgdI"
         >
                      
         </span>
@@ -357,62 +357,62 @@ exports[`client/messaging/common-message-layout/TextMessage > message with a men
   data-testid="message-container"
 >
   <div
-    class="sc-jvDgNt kzcowL"
+    class="sc-ewKWQi lczqpc"
     data-message-id="MESSAGE_ID"
     role="document"
   >
     <div
-      class="sc-ikrMhg iRLQJB sc-hjIEjD cGTiYu"
+      class="sc-ikrMhg iRLQJB sc-hZoehQ gpXEYv"
       tabindex="0"
     >
       <span
-        class="sc-bRBteW kFvymL"
+        class="sc-hKOsxR bpFDMS"
       >
         <i
           aria-hidden="true"
-          class="sc-jhbick fENxjz"
+          class="sc-iXWgTX cKQkDT"
         >
           [
         </i>
         12:00 AM
         <i
           aria-hidden="true"
-          class="sc-jhbick fENxjz"
+          class="sc-iXWgTX cKQkDT"
         >
           ] 
         </i>
       </span>
     </div>
     <span
-      class="sc-gHmoSK kRelkX sc-fylCKh hhpGLA"
+      class="sc-edvVIM BgKKj sc-iuKxBX dcHVMW"
       tabindex="0"
     >
       <span
         aria-label="Username loading…"
-        class="sc-djMJHV upVlS"
+        class="sc-jmvSDW kJMgdI"
       >
                    
       </span>
     </span>
     <i
       aria-hidden="true"
-      class="sc-jhbick fENxjz"
+      class="sc-iXWgTX cKQkDT"
     >
       : 
     </i>
     <span
-      class="sc-gerFA dEeYPb"
+      class="sc-dcDmxq joZYTb"
     >
       hey
        
       <span
-        class="sc-gHmoSK kRelkX sc-ciUawz ghjPtB"
+        class="sc-edvVIM BgKKj sc-egVbnM hxTwgj"
         tabindex="0"
       >
         @
         <span
           aria-label="Username loading…"
-          class="sc-djMJHV upVlS"
+          class="sc-jmvSDW kJMgdI"
         >
                      
         </span>
@@ -427,60 +427,60 @@ exports[`client/messaging/common-message-layout/TextMessage > message with a men
   data-testid="message-container"
 >
   <div
-    class="sc-jvDgNt kzcowL"
+    class="sc-ewKWQi lczqpc"
     data-message-id="MESSAGE_ID"
     role="document"
   >
     <div
-      class="sc-ikrMhg iRLQJB sc-hjIEjD cGTiYu"
+      class="sc-ikrMhg iRLQJB sc-hZoehQ gpXEYv"
       tabindex="0"
     >
       <span
-        class="sc-bRBteW kFvymL"
+        class="sc-hKOsxR bpFDMS"
       >
         <i
           aria-hidden="true"
-          class="sc-jhbick fENxjz"
+          class="sc-iXWgTX cKQkDT"
         >
           [
         </i>
         12:00 AM
         <i
           aria-hidden="true"
-          class="sc-jhbick fENxjz"
+          class="sc-iXWgTX cKQkDT"
         >
           ] 
         </i>
       </span>
     </div>
     <span
-      class="sc-gHmoSK kRelkX sc-fylCKh hhpGLA"
+      class="sc-edvVIM BgKKj sc-iuKxBX dcHVMW"
       tabindex="0"
     >
       <span
         aria-label="Username loading…"
-        class="sc-djMJHV upVlS"
+        class="sc-jmvSDW kJMgdI"
       >
                    
       </span>
     </span>
     <i
       aria-hidden="true"
-      class="sc-jhbick fENxjz"
+      class="sc-iXWgTX cKQkDT"
     >
       : 
     </i>
     <span
-      class="sc-gerFA dEeYPb"
+      class="sc-dcDmxq joZYTb"
     >
       <span
-        class="sc-gHmoSK kRelkX sc-ciUawz ghjPtB"
+        class="sc-edvVIM BgKKj sc-egVbnM hxTwgj"
         tabindex="0"
       >
         @
         <span
           aria-label="Username loading…"
-          class="sc-djMJHV upVlS"
+          class="sc-jmvSDW kJMgdI"
         >
                      
         </span>
@@ -503,51 +503,51 @@ exports[`client/messaging/common-message-layout/TextMessage > message with a men
   data-testid="message-container"
 >
   <div
-    class="sc-jvDgNt kzcowL"
+    class="sc-ewKWQi lczqpc"
     data-message-id="MESSAGE_ID"
     role="document"
   >
     <div
-      class="sc-ikrMhg iRLQJB sc-hjIEjD cGTiYu"
+      class="sc-ikrMhg iRLQJB sc-hZoehQ gpXEYv"
       tabindex="0"
     >
       <span
-        class="sc-bRBteW kFvymL"
+        class="sc-hKOsxR bpFDMS"
       >
         <i
           aria-hidden="true"
-          class="sc-jhbick fENxjz"
+          class="sc-iXWgTX cKQkDT"
         >
           [
         </i>
         12:00 AM
         <i
           aria-hidden="true"
-          class="sc-jhbick fENxjz"
+          class="sc-iXWgTX cKQkDT"
         >
           ] 
         </i>
       </span>
     </div>
     <span
-      class="sc-gHmoSK kRelkX sc-fylCKh hhpGLA"
+      class="sc-edvVIM BgKKj sc-iuKxBX dcHVMW"
       tabindex="0"
     >
       <span
         aria-label="Username loading…"
-        class="sc-djMJHV upVlS"
+        class="sc-jmvSDW kJMgdI"
       >
                    
       </span>
     </span>
     <i
       aria-hidden="true"
-      class="sc-jhbick fENxjz"
+      class="sc-iXWgTX cKQkDT"
     >
       : 
     </i>
     <span
-      class="sc-gerFA dEeYPb"
+      class="sc-dcDmxq joZYTb"
     >
       <a
         href="http://www.example.com"
@@ -559,13 +559,13 @@ exports[`client/messaging/common-message-layout/TextMessage > message with a men
        go here
        
       <span
-        class="sc-gHmoSK kRelkX sc-ciUawz ghjPtB"
+        class="sc-edvVIM BgKKj sc-egVbnM hxTwgj"
         tabindex="0"
       >
         @
         <span
           aria-label="Username loading…"
-          class="sc-djMJHV upVlS"
+          class="sc-jmvSDW kJMgdI"
         >
                      
         </span>
@@ -588,62 +588,62 @@ exports[`client/messaging/common-message-layout/TextMessage > message with a men
   data-testid="message-container"
 >
   <div
-    class="sc-jvDgNt bWKAqk"
+    class="sc-ewKWQi btpJXv"
     data-message-id="MESSAGE_ID"
     role="document"
   >
     <div
-      class="sc-ikrMhg iRLQJB sc-hjIEjD cGTiYu"
+      class="sc-ikrMhg iRLQJB sc-hZoehQ gpXEYv"
       tabindex="0"
     >
       <span
-        class="sc-bRBteW kFvymL"
+        class="sc-hKOsxR bpFDMS"
       >
         <i
           aria-hidden="true"
-          class="sc-jhbick fENxjz"
+          class="sc-iXWgTX cKQkDT"
         >
           [
         </i>
         12:00 AM
         <i
           aria-hidden="true"
-          class="sc-jhbick fENxjz"
+          class="sc-iXWgTX cKQkDT"
         >
           ] 
         </i>
       </span>
     </div>
     <span
-      class="sc-gHmoSK kRelkX sc-fylCKh hhpGLA"
+      class="sc-edvVIM BgKKj sc-iuKxBX dcHVMW"
       tabindex="0"
     >
       <span
         aria-label="Username loading…"
-        class="sc-djMJHV upVlS"
+        class="sc-jmvSDW kJMgdI"
       >
                    
       </span>
     </span>
     <i
       aria-hidden="true"
-      class="sc-jhbick fENxjz"
+      class="sc-iXWgTX cKQkDT"
     >
       : 
     </i>
     <span
-      class="sc-gerFA dEeYPb"
+      class="sc-dcDmxq joZYTb"
     >
       Hey
        
       <span
-        class="sc-gHmoSK kRelkX sc-ciUawz ghjPtB"
+        class="sc-edvVIM BgKKj sc-egVbnM hxTwgj"
         tabindex="0"
       >
         @
         <span
           aria-label="Username loading…"
-          class="sc-djMJHV upVlS"
+          class="sc-jmvSDW kJMgdI"
         >
                      
         </span>
@@ -658,60 +658,60 @@ exports[`client/messaging/common-message-layout/TextMessage > message with only 
   data-testid="message-container"
 >
   <div
-    class="sc-jvDgNt kzcowL"
+    class="sc-ewKWQi lczqpc"
     data-message-id="MESSAGE_ID"
     role="document"
   >
     <div
-      class="sc-ikrMhg iRLQJB sc-hjIEjD cGTiYu"
+      class="sc-ikrMhg iRLQJB sc-hZoehQ gpXEYv"
       tabindex="0"
     >
       <span
-        class="sc-bRBteW kFvymL"
+        class="sc-hKOsxR bpFDMS"
       >
         <i
           aria-hidden="true"
-          class="sc-jhbick fENxjz"
+          class="sc-iXWgTX cKQkDT"
         >
           [
         </i>
         12:00 AM
         <i
           aria-hidden="true"
-          class="sc-jhbick fENxjz"
+          class="sc-iXWgTX cKQkDT"
         >
           ] 
         </i>
       </span>
     </div>
     <span
-      class="sc-gHmoSK kRelkX sc-fylCKh hhpGLA"
+      class="sc-edvVIM BgKKj sc-iuKxBX dcHVMW"
       tabindex="0"
     >
       <span
         aria-label="Username loading…"
-        class="sc-djMJHV upVlS"
+        class="sc-jmvSDW kJMgdI"
       >
                    
       </span>
     </span>
     <i
       aria-hidden="true"
-      class="sc-jhbick fENxjz"
+      class="sc-iXWgTX cKQkDT"
     >
       : 
     </i>
     <span
-      class="sc-gerFA dEeYPb"
+      class="sc-dcDmxq joZYTb"
     >
       <span
-        class="sc-IAGWt chiZeR"
+        class="sc-iucATu bLJJAa"
       >
         🔥🔥
       </span>
        
       <span
-        class="sc-IAGWt chiZeR"
+        class="sc-iucATu bLJJAa"
       >
         🎉
       </span>
@@ -725,54 +725,54 @@ exports[`client/messaging/common-message-layout/TextMessage > message with too m
   data-testid="message-container"
 >
   <div
-    class="sc-jvDgNt kzcowL"
+    class="sc-ewKWQi lczqpc"
     data-message-id="MESSAGE_ID"
     role="document"
   >
     <div
-      class="sc-ikrMhg iRLQJB sc-hjIEjD cGTiYu"
+      class="sc-ikrMhg iRLQJB sc-hZoehQ gpXEYv"
       tabindex="0"
     >
       <span
-        class="sc-bRBteW kFvymL"
+        class="sc-hKOsxR bpFDMS"
       >
         <i
           aria-hidden="true"
-          class="sc-jhbick fENxjz"
+          class="sc-iXWgTX cKQkDT"
         >
           [
         </i>
         12:00 AM
         <i
           aria-hidden="true"
-          class="sc-jhbick fENxjz"
+          class="sc-iXWgTX cKQkDT"
         >
           ] 
         </i>
       </span>
     </div>
     <span
-      class="sc-gHmoSK kRelkX sc-fylCKh hhpGLA"
+      class="sc-edvVIM BgKKj sc-iuKxBX dcHVMW"
       tabindex="0"
     >
       <span
         aria-label="Username loading…"
-        class="sc-djMJHV upVlS"
+        class="sc-jmvSDW kJMgdI"
       >
                    
       </span>
     </span>
     <i
       aria-hidden="true"
-      class="sc-jhbick fENxjz"
+      class="sc-iXWgTX cKQkDT"
     >
       : 
     </i>
     <span
-      class="sc-gerFA dEeYPb"
+      class="sc-dcDmxq joZYTb"
     >
       <span
-        class="sc-IAGWt fONgRe"
+        class="sc-iucATu bAwULp"
       >
         😀😀😀😀😀😀😀😀😀😀😀
       </span>

--- a/client/social/friend-activity-status.tsx
+++ b/client/social/friend-activity-status.tsx
@@ -1,0 +1,162 @@
+import { TFunction } from 'i18next'
+import { useTranslation } from 'react-i18next'
+import styled from 'styled-components'
+import { FriendActivityStatus } from '../../common/users/relationships'
+import { SbUserId } from '../../common/users/sb-user-id'
+import { MaterialIcon } from '../icons/material/material-icon'
+import { Tooltip } from '../material/tooltip'
+import { useAppSelector } from '../redux-hooks'
+import { bodySmall, inter, singleLine } from '../styles/typography'
+
+/** Reads the current activity status of a friend, or `undefined` if they're not a friend. */
+export function useFriendActivityStatus(userId: SbUserId): FriendActivityStatus | undefined {
+  return useAppSelector(s => s.relationships.friendActivityStatus.get(userId))
+}
+
+interface ActivityDescriptor {
+  icon: string
+  color: string
+  label: string
+}
+
+/**
+ * Maps a friend's activity status to how it should be presented: which icon to use, what color to
+ * render it in, and its label. Returns `undefined` for the states that shouldn't render anything
+ * (online, offline, or not a friend at all).
+ */
+function getActivityDescriptor(
+  status: FriendActivityStatus | undefined,
+  t: TFunction,
+): ActivityDescriptor | undefined {
+  switch (status) {
+    case FriendActivityStatus.InLobby:
+      return {
+        icon: 'groups',
+        color: 'var(--theme-positive)',
+        label: t('users.activityStatus.inLobby', 'In lobby'),
+      }
+    case FriendActivityStatus.InQueue:
+      return {
+        icon: 'search',
+        color: 'var(--theme-amber)',
+        label: t('users.activityStatus.inQueue', 'In queue'),
+      }
+    case FriendActivityStatus.InGame:
+      return {
+        icon: 'strategy',
+        color: 'var(--color-blue80)',
+        label: t('users.activityStatus.inGame', 'In game'),
+      }
+    default:
+      return undefined
+  }
+}
+
+/**
+ * A full-width column layout for a name line plus an optional status line below it, used by rows
+ * that show a friend's activity status underneath their name.
+ */
+export const NameBlock = styled.div`
+  flex-grow: 1;
+  min-width: 0;
+
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+`
+
+export const NameLine = styled.div`
+  ${singleLine};
+  line-height: 20px;
+`
+
+const StatusLineRoot = styled.div<{ $color: string }>`
+  ${inter};
+  ${bodySmall};
+
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  line-height: 16px;
+  white-space: nowrap;
+  overflow: hidden;
+
+  color: ${props => props.$color};
+`
+
+const StatusLineIcon = styled(MaterialIcon)`
+  flex-shrink: 0;
+`
+
+// `singleLine`'s `text-overflow: ellipsis` only takes effect on a block's own inline content, not
+// on an anonymous flex item, so the label needs its own block-level element to truncate within the
+// flex row.
+const StatusLabel = styled.span`
+  ${singleLine};
+  min-width: 0;
+`
+
+/**
+ * A single line showing a friend's current activity status (icon + label), for rows with room for
+ * a second line below the name. Renders nothing if the user isn't a friend or has no active
+ * status.
+ */
+export function FriendActivityStatusLine({
+  userId,
+  className,
+}: {
+  userId: SbUserId
+  className?: string
+}) {
+  const { t } = useTranslation()
+  const status = useFriendActivityStatus(userId)
+  const descriptor = getActivityDescriptor(status, t)
+
+  if (!descriptor) {
+    return null
+  }
+
+  return (
+    <StatusLineRoot className={className} $color={descriptor.color}>
+      <StatusLineIcon icon={descriptor.icon} size={14} />
+      <StatusLabel>{descriptor.label}</StatusLabel>
+    </StatusLineRoot>
+  )
+}
+
+const GlyphContainer = styled.span<{ $color: string }>`
+  flex-shrink: 0;
+  color: ${props => props.$color};
+`
+
+/**
+ * An icon-only indicator of a friend's current activity status, for single-line rows that don't
+ * have room for a text label. Renders nothing if the user isn't a friend or has no active status.
+ */
+export function FriendActivityStatusGlyph({
+  userId,
+  className,
+}: {
+  userId: SbUserId
+  className?: string
+}) {
+  const { t } = useTranslation()
+  const status = useFriendActivityStatus(userId)
+  const descriptor = getActivityDescriptor(status, t)
+
+  if (!descriptor) {
+    return null
+  }
+
+  return (
+    <GlyphContainer
+      className={className}
+      $color={descriptor.color}
+      role='img'
+      aria-label={descriptor.label}>
+      <Tooltip text={descriptor.label} position='left' tabIndex={-1}>
+        <MaterialIcon icon={descriptor.icon} size={16} />
+      </Tooltip>
+    </GlyphContainer>
+  )
+}

--- a/client/social/friends-list.tsx
+++ b/client/social/friends-list.tsx
@@ -1,9 +1,9 @@
+import { TFunction } from 'i18next'
 import * as React from 'react'
 import { useCallback, useEffect, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Virtuoso } from 'react-virtuoso'
 import styled, { css } from 'styled-components'
-import { appendToMultimap } from '../../common/data-structures/maps'
 import { FriendActivityStatus, UserRelationshipJson } from '../../common/users/relationships'
 import { SbUserId } from '../../common/users/sb-user-id'
 import { useSelfUser } from '../auth/auth-utils'
@@ -21,7 +21,15 @@ import { UserSettingsPage } from '../settings/settings-page'
 import { DURATION_LONG } from '../snackbars/snackbar-durations'
 import { useSnackbarController } from '../snackbars/snackbar-overlay'
 import { styledWithAttrs } from '../styles/styled-with-attrs'
-import { bodyLarge, labelMedium, singleLine, titleLarge, titleSmall } from '../styles/typography'
+import {
+  bodyLarge,
+  bodySmall,
+  inter,
+  labelMedium,
+  singleLine,
+  titleLarge,
+  titleSmall,
+} from '../styles/typography'
 import { LiveLabel } from '../twitch/live-indicators'
 import { useLiveUserIds } from '../twitch/live-state'
 import { ConnectedUserContextMenu } from '../users/user-context-menu'
@@ -222,6 +230,7 @@ interface OnlineData {
   type: FriendsListRowType.Online
   userId: SbUserId
   isLive: boolean
+  status: FriendActivityStatus
 }
 
 interface OfflineData {
@@ -241,21 +250,22 @@ function VirtualizedFriendsList({ height }: { height: number }) {
     areUserEntriesEqual,
   )
   const liveUserIds = useLiveUserIds()
-  const friendsByStatus = useMemo(() => {
-    const result = new Map<FriendActivityStatus, SbUserId[]>()
-    for (const [id] of sortedFriendUserEntries) {
-      appendToMultimap(result, friendActivityStatus.get(id) ?? FriendActivityStatus.Offline, id)
-    }
-    return result
-  }, [friendActivityStatus, sortedFriendUserEntries])
 
   const rowData = useMemo((): ReadonlyArray<FriendsListRowData> => {
+    // Every status other than Offline (including the in-activity ones) belongs in the online group.
+    const online: SbUserId[] = []
+    const offline: SbUserId[] = []
+    for (const [id] of sortedFriendUserEntries) {
+      const status = friendActivityStatus.get(id) ?? FriendActivityStatus.Offline
+      ;(status === FriendActivityStatus.Offline ? offline : online).push(id)
+    }
+
     // Surface live friends first within each group (Array.sort is stable, so the existing name
     // order is preserved among equally-live friends).
     const liveFirst = (ids: SbUserId[]) =>
-      [...ids].sort((a, b) => (liveUserIds.has(b) ? 1 : 0) - (liveUserIds.has(a) ? 1 : 0))
+      ids.sort((a, b) => (liveUserIds.has(b) ? 1 : 0) - (liveUserIds.has(a) ? 1 : 0))
 
-    const onlineFriends = liveFirst(friendsByStatus.get(FriendActivityStatus.Online) ?? [])
+    const onlineFriends = liveFirst(online)
     let result: FriendsListRowData[] = [
       {
         type: FriendsListRowType.Header,
@@ -269,10 +279,11 @@ function VirtualizedFriendsList({ height }: { height: number }) {
         type: FriendsListRowType.Online,
         userId,
         isLive: liveUserIds.has(userId),
+        status: friendActivityStatus.get(userId) ?? FriendActivityStatus.Online,
       })),
     )
 
-    const offlineFriends = liveFirst(friendsByStatus.get(FriendActivityStatus.Offline) ?? [])
+    const offlineFriends = liveFirst(offline)
     if (offlineFriends.length > 0) {
       result.push({
         type: FriendsListRowType.Header,
@@ -290,7 +301,7 @@ function VirtualizedFriendsList({ height }: { height: number }) {
     }
 
     return result
-  }, [friendsByStatus, liveUserIds, t])
+  }, [friendActivityStatus, liveUserIds, sortedFriendUserEntries, t])
 
   const renderRow = useCallback((index: number, row: FriendsListRowData) => {
     if (row.type === FriendsListRowType.Header) {
@@ -301,7 +312,15 @@ function VirtualizedFriendsList({ height }: { height: number }) {
       )
     } else {
       const faded = row.type === FriendsListRowType.Offline
-      return <FriendEntry userId={row.userId} faded={faded} isLive={row.isLive} key={row.userId} />
+      return (
+        <FriendEntry
+          userId={row.userId}
+          faded={faded}
+          isLive={row.isLive}
+          status={row.type === FriendsListRowType.Online ? row.status : undefined}
+          key={row.userId}
+        />
+      )
     }
   }, [])
 
@@ -578,25 +597,61 @@ const FriendEntryRoot = styled.div<{ $isOverlayOpen?: boolean; $faded?: boolean 
 `
 
 const FriendEntryName = styled.div`
-  ${singleLine};
   flex-grow: 1;
+  min-width: 0;
 `
+
+const FriendEntryNameSingleLine = styled.div`
+  ${singleLine};
+`
+
+const FriendEntryNameLine = styled.div`
+  ${singleLine};
+  line-height: 20px;
+`
+
+const FriendEntryStatusLine = styled.div`
+  ${inter};
+  ${bodySmall};
+  ${singleLine};
+
+  color: var(--theme-on-surface-variant);
+`
+
+function getActivityStatusLabel(
+  t: TFunction,
+  status: FriendActivityStatus | undefined,
+): string | undefined {
+  switch (status) {
+    case FriendActivityStatus.InLobby:
+      return t('social.friendsList.status.inLobby', 'In lobby')
+    case FriendActivityStatus.InQueue:
+      return t('social.friendsList.status.inQueue', 'In queue')
+    case FriendActivityStatus.InGame:
+      return t('social.friendsList.status.inGame', 'In game')
+    default:
+      return undefined
+  }
+}
 
 function FriendEntry({
   userId,
   faded = false,
   isLive = false,
+  status,
   style,
   actions,
 }: {
   userId: SbUserId
   faded?: boolean
   isLive?: boolean
+  status?: FriendActivityStatus
   style?: React.CSSProperties
   actions?: React.ReactNode
 }) {
   const { t } = useTranslation()
   const user = useAppSelector(s => s.users.byId.get(userId))
+  const activityLabel = getActivityStatusLabel(t, status)
 
   const { profileOverlayProps, contextMenuProps, onClick, onContextMenu, isOverlayOpen } =
     useUserOverlays({
@@ -623,7 +678,16 @@ function FriendEntry({
           <StyledAvatar userId={userId} />
         </AvatarContainer>
         {user ? (
-          <FriendEntryName>{user.name}</FriendEntryName>
+          <FriendEntryName>
+            {activityLabel ? (
+              <>
+                <FriendEntryNameLine>{user.name}</FriendEntryNameLine>
+                <FriendEntryStatusLine>{activityLabel}</FriendEntryStatusLine>
+              </>
+            ) : (
+              <FriendEntryNameSingleLine>{user.name}</FriendEntryNameSingleLine>
+            )}
+          </FriendEntryName>
         ) : (
           <LoadingName aria-label={t('social.friendsList.loadingUsername', 'Username loading…')} />
         )}

--- a/client/social/friends-list.tsx
+++ b/client/social/friends-list.tsx
@@ -1,4 +1,3 @@
-import { TFunction } from 'i18next'
 import * as React from 'react'
 import { useCallback, useEffect, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -21,15 +20,7 @@ import { UserSettingsPage } from '../settings/settings-page'
 import { DURATION_LONG } from '../snackbars/snackbar-durations'
 import { useSnackbarController } from '../snackbars/snackbar-overlay'
 import { styledWithAttrs } from '../styles/styled-with-attrs'
-import {
-  bodyLarge,
-  bodySmall,
-  inter,
-  labelMedium,
-  singleLine,
-  titleLarge,
-  titleSmall,
-} from '../styles/typography'
+import { bodyLarge, labelMedium, singleLine, titleLarge, titleSmall } from '../styles/typography'
 import { LiveLabel } from '../twitch/live-indicators'
 import { useLiveUserIds } from '../twitch/live-state'
 import { ConnectedUserContextMenu } from '../users/user-context-menu'
@@ -42,6 +33,7 @@ import {
   getRelationshipsIfNeeded,
   removeFriendRequest,
 } from './action-creators'
+import { FriendActivityStatusLine, NameBlock, NameLine } from './friend-activity-status'
 import { userRelationshipErrorToString } from './relationship-errors'
 
 const FadedFriendsIcon = styledWithAttrs(MaterialIcon, { icon: 'group' })`
@@ -230,7 +222,6 @@ interface OnlineData {
   type: FriendsListRowType.Online
   userId: SbUserId
   isLive: boolean
-  status: FriendActivityStatus
 }
 
 interface OfflineData {
@@ -279,7 +270,6 @@ function VirtualizedFriendsList({ height }: { height: number }) {
         type: FriendsListRowType.Online,
         userId,
         isLive: liveUserIds.has(userId),
-        status: friendActivityStatus.get(userId) ?? FriendActivityStatus.Online,
       })),
     )
 
@@ -312,15 +302,7 @@ function VirtualizedFriendsList({ height }: { height: number }) {
       )
     } else {
       const faded = row.type === FriendsListRowType.Offline
-      return (
-        <FriendEntry
-          userId={row.userId}
-          faded={faded}
-          isLive={row.isLive}
-          status={row.type === FriendsListRowType.Online ? row.status : undefined}
-          key={row.userId}
-        />
-      )
+      return <FriendEntry userId={row.userId} faded={faded} isLive={row.isLive} key={row.userId} />
     }
   }, [])
 
@@ -596,62 +578,21 @@ const FriendEntryRoot = styled.div<{ $isOverlayOpen?: boolean; $faded?: boolean 
   }
 `
 
-const FriendEntryName = styled.div`
-  flex-grow: 1;
-  min-width: 0;
-`
-
-const FriendEntryNameSingleLine = styled.div`
-  ${singleLine};
-`
-
-const FriendEntryNameLine = styled.div`
-  ${singleLine};
-  line-height: 20px;
-`
-
-const FriendEntryStatusLine = styled.div`
-  ${inter};
-  ${bodySmall};
-  ${singleLine};
-
-  color: var(--theme-on-surface-variant);
-`
-
-function getActivityStatusLabel(
-  t: TFunction,
-  status: FriendActivityStatus | undefined,
-): string | undefined {
-  switch (status) {
-    case FriendActivityStatus.InLobby:
-      return t('social.friendsList.status.inLobby', 'In lobby')
-    case FriendActivityStatus.InQueue:
-      return t('social.friendsList.status.inQueue', 'In queue')
-    case FriendActivityStatus.InGame:
-      return t('social.friendsList.status.inGame', 'In game')
-    default:
-      return undefined
-  }
-}
-
 function FriendEntry({
   userId,
   faded = false,
   isLive = false,
-  status,
   style,
   actions,
 }: {
   userId: SbUserId
   faded?: boolean
   isLive?: boolean
-  status?: FriendActivityStatus
   style?: React.CSSProperties
   actions?: React.ReactNode
 }) {
   const { t } = useTranslation()
   const user = useAppSelector(s => s.users.byId.get(userId))
-  const activityLabel = getActivityStatusLabel(t, status)
 
   const { profileOverlayProps, contextMenuProps, onClick, onContextMenu, isOverlayOpen } =
     useUserOverlays({
@@ -678,16 +619,10 @@ function FriendEntry({
           <StyledAvatar userId={userId} />
         </AvatarContainer>
         {user ? (
-          <FriendEntryName>
-            {activityLabel ? (
-              <>
-                <FriendEntryNameLine>{user.name}</FriendEntryNameLine>
-                <FriendEntryStatusLine>{activityLabel}</FriendEntryStatusLine>
-              </>
-            ) : (
-              <FriendEntryNameSingleLine>{user.name}</FriendEntryNameSingleLine>
-            )}
-          </FriendEntryName>
+          <NameBlock>
+            <NameLine>{user.name}</NameLine>
+            <FriendActivityStatusLine userId={userId} />
+          </NameBlock>
         ) : (
           <LoadingName aria-label={t('social.friendsList.loadingUsername', 'Username loading…')} />
         )}

--- a/client/social/social-sidebar.tsx
+++ b/client/social/social-sidebar.tsx
@@ -48,6 +48,7 @@ import { ConnectedUserContextMenu } from '../users/user-context-menu'
 import { useUserOverlays } from '../users/user-overlays'
 import { closeWhisperSession, getWhisperSessions } from '../whispers/action-creators'
 import { urlForWhisper } from '../whispers/whisper-url'
+import { FriendActivityStatusGlyph } from './friend-activity-status'
 import { FriendsList, useRelationshipsLoader } from './friends-list'
 
 /** The width the window must be greater than for pinning to be enabled. */
@@ -620,6 +621,7 @@ function WhisperEntry({ userId }: { userId: SbUserId }) {
         link={urlForWhisper(userId, username ?? '')}
         button={button}
         icon={<ConnectedAvatar userId={userId} />}
+        trailing={<WhisperActivityGlyph userId={userId} />}
         needsAttention={hasUnread}
         urgentAttention={hasUnread}
         isActive={isOverlayOpen}
@@ -639,6 +641,10 @@ const LoadingName = styled.span`
   margin-right: 0.25em;
   background-color: var(--theme-skeleton);
   border-radius: 4px;
+`
+
+const WhisperActivityGlyph = styled(FriendActivityStatusGlyph)`
+  margin-left: 8px;
 `
 
 const EntryRoot = styled(Link)<{ $isCurrentPath: boolean; $isActive?: boolean }>`
@@ -683,6 +689,7 @@ const EntryText = styled.span`
 
   flex-grow: 1;
   flex-shrink: 1;
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
 `
@@ -737,6 +744,8 @@ interface EntryProps {
   title?: string
   button?: React.ReactNode
   icon?: React.ReactNode
+  /** Content rendered between the entry's text and its button, e.g. a friend activity glyph. */
+  trailing?: React.ReactNode
   needsAttention?: boolean
   /**
    * Whether the attention indicator should render in its urgent color, e.g. for a channel message
@@ -754,6 +763,7 @@ function Entry({
   title,
   button,
   icon,
+  trailing,
   needsAttention,
   urgentAttention,
   isActive,
@@ -787,6 +797,7 @@ function Entry({
       <EntryText ref={textRef} title={isOverflowing ? title : undefined} data-testid='entry-text'>
         {children}
       </EntryText>
+      {trailing}
       {button ? <EntryButton>{button}</EntryButton> : null}
 
       <EntryRipple ref={rippleRef} />

--- a/client/users/user-profile-overlay.tsx
+++ b/client/users/user-profile-overlay.tsx
@@ -25,6 +25,7 @@ import { Popover, PopoverProps } from '../material/popover'
 import { Tooltip } from '../material/tooltip'
 import { LoadingDotsArea } from '../progress/dots'
 import { useAppDispatch, useAppSelector } from '../redux-hooks'
+import { FriendActivityStatusLine } from '../social/friend-activity-status'
 import {
   BodyMedium,
   bodyLarge,
@@ -298,6 +299,7 @@ export function UserProfileOverlayContents({
           <Title>{t('users.titles.novice', 'Novice')}</Title>
         </UsernameAndTitle>
       </IdentityArea>
+      <FriendActivityStatusLine userId={userId} />
       {liveStream ? (
         <LiveWatchRow
           twitchLogin={liveStream.twitchLogin}

--- a/common/users/relationships.ts
+++ b/common/users/relationships.ts
@@ -88,10 +88,19 @@ export interface UserRelationshipDeleteEvent {
   targetUser: SbUserId
 }
 
-// TODO(tec27): Add more stuff to this, like ingame, idle, etc.
+/**
+ * What a friend is currently doing, as shown in the friends list. Only friends receive a user's
+ * status updates, so this never reveals activity beyond the friend graph.
+ */
 export enum FriendActivityStatus {
   Online = 'online',
   Offline = 'offline',
+  /** Seated in a custom lobby (including while that lobby's game is loading). */
+  InLobby = 'inLobby',
+  /** In matchmaking: searching, match found/accepting, drafting, or loading the matched game. */
+  InQueue = 'inQueue',
+  /** All players finished loading; lasts until this user's client reports the game exited. */
+  InGame = 'inGame',
 }
 
 export interface FriendActivityStatusUpdateEvent {

--- a/server/lib/games/game-api.test.ts
+++ b/server/lib/games/game-api.test.ts
@@ -46,6 +46,7 @@ function makeRehomeApi({
     {} as any,
     {} as any,
     netcodeV2Service as any,
+    {} as any,
   )
   return { api, netcodeV2Service }
 }
@@ -158,8 +159,16 @@ function makeStatusApi({
     registerGameAsLoaded: vi.fn().mockReturnValue(true),
     maybeCancelLoading: vi.fn().mockReturnValue(true),
   }
-  const api = new GameApi({} as any, gameLoader as any, {} as any, {} as any, {} as any)
-  return { api, gameLoader }
+  const activityStatusService = { clearInGame: vi.fn() }
+  const api = new GameApi(
+    {} as any,
+    gameLoader as any,
+    {} as any,
+    {} as any,
+    {} as any,
+    activityStatusService as any,
+  )
+  return { api, gameLoader, activityStatusService }
 }
 
 describe('games/game-api/GameApi#updateGameStatus', () => {
@@ -186,12 +195,13 @@ describe('games/game-api/GameApi#updateGameStatus', () => {
   })
 
   test('cancels the load on a client-reported error regardless of transport', async () => {
-    const { api, gameLoader } = makeStatusApi({ isLocalOnlyLoad: false })
+    const { api, gameLoader, activityStatusService } = makeStatusApi({ isLocalOnlyLoad: false })
     const ctx = makeStatusCtx(GameStatus.Error)
 
     await api.updateGameStatus(ctx)
 
     expect(gameLoader.maybeCancelLoading).toHaveBeenCalledWith('game-1', makeSbUserId(1))
+    expect(activityStatusService.clearInGame).toHaveBeenCalledWith(makeSbUserId(1), 'game-1')
     expect(ctx.status).toBe(204)
   })
 
@@ -219,7 +229,14 @@ function makeFlightApi({ isEnabled = true }: { isEnabled?: boolean } = {}) {
     listFlightBlobs: vi.fn(),
     fetchFlightBlob: vi.fn(),
   }
-  const api = new GameApi({} as any, {} as any, {} as any, {} as any, netcodeV2Service as any)
+  const api = new GameApi(
+    {} as any,
+    {} as any,
+    {} as any,
+    {} as any,
+    netcodeV2Service as any,
+    {} as any,
+  )
   return { api, netcodeV2Service }
 }
 

--- a/server/lib/games/game-api.ts
+++ b/server/lib/games/game-api.ts
@@ -54,6 +54,7 @@ import throttleMiddleware, {
   throttleByUser,
   throttleByUserOrIp,
 } from '../throttle/middleware'
+import { ActivityStatusService } from '../users/activity-status-service'
 import { findUsersByIdAsMap } from '../users/user-model'
 import { joiUserId } from '../users/user-validators'
 import { validateRequest } from '../validation/joi-validator'
@@ -233,6 +234,7 @@ export class GameApi {
     private replayService: ReplayService,
     private gamePointsRefundService: GamePointsRefundService,
     private netcodeV2Service: NetcodeV2Service,
+    private activityStatusService: ActivityStatusService,
   ) {}
 
   @httpPost('/:gameId/nullify-points')
@@ -499,6 +501,12 @@ export class GameApi {
 
     if (status > GameStatus.Finished && status !== GameStatus.Error) {
       throw new httpErrors.BadRequest('invalid game status')
+    }
+
+    if (status === GameStatus.Finished || status === GameStatus.Error) {
+      // Done ahead of the checks below so that a report which arrives too late to be interesting to
+      // the game loader still ends the user's in-game state.
+      this.activityStatusService.clearInGame(user.id, gameId)
     }
 
     if (

--- a/server/lib/games/game-loader.test.ts
+++ b/server/lib/games/game-loader.test.ts
@@ -143,6 +143,7 @@ describe('games/game-loader/GameLoader', () => {
       }>
     >
   }
+  let activityStatusService: { setInGame: ReturnType<typeof vi.fn> }
   let gameLoader: GameLoader
 
   beforeEach(() => {
@@ -166,12 +167,14 @@ describe('games/game-loader/GameLoader', () => {
         .fn()
         .mockResolvedValue({ known: false, connectedSlots: [], startedSlots: [] }),
     }
+    activityStatusService = { setInGame: vi.fn() }
 
     gameLoader = new GameLoader(
       publisher as any,
       activityRegistry as any,
       restrictionService as any,
       netcodeV2Service as any,
+      activityStatusService as any,
     )
   })
 
@@ -783,6 +786,18 @@ describe('games/game-loader/GameLoader', () => {
       expect.objectContaining({ useNetcodeV2: true }),
     )
     expect(netcodeV2Service.createSessionForGame).toHaveBeenCalledTimes(1)
+
+    expect(activityStatusService.setInGame).toHaveBeenCalledTimes(2)
+    expect(activityStatusService.setInGame).toHaveBeenCalledWith(
+      p1,
+      'game-multi',
+      expect.objectContaining({ userId: p1 }),
+    )
+    expect(activityStatusService.setInGame).toHaveBeenCalledWith(
+      p2,
+      'game-multi',
+      expect.objectContaining({ userId: p2 }),
+    )
   })
 
   test('threads each player selected region through to createSessionForGame', async () => {

--- a/server/lib/games/game-loader.ts
+++ b/server/lib/games/game-loader.ts
@@ -21,6 +21,7 @@ import { getMapInfos } from '../maps/map-models'
 import { deleteUserRecordsForGame } from '../models/games-users'
 import { NetcodeV2Service, NetcodeV2SessionLoadState } from '../netcode-v2/netcode-v2-service'
 import { monotonicNow } from '../time/monotonic-now'
+import { ActivityStatusService } from '../users/activity-status-service'
 import { RestrictionService } from '../users/restriction-service'
 import { findUsersById } from '../users/user-model'
 import { TypedPublisher } from '../websockets/typed-publisher'
@@ -345,6 +346,7 @@ export class GameLoader {
     private activityRegistry: GameplayActivityRegistry,
     private restrictionService: RestrictionService,
     private netcodeV2Service: NetcodeV2Service,
+    private activityStatusService: ActivityStatusService,
   ) {}
 
   /**
@@ -532,6 +534,10 @@ export class GameLoader {
       .filter(c => !!c)
     for (const client of activeClients) {
       client.unsubscribe(gameUserPath(gameId, client.userId))
+      // Marking the players as in-game before the load is resolved means the lobby/matchmaking
+      // teardown that follows sees them as playing, and its attempt to clear their lobby/queue
+      // status is a no-op instead of knocking them back to just being online.
+      this.activityStatusService.setInGame(client.userId, gameId, client)
     }
 
     this.recentlyLoadedGames.add(gameId)

--- a/server/lib/games/gameplay-activity-registry.ts
+++ b/server/lib/games/gameplay-activity-registry.ts
@@ -1,17 +1,29 @@
 import { singleton } from 'tsyringe'
 import { SbUserId } from '../../../common/users/sb-user-id'
+import { ActivityStatusService, GameplayActivityStatus } from '../users/activity-status-service'
 import { ClientSocketsGroup } from '../websockets/socket-groups'
+
+interface RegisteredActivity {
+  client: ClientSocketsGroup
+  status: GameplayActivityStatus
+}
 
 @singleton()
 export class GameplayActivityRegistry {
-  private userClients = new Map<SbUserId, ClientSocketsGroup>()
+  private userClients = new Map<SbUserId, RegisteredActivity>()
+
+  constructor(private activityStatusService: ActivityStatusService) {}
 
   /**
    * Attempts to register a client as owning the active gameplay activity for a user.
    *
    * @returns true if no other client was registered for the user, false otherwise.
    */
-  registerActiveClient(userId: SbUserId, client: ClientSocketsGroup): boolean {
+  registerActiveClient(
+    userId: SbUserId,
+    client: ClientSocketsGroup,
+    status: GameplayActivityStatus,
+  ): boolean {
     if (!client.isConnected()) {
       throw new Error('Cannot register a disconnected client')
     }
@@ -20,31 +32,9 @@ export class GameplayActivityRegistry {
       return false
     }
 
-    this.userClients.set(userId, client)
+    this.userClients.set(userId, { client, status })
+    this.activityStatusService.setActivity(userId, status)
     return true
-  }
-
-  /**
-   * Attempts to register all of the specified clients as being in an active gameplay activity. If
-   * any user already has an active client, no clients will be registered.
-   *
-   * @returns A tuple of if the clients were registered, and an array of user IDs that could not be
-   *     registered (empty if they were registered).
-   */
-  registerAll(
-    clients: ReadonlyArray<[userId: SbUserId, client: ClientSocketsGroup]>,
-  ): [registered: boolean, alreadyActiveUsers: SbUserId[]] {
-    const alreadyActiveUsers = clients
-      .filter(([userId, _]) => this.userClients.has(userId))
-      .map(([userId, _]) => userId)
-    if (alreadyActiveUsers.length > 0) {
-      return [false, alreadyActiveUsers]
-    }
-
-    for (const [userId, client] of clients) {
-      this.userClients.set(userId, client)
-    }
-    return [true, []]
   }
 
   /**
@@ -53,13 +43,20 @@ export class GameplayActivityRegistry {
    * @returns true if a client was registered for that user, false otherwise.
    */
   unregisterClientForUser(userId: SbUserId): boolean {
-    return this.userClients.delete(userId)
+    const registered = this.userClients.get(userId)
+    if (!registered) {
+      return false
+    }
+
+    this.userClients.delete(userId)
+    this.activityStatusService.clearActivity(userId, registered.status)
+    return true
   }
 
   /**
    * Returns the currently active client for a user. If no client was active, returns undefined.
    */
   getClientForUser(userId: SbUserId): ClientSocketsGroup | undefined {
-    return this.userClients.get(userId)
+    return this.userClients.get(userId)?.client
   }
 }

--- a/server/lib/lobbies/lobby-service.test.ts
+++ b/server/lib/lobbies/lobby-service.test.ts
@@ -18,6 +18,7 @@ import { getMapInfos } from '../maps/map-models'
 import { reparseMapsAsNeeded } from '../maps/map-operations'
 import { NetcodeV2Service } from '../netcode-v2/netcode-v2-service'
 import { RestrictionService } from '../users/restriction-service'
+import { createFakeActivityStatusService } from '../users/testing/activity-status-service'
 import { findUsersById } from '../users/user-model'
 import { RequestSessionLookup } from '../websockets/session-lookup'
 import {
@@ -209,7 +210,7 @@ describe('lobbies/lobby-service', () => {
     loadGameRequests = []
     lobbyService = new LobbyService(
       new TypedPublisher(nydus),
-      new GameplayActivityRegistry(),
+      new GameplayActivityRegistry(createFakeActivityStatusService()),
       {
         loadGame: vi.fn(async (request: GameLoadRequest) => {
           loadGameRequests.push(request)

--- a/server/lib/lobbies/lobby-service.ts
+++ b/server/lib/lobbies/lobby-service.ts
@@ -31,6 +31,7 @@ import { Slot, SlotType } from '../../../common/lobbies/slot'
 import { SbMapId } from '../../../common/maps'
 import { RaceChar } from '../../../common/races'
 import { urlPath } from '../../../common/urls'
+import { FriendActivityStatus } from '../../../common/users/relationships'
 import { RestrictionKind } from '../../../common/users/restrictions'
 import { makeSbUserId, SbUserId } from '../../../common/users/sb-user-id'
 import { toBasicChannelInfo } from '../chat/chat-models'
@@ -333,7 +334,9 @@ export class LobbyService {
       this._leaveCurrentLobby(client)
     }
 
-    if (!this.activityRegistry.registerActiveClient(user.userId, client)) {
+    if (
+      !this.activityRegistry.registerActiveClient(user.userId, client, FriendActivityStatus.InLobby)
+    ) {
       throw new LobbyServiceError(
         LobbyServiceErrorCode.AlreadyInActivity,
         'user is already active in a gameplay activity',
@@ -466,7 +469,9 @@ export class LobbyService {
       this._leaveCurrentLobby(client)
     }
 
-    if (!this.activityRegistry.registerActiveClient(user.userId, client)) {
+    if (
+      !this.activityRegistry.registerActiveClient(user.userId, client, FriendActivityStatus.InLobby)
+    ) {
       throw new LobbyServiceError(
         LobbyServiceErrorCode.JoinAlreadyInActivity,
         'user is already active in a gameplay activity',

--- a/server/lib/lobbies/lobby-socket-api.test.ts
+++ b/server/lib/lobbies/lobby-socket-api.test.ts
@@ -15,6 +15,7 @@ import { getMapInfos } from '../maps/map-models'
 import { reparseMapsAsNeeded } from '../maps/map-operations'
 import { NetcodeV2Service } from '../netcode-v2/netcode-v2-service'
 import { RestrictionService } from '../users/restriction-service'
+import { createFakeActivityStatusService } from '../users/testing/activity-status-service'
 import { findUsersById } from '../users/user-model'
 import { RequestSessionLookup } from '../websockets/session-lookup'
 import { ClientSocketsManager, UserSocketsManager } from '../websockets/socket-groups'
@@ -109,7 +110,7 @@ describe('lobbies/lobby-socket-api', () => {
 
     lobbyService = new LobbyService(
       new TypedPublisher(nydus),
-      new GameplayActivityRegistry(),
+      new GameplayActivityRegistry(createFakeActivityStatusService()),
       { loadGame: vi.fn() } as unknown as GameLoader,
       { isRestricted: async () => false } as unknown as RestrictionService,
       { getRegions: async () => [] } as unknown as GameServerRegionsService,

--- a/server/lib/matchmaking/matchmaking-service.test.ts
+++ b/server/lib/matchmaking/matchmaking-service.test.ts
@@ -15,6 +15,7 @@ import { makeSbUserId, SbUserId } from '../../../common/users/sb-user-id'
 import { BaseGameLoaderError, GameLoadErrorType } from '../games/game-loader'
 import { GameplayActivityRegistry } from '../games/gameplay-activity-registry'
 import { FakeClock } from '../time/testing/fake-clock'
+import { createFakeActivityStatusService } from '../users/testing/activity-status-service'
 import { ClientSocketsGroup } from '../websockets/socket-groups'
 import { TypedPublisher } from '../websockets/typed-publisher'
 import {
@@ -206,7 +207,7 @@ describe('matchmaking/matchmaking-service', () => {
     clock.setCurrentTime(1_000_000)
 
     publisher = { publish: vi.fn() }
-    activityRegistry = new GameplayActivityRegistry()
+    activityRegistry = new GameplayActivityRegistry(createFakeActivityStatusService())
     banUser = vi.fn().mockResolvedValue(undefined)
     clientSockets = new Map([
       [USER_A, createFakeClient(USER_A, CLIENT_A)],

--- a/server/lib/matchmaking/matchmaking-service.ts
+++ b/server/lib/matchmaking/matchmaking-service.ts
@@ -35,6 +35,7 @@ import {
 import { RaceChar } from '../../../common/races'
 import { randomInt, randomItem } from '../../../common/random'
 import { MatchFoundMessage, PublishedMatchmakingMessage } from '../../../common/typeshare'
+import { FriendActivityStatus } from '../../../common/users/relationships'
 import { RestrictionKind } from '../../../common/users/restrictions'
 import { makeSbUserId, SbUserId } from '../../../common/users/sb-user-id'
 import { withDbClient } from '../db'
@@ -519,7 +520,13 @@ export class MatchmakingService {
       }
     }
 
-    if (!this.activityRegistry.registerActiveClient(userId, clientSockets)) {
+    if (
+      !this.activityRegistry.registerActiveClient(
+        userId,
+        clientSockets,
+        FriendActivityStatus.InQueue,
+      )
+    ) {
       throw new MatchmakingServiceError(
         MatchmakingServiceErrorCode.GameplayConflict,
         'User is already active in a gameplay activity',
@@ -1334,7 +1341,6 @@ export class MatchmakingService {
     }
     for (const client of clients) {
       this.publishToActiveClient(client.userId, { type: 'gameStarted' })
-      // TODO(tec27): Should this be maintained until the client reports game exit instead?
       this.unregisterActivity(client.userId)
     }
 

--- a/server/lib/users/activity-status-service.test.ts
+++ b/server/lib/users/activity-status-service.test.ts
@@ -1,0 +1,223 @@
+import { NydusServer } from 'nydus'
+import { beforeEach, describe, expect, test } from 'vitest'
+import { FriendActivityStatus } from '../../../common/users/relationships'
+import { makeSbUserId, SbUserId } from '../../../common/users/sb-user-id'
+import { FakeClock, StopCriteria } from '../time/testing/fake-clock'
+import { RequestSessionLookup } from '../websockets/session-lookup'
+import { ClientSocketsManager, UserSocketsManager } from '../websockets/socket-groups'
+import {
+  clearTestLogs,
+  createFakeNydusServer,
+  FakeNydusServer,
+  InspectableNydusClient,
+  NydusConnector,
+} from '../websockets/testing/websockets'
+import { TypedPublisher } from '../websockets/typed-publisher'
+import { ActivityStatusService, getFriendActivityStatusPath } from './activity-status-service'
+
+const USER = makeSbUserId(1)
+const GAME_ID = 'game-1'
+const GRACE_MS = 60_000
+
+describe('users/activity-status-service', () => {
+  let nydus: NydusServer
+  let fakeNydus: FakeNydusServer
+  let clientSocketsManager: ClientSocketsManager
+  let connector: NydusConnector
+  let clock: FakeClock
+  let activityStatusService: ActivityStatusService
+
+  beforeEach(() => {
+    nydus = createFakeNydusServer()
+    fakeNydus = nydus as unknown as FakeNydusServer
+    const sessionLookup = new RequestSessionLookup()
+    clientSocketsManager = new ClientSocketsManager(nydus, sessionLookup)
+    const userSocketsManager = new UserSocketsManager(nydus, sessionLookup, async () => {})
+    const publisher = new TypedPublisher(nydus)
+
+    clock = new FakeClock()
+    clock.autoRunTimeouts = false
+    clock.setCurrentTime(Number(new Date('2022-08-31T00:00:00.000Z')))
+
+    activityStatusService = new ActivityStatusService(
+      publisher,
+      userSocketsManager,
+      clientSocketsManager,
+      clock,
+    )
+    connector = new NydusConnector(nydus, sessionLookup)
+  })
+
+  function connect(userId: SbUserId, clientId: string): InspectableNydusClient {
+    return connector.connectClient({ id: userId, name: `user-${userId}`, created: 0 }, clientId)
+  }
+
+  function expectPublished(userId: SbUserId, status: FriendActivityStatus) {
+    expect(fakeNydus.publish).toHaveBeenCalledWith(getFriendActivityStatusPath(userId), {
+      userId,
+      status,
+    })
+  }
+
+  function expectNotPublished(userId: SbUserId) {
+    expect(fakeNydus.publish).not.toHaveBeenCalledWith(
+      getFriendActivityStatusPath(userId),
+      expect.anything(),
+    )
+  }
+
+  test('is offline for a user with no sockets', () => {
+    expect(activityStatusService.getStatus(USER)).toBe(FriendActivityStatus.Offline)
+  })
+
+  test('is online for a connected user and publishes on connect', () => {
+    connect(USER, 'one')
+
+    expect(activityStatusService.getStatus(USER)).toBe(FriendActivityStatus.Online)
+    expectPublished(USER, FriendActivityStatus.Online)
+  })
+
+  test('publishes offline when the last socket disconnects', () => {
+    const client = connect(USER, 'one')
+    clearTestLogs(nydus)
+
+    client.disconnect()
+
+    expect(activityStatusService.getStatus(USER)).toBe(FriendActivityStatus.Offline)
+    expectPublished(USER, FriendActivityStatus.Offline)
+  })
+
+  test('publishes an activity when it is set, and only when it changes', () => {
+    connect(USER, 'one')
+    clearTestLogs(nydus)
+
+    activityStatusService.setActivity(USER, FriendActivityStatus.InLobby)
+
+    expect(activityStatusService.getStatus(USER)).toBe(FriendActivityStatus.InLobby)
+    expectPublished(USER, FriendActivityStatus.InLobby)
+
+    clearTestLogs(nydus)
+    activityStatusService.setActivity(USER, FriendActivityStatus.InLobby)
+
+    expectNotPublished(USER)
+  })
+
+  test('clearing an activity the user is not doing is a no-op', () => {
+    connect(USER, 'one')
+    activityStatusService.setActivity(USER, FriendActivityStatus.InQueue)
+    clearTestLogs(nydus)
+
+    activityStatusService.clearActivity(USER, FriendActivityStatus.InLobby)
+
+    expect(activityStatusService.getStatus(USER)).toBe(FriendActivityStatus.InQueue)
+    expectNotPublished(USER)
+
+    activityStatusService.clearActivity(USER, FriendActivityStatus.InQueue)
+
+    expect(activityStatusService.getStatus(USER)).toBe(FriendActivityStatus.Online)
+    expectPublished(USER, FriendActivityStatus.Online)
+  })
+
+  test('clearing a lobby activity for an in-game user is a no-op', () => {
+    connect(USER, 'one')
+    activityStatusService.setActivity(USER, FriendActivityStatus.InLobby)
+    activityStatusService.setInGame(USER, GAME_ID, clientSocketsManager.getById(USER, 'one')!)
+    clearTestLogs(nydus)
+
+    activityStatusService.clearActivity(USER, FriendActivityStatus.InLobby)
+
+    expect(activityStatusService.getStatus(USER)).toBe(FriendActivityStatus.InGame)
+    expectNotPublished(USER)
+  })
+
+  test('clearing the in-game state only works for the game being played', () => {
+    connect(USER, 'one')
+    activityStatusService.setInGame(USER, GAME_ID, clientSocketsManager.getById(USER, 'one')!)
+    clearTestLogs(nydus)
+
+    activityStatusService.clearInGame(USER, 'some-other-game')
+
+    expect(activityStatusService.getStatus(USER)).toBe(FriendActivityStatus.InGame)
+    expectNotPublished(USER)
+
+    activityStatusService.clearInGame(USER, GAME_ID)
+
+    expect(activityStatusService.getStatus(USER)).toBe(FriendActivityStatus.Online)
+    expectPublished(USER, FriendActivityStatus.Online)
+  })
+
+  test('the in-game state outlives a short disconnect of the playing client', async () => {
+    const playingClient = connect(USER, 'playing')
+    connect(USER, 'other')
+    activityStatusService.setInGame(USER, GAME_ID, clientSocketsManager.getById(USER, 'playing')!)
+
+    playingClient.disconnect()
+    clearTestLogs(nydus)
+
+    expect(activityStatusService.getStatus(USER)).toBe(FriendActivityStatus.InGame)
+    expectNotPublished(USER)
+
+    await clock.runTimeoutsUntil({
+      criteria: StopCriteria.TimeReached,
+      timeMillis: clock.now() + GRACE_MS,
+    })
+
+    expect(activityStatusService.getStatus(USER)).toBe(FriendActivityStatus.Online)
+    expectPublished(USER, FriendActivityStatus.Online)
+  })
+
+  test('the playing client reconnecting cancels the in-game grace period', async () => {
+    const playingClient = connect(USER, 'playing')
+    connect(USER, 'other')
+    activityStatusService.setInGame(USER, GAME_ID, clientSocketsManager.getById(USER, 'playing')!)
+
+    playingClient.disconnect()
+    const reconnectedClient = connect(USER, 'playing')
+    clearTestLogs(nydus)
+
+    await clock.runTimeoutsUntil({ criteria: StopCriteria.EmptyQueue })
+
+    expect(activityStatusService.getStatus(USER)).toBe(FriendActivityStatus.InGame)
+    expectNotPublished(USER)
+
+    // The grace period has to restart for the reconnected client, otherwise the user would be stuck
+    // in the in-game state forever.
+    reconnectedClient.disconnect()
+    await clock.runTimeoutsUntil({ criteria: StopCriteria.EmptyQueue })
+
+    expect(activityStatusService.getStatus(USER)).toBe(FriendActivityStatus.Online)
+    expectPublished(USER, FriendActivityStatus.Online)
+  })
+
+  test('reconnecting after a full disconnect publishes the in-game state again', async () => {
+    const client = connect(USER, 'playing')
+    activityStatusService.setInGame(USER, GAME_ID, clientSocketsManager.getById(USER, 'playing')!)
+
+    client.disconnect()
+    expect(activityStatusService.getStatus(USER)).toBe(FriendActivityStatus.Offline)
+    clearTestLogs(nydus)
+
+    connect(USER, 'playing')
+
+    expect(activityStatusService.getStatus(USER)).toBe(FriendActivityStatus.InGame)
+    expectPublished(USER, FriendActivityStatus.InGame)
+
+    await clock.runTimeoutsUntil({ criteria: StopCriteria.EmptyQueue })
+
+    expect(activityStatusService.getStatus(USER)).toBe(FriendActivityStatus.InGame)
+  })
+
+  test('the in-game state is dropped if the user stays disconnected past the grace period', async () => {
+    const client = connect(USER, 'playing')
+    activityStatusService.setInGame(USER, GAME_ID, clientSocketsManager.getById(USER, 'playing')!)
+
+    client.disconnect()
+    await clock.runTimeoutsUntil({ criteria: StopCriteria.EmptyQueue })
+    clearTestLogs(nydus)
+
+    connect(USER, 'playing')
+
+    expect(activityStatusService.getStatus(USER)).toBe(FriendActivityStatus.Online)
+    expectPublished(USER, FriendActivityStatus.Online)
+  })
+})

--- a/server/lib/users/activity-status-service.ts
+++ b/server/lib/users/activity-status-service.ts
@@ -1,0 +1,207 @@
+import { singleton } from 'tsyringe'
+import {
+  FriendActivityStatus,
+  FriendActivityStatusUpdateEvent,
+} from '../../../common/users/relationships'
+import { SbUserId } from '../../../common/users/sb-user-id'
+import { Clock, TimeoutId } from '../time/clock'
+import {
+  ClientSocketsGroup,
+  ClientSocketsManager,
+  UserSocketsManager,
+} from '../websockets/socket-groups'
+import { TypedPublisher } from '../websockets/typed-publisher'
+
+/**
+ * How long a user stays in the in-game state after the client that was playing the game
+ * disconnects, so that a short network blip doesn't bounce them out of (and back into) that state.
+ */
+const IN_GAME_DISCONNECT_GRACE_MS = 60_000
+
+export function getFriendActivityStatusPath(userId: SbUserId): string {
+  return `/friends/status/${userId}`
+}
+
+/**
+ * The activity statuses that are owned by a client's entry in the gameplay activity registry (as
+ * opposed to being derived from a game that is actually running).
+ */
+export type GameplayActivityStatus = FriendActivityStatus.InLobby | FriendActivityStatus.InQueue
+
+interface GameplayActivity {
+  status: GameplayActivityStatus
+}
+
+interface InGameActivity {
+  status: FriendActivityStatus.InGame
+  gameId: string
+  /** The client that is playing the game, and whose disconnect ends the in-game state. */
+  clientId: string
+  /** Set while the client is disconnected and the grace period hasn't elapsed yet. */
+  disconnectTimer?: TimeoutId
+  /** Removes the close listener that starts the disconnect grace period. */
+  unbindClose: () => void
+}
+
+type Activity = GameplayActivity | InGameActivity
+
+/**
+ * Tracks what each user is currently doing and publishes changes to their friends. This is the
+ * single source of truth for `FriendActivityStatus`: everything that can change it (the gameplay
+ * activity registry, the game loader, game status reports from clients, and socket connects and
+ * disconnects) routes through here.
+ */
+@singleton()
+export class ActivityStatusService {
+  private activities = new Map<SbUserId, Activity>()
+
+  constructor(
+    private publisher: TypedPublisher<FriendActivityStatusUpdateEvent>,
+    private userSocketsManager: UserSocketsManager,
+    clientSocketsManager: ClientSocketsManager,
+    private clock: Clock,
+  ) {
+    userSocketsManager
+      .on('newUser', userSockets => {
+        this.publish(userSockets.userId, this.getStatus(userSockets.userId))
+      })
+      .on('userQuit', userId => {
+        // The activity entry is deliberately left in place: lobby and queue entries get cleared
+        // when those services react to the disconnect, and an in-game entry has to outlive a brief
+        // disconnect so that a reconnecting player is still playing their game.
+        this.publish(userId, FriendActivityStatus.Offline)
+      })
+
+    clientSocketsManager.on('newClient', client => {
+      const activity = this.activities.get(client.userId)
+      if (
+        activity?.status !== FriendActivityStatus.InGame ||
+        activity.clientId !== client.clientId ||
+        activity.disconnectTimer === undefined
+      ) {
+        return
+      }
+
+      this.clock.clearTimeout(activity.disconnectTimer)
+      activity.disconnectTimer = undefined
+      activity.unbindClose = this.bindClose(client.userId, client, activity)
+    })
+  }
+
+  /** Returns what the given user is currently doing. */
+  getStatus(userId: SbUserId): FriendActivityStatus {
+    if (!this.userSocketsManager.getById(userId)) {
+      return FriendActivityStatus.Offline
+    }
+
+    return this.activities.get(userId)?.status ?? FriendActivityStatus.Online
+  }
+
+  /** Marks a user as being in a lobby or in the matchmaking queue. */
+  setActivity(userId: SbUserId, status: GameplayActivityStatus): void {
+    this.updateActivity(userId, { status })
+  }
+
+  /**
+   * Clears a user's lobby or matchmaking queue activity. This only has an effect if that is what
+   * the user is currently doing: a user that has since moved on to playing the game stays in the
+   * in-game state.
+   */
+  clearActivity(userId: SbUserId, status: GameplayActivityStatus): void {
+    if (this.activities.get(userId)?.status !== status) {
+      return
+    }
+
+    this.updateActivity(userId, undefined)
+  }
+
+  /**
+   * Marks a user as playing a game. The state lasts until the game is reported as over, or until
+   * `client` has been disconnected for longer than the grace period.
+   */
+  setInGame(userId: SbUserId, gameId: string, client: ClientSocketsGroup): void {
+    const activity: InGameActivity = {
+      status: FriendActivityStatus.InGame,
+      gameId,
+      clientId: client.clientId,
+      unbindClose: () => {},
+    }
+    activity.unbindClose = this.bindClose(userId, client, activity)
+
+    this.updateActivity(userId, activity)
+  }
+
+  /** Clears a user's in-game state, if they are currently playing the given game. */
+  clearInGame(userId: SbUserId, gameId: string): void {
+    const current = this.activities.get(userId)
+    if (current?.status !== FriendActivityStatus.InGame || current.gameId !== gameId) {
+      return
+    }
+
+    this.updateActivity(userId, undefined)
+  }
+
+  private updateActivity(userId: SbUserId, activity: Activity | undefined): void {
+    const prevStatus = this.getStatus(userId)
+    const prev = this.activities.get(userId)
+    if (prev && prev !== activity) {
+      tearDownActivity(prev, this.clock)
+    }
+
+    if (activity) {
+      this.activities.set(userId, activity)
+    } else {
+      this.activities.delete(userId)
+    }
+
+    const status = this.getStatus(userId)
+    if (status !== prevStatus) {
+      this.publish(userId, status)
+    }
+  }
+
+  private bindClose(
+    userId: SbUserId,
+    client: ClientSocketsGroup,
+    activity: InGameActivity,
+  ): () => void {
+    const onClose = () => {
+      activity.disconnectTimer = this.clock.setTimeout(() => {
+        activity.disconnectTimer = undefined
+        if (this.activities.get(userId) !== activity) {
+          return
+        }
+
+        this.activities.delete(userId)
+        if (this.userSocketsManager.getById(userId)) {
+          this.publish(userId, this.getStatus(userId))
+        }
+      }, IN_GAME_DISCONNECT_GRACE_MS)
+    }
+
+    client.once('close', onClose)
+    if (!client.isConnected()) {
+      // A group that has no sockets left has already emitted its close event, so the listener above
+      // would never fire and the entry would be stuck in-game forever.
+      onClose()
+    }
+
+    return () => client.off('close', onClose)
+  }
+
+  private publish(userId: SbUserId, status: FriendActivityStatus): void {
+    this.publisher.publish(getFriendActivityStatusPath(userId), { userId, status })
+  }
+}
+
+function tearDownActivity(activity: Activity, clock: Clock): void {
+  if (activity.status !== FriendActivityStatus.InGame) {
+    return
+  }
+
+  if (activity.disconnectTimer !== undefined) {
+    clock.clearTimeout(activity.disconnectTimer)
+    activity.disconnectTimer = undefined
+  }
+  activity.unbindClose()
+}

--- a/server/lib/users/testing/activity-status-service.ts
+++ b/server/lib/users/testing/activity-status-service.ts
@@ -1,0 +1,18 @@
+import { vi } from 'vitest'
+import { FriendActivityStatus } from '../../../../common/users/relationships'
+import { ActivityStatusService } from '../activity-status-service'
+
+export class FakeActivityStatusService implements Pick<
+  ActivityStatusService,
+  keyof ActivityStatusService
+> {
+  getStatus = vi.fn().mockReturnValue(FriendActivityStatus.Online)
+  setActivity = vi.fn()
+  clearActivity = vi.fn()
+  setInGame = vi.fn()
+  clearInGame = vi.fn()
+}
+
+export function createFakeActivityStatusService(): ActivityStatusService {
+  return new FakeActivityStatusService() as any as ActivityStatusService
+}

--- a/server/lib/users/user-relationship-service.test.ts
+++ b/server/lib/users/user-relationship-service.test.ts
@@ -15,7 +15,7 @@ import NotificationService from '../notifications/notification-service'
 import { createFakeNotificationService } from '../notifications/testing/notification-service'
 import { FakeClock } from '../time/testing/fake-clock'
 import { RequestSessionLookup } from '../websockets/session-lookup'
-import { UserSocketsManager } from '../websockets/socket-groups'
+import { ClientSocketsManager, UserSocketsManager } from '../websockets/socket-groups'
 import {
   InspectableNydusClient,
   NydusConnector,
@@ -23,11 +23,8 @@ import {
   createFakeNydusServer,
 } from '../websockets/testing/websockets'
 import { TypedPublisher } from '../websockets/typed-publisher'
-import {
-  UserRelationshipService,
-  getFriendActivityStatusPath,
-  getRelationshipsPath,
-} from './user-relationship-service'
+import { ActivityStatusService, getFriendActivityStatusPath } from './activity-status-service'
+import { UserRelationshipService, getRelationshipsPath } from './user-relationship-service'
 
 function clearFakeDb() {
   ;(global as any).__TESTONLY_CLEAR_DB()
@@ -369,6 +366,7 @@ describe('users/user-relationship-service', () => {
   beforeEach(() => {
     nydus = createFakeNydusServer()
     const sessionLookup = new RequestSessionLookup()
+    const clientSocketsManager = new ClientSocketsManager(nydus, sessionLookup)
     const userSocketsManager = new UserSocketsManager(nydus, sessionLookup, async () => {})
     const publisher = new TypedPublisher(nydus)
 
@@ -378,11 +376,18 @@ describe('users/user-relationship-service', () => {
 
     clearFakeDb()
 
+    const activityStatusService = new ActivityStatusService(
+      publisher,
+      userSocketsManager,
+      clientSocketsManager,
+      clock,
+    )
     userRelationshipService = new UserRelationshipService(
       clock,
       publisher,
       userSocketsManager,
       notificationService,
+      activityStatusService,
     )
     connector = new NydusConnector(nydus, sessionLookup)
 

--- a/server/lib/users/user-relationship-service.ts
+++ b/server/lib/users/user-relationship-service.ts
@@ -19,6 +19,7 @@ import NotificationService from '../notifications/notification-service'
 import { Clock } from '../time/clock'
 import { UserSocketsGroup, UserSocketsManager } from '../websockets/socket-groups'
 import { TypedPublisher } from '../websockets/typed-publisher'
+import { ActivityStatusService, getFriendActivityStatusPath } from './activity-status-service'
 import {
   acceptFriendRequest,
   blockUser,
@@ -38,54 +39,40 @@ export function getRelationshipsPath(userId: SbUserId): string {
   return `/relationships/${userId}`
 }
 
-export function getFriendActivityStatusPath(userId: SbUserId): string {
-  return `/friends/status/${userId}`
-}
-
 @singleton()
 export class UserRelationshipService {
   constructor(
     private clock: Clock,
-    private publisher: TypedPublisher<UserRelationshipEvent | FriendActivityStatusUpdateEvent>,
+    private publisher: TypedPublisher<UserRelationshipEvent>,
     private userSocketsManager: UserSocketsManager,
     private notificationService: NotificationService,
+    private activityStatusService: ActivityStatusService,
   ) {
-    userSocketsManager
-      .on('newUser', userSockets => {
-        // NOTE(tec27): We don't provide initial data over this as it's potentially a lot of stuff
-        // to send over websockets. We instead expect that the client will get this info by making a
-        // request on load
-        userSockets.subscribe(getRelationshipsPath(userSockets.userId))
-        publisher.publish(getFriendActivityStatusPath(userSockets.userId), {
-          userId: userSockets.userId,
-          status: FriendActivityStatus.Online,
+    userSocketsManager.on('newUser', userSockets => {
+      // NOTE(tec27): We don't provide initial data over this as it's potentially a lot of stuff
+      // to send over websockets. We instead expect that the client will get this info by making a
+      // request on load
+      userSockets.subscribe(getRelationshipsPath(userSockets.userId))
+
+      Promise.resolve()
+        .then(async () => {
+          if (!userSockets.sockets.size) {
+            return
+          }
+
+          const summary = await getRelationshipSummaryForUser(userSockets.userId)
+          if (!userSockets.sockets.size) {
+            return
+          }
+
+          for (const { toId: friendId } of summary.friends) {
+            this.subscribeToFriendActivityStatusUpdates(userSockets, friendId)
+          }
         })
-
-        Promise.resolve()
-          .then(async () => {
-            if (!userSockets.sockets.size) {
-              return
-            }
-
-            const summary = await getRelationshipSummaryForUser(userSockets.userId)
-            if (!userSockets.sockets.size) {
-              return
-            }
-
-            for (const { toId: friendId } of summary.friends) {
-              this.subscribeToFriendActivityStatusUpdates(userSockets, friendId)
-            }
-          })
-          .catch(err => {
-            logger.error({ err }, 'Error subscribing to status updates for friends')
-          })
-      })
-      .on('userQuit', userId => {
-        publisher.publish(getFriendActivityStatusPath(userId), {
-          userId,
-          status: FriendActivityStatus.Offline,
+        .catch(err => {
+          logger.error({ err }, 'Error subscribing to status updates for friends')
         })
-      })
+    })
   }
 
   private publishUpsert(userId: SbUserId, relationship: UserRelationship) {
@@ -118,12 +105,8 @@ export class UserRelationshipService {
         // NOTE(tec27): We only send updates for online users, just to minimize the amount of data
         // that needs to be sent. Clients can assume their friends are offline until they receive
         // this event
-        return this.userSocketsManager.getById(friendId)
-          ? {
-              userId: friendId,
-              status: FriendActivityStatus.Online,
-            }
-          : undefined
+        const status = this.activityStatusService.getStatus(friendId)
+        return status !== FriendActivityStatus.Offline ? { userId: friendId, status } : undefined
       },
     )
   }

--- a/server/public/locales/en/global.json
+++ b/server/public/locales/en/global.json
@@ -2098,6 +2098,11 @@
         "outgoing": "Outgoing"
       },
       "loadingUsername": "Username loading…",
+      "status": {
+        "inGame": "In game",
+        "inLobby": "In lobby",
+        "inQueue": "In queue"
+      },
       "tabs": {
         "addFriends": "Add friends",
         "friendsList": "Friends list",

--- a/server/public/locales/en/global.json
+++ b/server/public/locales/en/global.json
@@ -2098,11 +2098,6 @@
         "outgoing": "Outgoing"
       },
       "loadingUsername": "Username loading…",
-      "status": {
-        "inGame": "In game",
-        "inLobby": "In lobby",
-        "inQueue": "In queue"
-      },
       "tabs": {
         "addFriends": "Add friends",
         "friendsList": "Friends list",
@@ -2179,6 +2174,11 @@
     }
   },
   "users": {
+    "activityStatus": {
+      "inGame": "In game",
+      "inLobby": "In lobby",
+      "inQueue": "In queue"
+    },
     "admin": {
       "avatar": {
         "description": "Permanently remove this user's avatar. This can't be undone.",


### PR DESCRIPTION
The friends list only distinguished online from offline. Friends now show a second line under their name while they're in a custom lobby ("In lobby"), in matchmaking ("In queue", covering searching through match found and loading), or playing ("In game"). Only friends receive a user's status, exactly as before.

**Server**

- New `ActivityStatusService` is the single source of truth for `FriendActivityStatus` and owns the `/friends/status/:userId` publishing that used to live in `UserRelationshipService`.
- `GameplayActivityRegistry.registerActiveClient` now takes the activity kind (lobby vs. queue) and reports it; unregistering clears it, guarded by kind so the post-load lobby/matchmaking teardown can't knock a player back to Online. The unused `registerAll` is gone.
- `GameLoader` marks every player in-game once all of them have loaded, before resolving the load (this is the `TODO(tec27)` in matchmaking's `doGameLoad` about keeping the activity until the client reports exit).
- `GameApi.updateGameStatus` ends the in-game state on a `Finished`/`Error` report. As a fallback, the playing client's socket group closing starts a 60s grace timer; a reconnect with the same client id cancels it, so a brief network blip mid-game doesn't bounce the user through Online.

**Client**

- The renderer now reports game exit to the server. The app emits `finished` for a clean game-over and `unknown` when the process went away without one (crash, window closed, forced quit); both are reported as `Finished`, and unlike the `playing`/`error` report a failure never quits the game.
- Friends list: every non-offline status lands in the Online group; active rows render a name + status line inside the same 44px row so nothing shifts.

**Verified live** with two Electron clients (claude-1/claude-2) and a third browser client (claude-3) watching its friends list: create lobby → "In lobby"; join → both "In lobby"; start game → both "In game" once loaded; force-quit → both back to Online (exit report logged); Find match → "In queue" → cancel → Online. Full `pnpm run typecheck`, `vitest` (159 files / 2521 tests), and `lint` are clean; 11 new unit tests cover the service including the disconnect grace and reconnect paths.
