### PR TITLE
Add a Mark as read action for channels and whispers.

### DIFF
--- a/client/chat/action-creators.test.ts
+++ b/client/chat/action-creators.test.ts
@@ -1,12 +1,23 @@
-import { beforeEach, describe, expect, test, vi } from 'vitest'
-import { ChannelPermissions, SbChannelId, makeSbChannelId } from '../../common/chat'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import {
+  ChannelPermissions,
+  ChannelTextMessage,
+  SbChannelId,
+  ServerChatMessageType,
+  makeSbChannelId,
+} from '../../common/chat'
 import { asMockedFunction } from '../../common/testing/mocks'
 import { SbUserId, makeSbUserId } from '../../common/users/sb-user-id'
 import { DispatchFunction } from '../dispatch-registry'
 import { LastReadSender, reportLastRead } from '../messaging/last-read'
 import { fetchJson } from '../network/fetch'
 import { RootState } from '../root-reducer'
-import { ChannelLeaveSeverity, getChannelLeaveSeverity, markChannelRead } from './action-creators'
+import {
+  ChannelLeaveSeverity,
+  getChannelLeaveSeverity,
+  markChannelRead,
+  markChannelReadNow,
+} from './action-creators'
 
 vi.mock('../network/fetch', () => ({
   fetchJson: vi.fn(),
@@ -207,5 +218,107 @@ describe('chat/action-creators/markChannelRead', () => {
     const { send } = runMarkRead()
 
     await expect(send(LAST_READ_TIME)).rejects.toBe(error)
+  })
+})
+
+const NOW = 5_000_000
+
+/** A `RootState` carrying just the chat slice `markChannelReadNow` reads. */
+function makeReadPositionState({
+  messages = [],
+  latestMentionTime,
+}: {
+  messages?: ChannelTextMessage[]
+  latestMentionTime?: number
+} = {}): RootState {
+  const chat = {
+    idToMessages: new Map([
+      [
+        CHANNEL_ID,
+        {
+          messages,
+          carriedClientMessages: [],
+          loadingHistory: false,
+          hasHistory: true,
+          loadingNewer: false,
+          hasNewer: false,
+          detachedNewestTime: undefined,
+          windowGen: 0,
+        },
+      ],
+    ]),
+    idToLatestMentionTime: new Map(
+      latestMentionTime !== undefined ? [[CHANNEL_ID, latestMentionTime]] : [],
+    ),
+  }
+  return { chat } as unknown as RootState
+}
+
+function textMessage(time: number): ChannelTextMessage {
+  return {
+    id: `text-${time}`,
+    type: ServerChatMessageType.TextMessage,
+    channelId: CHANNEL_ID,
+    time,
+    from: OTHER_ID,
+    text: 'hello',
+  }
+}
+
+/** Runs the `markChannelReadNow` thunk against `state` and hands back what it dispatched. */
+function runMarkReadNow(state: RootState) {
+  const dispatched: unknown[] = []
+  const dispatch = ((action: unknown) => {
+    dispatched.push(action)
+  }) as DispatchFunction<any>
+
+  markChannelReadNow(CHANNEL_ID)(dispatch, () => state)
+
+  return { dispatched }
+}
+
+describe('chat/action-creators/markChannelReadNow', () => {
+  beforeEach(() => {
+    fetchJsonMock.mockReset()
+    reportLastReadMock.mockReset()
+    vi.useFakeTimers()
+    vi.setSystemTime(NOW)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  test('marks read as of now when nothing known is newer', () => {
+    const { dispatched } = runMarkReadNow(
+      makeReadPositionState({ messages: [textMessage(NOW - 100)] }),
+    )
+
+    expect(dispatched).toEqual([
+      {
+        type: '@chat/updateLastReadTime',
+        payload: { channelId: CHANNEL_ID, lastReadTime: NOW, dismissUnreadLine: true },
+      },
+    ])
+    expect(reportLastReadMock).toHaveBeenCalledWith(expect.any(String), NOW, expect.any(Function))
+  })
+
+  test('reports a known time that has run ahead of the local clock', () => {
+    const newerTime = NOW + 5000
+    const { dispatched } = runMarkReadNow(
+      makeReadPositionState({ messages: [textMessage(newerTime)], latestMentionTime: NOW - 100 }),
+    )
+
+    expect(dispatched).toEqual([
+      {
+        type: '@chat/updateLastReadTime',
+        payload: { channelId: CHANNEL_ID, lastReadTime: newerTime, dismissUnreadLine: true },
+      },
+    ])
+    expect(reportLastReadMock).toHaveBeenCalledWith(
+      expect.any(String),
+      newerTime,
+      expect.any(Function),
+    )
   })
 })

--- a/client/chat/action-creators.ts
+++ b/client/chat/action-creators.ts
@@ -48,7 +48,11 @@ import {
   UpdateChannelAtBottom,
 } from './actions'
 import { urlForChannel } from './channel-url'
-import { newestServerOriginTime, oldestServerOriginTime } from './chat-reducer'
+import {
+  newestKnownChannelTime,
+  newestServerOriginTime,
+  oldestServerOriginTime,
+} from './chat-reducer'
 
 export function getJoinedChannels(spec: RequestHandlingSpec<void>): ThunkAction {
   return abortableThunk(spec, async dispatch => {
@@ -83,20 +87,45 @@ export function markChannelRead(channelId: SbChannelId, lastReadTime: number): T
       payload: { channelId, lastReadTime },
     })
 
-    // The rejection is passed back out so the coalescer knows the position never landed and lets
-    // the next report carry it again.
-    reportLastRead(getChannelLastReadKey(channelId), lastReadTime, time =>
-      fetchJson<void>(apiUrl`chat/${channelId}/mark-read`, {
-        method: 'POST',
-        body: encodeBodyAsParams<MarkChannelReadRequest>({ lastReadTime: time }),
-      }).catch(err => {
-        logger.error(
-          `Error reporting read position for channel ${channelId}: ${getErrorStack(err)}`,
-        )
-        throw err
-      }),
-    )
+    reportChannelLastRead(channelId, lastReadTime)
   }
+}
+
+/**
+ * Marks a channel read as of now on the user's explicit request, whether or not the channel is open
+ * or has any messages loaded. The reported position is the later of the local clock and the newest
+ * time the client knows about in the channel: server-stamped message times can run ahead of a
+ * client clock that lags the server's, and a position behind the newest message would leave it
+ * unread. (The server clamps whatever is reported to its own clock.) Unlike a position the open
+ * view reports, this also drops the frozen unread divider of an activated channel.
+ */
+export function markChannelReadNow(channelId: SbChannelId): ThunkAction {
+  return (dispatch, getState) => {
+    const newestKnownTime = newestKnownChannelTime(getState().chat, channelId)
+    const lastReadTime = Math.max(Date.now(), newestKnownTime ?? -Infinity)
+
+    dispatch({
+      type: '@chat/updateLastReadTime',
+      payload: { channelId, lastReadTime, dismissUnreadLine: true },
+    })
+
+    reportChannelLastRead(channelId, lastReadTime)
+  }
+}
+
+/** Sends a channel's read position to the server, coalescing rapid-fire reports. */
+function reportChannelLastRead(channelId: SbChannelId, lastReadTime: number): void {
+  // The rejection is passed back out so the coalescer knows the position never landed and lets
+  // the next report carry it again.
+  reportLastRead(getChannelLastReadKey(channelId), lastReadTime, time =>
+    fetchJson<void>(apiUrl`chat/${channelId}/mark-read`, {
+      method: 'POST',
+      body: encodeBodyAsParams<MarkChannelReadRequest>({ lastReadTime: time }),
+    }).catch(err => {
+      logger.error(`Error reporting read position for channel ${channelId}: ${getErrorStack(err)}`)
+      throw err
+    }),
+  )
 }
 
 /**

--- a/client/chat/actions.ts
+++ b/client/chat/actions.ts
@@ -448,6 +448,13 @@ export interface UpdateLastReadTime {
   payload: {
     channelId: SbChannelId
     lastReadTime: number
+    /**
+     * When true, the update comes from the user explicitly marking the channel read, and the frozen
+     * unread divider is dropped even for an activated channel. An ordinary read report only
+     * re-evaluates the divider of a channel that isn't being viewed, so it holds still under the
+     * reader.
+     */
+    dismissUnreadLine?: boolean
   }
 }
 

--- a/client/chat/channel.tsx
+++ b/client/chat/channel.tsx
@@ -40,6 +40,7 @@ import {
   jumpToPresent,
   leaveChannelWithConfirmation,
   markChannelRead,
+  markChannelReadNow,
   resetMessageWindow,
   retrieveUserList,
   sendMessage,
@@ -434,6 +435,10 @@ export function ConnectedChatChannel({
     }
   }
 
+  const onMarkRead = () => {
+    dispatch(markChannelReadNow(channelId))
+  }
+
   const onAtBottomChange = (atBottom: boolean) => {
     dispatch(updateChannelAtBottom(channelId, atBottom))
   }
@@ -476,6 +481,7 @@ export function ConnectedChatChannel({
             onAtBottomChange={onAtBottomChange}
             onJumpToPresent={onJumpToPresent}
             onSeekToUnread={onSeekToUnread}
+            onMarkRead={onMarkRead}
             escapeJumpsToBottom
             header={
               // These are basically guaranteed to be defined here, but still doing the check instead

--- a/client/chat/chat-reducer.test.ts
+++ b/client/chat/chat-reducer.test.ts
@@ -117,10 +117,10 @@ function makeState(
   return state as Immutable<ChatState>
 }
 
-function updateLastReadTimeAction(lastReadTime: number): ChatActions {
+function updateLastReadTimeAction(lastReadTime: number, dismissUnreadLine?: boolean): ChatActions {
   return {
     type: '@chat/updateLastReadTime',
-    payload: { channelId: CHANNEL_ID, lastReadTime },
+    payload: { channelId: CHANNEL_ID, lastReadTime, dismissUnreadLine },
   }
 }
 
@@ -359,6 +359,35 @@ describe('client/chat/chat-reducer', () => {
       // The read position itself still advances even while activated, since this is also the path
       // this session's own optimistic mark-read reports take.
       expect(result.idToLastReadTime.get(CHANNEL_ID)).toBe(200)
+    })
+
+    test('drops the frozen divider of an activated channel when dismissing it', () => {
+      const state = makeState({
+        activated: true,
+        unreadLineTime: 100,
+        lastReadTime: 100,
+        messages: [textMessage(150)],
+      })
+
+      const result = chatReducer(state, updateLastReadTimeAction(200, true))
+
+      expect(result.idToUnreadLineTime.has(CHANNEL_ID)).toBe(false)
+      expect(result.unreadChannels.has(CHANNEL_ID)).toBe(false)
+    })
+
+    test('keeps the flag while the latest mention is newer than any loaded message', () => {
+      const state = makeState({
+        unread: true,
+        lastReadTime: 100,
+        latestMentionTime: 300,
+        messages: [textMessage(150)],
+      })
+
+      const stillUnread = chatReducer(state, updateLastReadTimeAction(200))
+      expect(stillUnread.unreadChannels.has(CHANNEL_ID)).toBe(true)
+
+      const covered = chatReducer(state, updateLastReadTimeAction(300))
+      expect(covered.unreadChannels.has(CHANNEL_ID)).toBe(false)
     })
 
     test('clears an activated channel flag once the position covers the newest message', () => {

--- a/client/chat/chat-reducer.ts
+++ b/client/chat/chat-reducer.ts
@@ -276,6 +276,25 @@ export function newestServerOriginTime(messages: readonly ChatMessage[]): number
 }
 
 /**
+ * The newest time (epoch ms) of anything known to exist in a channel: the newest loaded
+ * server-origin message, the present of a detached window, and the latest mention. A read position
+ * covering this covers everything the client knows about.
+ */
+export function newestKnownChannelTime(
+  chatState: Immutable<ChatState>,
+  channelId: SbChannelId,
+): number | undefined {
+  const channelMessages = chatState.idToMessages.get(channelId)
+  const knownTimes = [
+    channelMessages ? newestServerOriginTime(channelMessages.messages) : undefined,
+    channelMessages?.detachedNewestTime,
+    chatState.idToLatestMentionTime.get(channelId),
+  ].filter(t => t !== undefined)
+
+  return knownTimes.length ? Math.max(...knownTimes) : undefined
+}
+
+/**
  * Returns the time (epoch ms) of the oldest message in `messages` that carries a server-recorded
  * timestamp, or `undefined` if there is none. See `newestServerOriginTime` for why client-only
  * messages are excluded: a window can open with one at its head (the self-join banner, or all
@@ -1151,9 +1170,12 @@ export default immerKeyedReducer(DEFAULT_CHAT_STATE, {
   // message arriving while the app window is unfocused counts as unread no matter what's on screen,
   // and this is what lowers it once the read position covers that message. The frozen divider is
   // only re-evaluated for a channel that isn't activated: while one is being viewed the divider has
-  // to hold still where it is, and `deactivateChannel` is what re-evaluates it.
+  // to hold still where it is, and `deactivateChannel` is what re-evaluates it. An explicit
+  // mark-read carries `dismissUnreadLine`, which drops the divider whether or not the channel is
+  // activated, because the user asked for the unread state to go rather than merely scrolling past
+  // it.
   ['@chat/updateLastReadTime'](state, action) {
-    const { channelId, lastReadTime } = action.payload
+    const { channelId, lastReadTime, dismissUnreadLine } = action.payload
 
     const existing = state.idToLastReadTime.get(channelId)
     if (existing === undefined || lastReadTime > existing) {
@@ -1162,20 +1184,18 @@ export default immerKeyedReducer(DEFAULT_CHAT_STATE, {
     const effective = state.idToLastReadTime.get(channelId)!
 
     // A detached window's present has run ahead of what's loaded, so the newest loaded message
-    // isn't the newest one known to exist. Clearing the flag against the loaded window alone would
-    // call the channel read on the strength of a position that only covers that window.
-    const channelMessages = state.idToMessages.get(channelId)
-    const knownTimes = [
-      channelMessages ? newestServerOriginTime(channelMessages.messages) : undefined,
-      channelMessages?.detachedNewestTime,
-    ].filter(t => t !== undefined)
-    const newestKnownTime = knownTimes.length ? Math.max(...knownTimes) : undefined
+    // isn't the newest one known to exist; the helper covers that along with a mention newer than
+    // anything loaded. Clearing the flag against the loaded window alone would call the channel
+    // read on the strength of a position that only covers that window.
+    const newestKnownTime = newestKnownChannelTime(state, channelId)
 
     if (newestKnownTime === undefined || newestKnownTime <= effective) {
       state.unreadChannels.delete(channelId)
     }
 
-    if (!state.activatedChannels.has(channelId)) {
+    if (dismissUnreadLine) {
+      state.idToUnreadLineTime.delete(channelId)
+    } else if (!state.activatedChannels.has(channelId)) {
       const unreadLineTime = state.idToUnreadLineTime.get(channelId)
       if (unreadLineTime !== undefined && effective > unreadLineTime) {
         state.idToUnreadLineTime.delete(channelId)

--- a/client/messaging/chat.tsx
+++ b/client/messaging/chat.tsx
@@ -3,7 +3,7 @@ import * as m from 'motion/react-m'
 import * as React from 'react'
 import { useContext, useEffect, useEffectEvent, useLayoutEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 import { Merge, Simplify } from 'type-fest'
 import { SbUserId } from '../../common/users/sb-user-id'
 import { MaterialIcon } from '../icons/material/material-icon'
@@ -190,31 +190,56 @@ const JumpToBottomButton = styled(ElevatedButton)`
   pointer-events: auto;
 `
 
-const UnreadBannerButton = styled(m.button)`
-  ${buttonReset};
-  ${labelMedium};
-
+const UnreadBanner = styled(m.div)`
   position: absolute;
   top: 0;
   left: 0;
   right: 0;
   height: 24px;
-  padding: 0 12px;
 
   display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 8px;
+  align-items: stretch;
 
   background-color: var(--theme-amber-container);
   border-radius: 0 0 4px 4px;
   color: var(--theme-on-amber-container);
+`
+
+const unreadBannerActionCss = css`
+  ${buttonReset};
+  ${labelMedium};
+
+  height: 100%;
+  padding: 0 12px;
+
+  display: flex;
+  align-items: center;
+  gap: 8px;
+
+  color: inherit;
   text-align: left;
 
   &:focus-visible {
     outline: 2px solid var(--theme-on-amber-container);
     outline-offset: -2px;
   }
+`
+
+/**
+ * The banner's primary action: the whole width that isn't the mark-read action jumps to the
+ * divider.
+ */
+const UnreadBannerJump = styled.button`
+  ${unreadBannerActionCss};
+  flex-grow: 1;
+  min-width: 0;
+`
+
+const UnreadBannerMarkRead = styled.button`
+  ${unreadBannerActionCss};
+  flex-shrink: 0;
+  gap: 4px;
+  border-left: 1px solid rgb(from var(--theme-on-amber-container) r g b / 0.24);
 `
 
 const jumpToBottomVariants: Variants = {
@@ -314,6 +339,12 @@ export interface ChatProps {
    */
   onSeekToUnread?: () => void
   /**
+   * Called when the user asks, from the "New messages" banner, for everything in the conversation
+   * to count as read without moving the view. Owners are expected to advance the read position to
+   * now and drop the unread divider. The banner only offers the action when this is provided.
+   */
+  onMarkRead?: () => void
+  /**
    * If true, pressing Escape moves the list to the newest message the same way the jump-to-bottom
    * button does. Escape is left for other handlers when the list is already at the bottom, since
    * there is nothing for it to do there. Defaults to false.
@@ -342,6 +373,7 @@ export function Chat({
   onAtBottomChange,
   onJumpToPresent,
   onSeekToUnread,
+  onMarkRead,
   escapeJumpsToBottom = false,
 }: ChatProps) {
   const { t } = useTranslation()
@@ -955,17 +987,24 @@ export function Chat({
             />
             <AnimatePresence>
               {showUnreadBanner && unreadLineTime !== undefined ? (
-                <UnreadBannerButton
+                <UnreadBanner
                   key='new-messages'
                   variants={unreadBannerVariants}
                   initial='initial'
                   animate='visible'
                   exit='exit'
-                  transition={overlayTransition}
-                  onClick={onUnreadBannerClick}>
-                  <span>{t('messaging.newMessages', 'New messages')}</span>
-                  <MaterialIcon icon='arrow_upward' size={16} />
-                </UnreadBannerButton>
+                  transition={overlayTransition}>
+                  <UnreadBannerJump onClick={onUnreadBannerClick}>
+                    <span>{t('messaging.newMessages', 'New messages')}</span>
+                    <MaterialIcon icon='arrow_upward' size={16} />
+                  </UnreadBannerJump>
+                  {onMarkRead ? (
+                    <UnreadBannerMarkRead onClick={onMarkRead}>
+                      <span>{t('common.actions.markAsRead', 'Mark as read')}</span>
+                      <MaterialIcon icon='check' size={16} />
+                    </UnreadBannerMarkRead>
+                  ) : null}
+                </UnreadBanner>
               ) : null}
             </AnimatePresence>
             <AnimatePresence>

--- a/client/messaging/message-list.tsx
+++ b/client/messaging/message-list.tsx
@@ -16,6 +16,7 @@ import {
   BlockedMessage,
   NewDayMessage,
   TextMessage,
+  UNREAD_LINE_SELECTOR,
   UnreadLineMessage,
 } from './common-message-layout'
 import {
@@ -331,6 +332,8 @@ interface MessageListSnapshot {
   lastScrollTop: number
   /** What the scroll height of the content was before the last update. */
   lastScrollHeight: number
+  /** Whether an unread divider that this update removes sat entirely above the viewport. */
+  removedUnreadLineAboveViewport: boolean
 }
 
 export class MessageList extends React.Component<MessageListProps> {
@@ -381,13 +384,34 @@ export class MessageList extends React.Component<MessageListProps> {
     }
 
     if (!this.scrollableRef.current) {
-      return { wasAtBottom: true, lastScrollTop: 0, lastScrollHeight: 0 }
+      return {
+        wasAtBottom: true,
+        lastScrollTop: 0,
+        lastScrollHeight: 0,
+        removedUnreadLineAboveViewport: false,
+      }
     }
 
     const scrollable = this.scrollableRef.current
     const lastScrollTop = scrollable.scrollTop
     const lastScrollHeight = scrollable.scrollHeight
-    return { wasAtBottom: isScrolledToBottom(scrollable), lastScrollTop, lastScrollHeight }
+
+    // The DOM still holds the divider this update takes away, so this is the only chance to see
+    // where it was relative to the viewport.
+    let removedUnreadLineAboveViewport = false
+    if (prevProps.unreadLineTime !== undefined && this.props.unreadLineTime === undefined) {
+      const unreadLine = scrollable.querySelector<HTMLElement>(UNREAD_LINE_SELECTOR)
+      removedUnreadLineAboveViewport =
+        !!unreadLine &&
+        unreadLine.getBoundingClientRect().bottom <= scrollable.getBoundingClientRect().top
+    }
+
+    return {
+      wasAtBottom: isScrolledToBottom(scrollable),
+      lastScrollTop,
+      lastScrollHeight,
+      removedUnreadLineAboveViewport,
+    }
   }
 
   override componentDidMount() {
@@ -447,6 +471,12 @@ export class MessageList extends React.Component<MessageListProps> {
         prevProps.messages[0] !== this.props.messages[0]
       ) {
         // Inserted elements at the top, maintain scroll position relative to the last top element
+        scrollable.scrollTop =
+          snapshot.lastScrollTop + scrollable.scrollHeight - snapshot.lastScrollHeight
+      } else if (snapshot.removedUnreadLineAboveViewport) {
+        // The divider that went away sat above the viewport, so what's on screen would slide up by
+        // its height unless the scroll position gives that height back. A divider below the
+        // viewport needs no compensation, since nothing above the viewport changed.
         scrollable.scrollTop =
           snapshot.lastScrollTop + scrollable.scrollHeight - snapshot.lastScrollHeight
       }

--- a/client/social/social-sidebar.tsx
+++ b/client/social/social-sidebar.tsx
@@ -8,6 +8,7 @@ import styled, { css } from 'styled-components'
 import { Link } from 'wouter'
 import { usePathname } from 'wouter/use-browser-location'
 import { SbChannelId } from '../../common/chat'
+import { cloneMultimap, prependToMultimap } from '../../common/data-structures/maps'
 import { getErrorStack } from '../../common/errors'
 import { urlPath } from '../../common/urls'
 import { FriendActivityStatus } from '../../common/users/relationships'
@@ -17,6 +18,7 @@ import {
   getBatchChannelInfo,
   getJoinedChannels,
   leaveChannelWithConfirmation,
+  markChannelReadNow,
 } from '../chat/action-creators'
 import { ConnectedChannelBadge } from '../chat/channel-badge'
 import { channelHasUnreadMention } from '../chat/chat-reducer'
@@ -25,10 +27,15 @@ import { DialogType } from '../dialogs/dialog-type'
 import { useWindowSize } from '../dom/dimension-hooks'
 import { FocusTrap } from '../dom/focus-trap'
 import { useOverflowingElement } from '../dom/overflowing-element'
+import { useContextMenu } from '../dom/use-context-menu'
 import { MaterialIcon } from '../icons/material/material-icon'
 import { useKeyListener } from '../keyboard/key-listener'
 import logger from '../logging/logger'
 import { IconButton, keyEventMatches, OutlinedButton, useButtonState } from '../material/button'
+import { Divider } from '../material/menu/divider'
+import { DestructiveMenuItem, MenuItem } from '../material/menu/item'
+import { MenuList } from '../material/menu/menu'
+import { Popover } from '../material/popover'
 import { Ripple } from '../material/ripple'
 import { ScrollDivider, useScrollIndicatorState } from '../material/scroll-indicator'
 import { elevationPlus1 } from '../material/shadows'
@@ -44,9 +51,17 @@ import { useSnackbarController } from '../snackbars/snackbar-overlay'
 import { dialogScrimOpacity } from '../styles/colors'
 import { bodyLarge, labelMedium, singleLine, titleSmall } from '../styles/typography'
 import { getBatchUserInfo } from '../users/action-creators'
-import { ConnectedUserContextMenu } from '../users/user-context-menu'
+import {
+  ConnectedUserContextMenu,
+  MenuItemCategory,
+  UserMenuProps,
+} from '../users/user-context-menu'
 import { useUserOverlays } from '../users/user-overlays'
-import { closeWhisperSession, getWhisperSessions } from '../whispers/action-creators'
+import {
+  closeWhisperSession,
+  getWhisperSessions,
+  markWhisperReadNow,
+} from '../whispers/action-creators'
 import { urlForWhisper } from '../whispers/whisper-url'
 import { FriendActivityStatusGlyph } from './friend-activity-status'
 import { FriendsList, useRelationshipsLoader } from './friends-list'
@@ -523,7 +538,10 @@ function ChannelEntry({
   const basicInfo = useAppSelector(s => s.chat.idToBasicInfo.get(channelId))
   const hasUnread = useAppSelector(s => s.chat.unreadChannels.has(channelId))
   const hasUnreadMention = useAppSelector(s => channelHasUnreadMention(s.chat, channelId))
+  const hasUnreadLine = useAppSelector(s => s.chat.idToUnreadLineTime.has(channelId))
+  const canMarkRead = hasUnread || hasUnreadMention || hasUnreadLine
   const { onNavigation } = useNavigationTracker()
+  const { onContextMenu, contextMenuPopoverProps } = useContextMenu()
 
   useEffect(() => {
     dispatch(getBatchChannelInfo(channelId))
@@ -549,20 +567,45 @@ function ChannelEntry({
   )
 
   return (
-    <Entry
-      link={urlPath`/chat/${channelId}/${basicInfo?.name}`}
-      needsAttention={hasUnread || hasUnreadMention}
-      urgentAttention={hasUnreadMention}
-      title={basicInfo ? `#${basicInfo.name}` : undefined}
-      button={button}
-      icon={<ConnectedChannelBadge channelId={channelId} />}
-      onClick={event => {
-        if (!event.defaultPrevented) {
-          onNavigation()
-        }
-      }}>
-      {displayName}
-    </Entry>
+    <>
+      <Popover {...contextMenuPopoverProps}>
+        <MenuList dense={true}>
+          <MenuItem
+            text={t('common.actions.markAsRead', 'Mark as read')}
+            disabled={!canMarkRead}
+            onClick={() => {
+              contextMenuPopoverProps.onDismiss()
+              dispatch(markChannelReadNow(channelId))
+            }}
+          />
+          <Divider $dense={true} />
+          <DestructiveMenuItem
+            text={t('chat.navEntry.leaveChannel', 'Leave channel')}
+            onClick={() => {
+              contextMenuPopoverProps.onDismiss()
+              onLeave(channelId)
+            }}
+          />
+        </MenuList>
+      </Popover>
+
+      <Entry
+        link={urlPath`/chat/${channelId}/${basicInfo?.name}`}
+        needsAttention={hasUnread || hasUnreadMention}
+        urgentAttention={hasUnreadMention}
+        title={basicInfo ? `#${basicInfo.name}` : undefined}
+        button={button}
+        icon={<ConnectedChannelBadge channelId={channelId} />}
+        isActive={contextMenuPopoverProps.open}
+        onContextMenu={onContextMenu}
+        onClick={event => {
+          if (!event.defaultPrevented) {
+            onNavigation()
+          }
+        }}>
+        {displayName}
+      </Entry>
+    </>
   )
 }
 
@@ -577,6 +620,7 @@ function WhisperEntry({ userId }: { userId: SbUserId }) {
 
   const { isOverlayOpen, contextMenuProps, onContextMenu } = useUserOverlays({
     userId,
+    UserMenu: WhisperEntryUserMenu,
   })
 
   useEffect(() => {
@@ -635,6 +679,36 @@ function WhisperEntry({ userId }: { userId: SbUserId }) {
       </Entry>
     </>
   )
+}
+
+/**
+ * Adds "Mark as read" to the user context menu when it's opened from a whisper entry, the one place
+ * the menu is about the conversation as much as the user.
+ */
+function WhisperEntryUserMenu({ userId, items, onMenuClose, MenuComponent }: UserMenuProps) {
+  const { t } = useTranslation()
+  const dispatch = useAppDispatch()
+  const canMarkRead = useAppSelector(s => {
+    const session = s.whispers.byId.get(userId)
+    return session !== undefined && (session.hasUnread || session.unreadLineTime !== undefined)
+  })
+
+  const menuItems = cloneMultimap(items)
+  prependToMultimap(
+    menuItems,
+    MenuItemCategory.General,
+    <MenuItem
+      key='mark-as-read'
+      text={t('common.actions.markAsRead', 'Mark as read')}
+      disabled={!canMarkRead}
+      onClick={() => {
+        onMenuClose()
+        dispatch(markWhisperReadNow(userId))
+      }}
+    />,
+  )
+
+  return <MenuComponent items={menuItems} userId={userId} onMenuClose={onMenuClose} />
 }
 
 const LoadingName = styled.span`

--- a/client/whispers/action-creators.test.ts
+++ b/client/whispers/action-creators.test.ts
@@ -1,11 +1,12 @@
-import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { asMockedFunction } from '../../common/testing/mocks'
 import { makeSbUserId } from '../../common/users/sb-user-id'
 import { DispatchFunction } from '../dispatch-registry'
 import { LastReadSender, reportLastRead } from '../messaging/last-read'
+import { CommonMessageType, CommonTextMessage } from '../messaging/message-records'
 import { fetchJson } from '../network/fetch'
 import { RootState } from '../root-reducer'
-import { markWhisperRead } from './action-creators'
+import { markWhisperRead, markWhisperReadNow } from './action-creators'
 
 vi.mock('../network/fetch', () => ({
   fetchJson: vi.fn(),
@@ -88,5 +89,90 @@ describe('client/whispers/action-creators/markWhisperRead', () => {
     const { send } = runMarkRead()
 
     await expect(send(LAST_READ_TIME)).rejects.toBe(error)
+  })
+})
+
+const NOW = 5_000_000
+
+function textMessage(time: number): CommonTextMessage {
+  return {
+    id: `text-${time}`,
+    type: CommonMessageType.TextMessage,
+    time,
+    from: TARGET_ID,
+    text: 'hello',
+  }
+}
+
+/** A `RootState` carrying just the whisper slice `markWhisperReadNow` reads. */
+function makeReadPositionState(messages: CommonTextMessage[]): RootState {
+  const session = {
+    target: TARGET_ID,
+    messages,
+    loadingHistory: false,
+    hasHistory: true,
+    loadingNewer: false,
+    hasNewer: false,
+    detachedNewestTime: undefined,
+    windowGen: 0,
+    activated: false,
+    atBottom: false,
+    hasUnread: false,
+  }
+  const whispers = { sessions: new Set([TARGET_ID]), byId: new Map([[TARGET_ID, session]]) }
+  return { whispers } as unknown as RootState
+}
+
+/** Runs the `markWhisperReadNow` thunk against `state` and hands back what it dispatched. */
+function runMarkReadNow(state: RootState) {
+  const dispatched: unknown[] = []
+  const dispatch = ((action: unknown) => {
+    dispatched.push(action)
+  }) as DispatchFunction<any>
+
+  markWhisperReadNow(TARGET_ID)(dispatch, () => state)
+
+  return { dispatched }
+}
+
+describe('client/whispers/action-creators/markWhisperReadNow', () => {
+  beforeEach(() => {
+    fetchJsonMock.mockReset()
+    reportLastReadMock.mockReset()
+    vi.useFakeTimers()
+    vi.setSystemTime(NOW)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  test('marks read as of now when nothing known is newer', () => {
+    const { dispatched } = runMarkReadNow(makeReadPositionState([textMessage(NOW - 100)]))
+
+    expect(dispatched).toEqual([
+      {
+        type: '@whispers/updateLastReadTime',
+        payload: { targetId: TARGET_ID, lastReadTime: NOW, dismissUnreadLine: true },
+      },
+    ])
+    expect(reportLastReadMock).toHaveBeenCalledWith(expect.any(String), NOW, expect.any(Function))
+  })
+
+  test('reports a known time that has run ahead of the local clock', () => {
+    const newerTime = NOW + 5000
+    const { dispatched } = runMarkReadNow(makeReadPositionState([textMessage(newerTime)]))
+
+    expect(dispatched).toEqual([
+      {
+        type: '@whispers/updateLastReadTime',
+        payload: { targetId: TARGET_ID, lastReadTime: newerTime, dismissUnreadLine: true },
+      },
+    ])
+    expect(reportLastReadMock).toHaveBeenCalledWith(
+      expect.any(String),
+      newerTime,
+      expect.any(Function),
+    )
   })
 })

--- a/client/whispers/action-creators.ts
+++ b/client/whispers/action-creators.ts
@@ -20,7 +20,7 @@ import {
   ResetMessageWindow,
   UpdateSessionAtBottom,
 } from './actions'
-import { newestServerOriginTime } from './whisper-reducer'
+import { newestKnownWhisperTime, newestServerOriginTime } from './whisper-reducer'
 import { urlForWhisper } from './whisper-url'
 
 export function getWhisperSessions(spec: RequestHandlingSpec<void>): ThunkAction {
@@ -56,18 +56,46 @@ export function markWhisperRead(targetId: SbUserId, lastReadTime: number): Thunk
       payload: { targetId, lastReadTime },
     })
 
-    // The rejection is passed back out so the coalescer knows the position never landed and lets
-    // the next report carry it again.
-    reportLastRead(getWhisperLastReadKey(targetId), lastReadTime, time =>
-      fetchJson<void>(apiUrl`whispers/${targetId}/mark-read`, {
-        method: 'POST',
-        body: encodeBodyAsParams<MarkWhisperReadRequest>({ lastReadTime: time }),
-      }).catch(err => {
-        logger.error(`Error reporting read position for whisper ${targetId}: ${getErrorStack(err)}`)
-        throw err
-      }),
-    )
+    reportWhisperLastRead(targetId, lastReadTime)
   }
+}
+
+/**
+ * Marks a whisper conversation read as of now on the user's explicit request, whether or not it is
+ * open or has any messages loaded. The reported position is the later of the local clock and the
+ * newest time the client knows about in the conversation: server-stamped message times can run
+ * ahead of a client clock that lags the server's, and a position behind the newest message would
+ * leave it unread. (The server clamps whatever is reported to its own clock.) Unlike a position the
+ * open view reports, this also drops the frozen unread divider of an activated conversation.
+ */
+export function markWhisperReadNow(targetId: SbUserId): ThunkAction {
+  return (dispatch, getState) => {
+    const session = getState().whispers.byId.get(targetId)
+    const newestKnownTime = session ? newestKnownWhisperTime(session) : undefined
+    const lastReadTime = Math.max(Date.now(), newestKnownTime ?? -Infinity)
+
+    dispatch({
+      type: '@whispers/updateLastReadTime',
+      payload: { targetId, lastReadTime, dismissUnreadLine: true },
+    })
+
+    reportWhisperLastRead(targetId, lastReadTime)
+  }
+}
+
+/** Sends a whisper conversation's read position to the server, coalescing rapid-fire reports. */
+function reportWhisperLastRead(targetId: SbUserId, lastReadTime: number): void {
+  // The rejection is passed back out so the coalescer knows the position never landed and lets
+  // the next report carry it again.
+  reportLastRead(getWhisperLastReadKey(targetId), lastReadTime, time =>
+    fetchJson<void>(apiUrl`whispers/${targetId}/mark-read`, {
+      method: 'POST',
+      body: encodeBodyAsParams<MarkWhisperReadRequest>({ lastReadTime: time }),
+    }).catch(err => {
+      logger.error(`Error reporting read position for whisper ${targetId}: ${getErrorStack(err)}`)
+      throw err
+    }),
+  )
 }
 
 export function startWhisperSessionByName(

--- a/client/whispers/actions.ts
+++ b/client/whispers/actions.ts
@@ -266,6 +266,13 @@ export interface UpdateLastReadTime {
   payload: {
     targetId: SbUserId
     lastReadTime: number
+    /**
+     * When true, the update comes from the user explicitly marking the conversation read, and the
+     * frozen unread divider is dropped even for an activated session. An ordinary read report only
+     * re-evaluates the divider of a session that isn't being viewed, so it holds still under the
+     * reader.
+     */
+    dismissUnreadLine?: boolean
   }
 }
 

--- a/client/whispers/whisper-reducer.test.ts
+++ b/client/whispers/whisper-reducer.test.ts
@@ -73,10 +73,13 @@ function makeState(
   return state as Immutable<WhisperState>
 }
 
-function updateLastReadTimeAction(lastReadTime: number): WhisperActions {
+function updateLastReadTimeAction(
+  lastReadTime: number,
+  dismissUnreadLine?: boolean,
+): WhisperActions {
   return {
     type: '@whispers/updateLastReadTime',
-    payload: { targetId: TARGET_ID, lastReadTime },
+    payload: { targetId: TARGET_ID, lastReadTime, dismissUnreadLine },
   }
 }
 
@@ -306,6 +309,21 @@ describe('client/whispers/whisper-reducer', () => {
       // The read position itself still advances even while activated, since this is also the path
       // this session's own optimistic mark-read reports take.
       expect(session.lastReadTime).toBe(200)
+    })
+
+    test('drops the frozen divider of an activated session when dismissing it', () => {
+      const state = makeState({
+        activated: true,
+        unreadLineTime: 100,
+        lastReadTime: 100,
+        messages: [textMessage(150)],
+      })
+
+      const result = whisperReducer(state, updateLastReadTimeAction(200, true))
+
+      const session = sessionOf(result)
+      expect(session.unreadLineTime).toBeUndefined()
+      expect(session.hasUnread).toBe(false)
     })
 
     test('clears an activated session flag once the position covers the newest message', () => {

--- a/client/whispers/whisper-reducer.ts
+++ b/client/whispers/whisper-reducer.ts
@@ -112,6 +112,19 @@ export function newestServerOriginTime(messages: readonly CommonTextMessage[]): 
 }
 
 /**
+ * The newest time (epoch ms) of anything known to exist in a whisper session: the newest loaded
+ * server-origin message and the present of a detached window. A read position covering this covers
+ * everything the client knows about.
+ */
+export function newestKnownWhisperTime(session: Immutable<WhisperSession>): number | undefined {
+  const knownTimes = [newestServerOriginTime(session.messages), session.detachedNewestTime].filter(
+    t => t !== undefined,
+  )
+
+  return knownTimes.length ? Math.max(...knownTimes) : undefined
+}
+
+/**
  * Returns `incoming` with every message already present in `existing` removed. The history
  * endpoints seek by millisecond-precision time, so a page boundary landing inside a group of
  * messages that share a timestamp can hand back messages the window already holds.
@@ -598,9 +611,12 @@ export default immerKeyedReducer(DEFAULT_STATE, {
   // message arriving while the app window is unfocused counts as unread no matter what's on screen,
   // and this is what lowers it once the read position covers that message. The frozen divider is
   // only re-evaluated for a session that isn't activated: while one is being viewed the divider has
-  // to hold still where it is, and `deactivateWhisperSession` is what re-evaluates it.
+  // to hold still where it is, and `deactivateWhisperSession` is what re-evaluates it. An explicit
+  // mark-read carries `dismissUnreadLine`, which drops the divider whether or not the session is
+  // activated, because the user asked for the unread state to go rather than merely scrolling past
+  // it.
   ['@whispers/updateLastReadTime'](state, action) {
-    const { targetId, lastReadTime } = action.payload
+    const { targetId, lastReadTime, dismissUnreadLine } = action.payload
 
     const session = state.byId.get(targetId)
     if (!session) {
@@ -613,19 +629,18 @@ export default immerKeyedReducer(DEFAULT_STATE, {
     const effective = session.lastReadTime!
 
     // A detached window's present has run ahead of what's loaded, so the newest loaded message
-    // isn't the newest one known to exist. Clearing the flag against the loaded window alone would
-    // call the session read on the strength of a position that only covers that window.
-    const knownTimes = [
-      newestServerOriginTime(session.messages),
-      session.detachedNewestTime,
-    ].filter(t => t !== undefined)
-    const newestKnownTime = knownTimes.length ? Math.max(...knownTimes) : undefined
+    // isn't the newest one known to exist; the helper covers that. Clearing the flag against the
+    // loaded window alone would call the session read on the strength of a position that only
+    // covers that window.
+    const newestKnownTime = newestKnownWhisperTime(session)
 
     if (newestKnownTime === undefined || newestKnownTime <= effective) {
       session.hasUnread = false
     }
 
-    if (
+    if (dismissUnreadLine) {
+      session.unreadLineTime = undefined
+    } else if (
       !session.activated &&
       session.unreadLineTime !== undefined &&
       effective > session.unreadLineTime

--- a/client/whispers/whisper.tsx
+++ b/client/whispers/whisper.tsx
@@ -31,6 +31,7 @@ import {
   getWhisperLastReadKey,
   jumpToPresent,
   markWhisperRead,
+  markWhisperReadNow,
   resetMessageWindow,
   sendMessage,
   startWhisperSessionById,
@@ -351,6 +352,10 @@ export function ConnectedWhisper({
     )
   }
 
+  const onMarkRead = () => {
+    dispatch(markWhisperReadNow(targetId))
+  }
+
   const onAtBottomChange = (atBottom: boolean) => {
     dispatch(updateSessionAtBottom(targetId, atBottom))
   }
@@ -407,6 +412,7 @@ export function ConnectedWhisper({
         onAtBottomChange={onAtBottomChange}
         onJumpToPresent={onJumpToPresent}
         onSeekToUnread={onSeekToUnread}
+        onMarkRead={onMarkRead}
         escapeJumpsToBottom
         extraContent={
           <UserInfoContainer>

--- a/server/public/locales/en/global.json
+++ b/server/public/locales/en/global.json
@@ -491,6 +491,7 @@
       "edit": "Edit",
       "hide": "Hide",
       "join": "Join",
+      "markAsRead": "Mark as read",
       "next": "Next",
       "okay": "Okay",
       "paste": "Paste",


### PR DESCRIPTION
An unread mark on a channel or whisper could only be cleared by opening the conversation, scrolling to the bottom, and having the window focused. This adds a "Mark as read" action in three places: a context menu on the sidebar's channel entries (with "Leave channel" alongside), the whisper entry's user context menu, and the "New messages" banner over an open conversation. All of them go through the existing mark-read reporting path with the read position set to now, so the server clamps as before and the user's other sessions pick it up like any read report. An explicit mark also drops the frozen divider of the open conversation, and the message list compensates for the divider's height when it sat above the viewport so the view stays where it is.

Fixes #1491

## Acceptance criteria

- [x] Right-clicking a channel entry opens a context menu with "Mark as read" — verified live: menu opens with "Mark as read" and "Leave channel".
- [x] The whisper entry's context menu carries "Mark as read" when opened from the sidebar — verified live: item appears first in the shared user menu, above "View profile"; chat-message and friends-list menus are untouched.
- [x] Choosing it reports the current time through `markChannelRead`/`markWhisperRead`'s path, clears the unread flag and mention state locally, and propagates to other sessions — verified live with a second `SB_SESSION` client for claude-2: unread flag, urgent mention dot, and whisper unread all cleared on both sessions; `channel_users.last_read_time` / `whisper_sessions.last_read_time` moved to now (age ~6s at query time); `POST …/mark-read` 204 in the request log.
- [x] Works for a conversation that is not open and has no messages loaded — verified live from the home page for both a channel and a whisper.
- [x] For the open conversation it also clears the frozen divider immediately — verified live for an activated channel and an activated whisper: `idToUnreadLineTime` / `session.unreadLineTime` cleared, `[data-unread-line]` gone from the DOM. Unit tests cover the reducer branch.
- [x] Shown for every entry, disabled when nothing is unread — verified live (`disabled=true` with nothing unread, enabled with an unread flag, mention, or frozen divider).
- [x] The "New messages" banner gains a "Mark as read" action next to the jump — verified live with the divider 512px above the viewport and the list scrolled up: banner and divider gone, the reference message stayed at the same pixel (`top` 161.34 before and after), scroll height shrank by the divider row, DB position now.

## Drift

Pinned to 637273795; only #1498 landed since. Whisper report effect moved to `client/whispers/whisper.tsx:292`-`300` and the banner to `client/messaging/chat.tsx:957`-`968`. No claim changed.

## Calls made

The issue was in Todo with `needs-decision`; built on the issue's own recommendations:

- **Whisper placement**: "Mark as read" added to the shared user context menu only when opened from the sidebar entry (`WhisperEntryUserMenu` passed as `UserMenu`). Passed on: a separate small menu for the whisper entry.
- **Channel menu contents**: "Mark as read" plus a divider and "Leave channel" (styled like the channel header's leave item); the hover close button stays. Passed on: a one-item menu.
- **Nothing unread**: item stays visible and disabled. Passed on: hiding it.
- **Banner layout**: text action with a check icon on the banner's right edge, separated by a hairline; the rest of the banner remains the jump. Passed on: a separate small button.

Two implementation choices worth a look:

- The reported time is `max(Date.now(), newest known time in the conversation)` rather than bare `Date.now()`: message times are server-stamped, so a client clock behind the server's would otherwise report a position older than the newest message and leave it unread (the server clamps to its own `now()` either way).
- `newestKnownChannelTime` now also considers `idToLatestMentionTime` when deciding whether the read position covers everything. This is a slight widening of the existing unread-flag check: a mention newer than any loaded message means a message the client doesn't hold, so the flag stays up. Covered by a reducer test.

## Verification

T0: `pnpm run lint`, `pnpm run typecheck`, `vitest run client/chat client/whispers client/messaging client/social` — 13 files, 302 tests passed. New tests for `markChannelReadNow` / `markWhisperReadNow` (fake timers, both the now-wins and known-time-wins cases) and the `dismissUnreadLine` reducer branch in both reducers.

T3: three dev Electron clients (claude-1 as sender; claude-2 on two `SB_SESSION`s), messages sent through the REST API, state read from `window.__sbReduxStore`, positions checked in Postgres. Ran the issue's recipe as written (plain unread, mention, whisper, open channel divider via sidebar, banner action while scrolled up) plus an activated-whisper divider via the sidebar. No message-list unit test for the scroll compensation: `message-list.test.ts` only exercises pure helpers and has no rendering harness.
