### PR TITLE
Withhold a private channel's info from non-members on every path.

### DIFF
--- a/client/chat/channel-info-card.tsx
+++ b/client/chat/channel-info-card.tsx
@@ -92,6 +92,23 @@ const PrivateChannelDescriptionText = styled.span`
   text-align: center;
 `
 
+/** The notice shown in place of a private channel's info to anyone who can't see it. */
+export function PrivateChannelNotice() {
+  const { t } = useTranslation()
+
+  return (
+    <PrivateChannelDescriptionContainer>
+      <PrivateChannelIcon size={40} />
+      <PrivateChannelDescriptionText>
+        {t(
+          'chat.channelInfoCard.private',
+          'This channel is private and requires an invite to join.',
+        )}
+      </PrivateChannelDescriptionText>
+    </PrivateChannelDescriptionContainer>
+  )
+}
+
 export const ChannelDescriptionContainer = styled.div`
   ${bodyMedium};
   margin-top: 16px;
@@ -198,17 +215,7 @@ export function ConnectedChannelInfoCard({
   if (!basicChannelInfo) {
     channelDescription = <LoadingDotsArea />
   } else if (basicChannelInfo.private && !isUserInChannel) {
-    channelDescription = (
-      <PrivateChannelDescriptionContainer>
-        <PrivateChannelIcon size={40} />
-        <PrivateChannelDescriptionText>
-          {t(
-            'chat.channelInfoCard.private',
-            'This channel is private and requires an invite to join.',
-          )}
-        </PrivateChannelDescriptionText>
-      </PrivateChannelDescriptionContainer>
-    )
+    channelDescription = <PrivateChannelNotice />
   } else if (detailedChannelInfo?.description) {
     channelDescription = (
       <ChannelDescriptionContainer>

--- a/client/chat/channel-menu-items.tsx
+++ b/client/chat/channel-menu-items.tsx
@@ -135,7 +135,7 @@ export function ChannelMessageMenu({
   const { t } = useTranslation()
   const dispatch = useAppDispatch()
   const { channelId } = useContext(ChannelContext)
-  const channelName = useAppSelector(s => s.chat.idToBasicInfo.get(channelId)?.name)
+  const basicChannelInfo = useAppSelector(s => s.chat.idToBasicInfo.get(channelId))
   const isServerModerator = useHasAnyPermission('moderateChatChannels')
 
   const menuItems = new Map(items)
@@ -146,6 +146,10 @@ export function ChannelMessageMenu({
       key='copy-message-link'
       text={t('chat.messageMenu.copyMessageLink', 'Copy message link')}
       onClick={() => {
+        // A private channel's name is only for its members, and a copied link can be pasted
+        // anywhere, so the link names the channel by id alone; the channel page fills in the
+        // name for whoever is allowed to see it.
+        const channelName = basicChannelInfo?.private ? undefined : basicChannelInfo?.name
         navigator.clipboard
           .writeText(getServerOrigin() + urlForChannelMessage(channelId, channelName, messageId))
           .catch(err => logger.error(`Error writing to clipboard: ${getErrorStack(err)}`))

--- a/client/chat/channel.tsx
+++ b/client/chat/channel.tsx
@@ -46,7 +46,7 @@ import {
 } from './action-creators'
 import { ChannelContext } from './channel-context'
 import { CHANNEL_HEADER_HEIGHT, ChannelHeader } from './channel-header'
-import { ConnectedChannelInfoCard } from './channel-info-card'
+import { ConnectedChannelInfoCard, PrivateChannelNotice } from './channel-info-card'
 import { ChannelMessageMenu, ChannelUserMenu } from './channel-menu-items'
 import { ConnectedChannelSettings } from './channel-settings/channel-settings'
 import { MESSAGE_LINK_PARAM } from './channel-url'
@@ -585,6 +585,10 @@ function ChannelInfoPage({
   let contents
   if (isLoading) {
     contents = <LoadingDotsArea />
+  } else if (error && isFetchError(error) && error.code === ChatServiceErrorCode.ChannelPrivate) {
+    // A private channel's name is only for its members and server moderators, so a requester
+    // who is neither doesn't get the URL's name segment echoed back to them either.
+    contents = <PrivateChannelNotice />
   } else if (error) {
     let errorText
     if (isFetchError(error)) {

--- a/common/chat.ts
+++ b/common/chat.ts
@@ -34,6 +34,11 @@ export enum ChatServiceErrorCode {
   CannotModerateChannelModerator = 'CannotModerateChannelModerator',
   CannotModerateYourself = 'CannotModerateYourself',
   ChannelNotFound = 'ChannelNotFound',
+  /**
+   * The channel exists and is private, and the requester is neither a member nor a server
+   * moderator.
+   */
+  ChannelPrivate = 'ChannelPrivate',
   InappropriateImage = 'InappropriateImage',
   MaximumJoinedChannels = 'MaximumJoinedChannels',
   MaximumOwnedChannels = 'MaximumOwnedChannels',

--- a/server/lib/chat/chat-api.ts
+++ b/server/lib/chat/chat-api.ts
@@ -222,6 +222,7 @@ function convertChatServiceError(err: unknown) {
     case ChatServiceErrorCode.CannotEditChannel:
     case ChatServiceErrorCode.CannotModerateChannelOwner:
     case ChatServiceErrorCode.CannotModerateChannelModerator:
+    case ChatServiceErrorCode.ChannelPrivate:
     case ChatServiceErrorCode.MaximumJoinedChannels:
     case ChatServiceErrorCode.MaximumOwnedChannels:
     case ChatServiceErrorCode.NotEnoughPermissions:
@@ -613,7 +614,11 @@ export class ChatApi {
       }),
     })
 
-    return await this.chatService.getChannelInfos(channelIds, ctx.session!.user.id)
+    return await this.chatService.getChannelInfos(
+      channelIds,
+      ctx.session!.user.id,
+      isServerModerator(ctx),
+    )
   }
 
   // NOTE: @koa/router 15 (path-to-regexp v8) no longer supports inline regex path params, so the

--- a/server/lib/chat/chat-service.test.ts
+++ b/server/lib/chat/chat-service.test.ts
@@ -1928,18 +1928,13 @@ describe('chat/chat-service', () => {
     })
 
     describe('when channel is private', () => {
-      test("doesn't return detailed channel info", async () => {
+      test('rejects for a non-member who is not a server moderator', async () => {
         asMockedFunction(getChannelInfo).mockResolvedValue({ ...testChannel, private: true })
 
-        const result = await chatService.getChannelInfo(testChannel.id, user1.id, REGULAR_USER)
-
-        expect(result).toEqual({
-          channelInfo: {
-            ...testBasicInfo,
-            private: true,
-          },
-          detailedChannelInfo: undefined,
-          joinedChannelInfo: undefined,
+        await expect(
+          chatService.getChannelInfo(testChannel.id, user1.id, REGULAR_USER),
+        ).rejects.toMatchObject({
+          code: ChatServiceErrorCode.ChannelPrivate,
         })
       })
 
@@ -2078,6 +2073,22 @@ describe('chat/chat-service', () => {
             shieldBatteryDetailedInfo,
             { ...testDetailedInfo, userCount: testChannel.userCount },
           ],
+          joinedChannelInfos: [shieldBatteryJoinedInfo, testJoinedInfo],
+          deletedChannels: [],
+          privateChannels: [],
+        })
+      })
+
+      test('returns detailed and joined channel info to a server moderator who is not a member', async () => {
+        const result = await chatService.getChannelInfos(
+          [shieldBatteryChannel.id, testChannel.id],
+          user1.id,
+          SERVER_MODERATOR,
+        )
+
+        expect(result).toEqual({
+          channelInfos: [shieldBatteryBasicInfo, { ...testBasicInfo, private: true }],
+          detailedChannelInfos: [shieldBatteryDetailedInfo, testDetailedInfo],
           joinedChannelInfos: [shieldBatteryJoinedInfo, testJoinedInfo],
           deletedChannels: [],
           privateChannels: [],

--- a/server/lib/chat/chat-service.ts
+++ b/server/lib/chat/chat-service.ts
@@ -883,20 +883,24 @@ export default class ChatService {
       throw new ChatServiceError(ChatServiceErrorCode.ChannelNotFound, 'Channel not found')
     }
 
-    // A private channel's details are only for its members, plus server moderators, who hold the
-    // owner's authority in it and moderate it without joining.
-    const canSeePrivateDetails = !channelInfo.private || isUserInChannel || isServerModerator
+    // A private channel's info, its name included, is only for its members and for server
+    // moderators, who hold the owner's authority in it and moderate it without joining. Anyone
+    // else learns only that the channel is private.
+    if (channelInfo.private && !isUserInChannel && !isServerModerator) {
+      throw new ChatServiceError(ChatServiceErrorCode.ChannelPrivate, 'Channel is private')
+    }
 
     return {
       channelInfo: toBasicChannelInfo(channelInfo),
-      detailedChannelInfo: canSeePrivateDetails ? toDetailedChannelInfo(channelInfo) : undefined,
-      joinedChannelInfo: canSeePrivateDetails ? toJoinedChannelInfo(channelInfo) : undefined,
+      detailedChannelInfo: toDetailedChannelInfo(channelInfo),
+      joinedChannelInfo: toJoinedChannelInfo(channelInfo),
     }
   }
 
   async getChannelInfos(
     channelIds: SbChannelId[],
     userId: SbUserId,
+    isServerModerator = false,
   ): Promise<GetBatchedChannelInfosResponse> {
     const [channelInfos, userChannelEntries] = await Promise.all([
       getChannelInfos(channelIds),
@@ -910,9 +914,10 @@ export default class ChatService {
     const privateChannels: SbChannelId[] = []
 
     for (const channel of channelInfos) {
-      if (channel.private && !userJoinedChannelsSet.has(channel.id)) {
-        // A private channel's info (including its name) is only for its members; a non-member
-        // gets nothing about it beyond confirmation that the id belongs to a private channel.
+      // A private channel's info, its name included, is only for its members and for server
+      // moderators, who hold the owner's authority in it and moderate it without joining. Anyone
+      // else learns only that the id belongs to a private channel.
+      if (channel.private && !userJoinedChannelsSet.has(channel.id) && !isServerModerator) {
         privateChannels.push(channel.id)
         continue
       }


### PR DESCRIPTION
Follow-up to #1451.

A private channel's name is only for its members and server moderators. The batch channel-info endpoint already withheld it from non-members (that's what renders the `#private-channel` chip), but the single-channel endpoint still returned the basic info, name included, so clicking such a chip showed the name on the channel page one step later. The two endpoints also disagreed about server moderators.

- `GET /chat/:channelId` answers 403 with a new `ChannelPrivate` code for a requester who is neither a member nor a server moderator. The channel page renders the private-channel notice for it, without echoing the URL's name segment.
- `GET /chat/batch-info` gains the moderator exception the single endpoint already had, so moderators see the real name in chips.
- "Copy message link" in a private channel mints `/chat/<id>/_?m=<messageId>` (placeholder name segment), since the link can be pasted anywhere; the channel page fills the name in for whoever is allowed to see it.

Verified live with three clients (owner, non-member, server moderator): the copied link carries `_`; the non-member sees `#private-channel › message`, batch-info lists the id under `privateChannels`, and clicking lands on the lock notice with a 403 and no name anywhere on the page; the moderator sees the real name in the chip and the info card with Join disabled; the owner's click-through fills the name in, keeps `?m=`, and jumps to the message.

Side note from verification: there is currently no UI to flip a channel's `private` flag (`togglePrivate` exists only as a permission), so the test channel was made private via SQL.
