### PR TITLE
Jump to the newest message on Escape in channels and whispers.

### DIFF
--- a/client/chat/channel.tsx
+++ b/client/chat/channel.tsx
@@ -476,6 +476,7 @@ export function ConnectedChatChannel({
             onAtBottomChange={onAtBottomChange}
             onJumpToPresent={onJumpToPresent}
             onSeekToUnread={onSeekToUnread}
+            escapeJumpsToBottom
             header={
               // These are basically guaranteed to be defined here, but still doing the check instead
               // of asserting them with ! because better to be safe than sorry, or something.

--- a/client/messaging/chat.tsx
+++ b/client/messaging/chat.tsx
@@ -7,6 +7,7 @@ import styled from 'styled-components'
 import { Merge, Simplify } from 'type-fest'
 import { SbUserId } from '../../common/users/sb-user-id'
 import { MaterialIcon } from '../icons/material/material-icon'
+import { useKeyListener } from '../keyboard/key-listener'
 import { ElevatedButton } from '../material/button'
 import { buttonReset } from '../material/button-reset'
 import { MenuItem, MenuItemProps } from '../material/menu/item'
@@ -251,6 +252,8 @@ const overlayTransition: Transition = {
   duration: 0.12,
 }
 
+const ESCAPE = 'Escape'
+
 export interface ChatProps {
   className?: string
   listProps: Omit<MessageListProps, 'onScrollUpdate' | 'isRestorePending'>
@@ -310,6 +313,12 @@ export interface ChatProps {
    * surfaces that keep history on the server; without it the jump can't reach past what's loaded.
    */
   onSeekToUnread?: () => void
+  /**
+   * If true, pressing Escape moves the list to the newest message the same way the jump-to-bottom
+   * button does. Escape is left for other handlers when the list is already at the bottom, since
+   * there is nothing for it to do there. Defaults to false.
+   */
+  escapeJumpsToBottom?: boolean
 }
 
 /**
@@ -333,6 +342,7 @@ export function Chat({
   onAtBottomChange,
   onJumpToPresent,
   onSeekToUnread,
+  escapeJumpsToBottom = false,
 }: ChatProps) {
   const { t } = useTranslation()
   const dispatch = useAppDispatch()
@@ -818,18 +828,40 @@ export function Chat({
     driveLinkedMessageJump()
   }, [messages])
 
-  const onJumpToBottomClick = () => {
+  /**
+   * Moves the list to the newest message. Returns whether anything had to move: false means the
+   * list was already at the bottom of the newest window (or has no scroller yet).
+   */
+  const jumpToBottom = (): boolean => {
     if (hasNewerMessages) {
       // The bottom of the loaded window isn't the newest message, so getting there takes a fetch.
       onJumpToPresent?.()
-      return
+      return true
     }
 
     const scroller = scrollerRef.current
-    if (scroller) {
-      scroller.scrollTop = scroller.scrollHeight
+    if (!scroller || isScrolledToBottom(scroller)) {
+      return false
     }
+
+    scroller.scrollTop = scroller.scrollHeight
+    return true
   }
+
+  const onJumpToBottomClick = () => {
+    jumpToBottom()
+  }
+
+  useKeyListener({
+    onKeyDown: event => {
+      // An Escape during IME composition cancels the composition; it isn't meant for the list.
+      if (!escapeJumpsToBottom || event.code !== ESCAPE || event.isComposing) {
+        return false
+      }
+
+      return jumpToBottom()
+    },
+  })
 
   const onUnreadBannerClick = () => {
     const scroller = scrollerRef.current

--- a/client/whispers/whisper.tsx
+++ b/client/whispers/whisper.tsx
@@ -407,6 +407,7 @@ export function ConnectedWhisper({
         onAtBottomChange={onAtBottomChange}
         onJumpToPresent={onJumpToPresent}
         onSeekToUnread={onSeekToUnread}
+        escapeJumpsToBottom
         extraContent={
           <UserInfoContainer>
             <UserProfileOverlayContents userId={targetId} showHintText={false} />


### PR DESCRIPTION
When a channel or whisper has new messages above the current scroll position, there was no keyboard way back to the newest message. Escape now reuses the jump-to-bottom button's logic in `Chat` (fetch the present when the loaded window is detached, otherwise a direct scroll), and reaching the bottom reports the read position through the existing at-bottom path, so the window-focus gate still applies. The handler lives behind an opt-in `escapeJumpsToBottom` prop that only the channel and whisper views set.

Fixes #1462

## Acceptance criteria

- [x] Escape in a focused channel or whisper, with no dialog/popover/`KeyListenerBoundary` intercepting, scrolls to the newest message using the jump-to-bottom logic. Verified live (T3): direct-scroll case in a channel and a whisper; detached-window case via a message link into old history on a fresh client (`hasNewer` true, "Jump to present" shown) where Escape fetched the newest window and landed at the bottom. Escape with the channel overflow menu open closed the menu and left the list scrolled up; same with channel settings open (opened by pushing its history state); the next Escape then jumped.
- [x] Reaching the bottom reports the read position via `markChannelRead`/`markWhisperRead`, subject to the existing focus gate, no new gate. Verified live: each jump produced one `mark-read` POST (204) and `channel_users.last_read_time` / `whisper_sessions.last_read_time` moved to the newest server message. Unfocused case: with the reader's window blurred via a real Alt+Tab, Escape over CDP scrolled the list to the bottom (in-page store recorder shows at-bottom flipping with the read time unchanged), the DB stayed put, and the report went out 2 ms after the window regained focus.
- [x] Escape is a no-op when already at the bottom with nothing unread. Verified live in both a channel and a whisper: scroll position unchanged, no additional `mark-read` request, no console errors. The handler returns `false` there so any other Escape listener still gets the key.
- [x] Implemented for both channel and whisper views.

## Notes for review

- Lobby chat and the draft-screen chat keep their current behavior (they don't set the new prop); the issue scoped this to channels and whispers.
- Escape is ignored while `event.isComposing` is true, since an IME uses it to cancel composition.
- No new strings; `gen-translations` produced no changes.

## Drift

None. Every Current-behavior pointer still matched master at `637273795`; no commits touched the referenced files since the pinned `6367ffa99`.

## Verification

- T0: eslint + prettier on the three changed files, `pnpm run typecheck`, `vitest run client/messaging client/chat client/whispers` (13 files, 295 tests, all passing).
- T3: two dev Electron instances (claude-1 sending via the HTTP API, claude-2 reading over CDP) on the ShieldBattery channel and a claude-1 ↔ claude-2 whisper, per the issue's recipe plus the detached-window and popover cases above.
