### PR TITLE
Add the issue and implement skills for the GitHub Issues workflow.

### DIFF
--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: implement
+description: Implement a GitHub issue end to end (`/implement #N`) - read the issue and its parent, verify its premise against the pinned commit and current master BEFORE writing code, report drift in chat, build on a short branch within the issue's stated scope, verify at the tier the issue names, and open a PR with `Fixes #N`. Never edits the issue. Use when asked to implement, work on, pick up, build, or fix an issue by number.
+---
+
+# Implementing an issue
+
+Issues filed from this repo carry seven sections (Why, Current behavior pinned to a commit, Desired
+behavior, Decisions, Verification, Out of scope, Links). The issue is the spec; the Decisions
+section is settled; the Desired behavior bullets are the acceptance criteria. Hand-filed issues may
+have none of that: then step 2 is where you build the missing spec, in chat, before coding.
+
+## Rules
+
+- **Never edit the issue.** No body edits, comments, labels, assignees or board moves. Drift,
+  questions and progress go in chat and in the PR body.
+- **Premise before code.** Nothing is written until the drift report (step 2) is in chat.
+- **Scope is the issue.** Desired behavior in, Out of scope out. Anything else you find becomes a
+  spin-off issue via the `issue` skill, not part of this PR.
+- **Decisions are locked; rejected alternatives are off the table.** If the code makes a locked
+  decision impossible, stop and say so; don't quietly pick the rejected option.
+
+## Steps
+
+### 1. Fetch the issue and its context
+
+```bash
+gh issue view N --json number,title,body,labels,milestone,state,url
+gh api graphql -f query='{ repository(owner:"ShieldBattery", name:"ShieldBattery"){ issue(number:N){ parent{ number title } subIssues(first:20){ nodes{ number title state } } } } }'
+gh pr list --state all --search "N in:body" --json number,title,state,headRefName
+```
+
+Stop and report if the issue is closed, or already has an open PR that references it. If it has a
+parent, read the parent's Decisions and rejected alternatives too; they apply. If it has
+sub-issues, it is a parent: implement a child, not the parent.
+
+### 2. Verify the premise and report drift
+
+Take the `Written against <sha>` line. For every `path:line` pointer and every claim in Current
+behavior, check it at that commit and at current master:
+
+```bash
+git show <sha>:<path> | sed -n 'L,L+10p'      # should match the claim
+git log --oneline <sha>..master -- <path>     # what changed since
+git grep -n "<symbol>" master -- <path>       # where it lives now
+```
+
+Also check whether any Desired behavior bullet is already true on master (someone may have shipped
+part of it). Then post a short drift report in chat before writing code:
+
+- **Holds**: claims still true on master (one line, no need to list them all).
+- **Moved**: pointers whose code moved or was renamed, with the new location.
+- **Changed**: claims no longer true, with what the code does now.
+- **Already done**: acceptance criteria master already satisfies.
+
+If drift is cosmetic, proceed. If a Current behavior claim the design rests on is false, or a locked
+decision conflicts with what master now does, stop with a specific question. If the issue lacks a
+pinned commit or pointers (hand-filed), write the Current behavior yourself in chat, at master, and
+proceed on that.
+
+### 3. Branch
+
+Short, descriptive, no issue number: `friend-presence`, `emote-flag`, not `issue-1462-esc-jumps`.
+From master. A child of a stacked chain branches from the previous child's branch; keep the chain
+rebased, never merged (see the stacked-PR rules in memory or ask).
+
+### 4. Build
+
+Follow `AGENTS.md`. Keep `TODO(context)`/`NOTE(context)` comments; write comments that stand alone
+(no "per issue #N" in code; the commit message carries provenance). Run codegen after schema
+changes (`pnpm run gen-graphql`, `pnpm run gen-typeshare`), `pnpm run gen-translations` after any
+client string change, `cargo fmt` + clippy for Rust. Delete code the change makes unused.
+
+While building, anything outside the issue's scope that needs fixing is a spin-off (`issue`
+skill, spin-off mode), mentioned in your report, not fixed here.
+
+### 5. Verify at the issue's tier
+
+The issue's Verification section names a verify-pr tier and a recipe. Run that tier (see
+`.claude/skills/verify-pr/SKILL.md`; T2+ means the real Electron app via the `verify-app` skill,
+T3 means two clients, T4 a real game). Run the recipe as written, plus lint, typecheck and the
+nearby unit tests. Record what you ran and what you saw; failures are reported verbatim, not
+smoothed over.
+
+### 6. Open the PR
+
+Commit with the repo's message style (one imperative subject sentence ending in a period, body only
+if warranted, no attribution lines). Then:
+
+```bash
+gh pr create --title "<subject>" --body-file <body.md>
+```
+
+PR body:
+
+- One paragraph: what changed and why (the issue's Why, condensed).
+- `Fixes #N` on its own line (`Part of #N` if the PR is one of several for the issue; the last one
+  says `Fixes`).
+- Acceptance criteria as a checklist copied from the issue's Desired behavior, each checked with
+  how it was verified, unchecked with why it is deferred.
+- Drift notes from step 2 if there were any.
+- Verification performed, tier and outcome.
+
+Draft PR if verification is incomplete. After pushing, the `pr-fix` skill handles CI and review
+comments.
+
+### 7. Report
+
+In chat: the PR URL, which acceptance criteria are met and which are not, drift that mattered,
+spin-off drafts awaiting a go-ahead, and what the next child in the chain is if this was one.

--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -61,8 +61,11 @@ proceed on that.
 ### 3. Branch
 
 Short, descriptive, no issue number: `friend-presence`, `emote-flag`, not `issue-1462-esc-jumps`.
-From master. A child of a stacked chain branches from the previous child's branch; keep the chain
-rebased, never merged (see the stacked-PR rules in memory or ask).
+From master. A child of a stacked chain branches from the previous child's branch. Stacked branches
+stay linear: each carries only its own commits on top of its parent, so when the parent moves,
+`git rebase --onto <parent-tip> <old-parent-tip>` the child and push with `--force-with-lease`;
+never merge the parent in. When a stack merges bottom-up, retarget the child PR's base to master
+before the parent's branch is deleted, or GitHub auto-closes the child.
 
 ### 4. Build
 
@@ -101,8 +104,8 @@ PR body:
 - Drift notes from step 2 if there were any.
 - Verification performed, tier and outcome.
 
-Draft PR if verification is incomplete. After pushing, the `pr-fix` skill handles CI and review
-comments.
+Draft PR if verification is incomplete. CI results and review comments arrive after the push and
+are separate follow-up work, not part of this skill.
 
 ### 7. Report
 

--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -19,13 +19,18 @@ have none of that: then step 2 is where you build the missing spec, in chat, bef
   spin-off issue via the `issue` skill, not part of this PR.
 - **Decisions are locked; rejected alternatives are off the table.** If the code makes a locked
   decision impossible, stop and say so; don't quietly pick the rejected option.
+- **Open decisions are a soft gate, not a wall.** A `needs-design` or `needs-decision` label, or a
+  board status of Todo instead of Ready, means the maintainers still owe the issue something. Say
+  so once, with your recommendation for each open item, and wait. If the user still says go, they
+  are asking for your judgment, not for another question: build on your recommendations and record
+  every call in the PR body.
 
 ## Steps
 
 ### 1. Fetch the issue and its context
 
 ```bash
-gh issue view N --json number,title,body,labels,milestone,state,url
+gh issue view N --json number,title,body,labels,milestone,state,url,projectItems
 gh api graphql -f query='{ repository(owner:"ShieldBattery", name:"ShieldBattery"){ issue(number:N){ parent{ number title } subIssues(first:20){ nodes{ number title state } } } } }'
 gh pr list --state all --search "N in:body" --json number,title,state,headRefName
 ```
@@ -33,6 +38,21 @@ gh pr list --state all --search "N in:body" --json number,title,state,headRefNam
 Stop and report if the issue is closed, or already has an open PR that references it. If it has a
 parent, read the parent's Decisions and rejected alternatives too; they apply. If it has
 sub-issues, it is a parent: implement a child, not the parent.
+
+Then check readiness. The board's Ready column (`projectItems[].status.name`) means every decision
+is locked, no `needs-*` label remains, dependencies are on master and the issue is not a parent.
+If the issue is in Todo instead, or carries `needs-design` or `needs-decision`, post in chat before
+anything else:
+
+- each open item in Decisions, each design question, and each dependency in Links that is not on
+  master yet;
+- your recommended answer for each, one line; for `needs-design`, the two or three options in a
+  line each and which one you would build.
+
+Then ask once whether to proceed. A go-ahead, in chat or in the invocation itself ("implement #N,
+go with your calls"), means: build on your recommendations, leave the issue untouched, and list
+every call in the PR body under **Calls made** so the author can override at review. A go-ahead
+does not skip step 2 and does not widen the scope.
 
 ### 2. Verify the premise and report drift
 
@@ -102,6 +122,8 @@ PR body:
 - Acceptance criteria as a checklist copied from the issue's Desired behavior, each checked with
   how it was verified, unchecked with why it is deferred.
 - Drift notes from step 2 if there were any.
+- **Calls made**, when step 1 flagged open decisions: each one, the option you built and the ones
+  you passed on.
 - Verification performed, tier and outcome.
 
 Draft PR if verification is incomplete. After pushing, the `pr-fix` skill
@@ -109,5 +131,6 @@ Draft PR if verification is incomplete. After pushing, the `pr-fix` skill
 
 ### 7. Report
 
-In chat: the PR URL, which acceptance criteria are met and which are not, drift that mattered,
-spin-off drafts awaiting a go-ahead, and what the next child in the chain is if this was one.
+In chat: the PR URL, which acceptance criteria are met and which are not, drift that mattered, the
+calls you made on a go-ahead, spin-off drafts awaiting a go-ahead, and what the next child in the
+chain is if this was one.

--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -104,8 +104,8 @@ PR body:
 - Drift notes from step 2 if there were any.
 - Verification performed, tier and outcome.
 
-Draft PR if verification is incomplete. CI results and review comments arrive after the push and
-are separate follow-up work, not part of this skill.
+Draft PR if verification is incomplete. After pushing, the `pr-fix` skill
+(`.claude/skills/pr-fix/SKILL.md`) handles CI and review comments.
 
 ### 7. Report
 

--- a/.claude/skills/issue/SKILL.md
+++ b/.claude/skills/issue/SKILL.md
@@ -6,7 +6,9 @@ description: File a GitHub issue for ShieldBattery the way this repo wants them 
 # Filing an issue
 
 GitHub Issues is the tracker (org Project board "ShieldBattery" #1 is fed automatically by area
-labels). An issue is a self-contained brief: someone with the repo and the issue, and nothing else,
+labels; its columns are Todo, Ready, In Progress, Done, and Ready means every decision is locked,
+no `needs-*` label remains, dependencies are on master and the issue is not a parent). An issue is
+a self-contained brief: someone with the repo and the issue, and nothing else,
 can do the work. The shape is fixed by `template.md` in this directory; #1460, #1461 and #1457 are
 filed examples of it.
 
@@ -66,7 +68,8 @@ gh issue list --state open --label <area> --limit 100
 | --- | --- |
 | Type | `Bug` (wrong behavior today), `Feature` (new user-facing behavior), `Task` (design, cleanup, infra). Org-level issue types; the legacy `bug`/`enhancement` labels are not used. |
 | Area label | One of `chat`, `lobbies`, `matchmaking`, `replays`: a long-running area, never a feature. The label puts the issue on the board (labeling is the triage act). If none fits, file with no area label and say in chat that it lands in the inbox. |
-| `needs-design` | Add when a product or visual decision gates implementation. |
+| `needs-design` | Add when a visual or interaction design gates implementation: options must be proposed and one picked before code. |
+| `needs-decision` | Add when Decisions has an open item only the maintainers can settle and there is nothing to explore, just a call to make. Both labels may apply. Either is a soft gate for the `implement` skill: it asks once, then builds on its own recommendation if told to go. |
 | Parent | Native sub-issue of a parent when the issue is one phase of a multi-phase plan or one PR of a stacked chain. Design docs live in the parent's body (`docs/` only when they outgrow it). |
 | Milestone | One per multi-phase plan (e.g. "Chat commands"), on the parent and every child. |
 
@@ -81,7 +84,9 @@ correct attribution, no Discord content, and scope that matches one PR. Cross-re
 drafts by `[Working title]`; numbers are substituted at filing.
 
 Section reminders beyond the template: Decisions carries every locked choice AND every rejected
-alternative with who/when, so nobody re-proposes them; Verification names the verify-pr tier and a
+alternative with who/when, so nobody re-proposes them, and anything still open goes under an
+**Open** sub-list with your recommended answer (the issue then carries `needs-decision` or
+`needs-design`); Verification names the verify-pr tier and a
 concrete recipe (which clients, which flow, what to check); Out of scope names the neighbours.
 
 ### 5. Show it
@@ -117,8 +122,8 @@ python .claude/skills/issue/file_issues.py <draft-dir>            # dry run
 python .claude/skills/issue/file_issues.py --create <draft-dir>
 ```
 
-Report the URLs. An issue with an area label lands on the board in Todo by itself; don't touch the
-board.
+Report the URLs. An issue with an area label lands on the board in Todo by itself; whether it moves
+to Ready is the maintainers' call after they read Decisions. Don't touch the board.
 
 ## Spin-off mode
 

--- a/.claude/skills/issue/SKILL.md
+++ b/.claude/skills/issue/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: issue
+description: File a GitHub issue for ShieldBattery the way this repo wants them - read the code first, dedupe against the whole backlog, draft seven fixed sections pinned to a commit, show the draft, then create it with type, area label, parent and milestone set at creation. Use whenever asked to file, open, create or write up an issue or ticket; to turn a roadmap item, review finding, design decision or Discord thread into an issue; or to raise a side-issue discovered while working on something else (spin-off mode). Creates issues only - never comments, edits, relabels, assigns, closes or moves them.
+---
+
+# Filing an issue
+
+GitHub Issues is the tracker (org Project board "ShieldBattery" #1 is fed automatically by area
+labels). An issue is a self-contained brief: someone with the repo and the issue, and nothing else,
+can do the work. The shape is fixed by `template.md` in this directory; #1460, #1461 and #1457 are
+filed examples of it.
+
+## Write rules (non-negotiable)
+
+- You may **create** issues, with type, labels, parent and milestone set at creation. You may
+  create a milestone when filing a multi-phase plan. Nothing else: no comments, body edits,
+  relabeling, assigning, closing, reopening or board moves unless the user explicitly asks for that
+  action in the current session. Comments are for humans.
+- **Discord is private; the repo is public.** Anything from Discord is input only: restate the
+  need in your own words with the person's name and the date. Never quote, paraphrase closely,
+  paste, or link Discord messages. Public sources (PR reviews, existing issues) may be quoted.
+- Show the draft before creating it. The user may cut anything. "Just file it" (or an explicit
+  "file it without showing me") skips the pause; nothing else does.
+- Don't invent behavior. Every code claim in the issue is verified against the pinned commit.
+- No issue forms or templates get added to the repo. Outside filers write whatever they want;
+  the seven sections are for issues filed from here.
+
+## Steps
+
+### 1. Pin the commit and read the code
+
+```bash
+git rev-parse --short=9 master && git log -1 --format=%cs master
+```
+
+Pin to the master tip unless the issue is explicitly about a branch. Every `path:line` in Current
+behavior is looked up at that commit, not in the working tree:
+
+```bash
+git grep -n "<pattern>" <sha> -- <path>
+git show <sha>:<path> | sed -n '120,160p'
+```
+
+Read enough to state what the code does today and why the desired change is not already there.
+If the request's premise turns out to be false in the code, the issue says what the code actually
+does and the chat reply says the premise was off.
+
+### 2. Dedupe against the whole backlog
+
+The 100+ open issues without an area label are an untriaged inbox and count. Search titles and
+bodies, open and closed:
+
+```bash
+gh issue list --state all --limit 50 --search "<keyword> <keyword>"
+gh issue list --state open --label <area> --limit 100
+```
+
+- Exact match open: report it in chat and stop; do not file a duplicate.
+- Old stub on the same topic (a one-line placeholder): file the full issue and tell the user the
+  stub exists; closing it as a duplicate is their call (or an explicit instruction to you).
+- Closed match: read why it was closed before re-raising; say so in chat.
+
+### 3. Classify
+
+| Axis | Rule |
+| --- | --- |
+| Type | `Bug` (wrong behavior today), `Feature` (new user-facing behavior), `Task` (design, cleanup, infra). Org-level issue types; the legacy `bug`/`enhancement` labels are not used. |
+| Area label | One of `chat`, `lobbies`, `matchmaking`, `replays`: a long-running area, never a feature. The label puts the issue on the board (labeling is the triage act). If none fits, file with no area label and say in chat that it lands in the inbox. |
+| `needs-design` | Add when a product or visual decision gates implementation. |
+| Parent | Native sub-issue of a parent when the issue is one phase of a multi-phase plan or one PR of a stacked chain. Design docs live in the parent's body (`docs/` only when they outgrow it). |
+| Milestone | One per multi-phase plan (e.g. "Chat commands"), on the parent and every child. |
+
+### 4. Draft
+
+Write the draft to the session scratchpad as `issues/<slug>.md` following `template.md` exactly
+(title line, metadata line, seven sections). For a batch, write a `BRIEF.md` in that directory
+covering the shared facts (pinned commit, supersession order of decisions, attribution rules, the
+table of working titles with type/labels/parent/milestone) and have one subagent per one or two
+issues draft against the pinned commit; review every draft in the main loop for verified pointers,
+correct attribution, no Discord content, and scope that matches one PR. Cross-reference sibling
+drafts by `[Working title]`; numbers are substituted at filing.
+
+Section reminders beyond the template: Decisions carries every locked choice AND every rejected
+alternative with who/when, so nobody re-proposes them; Verification names the verify-pr tier and a
+concrete recipe (which clients, which flow, what to check); Out of scope names the neighbours.
+
+### 5. Show it
+
+Single issue: the full draft in chat. Batch: a table of titles with type/labels/parent plus the
+drafts' paths, and the full text of anything the user asked to see. Then wait. Apply cuts and
+edits to the draft files, not in your head.
+
+### 6. Create
+
+Single issue (`gh` 2.94+ sets type and milestone directly):
+
+```bash
+gh issue create --title "<title>" --body-file <draft-without-title-and-metadata> \
+  --label chat --type Feature --milestone "Chat commands"
+```
+
+Then, if it has a parent, link it as a native sub-issue:
+
+```bash
+gh api graphql -f query='mutation($p:ID!,$c:ID!){ addSubIssue(input:{issueId:$p, subIssueId:$c}){ issue{number} subIssue{number} } }' \
+  -f p=<parent node id> -f c=<child node id>     # ids from: gh issue view N --json id -q .id
+```
+
+Batch (parent + children, cross-references, milestone creation): `file_issues.py` in this
+directory. Dry run first; it validates types, labels, parents and unresolved `[Working title]`
+references and says which milestone it would create. `--create` files in order, links sub-issues,
+then rewrites `[Working title]` to `#N` in the filed bodies, and is idempotent via `filed.json`
+next to the drafts.
+
+```bash
+python .claude/skills/issue/file_issues.py <draft-dir>            # dry run
+python .claude/skills/issue/file_issues.py --create <draft-dir>
+```
+
+Report the URLs. An issue with an area label lands on the board in Todo by itself; don't touch the
+board.
+
+## Spin-off mode
+
+While working on issue #N and something unrelated turns up (a bug in adjacent code, a missing
+endpoint, a design gap), don't widen the current work. Spawn a background `fork` subagent with the
+finding and this skill's steps 1-4; it drafts to the scratchpad and returns. Its Why section opens
+with "Raised while working on #N, <date>." Show the draft with your next report on the main task;
+file it only on the go-ahead (or immediately if the user already said "just file it" for
+spin-offs this session).
+
+## Don'ts
+
+- Don't relabel, comment on, edit, assign, close or reopen anything, including issues you created
+  earlier in the session, unless asked.
+- Don't add "raised by Claude" or any attribution lines; the account filing it is the author.
+- Don't put Discord text, links or message ids anywhere in an issue.
+- Don't describe branches, memory files, chat transcripts or "the plan doc"; the issue stands on
+  its own.
+- Don't use em-dashes.

--- a/.claude/skills/issue/file_issues.py
+++ b/.claude/skills/issue/file_issues.py
@@ -1,0 +1,475 @@
+"""File GitHub issue drafts via the `gh` CLI.
+
+Usage:
+    python file_issues.py [--create] [--repo OWNER/NAME] <draft-dir | draft-file ...>
+
+Default is a dry run: it parses every draft, resolves types/labels/milestones/parents
+against the live repo, and prints a plan plus any problems it finds. Pass --create to
+actually file the issues (idempotently -- see below).
+
+--repo defaults to the repo `gh` infers from the current directory.
+
+If a single directory is given, every `*.md` file in it is used as a draft, except ones
+whose name starts with "_", "TEMPLATE", or "BRIEF" -- sorted by file name. Otherwise, each
+path given is treated as a draft file, in the order given.
+
+Draft format
+------------
+The first line of a draft is its title:
+
+    # Add a widget to the sidebar
+
+Somewhere in the next four lines (so within the first five lines of the file) there must
+be a single-line HTML comment with ";"-separated "key: value" metadata fields:
+
+    <!-- type: Feature ; labels: chat,needs-design ; parent: [Working title] ; milestone: Chat commands -->
+
+- type (required): one of the issue types configured in the repo (e.g. Bug, Feature, Task).
+- labels (required, may be empty): comma-separated label names, all of which must exist.
+- parent (optional): either the "[Working title]" of another draft being filed in the same
+  run, or "#123" for an issue that already exists. Creates a GitHub sub-issue link.
+- milestone (optional): a milestone title. Created automatically if it doesn't exist yet.
+
+Everything after the metadata line, stripped of leading/trailing blank lines, is the issue
+body. Within the body, "[Working title]" (matching another draft's title exactly) may be
+used to cross-reference a sibling draft; after all drafts in a run are filed, every such
+reference is rewritten to "#<number>" in a post-pass.
+
+Create mode and idempotency
+----------------------------
+--create writes `filed.json` next to the drafts, recording each filed issue's number, node
+id, URL and title (plus "linked"/"refs_resolved" flags once those steps complete). Re-running
+with --create skips anything already recorded, so an interrupted run can simply be re-run.
+
+Requires the `gh` CLI to be authenticated with access to the target repo.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import glob
+import json
+import os
+import re
+import subprocess
+import sys
+from typing import Optional
+
+# ---------------------------------------------------------------------------
+# gh CLI / GraphQL helpers
+# ---------------------------------------------------------------------------
+
+
+def run_gh(args: list[str], input_text: Optional[str] = None) -> str:
+    """Run a `gh` command and return its stdout, or raise SystemExit with its stderr."""
+    proc = subprocess.run(
+        ["gh", *args],
+        input=input_text,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    )
+    if proc.returncode != 0:
+        raise SystemExit(f"gh {' '.join(args)} failed:\n{proc.stderr.strip()}")
+    return proc.stdout
+
+
+def graphql(query: str, variables: dict) -> dict:
+    payload = json.dumps({"query": query, "variables": variables})
+    out = run_gh(["api", "graphql", "--input", "-"], input_text=payload)
+    data = json.loads(out)
+    if data.get("errors"):
+        raise SystemExit(f"GraphQL error:\n{json.dumps(data['errors'], indent=2)}")
+    return data["data"]
+
+
+def current_repo() -> str:
+    return run_gh(["repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"]).strip()
+
+
+# ---------------------------------------------------------------------------
+# Repo metadata (labels, issue types, open milestones) -- resolved at runtime,
+# never hardcoded.
+# ---------------------------------------------------------------------------
+
+REPO_META_QUERY = """
+query($owner: String!, $name: String!) {
+  repository(owner: $owner, name: $name) {
+    id
+    labels(first: 100) { nodes { id name } }
+    issueTypes(first: 50) { nodes { id name } }
+    milestones(states: OPEN, first: 100) { nodes { id number title } }
+  }
+}
+"""
+
+
+@dataclasses.dataclass
+class RepoMeta:
+    repo: str
+    owner: str
+    name: str
+    id: str
+    label_ids: dict[str, str]
+    type_ids: dict[str, str]
+    milestones: dict[str, dict]  # title -> {"id": ..., "number": ...}
+
+
+def fetch_repo_meta(repo: str) -> RepoMeta:
+    owner, _, name = repo.partition("/")
+    data = graphql(REPO_META_QUERY, {"owner": owner, "name": name})["repository"]
+    return RepoMeta(
+        repo=repo,
+        owner=owner,
+        name=name,
+        id=data["id"],
+        label_ids={n["name"]: n["id"] for n in data["labels"]["nodes"]},
+        type_ids={n["name"]: n["id"] for n in data["issueTypes"]["nodes"]},
+        milestones={n["title"]: {"id": n["id"], "number": n["number"]} for n in data["milestones"]["nodes"]},
+    )
+
+
+def ensure_milestone(meta: RepoMeta, title: str) -> dict:
+    """Return {"id", "number"} for an open milestone, creating it via REST if needed."""
+    existing = meta.milestones.get(title)
+    if existing is not None:
+        return existing
+    payload = json.dumps({"title": title})
+    out = run_gh(["api", f"repos/{meta.repo}/milestones", "--method", "POST", "--input", "-"], input_text=payload)
+    data = json.loads(out)
+    created = {"id": data["node_id"], "number": data["number"]}
+    meta.milestones[title] = created
+    return created
+
+
+# ---------------------------------------------------------------------------
+# Draft parsing
+# ---------------------------------------------------------------------------
+
+METADATA_COMMENT_RE = re.compile(r"<!--(.*?)-->")
+METADATA_LINES_SEARCHED = 5
+
+
+class DraftError(Exception):
+    pass
+
+
+@dataclasses.dataclass
+class Draft:
+    stem: str
+    path: str
+    title: str
+    type: str
+    labels: list[str]
+    parent: Optional[str]  # raw metadata value: "[Working title]" or "#123"
+    milestone: Optional[str]
+    body: str
+
+
+def parse_metadata_fields(line: str) -> Optional[dict[str, str]]:
+    m = METADATA_COMMENT_RE.search(line)
+    if m is None:
+        return None
+    fields = {}
+    for part in m.group(1).split(";"):
+        part = part.strip()
+        if not part or ":" not in part:
+            continue
+        key, _, value = part.partition(":")
+        fields[key.strip()] = value.strip()
+    return fields
+
+
+def parse_draft(path: str) -> Draft:
+    stem = os.path.splitext(os.path.basename(path))[0]
+    with open(path, encoding="utf-8") as f:
+        lines = f.read().splitlines()
+
+    if not lines or not lines[0].startswith("# "):
+        raise DraftError(f"{stem}: first line must be '# <title>'")
+    title = lines[0][2:].strip()
+    if not title:
+        raise DraftError(f"{stem}: title is empty")
+
+    meta_idx, fields = None, None
+    for i in range(1, min(METADATA_LINES_SEARCHED, len(lines))):
+        parsed = parse_metadata_fields(lines[i])
+        if parsed is not None:
+            meta_idx, fields = i, parsed
+            break
+    if fields is None:
+        raise DraftError(f"{stem}: metadata comment must be within the first {METADATA_LINES_SEARCHED} lines")
+    if not fields.get("type"):
+        raise DraftError(f"{stem}: metadata missing required 'type' field")
+    if "labels" not in fields:
+        raise DraftError(f"{stem}: metadata missing required 'labels' field (may be empty)")
+
+    labels = [l.strip() for l in fields["labels"].split(",") if l.strip()]
+    body = "\n".join(lines[meta_idx + 1 :]).strip() + "\n"
+
+    return Draft(
+        stem=stem,
+        path=path,
+        title=title,
+        type=fields["type"],
+        labels=labels,
+        parent=fields.get("parent", "").strip() or None,
+        milestone=fields.get("milestone", "").strip() or None,
+        body=body,
+    )
+
+
+def collect_draft_paths(paths: list[str]) -> list[str]:
+    if len(paths) == 1 and os.path.isdir(paths[0]):
+        skip_prefixes = ("_", "TEMPLATE", "BRIEF")
+        files = [
+            p
+            for p in glob.glob(os.path.join(paths[0], "*.md"))
+            if not os.path.basename(p).startswith(skip_prefixes)
+        ]
+        return sorted(files, key=lambda p: os.path.basename(p))
+    return paths
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+PARENT_ISSUE_REF_RE = re.compile(r"^#\d+$")
+# A bracketed [reference] that markdown wouldn't treat as a link, and that looks like a
+# working-title reference rather than incidental bracketed text.
+TITLE_LIKE_BRACKET_RE = re.compile(r"\[([^\]\n]+)\](?!\()")
+URL_LIKE_RE = re.compile(r"^\w+://|^www\.", re.IGNORECASE)
+
+
+def parent_ref_kind(parent: str) -> tuple[str, str]:
+    """Classify a draft's `parent` metadata value as ("issue", "123") or ("title", text)."""
+    if PARENT_ISSUE_REF_RE.match(parent):
+        return "issue", parent[1:]
+    if parent.startswith("[") and parent.endswith("]"):
+        return "title", parent[1:-1]
+    return "title", parent
+
+
+def find_title_like_refs(body: str) -> list[str]:
+    refs = []
+    for m in TITLE_LIKE_BRACKET_RE.finditer(body):
+        text = m.group(1)
+        if text[:1].isupper() and " " in text and not URL_LIKE_RE.match(text):
+            refs.append(text)
+    return refs
+
+
+def validate(drafts: list[Draft], meta: RepoMeta) -> tuple[list[str], list[str]]:
+    """Return (errors, warnings). Also prints the one-line plan for each draft."""
+    titles = {d.title for d in drafts}
+    errors: list[str] = []
+    warnings: list[str] = []
+
+    for d in drafts:
+        bad_labels = [l for l in d.labels if l not in meta.label_ids]
+        type_note = d.type + (" [UNKNOWN]" if d.type not in meta.type_ids else "")
+        labels_note = ",".join(d.labels) or "(none)"
+        if bad_labels:
+            labels_note += f" [UNKNOWN: {','.join(bad_labels)}]"
+        milestone_note = "-"
+        if d.milestone:
+            milestone_note = d.milestone
+            if d.milestone not in meta.milestones:
+                milestone_note += " (would create)"
+        parent_note = d.parent or "-"
+        print(
+            f"- {d.stem}: {type_note} [{labels_note}] milestone={milestone_note} "
+            f"parent={parent_note} {len(d.body)} chars | {d.title}"
+        )
+
+        if d.type not in meta.type_ids:
+            errors.append(f"{d.stem}: unknown type {d.type!r}")
+        for l in bad_labels:
+            errors.append(f"{d.stem}: unknown label {l!r}")
+        if d.parent is not None:
+            kind, ref = parent_ref_kind(d.parent)
+            if kind == "title" and ref not in titles:
+                errors.append(f"{d.stem}: parent {d.parent!r} matches neither a draft title nor '#N'")
+        for ref in find_title_like_refs(d.body):
+            if ref not in titles:
+                warnings.append(f"{d.stem}: possible unresolved working-title reference [{ref}]")
+
+    return errors, warnings
+
+
+# ---------------------------------------------------------------------------
+# Create mode
+# ---------------------------------------------------------------------------
+
+CREATE_ISSUE_MUTATION = """
+mutation($input: CreateIssueInput!) {
+  createIssue(input: $input) { issue { id number url } }
+}
+"""
+
+ADD_SUB_ISSUE_MUTATION = """
+mutation($parentId: ID!, $childId: ID!) {
+  addSubIssue(input: { issueId: $parentId, subIssueId: $childId }) {
+    issue { number }
+    subIssue { number }
+  }
+}
+"""
+
+UPDATE_ISSUE_BODY_MUTATION = """
+mutation($id: ID!, $body: String!) {
+  updateIssue(input: { id: $id, body: $body }) { issue { number } }
+}
+"""
+
+ISSUE_ID_BY_NUMBER_QUERY = """
+query($owner: String!, $name: String!, $number: Int!) {
+  repository(owner: $owner, name: $name) { issue(number: $number) { id } }
+}
+"""
+
+
+def load_state(path: str) -> dict:
+    if not os.path.exists(path):
+        return {}
+    with open(path, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def save_state(path: str, state: dict) -> None:
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(state, f, indent=2, sort_keys=True)
+        f.write("\n")
+
+
+def resolve_parent_id(meta: RepoMeta, draft: Draft, state: dict, titles_to_stem: dict[str, str]) -> tuple[str, int]:
+    kind, ref = parent_ref_kind(draft.parent)
+    if kind == "issue":
+        number = int(ref)
+        issue_id = graphql(ISSUE_ID_BY_NUMBER_QUERY, {"owner": meta.owner, "name": meta.name, "number": number})[
+            "repository"
+        ]["issue"]["id"]
+        return issue_id, number
+    parent_stem = titles_to_stem[ref]
+    parent_state = state[parent_stem]
+    return parent_state["id"], parent_state["number"]
+
+
+def create_issues(meta: RepoMeta, drafts: list[Draft], state_path: str, state: dict) -> None:
+    titles_to_stem = {d.title: d.stem for d in drafts}
+
+    milestone_titles = sorted({d.milestone for d in drafts if d.milestone})
+    for title in milestone_titles:
+        was_known = title in meta.milestones
+        ms = ensure_milestone(meta, title)
+        if not was_known:
+            print(f"created milestone {title!r} (#{ms['number']})")
+
+    for d in drafts:
+        if d.stem in state:
+            print(f"skip {d.stem}: already filed as #{state[d.stem]['number']}")
+            continue
+        input_obj = {
+            "repositoryId": meta.id,
+            "title": d.title,
+            "body": d.body,
+            "labelIds": [meta.label_ids[l] for l in d.labels],
+            "issueTypeId": meta.type_ids[d.type],
+        }
+        if d.milestone:
+            input_obj["milestoneId"] = meta.milestones[d.milestone]["id"]
+        issue = graphql(CREATE_ISSUE_MUTATION, {"input": input_obj})["createIssue"]["issue"]
+        state[d.stem] = {"number": issue["number"], "id": issue["id"], "url": issue["url"], "title": d.title}
+        save_state(state_path, state)
+        print(f"filed #{issue['number']} {d.title} {issue['url']}")
+
+    for d in drafts:
+        if d.parent is None or state[d.stem].get("linked"):
+            continue
+        parent_id, parent_number = resolve_parent_id(meta, d, state, titles_to_stem)
+        graphql(ADD_SUB_ISSUE_MUTATION, {"parentId": parent_id, "childId": state[d.stem]["id"]})
+        state[d.stem]["linked"] = True
+        save_state(state_path, state)
+        print(f"linked #{state[d.stem]['number']} under #{parent_number}")
+
+    by_title_number = {v["title"]: v["number"] for v in state.values()}
+    for d in drafts:
+        if state[d.stem].get("refs_resolved"):
+            continue
+        new_body = d.body
+        for title, number in by_title_number.items():
+            new_body = new_body.replace(f"[{title}]", f"#{number}")
+        if new_body != d.body:
+            graphql(UPDATE_ISSUE_BODY_MUTATION, {"id": state[d.stem]["id"], "body": new_body})
+            print(f"resolved refs in #{state[d.stem]['number']}")
+        state[d.stem]["refs_resolved"] = True
+        save_state(state_path, state)
+
+    print()
+    print("filed issues:")
+    for d in drafts:
+        print(f"  #{state[d.stem]['number']} {state[d.stem]['url']}")
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    if hasattr(sys.stdout, "reconfigure"):
+        sys.stdout.reconfigure(encoding="utf-8")
+
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--create", action="store_true", help="File the issues for real (default is a dry run).")
+    parser.add_argument("--repo", default=None, help="OWNER/NAME (default: current repo, via `gh repo view`).")
+    parser.add_argument("paths", nargs="+", help="A directory of drafts, or one or more draft files.")
+    args = parser.parse_args(argv)
+
+    repo = args.repo or current_repo()
+    draft_paths = collect_draft_paths(args.paths)
+    if not draft_paths:
+        raise SystemExit("no draft files found")
+
+    drafts: list[Draft] = []
+    errors: list[str] = []
+    for path in draft_paths:
+        try:
+            drafts.append(parse_draft(path))
+        except DraftError as e:
+            errors.append(str(e))
+
+    meta = fetch_repo_meta(repo)
+
+    print(f"{len(drafts)} draft(s) against {repo}\n")
+    validation_errors, warnings = validate(drafts, meta)
+    errors += validation_errors
+    print()
+
+    if warnings:
+        print("WARN:")
+        for w in warnings:
+            print(f"  {w}")
+        print()
+
+    if errors:
+        print("ERROR:")
+        for e in errors:
+            print(f"  {e}")
+        return 1
+
+    if not args.create:
+        print("dry run OK; pass --create to file")
+        return 0
+
+    draft_dir = os.path.dirname(os.path.abspath(draft_paths[0]))
+    state_path = os.path.join(draft_dir, "filed.json")
+    state = load_state(state_path)
+    create_issues(meta, drafts, state_path, state)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/skills/issue/template.md
+++ b/.claude/skills/issue/template.md
@@ -1,0 +1,53 @@
+# Issue drafting rules (read fully before writing)
+
+You are drafting GitHub issues for the public ShieldBattery repo. Each issue must be
+self-contained: someone with the repo and the issue, and nothing else, can do the work.
+
+## Output
+
+One markdown file per issue. First line is the title as `# <title>`. Second line is a metadata
+HTML comment with `;`-separated fields:
+
+`<!-- type: Bug|Feature|Task ; labels: chat|lobbies|matchmaking|replays[,needs-design] ; parent: [Working title] or #N ; milestone: <title> -->`
+
+`type` and `labels` are required (`labels` may be empty when no area fits). `parent` and
+`milestone` are optional. Then the seven sections below, as `## ` headings, in this order. Short is
+fine. Empty is not.
+
+## Title
+
+A plain statement of the problem (bugs) or the outcome (features and tasks), sentence case, no
+trailing period, no prefix tags. Good: "Whispers from blocked users still count as unread", "Sync
+account-level settings to the server". Bad: "[Chat] Fix unread bug", "Settings sync (phase 1)".
+
+## The seven sections
+
+1. **Why** — the problem in one paragraph, who raised it and when. Attribution is a name and a
+   date, e.g. "Raised by tec27 on Discord, 2026-09-03." NEVER quote or paraphrase-in-detail
+   anything said on Discord; the Discord server is private and this repo is public. Restate the
+   need in your own words. Public sources (PR review comments, existing GitHub issues) may be
+   quoted.
+2. **Current behavior** — what the code does today, with `path:line` pointers, written against the
+   pinned commit. Open with the line `Written against <sha> (<date>).` Every pointer must be
+   looked up with `git grep -n "<pattern>" <sha> -- <path>` or `git show <sha>:<path>` so the line
+   numbers are real for that commit. Do not cite a line you did not read. If a claim in the brief
+   turns out to be false in the code, say what the code actually does instead.
+3. **Desired behavior** — acceptance criteria as testable statements, one per bullet.
+4. **Decisions** — locked choices and rejected alternatives, with who locked them and when. Include
+   every decision the brief gives you. If none, say "None yet."
+5. **Verification** — the verify-pr tier (read `.claude/skills/verify-pr/SKILL.md`, section
+   "Verification tiers" and the changed-path matrix) plus the concrete recipe: which clients, which
+   flow, what to check in the DB or logs.
+6. **Out of scope** — adjacent work deliberately excluded. Reference sibling issues by their
+   working title in square brackets, e.g. `[Per-channel mute]`; the numbers are assigned at filing.
+   Existing issues go by number.
+7. **Links** — related PRs and issues by number, design pages by URL if given. No Discord links.
+
+## Style
+
+- Plain, direct sentences. No marketing, no hedging, no "we should consider".
+- Code identifiers in backticks. Paths relative to repo root.
+- Don't invent behavior. Where you are unsure, read more code; where the code is ambiguous, say so.
+- Don't reference this template, the brief, memory files, or chat transcripts anywhere in the
+  issue text.
+- No em-dashes.

--- a/.claude/skills/issue/template.md
+++ b/.claude/skills/issue/template.md
@@ -8,7 +8,7 @@ self-contained: someone with the repo and the issue, and nothing else, can do th
 One markdown file per issue. First line is the title as `# <title>`. Second line is a metadata
 HTML comment with `;`-separated fields:
 
-`<!-- type: Bug|Feature|Task ; labels: chat|lobbies|matchmaking|replays[,needs-design] ; parent: [Working title] or #N ; milestone: <title> -->`
+`<!-- type: Bug|Feature|Task ; labels: chat|lobbies|matchmaking|replays[,needs-design][,needs-decision] ; parent: [Working title] or #N ; milestone: <title> -->`
 
 `type` and `labels` are required (`labels` may be empty when no area fits). `parent` and
 `milestone` are optional. Then the seven sections below, as `## ` headings, in this order. Short is
@@ -34,7 +34,10 @@ account-level settings to the server". Bad: "[Chat] Fix unread bug", "Settings s
    turns out to be false in the code, say what the code actually does instead.
 3. **Desired behavior** — acceptance criteria as testable statements, one per bullet.
 4. **Decisions** — locked choices and rejected alternatives, with who locked them and when. Include
-   every decision the brief gives you. If none, say "None yet."
+   every decision the brief gives you. If none, say "None yet." Anything still open goes under an
+   **Open** sub-list, one bullet per question with your recommended answer, so a maintainer can
+   settle it in a word; an issue with an Open list carries `needs-decision`, or `needs-design`
+   when the answer needs options explored first.
 5. **Verification** — the verify-pr tier (read `.claude/skills/verify-pr/SKILL.md`, section
    "Verification tiers" and the changed-path matrix) plus the concrete recipe: which clients, which
    flow, what to check in the DB or logs.

--- a/.claude/skills/pr-fix/SKILL.md
+++ b/.claude/skills/pr-fix/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: pr-fix
+description: Bring a ShieldBattery PR to green and work through its review (`/pr-fix`, `/pr-fix N`) - read CI for the PR's head commit, tell a real regression from this repo's known flakes and rerun the flakes, verify every review claim against the code before changing anything, push fixes, then resolve the threads and minimize the comments that were addressed. Never posts replies or comments as the user. Use when asked to fix CI, address review, check on a PR, or after the implement skill has pushed one.
+---
+
+# Fixing up a PR
+
+## Rules
+
+- **Never write to the PR conversation as the user.** No replies, comments or reviews. Resolving a
+  thread and minimizing a comment are the only writes. Disagreement with feedback goes in chat.
+- **Verify before acting.** A reviewer, human or `claude[bot]`, can be wrong about the code. Check
+  the claim in the tree before changing anything; a claim that doesn't hold is reported, not fixed.
+- **Flakes get reruns, regressions get fixes.** Never both for the same failure.
+- **Ordinary commits.** Fixes are new commits on the PR branch in the repo's message style. No
+  amend or force-push except when rebasing a stacked child (step 4).
+
+## Steps
+
+### 1. Find the PR
+
+```bash
+gh pr view [N] --json number,headRefName,baseRefName,headRefOid,isDraft,url
+git checkout <headRefName> && git pull --ff-only
+```
+
+Without a number, the PR is the current branch's. If there is none, ask which PR; don't guess from
+`gh pr list`.
+
+### 2. Read CI
+
+```bash
+gh pr checks N                                   # one line per job, with run links
+gh run view <run-id> --json event,headSha,conclusion
+gh run view <run-id> --log-failed | tail -80
+```
+
+What runs, and when:
+
+| Workflow           | Jobs                                                                                                               | Runs on                                                                  |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------ |
+| JS CI              | `unit-tests`: vitest, typecheck, lint, circular-deps, translation catalogs, email templates, graphql codegen check | every `push` and `pull_request`                                          |
+|                    | `integration-tests`: docker compose stack + Playwright                                                             |                                                                          |
+| Game CI            | clippy (x86, x64), rustfmt, cargo test (x86, x64)                                                                  | `game/**`                                                                |
+| server-rs CI       | clippy, rustfmt, cargo test + `gen-schema` check, typeshare check, `sqlx prepare` check                            | `server-rs/**`, `migrations/**`, `schema.graphql`, `common/typeshare.ts` |
+| Claude Code Review | `claude-review`: posts a review from `claude[bot]`                                                                 | PR opened, synchronize, reopened, ready for review                       |
+
+Reading the results:
+
+- Every commit gets two runs of each workflow, one `push` and one `pull_request`. A job that fails
+  in one and passes in the other on the same SHA is a flake by definition.
+- All workflows cancel in-progress runs on a new push, so a pending rerun on the previous SHA ends
+  as `cancelled`. That is not a failure.
+- `claude` (the mention-triggered workflow) shows as `skipping` on every PR. Normal.
+
+Known flakes, both in `integration-tests`. Rerun with `gh run rerun <run-id> --failed`:
+
+- Step "Running Docker containers": `service "migration" didn't complete successfully: exit 1`. The
+  migration container connected before postgres was ready to serve queries.
+- Signup spec: `apiRequestContext.get: socket hang up` on `http://localhost:5528/sent/...`. The fake
+  mailgun sidecar dropped a connection.
+
+Anything else is a regression until proven otherwise: read the failed log, reproduce with the local
+equivalent, fix.
+
+```bash
+pnpm test && pnpm run typecheck && pnpm run lint && pnpm run check-circular
+pnpm gen-translations:app --fail-on-update && pnpm gen-translations:email --fail-on-update
+pnpm gen-emails && pnpm gen-graphql && git status --short     # generated files must be clean
+cd server-rs && cargo clippy --all-targets --workspace -- -D warnings && cargo fmt --all -- --check
+cd game && cargo clippy --all-targets --workspace -- -D warnings && cargo fmt --all -- --check
+pnpm sqlx-prepare && git status --short server-rs/.sqlx
+```
+
+### 3. Read the review
+
+Three sources; the top-level one is the one that gets missed:
+
+```bash
+# inline threads, with ids and resolved state
+gh api graphql -f query='{ repository(owner:"ShieldBattery", name:"ShieldBattery") { pullRequest(number:N) { reviewThreads(first:100) { nodes { id isResolved isOutdated path line comments(first:10) { nodes { databaseId author { login } body } } } } } } }'
+# top-level comments (node_id is what minimizeComment takes)
+gh api repos/ShieldBattery/ShieldBattery/issues/N/comments --paginate --jq '.[] | {node_id, user: .user.login, created_at, body}'
+# review bodies
+gh pr view N --json reviews --jq '.reviews[] | {author: .author.login, state, body}'
+```
+
+Unaddressed feedback is every unresolved thread plus every top-level comment or review body that
+isn't minimized. For each item, check the claim before touching code:
+
+- "X doesn't exist", "X is unused", "the repo already does Y": grep for it.
+- Formatting claims: `pnpm exec prettier --check <file>`. Character counts in a comment are not
+  evidence.
+- A thread from an earlier round may describe code that a later commit already changed: GitHub
+  re-anchors unresolved comments to the new head. Compare against the commit the comment was written
+  on before treating it as open.
+- Suggestion blocks can be malformed. Apply the idea by hand, then prettier.
+
+`claude[bot]` reviews again on every push, so the loop only continues while you keep pushing. Batch
+fixes into one push. When a round contradicts an earlier round, settle on the better design once,
+say why in chat, and resolve both threads rather than flipping the code back and forth.
+
+### 4. Fix and push
+
+Commit on the PR branch; run the local gates from step 2 for what you touched. On a stacked PR,
+fix at the tip when the change is local to it. A fix that belongs to a parent branch goes on the
+parent, then each child is rebased onto its parent's new tip
+(`git rebase --onto <parent-tip> <old-parent-tip>`) and pushed with `--force-with-lease`; never
+merge the parent into the child.
+
+After pushing, wait for the new runs (`gh pr checks N --watch`) and repeat step 2 until green or
+blocked on something only the user can decide.
+
+### 5. Bookkeeping
+
+```bash
+gh api graphql -f query='mutation { resolveReviewThread(input:{threadId:"PRRT_..."}) { thread { isResolved } } }'
+gh api graphql -f query='mutation { minimizeComment(input:{subjectId:"IC_...", classifier:RESOLVED}) { minimizedComment { isMinimized } } }'
+```
+
+Resolve a thread only once its fix is pushed. Leave open anything you disagreed with and anything
+that asks the user a question. Minimize a top-level comment once every point in it is handled.
+
+### 6. Report
+
+In chat: CI per job, naming which failures were flakes rerun and which were regressions fixed; each
+feedback item with how it was addressed or why it was skipped; what was resolved or minimized; and
+what is still open, with the reason.

--- a/.claude/skills/pr-fix/SKILL.md
+++ b/.claude/skills/pr-fix/SKILL.md
@@ -47,8 +47,13 @@ What runs, and when:
 
 Reading the results:
 
-- Every commit gets two runs of each workflow, one `push` and one `pull_request`. A job that fails
-  in one and passes in the other on the same SHA is a flake by definition.
+- Every commit gets two runs of each workflow, one `push` and one `pull_request`. Both report the
+  branch's head SHA, but `push` builds the branch tip and `pull_request` builds the branch merged
+  into master. A split result on the same SHA is a flake only when the branch is up to date with
+  master (`git fetch origin && git log --oneline HEAD..origin/master` prints nothing). Otherwise
+  the two runs built different code: a `pull_request`-only failure means the branch breaks once
+  merged, so rebase onto master, reproduce locally, and fix it as a regression; a `push`-only
+  failure means master already carries the fix, and the rebase clears it.
 - All workflows cancel in-progress runs on a new push, so a pending rerun on the previous SHA ends
   as `cancelled`. That is not a failure.
 - `claude` (the mention-triggered workflow) shows as `skipping` on every PR. Normal.
@@ -67,8 +72,8 @@ equivalent, fix.
 pnpm test && pnpm run typecheck && pnpm run lint && pnpm run check-circular
 pnpm gen-translations:app --fail-on-update && pnpm gen-translations:email --fail-on-update
 pnpm gen-emails && pnpm gen-graphql && git status --short     # generated files must be clean
-cd server-rs && cargo clippy --all-targets --workspace -- -D warnings && cargo fmt --all -- --check
-cd game && cargo clippy --all-targets --workspace -- -D warnings && cargo fmt --all -- --check
+(cd server-rs && cargo clippy --all-targets --workspace -- -D warnings && cargo fmt --all -- --check)
+(cd game && cargo clippy --all-targets --workspace -- -D warnings && cargo fmt --all -- --check)
 pnpm sqlx-prepare && git status --short server-rs/.sqlx
 ```
 


### PR DESCRIPTION
Adds the skills that drive the GitHub Issues workflow:

- `issue`: files an issue the way this repo wants them. Reads the code first, dedupes against the whole backlog including the unlabeled inbox, drafts seven fixed sections pinned to a commit, shows the draft, then creates it with type, area label, parent and milestone set at creation. Open questions go under an Open sub-list in Decisions with a recommended answer, and the issue carries `needs-decision` (or `needs-design` when options must be explored first). Creates only; never comments, edits, relabels, assigns or closes. Ships with the drafting rules (`template.md`) and a batch filing script (`file_issues.py`) that resolves label, type and milestone ids at runtime, links sub-issues, and rewrites `[Working title]` cross-references to issue numbers once the batch is filed.
- `implement`: takes an issue by number, verifies its Current behavior claims against the pinned commit and current master before writing code, reports drift in chat, builds on a short branch within the issue's stated scope, verifies at the tier the issue names, and opens a PR with `Fixes #N`. Readiness is a soft gate: on a `needs-design`/`needs-decision` label or a board status of Todo rather than Ready, it lists the open items with a recommendation each and asks once; a go-ahead means building on those recommendations and listing them in the PR body under "Calls made".
- `pr-fix`: brings a PR to green and works through its review: reads CI for the head commit, tells a regression from this repo's known flakes, verifies review claims against the code before changing anything, pushes fixes, then resolves the addressed threads.

The chat-commands batch (#1476 to #1485) was filed with the script.
