### PR TITLE
Play a rare transmission-glitch burst on the splash logotext.

### DIFF
--- a/client/home/bottom-links.tsx
+++ b/client/home/bottom-links.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from 'react-i18next'
-import styled from 'styled-components'
+import styled, { keyframes } from 'styled-components'
 import { Link } from 'wouter'
 import BlueskyLogo from '../icons/brands/bluesky.svg?react'
 import DiscordLogo from '../icons/brands/discord.svg?react'
@@ -15,6 +15,39 @@ const Root = styled.div`
   align-items: center;
 `
 
+/*
+ * A hover-only version of the splash logotext's transmission glitch: a stuttering two-tone
+ * chromatic split in the brand's blue and amber. It never plays on its own — this logo sits on
+ * surfaces players see constantly, so the interference is a small reward for poking at it rather
+ * than ambient motion.
+ */
+const gearGlitch = keyframes`
+  0%, 24.9%, 43%, 61.9%, 78%, 100% {
+    transform: none;
+    filter: none;
+  }
+  25% {
+    transform: translateX(-1px);
+    filter: drop-shadow(2px 0 0 rgb(from var(--color-amber60) r g b / 0.6))
+      drop-shadow(-2px 0 0 rgb(from var(--color-blue80) r g b / 0.6));
+  }
+  34% {
+    transform: translateX(1px) skewX(-1deg);
+    filter: drop-shadow(-2px 0 0 rgb(from var(--color-amber60) r g b / 0.6))
+      drop-shadow(2px 0 0 rgb(from var(--color-blue80) r g b / 0.6));
+  }
+  62% {
+    transform: translateX(1px);
+    filter: drop-shadow(-3px 0 0 rgb(from var(--color-amber60) r g b / 0.5))
+      drop-shadow(3px 0 0 rgb(from var(--color-blue80) r g b / 0.5));
+  }
+  70% {
+    transform: translateX(-1px);
+    filter: drop-shadow(1px 0 0 rgb(from var(--color-amber60) r g b / 0.6))
+      drop-shadow(-1px 0 0 rgb(from var(--color-blue80) r g b / 0.6));
+  }
+`
+
 const StyledLogo = styled(Logo)`
   width: 112px;
   height: auto;
@@ -24,6 +57,12 @@ const StyledLogo = styled(Logo)`
 
   & path {
     fill: currentColor !important;
+  }
+
+  @media (prefers-reduced-motion: no-preference) {
+    &:hover {
+      animation: ${gearGlitch} 1.1s linear infinite;
+    }
   }
 `
 

--- a/client/home/splash.tsx
+++ b/client/home/splash.tsx
@@ -1,6 +1,6 @@
 import * as m from 'motion/react-m'
 import { Trans, useTranslation } from 'react-i18next'
-import styled from 'styled-components'
+import styled, { keyframes } from 'styled-components'
 import { useResizeObserver } from '../dom/dimension-hooks'
 import { navigateToDownload } from '../download/download-navigate'
 import { MaterialIcon } from '../icons/material/material-icon'
@@ -70,9 +70,123 @@ const Logo = styled.img`
   height: auto;
 `
 
+/*
+ * The logotext plays a brief transmission-glitch burst every several seconds: the base image gets
+ * a two-tone chromatic split (the brand's blue and amber standing in for RGB fringing) while two
+ * displaced horizontal slices tear out of it. Each cycle idles for ~93% of its duration, so the
+ * effect reads as a rare flicker of interference rather than a looping animation. Hovering the
+ * logotext shortens the cycle so the burst repeats quickly.
+ */
+
+const glitchSplit = keyframes`
+  0%, 92.9%, 98.6%, 100% {
+    transform: none;
+    filter: none;
+  }
+  93% {
+    transform: translateX(-2px);
+    filter: drop-shadow(3px 0 0 rgb(from var(--color-amber60) r g b / 0.7))
+      drop-shadow(-3px 0 0 rgb(from var(--color-blue80) r g b / 0.7));
+  }
+  94.4% {
+    transform: translateX(2px) skewX(-1.5deg);
+    filter: drop-shadow(-4px 0 0 rgb(from var(--color-amber60) r g b / 0.7))
+      drop-shadow(4px 0 0 rgb(from var(--color-blue80) r g b / 0.7));
+  }
+  96% {
+    transform: translateX(-1px);
+    filter: drop-shadow(2px 0 0 rgb(from var(--color-amber60) r g b / 0.5))
+      drop-shadow(-2px 0 0 rgb(from var(--color-blue80) r g b / 0.5));
+  }
+`
+
+const glitchSliceTop = keyframes`
+  0%, 92.9%, 98.2%, 100% {
+    opacity: 0;
+    clip-path: inset(18% 0 64% 0);
+    transform: none;
+  }
+  93% {
+    opacity: 1;
+    clip-path: inset(18% 0 64% 0);
+    transform: translateX(7px);
+  }
+  94.6% {
+    clip-path: inset(8% 0 74% 0);
+    transform: translateX(-5px);
+  }
+  96.4% {
+    opacity: 1;
+    clip-path: inset(26% 0 58% 0);
+    transform: translateX(4px);
+  }
+`
+
+const glitchSliceBottom = keyframes`
+  0%, 93.3%, 98.5%, 100% {
+    opacity: 0;
+    clip-path: inset(62% 0 16% 0);
+    transform: none;
+  }
+  93.4% {
+    opacity: 1;
+    clip-path: inset(62% 0 16% 0);
+    transform: translateX(-6px);
+  }
+  95.2% {
+    clip-path: inset(70% 0 6% 0);
+    transform: translateX(5px);
+  }
+  97% {
+    opacity: 1;
+    clip-path: inset(54% 0 30% 0);
+    transform: translateX(-3px);
+  }
+`
+
 const LogoText = styled.img`
+  display: block;
   width: auto;
   height: 56px;
+`
+
+const GlitchSlice = styled.img`
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 56px;
+  width: auto;
+
+  opacity: 0;
+  pointer-events: none;
+`
+
+const GlitchSliceTop = styled(GlitchSlice)`
+  filter: drop-shadow(-2px 0 0 rgb(from var(--color-blue80) r g b / 0.8));
+`
+
+const GlitchSliceBottom = styled(GlitchSlice)`
+  filter: drop-shadow(2px 0 0 rgb(from var(--color-amber60) r g b / 0.8));
+`
+
+const LogoTextGlitch = styled.div`
+  position: relative;
+
+  @media (prefers-reduced-motion: no-preference) {
+    & ${LogoText} {
+      animation: ${glitchSplit} 7s linear infinite;
+    }
+    & ${GlitchSliceTop} {
+      animation: ${glitchSliceTop} 7s linear infinite;
+    }
+    & ${GlitchSliceBottom} {
+      animation: ${glitchSliceBottom} 7s linear infinite;
+    }
+
+    &:hover ${LogoText}, &:hover ${GlitchSliceTop}, &:hover ${GlitchSliceBottom} {
+      animation-duration: 1.4s;
+    }
+  }
 `
 
 const Subtitle = styled.div`
@@ -247,7 +361,11 @@ export function SplashContent() {
         <LogoLayout>
           <Logo src={logoImage} alt='' />
           <LogoTextAndSubtitle>
-            <LogoText src={logoText} alt='ShieldBattery' />
+            <LogoTextGlitch>
+              <LogoText src={logoText} alt='ShieldBattery' />
+              <GlitchSliceTop src={logoText} alt='' aria-hidden={true} />
+              <GlitchSliceBottom src={logoText} alt='' aria-hidden={true} />
+            </LogoTextGlitch>
             <Subtitle>
               {t('landing.splash.subtitle', 'The premier StarCraft 1 community platform')}
             </Subtitle>


### PR DESCRIPTION
A temporary, easily-reverted visual experiment — proposed as a **one-month trial** to see whether it draws interest to the landing page, after which it can be kept, tuned, or reverted (it's two isolated CSS-keyframe changes with no logic or dependencies).

## What it does

- **Splash logotext**: every ~7 seconds the "ShieldBattery" wordmark plays a ~400ms transmission-glitch burst — a chromatic split in the brand's blue and amber plus two horizontal slices that tear out and snap back. It idles the other 93% of the cycle so it reads as a rare flicker of interference rather than a looping animation. Hovering the wordmark speeds the cycle up.
- **Bottom-links gear logo**: the same interference, but **hover-only**, since that logo also sits on surfaces logged-in players see constantly.

Both are pure CSS on layered copies of the existing SVGs (no new assets, no JS timers), are `aria-hidden` on the duplicate layers, and are fully disabled under `prefers-reduced-motion`.

## Screenshots

Mid-burst frames of the splash logotext:

![Splash logotext glitch burst, slice displaced right](https://raw.githubusercontent.com/intrepidcanadian/ShieldBattery/pr-glitch-assets/splash-glitch-burst-1.png)
![Splash logotext glitch burst, bottom slice tearing left](https://raw.githubusercontent.com/intrepidcanadian/ShieldBattery/pr-glitch-assets/splash-glitch-burst-2.png)

The gear logo while hovered:

![Gear logo glitching on hover](https://raw.githubusercontent.com/intrepidcanadian/ShieldBattery/pr-glitch-assets/gear-glitch-hover.png)

## Verification

Verified live against the dev server (T0 + T1): lint/typecheck clean, burst frames inspected by pausing the animations at multiple points in the cycle, hover behavior confirmed on both the wordmark and the gear, and layout confirmed unchanged at rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)