### PR TITLE
Derive sidebar unread and mention marks from the read position alone.

### DIFF
--- a/client/chat/actions.ts
+++ b/client/chat/actions.ts
@@ -401,10 +401,9 @@ export interface SearchChannels {
 
 /**
  * Activate a particular chat channel. This is a purely client-side action which marks the channel
- * as "active", and removes the unread indicator if there is one. The message list reports the
- * at-bottom state it opened in (`UpdateChannelAtBottom`) ahead of this being dispatched, so the
- * reducer reads the current flag to tell an open at the newest messages from one restoring a
- * position further back.
+ * as "active". The message list reports the at-bottom state it opened in (`UpdateChannelAtBottom`)
+ * ahead of this being dispatched, so the reducer reads the current flag to tell an open at the
+ * newest messages from one restoring a position further back.
  */
 export interface ActivateChannel {
   type: '@chat/activateChannel'
@@ -575,9 +574,10 @@ export interface UpdateMessage {
      */
     isSelfMessage: boolean
     /**
-     * Whether the app window was focused when the live event arrived. A non-self message landing
-     * in an unfocused window can't have been seen no matter where the channel's view is scrolled,
-     * so the reducer counts it as unread regardless.
+     * Whether the app window was focused when the live event arrived. A non-self message counts as
+     * read on arrival only when the window is focused and the view sits at the bottom of a message
+     * window attached to the present; anything else leaves the channel unread until its read
+     * position covers the message.
      */
     windowFocused: boolean
   }

--- a/client/chat/chat-reducer.test.ts
+++ b/client/chat/chat-reducer.test.ts
@@ -9,6 +9,7 @@ import {
   GetBatchedChannelInfosResponse,
   GetChannelHistoryServerResponse,
   InitialChannelData,
+  JoinChannelMessage,
   SbChannelId,
   SelfJoinChannelMessage,
   ServerChatMessage,
@@ -16,7 +17,7 @@ import {
   makeSbChannelId,
 } from '../../common/chat'
 import { SbUser } from '../../common/users/sb-user'
-import { makeSbUserId } from '../../common/users/sb-user-id'
+import { SbUserId, makeSbUserId } from '../../common/users/sb-user-id'
 import { ChatActions } from './actions'
 import chatReducerImport, {
   ChatState,
@@ -43,6 +44,16 @@ function textMessage(time: number): ChannelTextMessage {
     time,
     from: USER_ID,
     text: 'hello',
+  }
+}
+
+function joinMessage(time: number): JoinChannelMessage {
+  return {
+    id: `user-join-${time}`,
+    type: ServerChatMessageType.JoinChannel,
+    channelId: CHANNEL_ID,
+    time,
+    userId: USER_ID,
   }
 }
 
@@ -77,9 +88,20 @@ function makeState(
   const state: ChatState = {
     joinedChannels: new Set([CHANNEL_ID]),
     idToBasicInfo: new Map(),
-    idToDetailedInfo: new Map(),
+    idToDetailedInfo: new Map([[CHANNEL_ID, { id: CHANNEL_ID, userCount: 1 }]]),
     idToJoinedInfo: new Map(),
-    idToUsers: new Map(),
+    idToUsers: new Map([
+      [
+        CHANNEL_ID,
+        {
+          active: new Set<SbUserId>(),
+          idle: new Set<SbUserId>(),
+          offline: new Set<SbUserId>(),
+          hasLoadedUserList: false,
+          loadingUserList: false,
+        },
+      ],
+    ]),
     idToMessages: new Map([
       [
         CHANNEL_ID,
@@ -133,7 +155,9 @@ const CHANNEL_BASIC_INFO: BasicChannelInfo = {
 
 const SENDER: SbUser = { id: USER_ID, name: 'sender', created: 0 }
 
-function initialChannelData(overrides: { latestMentionTime?: number } = {}): InitialChannelData {
+function initialChannelData(
+  overrides: { latestMentionTime?: number; hasUnread?: boolean; lastReadTime?: number } = {},
+): InitialChannelData {
   return {
     channelInfo: CHANNEL_BASIC_INFO,
     detailedChannelInfo: { id: CHANNEL_ID, userCount: 1 },
@@ -146,6 +170,8 @@ function initialChannelData(overrides: { latestMentionTime?: number } = {}): Ini
       togglePrivate: false,
       editPermissions: false,
     },
+    hasUnread: overrides.hasUnread,
+    lastReadTime: overrides.lastReadTime,
     latestMentionTime: overrides.latestMentionTime,
   }
 }
@@ -174,6 +200,18 @@ function updateMessageAction(
     type: '@chat/updateMessage',
     payload,
     meta: { channelId: CHANNEL_ID, mentionsSelf, isSelfMessage, windowFocused },
+  }
+}
+
+function updateJoinAction(time: number, windowFocused = true): ChatActions {
+  return {
+    type: '@chat/updateJoin',
+    payload: {
+      action: 'join2',
+      user: SENDER,
+      message: joinMessage(time),
+    },
+    meta: { channelId: CHANNEL_ID, windowFocused },
   }
 }
 
@@ -459,10 +497,10 @@ describe('client/chat/chat-reducer', () => {
       expect(channelHasUnreadMention(state, CHANNEL_ID)).toBe(false)
     })
 
-    test('is false for an activated channel, even with an unread mention', () => {
+    test('is true for an activated channel whose read position is behind the mention', () => {
       const state = makeState({ activated: true, lastReadTime: 100, latestMentionTime: 200 })
 
-      expect(channelHasUnreadMention(state, CHANNEL_ID)).toBe(false)
+      expect(channelHasUnreadMention(state, CHANNEL_ID)).toBe(true)
     })
   })
 
@@ -506,6 +544,17 @@ describe('client/chat/chat-reducer', () => {
       const result = chatReducer(state, getJoinedChannelsAction(initialChannelData()))
 
       expect(result.idToLatestMentionTime.has(CHANNEL_ID)).toBe(false)
+    })
+
+    test('seeds the unread flag from the server, for a channel on screen as well', () => {
+      const state = makeState({ activated: true, atBottom: true })
+
+      const result = chatReducer(
+        state,
+        getJoinedChannelsAction(initialChannelData({ hasUnread: true, lastReadTime: 100 })),
+      )
+
+      expect(result.unreadChannels.has(CHANNEL_ID)).toBe(true)
     })
   })
 
@@ -655,15 +704,34 @@ describe('client/chat/chat-reducer', () => {
 
       expect(result.unreadChannels.has(CHANNEL_ID)).toBe(true)
       expect(result.idToUnreadLineTime.get(CHANNEL_ID)).toBe(100)
+      expect(result.idToLastReadTime.get(CHANNEL_ID)).toBe(100)
     })
 
-    test('a message arriving at the bottom of a focused window counts as seen', () => {
+    test('a message arriving at the bottom of a focused window is read on arrival', () => {
       const state = makeState({ activated: true, atBottom: true, lastReadTime: 100 })
 
       const result = chatReducer(state, updateMessageAction(200, false, true))
 
       expect(result.unreadChannels.has(CHANNEL_ID)).toBe(false)
       expect(result.idToUnreadLineTime.has(CHANNEL_ID)).toBe(false)
+      expect(result.idToLastReadTime.get(CHANNEL_ID)).toBe(200)
+    })
+
+    test('a mention read on arrival is not an unread mention', () => {
+      const state = makeState({ activated: true, atBottom: true, lastReadTime: 100 })
+
+      const result = chatReducer(state, updateMessageAction(200, true, true))
+
+      expect(result.idToLatestMentionTime.get(CHANNEL_ID)).toBe(200)
+      expect(channelHasUnreadMention(result, CHANNEL_ID)).toBe(false)
+    })
+
+    test('a message read on arrival does not regress the read position', () => {
+      const state = makeState({ activated: true, atBottom: true, lastReadTime: 300 })
+
+      const result = chatReducer(state, updateMessageAction(200, false, true))
+
+      expect(result.idToLastReadTime.get(CHANNEL_ID)).toBe(300)
     })
 
     test('a message arriving while scrolled up in an unfocused window raises both', () => {
@@ -675,13 +743,14 @@ describe('client/chat/chat-reducer', () => {
       expect(result.idToUnreadLineTime.get(CHANNEL_ID)).toBe(100)
     })
 
-    test('a message arriving while scrolled up in a focused window only freezes the divider', () => {
+    test('a message arriving while scrolled up in a focused window raises both', () => {
       const state = makeState({ activated: true, atBottom: false, lastReadTime: 100 })
 
       const result = chatReducer(state, updateMessageAction(200, false, true))
 
-      expect(result.unreadChannels.has(CHANNEL_ID)).toBe(false)
+      expect(result.unreadChannels.has(CHANNEL_ID)).toBe(true)
       expect(result.idToUnreadLineTime.get(CHANNEL_ID)).toBe(100)
+      expect(result.idToLastReadTime.get(CHANNEL_ID)).toBe(100)
     })
 
     test('a message arriving in a channel that is not being viewed raises the unread flag', () => {
@@ -730,6 +799,37 @@ describe('client/chat/chat-reducer', () => {
       expect(result.unreadChannels.has(CHANNEL_ID)).toBe(false)
       expect(result.idToUnreadLineTime.has(CHANNEL_ID)).toBe(false)
       expect(result.idToLatestMentionTime.has(CHANNEL_ID)).toBe(false)
+    })
+  })
+
+  describe('@chat/updateJoin', () => {
+    test('a join read on arrival advances the read position like any server message', () => {
+      const state = makeState({ activated: true, atBottom: true, lastReadTime: 100 })
+
+      const result = chatReducer(state, updateJoinAction(200))
+
+      expect(messageIdsOf(result)).toEqual(['user-join-200'])
+      expect(result.unreadChannels.has(CHANNEL_ID)).toBe(false)
+      expect(result.idToUnreadLineTime.has(CHANNEL_ID)).toBe(false)
+      expect(result.idToLastReadTime.get(CHANNEL_ID)).toBe(200)
+    })
+
+    test('a join arriving while scrolled up raises the flag and leaves the read position', () => {
+      const state = makeState({ activated: true, atBottom: false, lastReadTime: 100 })
+
+      const result = chatReducer(state, updateJoinAction(200))
+
+      expect(result.unreadChannels.has(CHANNEL_ID)).toBe(true)
+      expect(result.idToUnreadLineTime.get(CHANNEL_ID)).toBe(100)
+      expect(result.idToLastReadTime.get(CHANNEL_ID)).toBe(100)
+    })
+
+    test('a banner arriving in a channel that is not being viewed raises the unread flag', () => {
+      const state = makeState({ activated: false, lastReadTime: 100 })
+
+      const result = chatReducer(state, updateJoinAction(200))
+
+      expect(result.unreadChannels.has(CHANNEL_ID)).toBe(true)
     })
   })
 
@@ -934,7 +1034,7 @@ describe('client/chat/chat-reducer', () => {
       expect(result.idToLatestMentionTime.get(CHANNEL_ID)).toBe(500)
     })
 
-    test('a live message freezes the unread divider even at the bottom of the loaded window', () => {
+    test('a live message goes unread at the bottom of the loaded window, freezing the divider', () => {
       const state = makeState({
         hasNewer: true,
         activated: true,
@@ -944,7 +1044,22 @@ describe('client/chat/chat-reducer', () => {
 
       const result = chatReducer(state, updateMessageAction(500, false))
 
+      expect(result.unreadChannels.has(CHANNEL_ID)).toBe(true)
       expect(result.idToUnreadLineTime.get(CHANNEL_ID)).toBe(100)
+      expect(result.idToLastReadTime.get(CHANNEL_ID)).toBe(100)
+    })
+
+    test('a live mention at the bottom of the loaded window is an unread mention', () => {
+      const state = makeState({
+        hasNewer: true,
+        activated: true,
+        atBottom: true,
+        lastReadTime: 100,
+      })
+
+      const result = chatReducer(state, updateMessageAction(500, true))
+
+      expect(channelHasUnreadMention(result, CHANNEL_ID)).toBe(true)
     })
 
     test('an attached channel at the bottom does not freeze the divider', () => {
@@ -1139,8 +1254,36 @@ describe('client/chat/chat-reducer', () => {
       const result = chatReducer(state, activateChannelAction())
 
       expect(result.idToUnreadLineTime.get(CHANNEL_ID)).toBe(100)
-      expect(result.unreadChannels.has(CHANNEL_ID)).toBe(false)
       expect(result.activatedChannels.has(CHANNEL_ID)).toBe(true)
+    })
+
+    test('keeps the unread flag until the read report covers the newest message', () => {
+      const state = makeState({
+        unread: true,
+        atBottom: true,
+        lastReadTime: 100,
+        messages: [textMessage(200)],
+      })
+
+      const activated = chatReducer(state, activateChannelAction())
+      expect(activated.unreadChannels.has(CHANNEL_ID)).toBe(true)
+
+      const read = chatReducer(activated, updateLastReadTimeAction(200))
+      expect(read.unreadChannels.has(CHANNEL_ID)).toBe(false)
+    })
+
+    test('keeps the unread flag when the view opens on a read report short of the newest', () => {
+      const state = makeState({
+        unread: true,
+        atBottom: false,
+        lastReadTime: 100,
+        messages: [textMessage(200)],
+      })
+
+      const activated = chatReducer(state, activateChannelAction())
+      const read = chatReducer(activated, updateLastReadTimeAction(150))
+
+      expect(read.unreadChannels.has(CHANNEL_ID)).toBe(true)
     })
 
     test('leaves the at-bottom state the view reported in place', () => {

--- a/client/chat/chat-reducer.ts
+++ b/client/chat/chat-reducer.ts
@@ -93,7 +93,12 @@ export interface ChatState {
   activatedChannels: Set<SbChannelId>
   /** A set of joined chat channels whose message list is scrolled to the bottom */
   atBottomChannels: Set<SbChannelId>
-  /** A set of joined chat channels that are unread */
+  /**
+   * A set of joined chat channels that are unread: a message from another user is newer than the
+   * channel's read position. Being on screen is no exemption — a message that arrives while the
+   * view is scrolled up, its window is detached from the present, or the app window is unfocused
+   * is unread until the read position covers it.
+   */
   unreadChannels: Set<SbChannelId>
   /** A set of channel IDs saved in various chat messages that no longer exist. */
   deletedChannels: Set<SbChannelId>
@@ -105,8 +110,9 @@ export interface ChatState {
   privateChannels: Set<SbChannelId>
   /**
    * A map of channel ID -> the client's view of the server-recorded read position (epoch ms).
-   * Seeded from the server at init, and advanced optimistically whenever the client reports a
-   * mark-read for the channel.
+   * Seeded from the server at init, advanced optimistically whenever the client reports a mark-read
+   * for the channel, and advanced over a message that lands in front of the user's eyes (see
+   * `recordLiveArrival`), ahead of the view reporting that same position.
    */
   idToLastReadTime: Map<SbChannelId, number>
   /**
@@ -147,7 +153,9 @@ const DEFAULT_CHAT_STATE: Immutable<ChatState> = {
 }
 
 /**
- * Returns whether `channelId` has an unread message that mentions the current user. The server
+ * Returns whether `channelId` has an unread message that mentions the current user. This is derived
+ * from the read position alone — having the channel on screen is not the same as having read it, so
+ * a channel being viewed keeps an unread mention until its read position covers it. The server
  * always sends a read marker for a joined channel (falling back to one millisecond before the
  * member's join date when none has been recorded), so a joined channel with mention state should
  * always have an `idToLastReadTime` entry; if one is somehow missing, `?? Infinity` fails toward
@@ -158,10 +166,6 @@ export function channelHasUnreadMention(
   chatState: Immutable<ChatState>,
   channelId: SbChannelId,
 ): boolean {
-  if (chatState.activatedChannels.has(channelId)) {
-    return false
-  }
-
   const latestMentionTime = chatState.idToLatestMentionTime.get(channelId)
   if (latestMentionTime === undefined) {
     return false
@@ -326,30 +330,39 @@ function dedupeAgainst(incoming: ChatMessage[], existing: readonly ChatMessage[]
 }
 
 /**
- * Records that a message the user hasn't seen has arrived in a channel: raises the unread flag and,
- * where applicable, freezes the unread divider. Both mean the same thing — a message arrived that
- * the user won't have seen — and an activated channel counts as seen only when its view sits at the
- * bottom of a window attached to the present *and* the app window is focused, since a message that
- * lands while the user is looking at something else can't have been read no matter where the list
- * is scrolled. The divider freezes at the read position so it marks where the user left off instead
- * of chasing the read position as it keeps advancing underneath it.
+ * Records that a live message or event reached a channel. It either counts as read on arrival —
+ * the channel is being viewed at the bottom of a window attached to the present with the app window
+ * focused, the one combination that puts the message in front of the user's eyes — in which case
+ * the read position advances over it here, ahead of the view reporting that same position, so the
+ * channel never reads as unread for even a frame; or it went unseen, and the unread flag goes up.
+ * A channel being viewed also freezes its unread divider at the read position, so the divider marks
+ * where the user left off instead of chasing the read position as it keeps advancing underneath it.
  *
  * Kept separate from `updateMessages` because a message arriving while the loaded window is
  * detached from the present isn't added to the window at all, yet counts as unread exactly the same.
  */
-function markChannelUnread(state: ChatState, channelId: SbChannelId, windowFocused: boolean) {
+function recordLiveArrival(state: ChatState, channelId: SbChannelId, arrival: LiveArrival) {
   const isChannelActivated = state.activatedChannels.has(channelId)
+  const isDetached = state.idToMessages.get(channelId)?.hasNewer ?? false
+  const readOnArrival =
+    isChannelActivated &&
+    state.atBottomChannels.has(channelId) &&
+    !isDetached &&
+    arrival.windowFocused
 
-  if (!state.unreadChannels.has(channelId) && (!isChannelActivated || !windowFocused)) {
-    state.unreadChannels.add(channelId)
+  if (readOnArrival) {
+    if (arrival.time !== undefined) {
+      state.idToLastReadTime.set(
+        channelId,
+        Math.max(state.idToLastReadTime.get(channelId) ?? -Infinity, arrival.time),
+      )
+    }
+    return
   }
 
-  const isDetached = state.idToMessages.get(channelId)?.hasNewer ?? false
-  if (
-    isChannelActivated &&
-    (!state.atBottomChannels.has(channelId) || isDetached || !windowFocused) &&
-    !state.idToUnreadLineTime.has(channelId)
-  ) {
+  state.unreadChannels.add(channelId)
+
+  if (isChannelActivated && !state.idToUnreadLineTime.has(channelId)) {
     const lastReadTime = state.idToLastReadTime.get(channelId)
     if (lastReadTime !== undefined) {
       state.idToUnreadLineTime.set(channelId, lastReadTime)
@@ -454,6 +467,12 @@ function dropMessageWindow(channelMessages: MessagesState) {
 interface LiveArrival {
   /** Whether the app window was focused at the moment the message arrived. */
   windowFocused: boolean
+  /**
+   * The server-recorded time (epoch ms) of the arriving message: a message read on arrival advances
+   * the read position over it. Unset for the client-only leave/kick/ban/owner-change banners, which
+   * are stamped with the local clock, a time the server would never accept as a read position.
+   */
+  time?: number
 }
 
 /**
@@ -500,7 +519,7 @@ function updateMessages(
   }
 
   if (arrival) {
-    markChannelUnread(state, channelId, arrival.windowFocused)
+    recordLiveArrival(state, channelId, arrival)
   }
 
   channelMessages.hasHistory = channelMessages.hasHistory || sliced
@@ -597,10 +616,10 @@ function initChannel(state: ChatState, channelId: SbChannelId, data: InitialChan
   }
 
   // Seeds the unread badge from the server's recorded read position, so it survives a restart
-  // instead of resetting to "read" until the next message arrives. The seed only concerns channels
-  // that aren't on screen: an activated channel's flag is driven by what arrives live and what the
-  // view reads, both of which know things this seed doesn't.
-  if (hasUnread && !state.activatedChannels.has(channelId)) {
+  // instead of resetting to "read" until the next message arrives. Whether the channel is on screen
+  // doesn't enter into it: the flag follows the read position either way, and the view's read
+  // report lowers it once that position covers the newest message.
+  if (hasUnread) {
     state.unreadChannels.add(channelId)
   }
 
@@ -646,7 +665,7 @@ export default immerKeyedReducer(DEFAULT_CHAT_STATE, {
     channelUsers.active.add(user.id)
     detailedChannelInfo.userCount += 1
 
-    updateMessages(state, channelId, { windowFocused }, m => {
+    updateMessages(state, channelId, { windowFocused, time: message.time }, m => {
       m.push(message)
       return m
     })
@@ -726,13 +745,18 @@ export default immerKeyedReducer(DEFAULT_CHAT_STATE, {
         newMessage.time,
       )
       if (!isSelfMessage) {
-        markChannelUnread(state, channelId, windowFocused)
+        recordLiveArrival(state, channelId, { windowFocused, time: newMessage.time })
       }
     } else {
-      updateMessages(state, channelId, isSelfMessage ? undefined : { windowFocused }, m => {
-        m.push(newMessage)
-        return m
-      })
+      updateMessages(
+        state,
+        channelId,
+        isSelfMessage ? undefined : { windowFocused, time: newMessage.time },
+        m => {
+          m.push(newMessage)
+          return m
+        },
+      )
     }
 
     updateChannelInfos(state, channelMentions)
@@ -1077,9 +1101,11 @@ export default immerKeyedReducer(DEFAULT_CHAT_STATE, {
     // reported yet and counts as away from the bottom, which is where it's headed.
     const atBottom = state.atBottomChannels.has(channelId)
 
-    // Freeze the unread divider at the read position before clearing the unread flag, so the
-    // divider marks where the user left off instead of where the read position ends up after the
-    // eager mark-read opening at the newest messages triggers.
+    // Freeze the unread divider at the read position, so it marks where the user left off instead
+    // of where the read position ends up after the eager mark-read opening at the newest messages
+    // triggers. Activation itself never lowers the unread flag: the flag follows the read position,
+    // and `@chat/updateLastReadTime` lowers it once the view's read report covers every known
+    // message.
     if (
       state.unreadChannels.has(channelId) &&
       !state.idToUnreadLineTime.has(channelId) &&
@@ -1103,7 +1129,6 @@ export default immerKeyedReducer(DEFAULT_CHAT_STATE, {
       }
     }
 
-    state.unreadChannels.delete(channelId)
     state.activatedChannels.add(channelId)
   },
 
@@ -1166,14 +1191,14 @@ export default immerKeyedReducer(DEFAULT_CHAT_STATE, {
   // This arrives both from this session's own optimistic mark-read reports (dispatched only while
   // the channel is activated) and from the socket handler relaying a mark-read made in one of the
   // user's other sessions (which can arrive for a channel this session isn't currently viewing).
-  // The unread flag is re-evaluated either way: an activated channel can carry the flag, since a
-  // message arriving while the app window is unfocused counts as unread no matter what's on screen,
-  // and this is what lowers it once the read position covers that message. The frozen divider is
-  // only re-evaluated for a channel that isn't activated: while one is being viewed the divider has
-  // to hold still where it is, and `deactivateChannel` is what re-evaluates it. An explicit
-  // mark-read carries `dismissUnreadLine`, which drops the divider whether or not the channel is
-  // activated, because the user asked for the unread state to go rather than merely scrolling past
-  // it.
+  // The unread flag is re-evaluated either way: an activated channel carries the flag whenever a
+  // message arrived that wasn't read on arrival — the view scrolled up, its window detached from
+  // the present, or the app window unfocused — and this is what lowers it once the read position
+  // covers every message known to exist. The frozen divider is only re-evaluated for a channel that
+  // isn't activated: while one is being viewed the divider has to hold still where it is, and
+  // `deactivateChannel` is what re-evaluates it. An explicit mark-read carries `dismissUnreadLine`,
+  // which drops the divider whether or not the channel is activated, because the user asked for the
+  // unread state to go rather than merely scrolling past it.
   ['@chat/updateLastReadTime'](state, action) {
     const { channelId, lastReadTime, dismissUnreadLine } = action.payload
 

--- a/client/whispers/actions.ts
+++ b/client/whispers/actions.ts
@@ -219,10 +219,9 @@ export interface ResetMessageWindow {
 
 /**
  * Activate a particular whisper session. This is a purely client-side action which marks the
- * session as "active", and removes the unread indicator if there is one. The message list reports
- * the at-bottom state it opened in (`UpdateSessionAtBottom`) ahead of this being dispatched, so
- * the reducer reads the current flag to tell an open at the newest messages from one restoring a
- * position further back.
+ * session as "active". The message list reports the at-bottom state it opened in
+ * (`UpdateSessionAtBottom`) ahead of this being dispatched, so the reducer reads the current flag
+ * to tell an open at the newest messages from one restoring a position further back.
  */
 export interface ActivateWhisperSession {
   type: '@whispers/activateWhisperSession'
@@ -312,9 +311,10 @@ export interface WhisperMessageUpdate {
      */
     isSelfMessage: boolean
     /**
-     * Whether the app window was focused when the live event arrived. A non-self message landing
-     * in an unfocused window can't have been seen no matter where the session's view is scrolled,
-     * so the reducer counts it as unread regardless.
+     * Whether the app window was focused when the live event arrived. A non-self message counts as
+     * read on arrival only when the window is focused and the view sits at the bottom of a message
+     * window attached to the present; anything else leaves the session unread until its read
+     * position covers the message.
      */
     windowFocused: boolean
   }

--- a/client/whispers/whisper-reducer.test.ts
+++ b/client/whispers/whisper-reducer.test.ts
@@ -245,6 +245,24 @@ function messageIdsOf(state: Immutable<WhisperState>): string[] {
 }
 
 describe('client/whispers/whisper-reducer', () => {
+  describe('@whispers/getWhisperSessions', () => {
+    test('seeds the unread flag from the server, for a session on screen as well', () => {
+      const state = makeState({ activated: true, atBottom: true })
+
+      const result = whisperReducer(state, {
+        type: '@whispers/getWhisperSessions',
+        payload: {
+          sessions: [TARGET_ID],
+          users: [],
+          unreadSessions: [TARGET_ID],
+          lastReadTimes: [{ targetId: TARGET_ID, lastReadTime: 100 }],
+        },
+      })
+
+      expect(sessionOf(result).hasUnread).toBe(true)
+    })
+  })
+
   describe('@whispers/updateLastReadTime', () => {
     test('does not regress the stored position when the incoming time is stale', () => {
       const state = makeState({ lastReadTime: 1000 })
@@ -550,7 +568,7 @@ describe('client/whispers/whisper-reducer', () => {
       expect(sessionOf(result).hasUnread).toBe(true)
     })
 
-    test('a live message freezes the unread divider even at the bottom of the loaded window', () => {
+    test('a live message goes unread at the bottom of the loaded window, freezing the divider', () => {
       const state = makeState({
         hasNewer: true,
         activated: true,
@@ -560,7 +578,10 @@ describe('client/whispers/whisper-reducer', () => {
 
       const result = whisperReducer(state, updateMessageAction(500))
 
-      expect(sessionOf(result).unreadLineTime).toBe(100)
+      const session = sessionOf(result)
+      expect(session.hasUnread).toBe(true)
+      expect(session.unreadLineTime).toBe(100)
+      expect(session.lastReadTime).toBe(100)
     })
 
     test('an attached session at the bottom does not freeze the divider', () => {
@@ -626,9 +647,10 @@ describe('client/whispers/whisper-reducer', () => {
       const session = sessionOf(result)
       expect(session.hasUnread).toBe(true)
       expect(session.unreadLineTime).toBe(100)
+      expect(session.lastReadTime).toBe(100)
     })
 
-    test('a message arriving at the bottom of a focused window counts as seen', () => {
+    test('a message arriving at the bottom of a focused window is read on arrival', () => {
       const state = makeState({ activated: true, atBottom: true, lastReadTime: 100 })
 
       const result = whisperReducer(state, updateMessageAction(200, true))
@@ -636,6 +658,15 @@ describe('client/whispers/whisper-reducer', () => {
       const session = sessionOf(result)
       expect(session.hasUnread).toBe(false)
       expect(session.unreadLineTime).toBeUndefined()
+      expect(session.lastReadTime).toBe(200)
+    })
+
+    test('a message read on arrival does not regress the read position', () => {
+      const state = makeState({ activated: true, atBottom: true, lastReadTime: 300 })
+
+      const result = whisperReducer(state, updateMessageAction(200, true))
+
+      expect(sessionOf(result).lastReadTime).toBe(300)
     })
 
     test('a message arriving while scrolled up in an unfocused window raises both', () => {
@@ -648,14 +679,15 @@ describe('client/whispers/whisper-reducer', () => {
       expect(session.unreadLineTime).toBe(100)
     })
 
-    test('a message arriving while scrolled up in a focused window only freezes the divider', () => {
+    test('a message arriving while scrolled up in a focused window raises both', () => {
       const state = makeState({ activated: true, atBottom: false, lastReadTime: 100 })
 
       const result = whisperReducer(state, updateMessageAction(200, true))
 
       const session = sessionOf(result)
-      expect(session.hasUnread).toBe(false)
+      expect(session.hasUnread).toBe(true)
       expect(session.unreadLineTime).toBe(100)
+      expect(session.lastReadTime).toBe(100)
     })
 
     test('a message arriving in a session that is not being viewed raises the unread flag', () => {
@@ -850,8 +882,36 @@ describe('client/whispers/whisper-reducer', () => {
 
       const session = sessionOf(result)
       expect(session.unreadLineTime).toBe(100)
-      expect(session.hasUnread).toBe(false)
       expect(session.activated).toBe(true)
+    })
+
+    test('keeps the unread flag until the read report covers the newest message', () => {
+      const state = makeState({
+        unread: true,
+        atBottom: true,
+        lastReadTime: 100,
+        messages: [textMessage(200)],
+      })
+
+      const activated = whisperReducer(state, activateSessionAction())
+      expect(sessionOf(activated).hasUnread).toBe(true)
+
+      const read = whisperReducer(activated, updateLastReadTimeAction(200))
+      expect(sessionOf(read).hasUnread).toBe(false)
+    })
+
+    test('keeps the unread flag when the view opens on a read report short of the newest', () => {
+      const state = makeState({
+        unread: true,
+        atBottom: false,
+        lastReadTime: 100,
+        messages: [textMessage(200)],
+      })
+
+      const activated = whisperReducer(state, activateSessionAction())
+      const read = whisperReducer(activated, updateLastReadTimeAction(150))
+
+      expect(sessionOf(read).hasUnread).toBe(true)
     })
 
     test('leaves the at-bottom state the view reported in place', () => {

--- a/client/whispers/whisper-reducer.ts
+++ b/client/whispers/whisper-reducer.ts
@@ -41,11 +41,18 @@ export interface WhisperSession {
   activated: boolean
   /** Whether this session's message list is scrolled to the bottom. */
   atBottom: boolean
+  /**
+   * Whether this session is unread: a message from the other user is newer than the session's read
+   * position. Being on screen is no exemption — a message that arrives while the view is scrolled
+   * up, its window is detached from the present, or the app window is unfocused is unread until the
+   * read position covers it.
+   */
   hasUnread: boolean
   /**
    * The client's view of the server-recorded read position (epoch ms) for this session. Seeded
-   * from the server at init, and advanced optimistically whenever the client reports a mark-read
-   * for the session.
+   * from the server at init, advanced optimistically whenever the client reports a mark-read for
+   * the session, and advanced over a message that lands in front of the user's eyes (see
+   * `recordLiveArrival`), ahead of the view reporting that same position.
    */
   lastReadTime?: number
   /**
@@ -142,25 +149,32 @@ function dedupeAgainst(
 }
 
 /**
- * Records that a message the user hasn't seen has arrived in a whisper session: raises the unread
- * flag and, where applicable, freezes the unread divider. Both mean the same thing — a message
- * arrived that the user won't have seen — and an activated session counts as seen only when its
- * view sits at the bottom of a window attached to the present *and* the app window is focused,
- * since a message that lands while the user is looking at something else can't have been read no
- * matter where the list is scrolled. The divider freezes at the read position so it marks where the
- * user left off instead of chasing the read position as it keeps advancing underneath it.
+ * Records that a live message reached a whisper session. It either counts as read on arrival — the
+ * session is being viewed at the bottom of a window attached to the present with the app window
+ * focused, the one combination that puts the message in front of the user's eyes — in which case
+ * the read position advances over it here, ahead of the view reporting that same position, so the
+ * session never reads as unread for even a frame; or it went unseen, and the unread flag goes up.
+ * A session being viewed also freezes its unread divider at the read position, so the divider marks
+ * where the user left off instead of chasing the read position as it keeps advancing underneath it.
  *
  * Kept separate from `updateMessages` because a message arriving while the loaded window is
  * detached from the present isn't added to the window at all, yet counts as unread exactly the same.
  */
-function markSessionUnread(session: WhisperSession, windowFocused: boolean) {
-  if (!session.hasUnread && (!session.activated || !windowFocused)) {
-    session.hasUnread = true
+function recordLiveArrival(session: WhisperSession, arrival: LiveArrival) {
+  const readOnArrival =
+    session.activated && session.atBottom && !session.hasNewer && arrival.windowFocused
+
+  if (readOnArrival) {
+    if (arrival.time !== undefined) {
+      session.lastReadTime = Math.max(session.lastReadTime ?? -Infinity, arrival.time)
+    }
+    return
   }
+
+  session.hasUnread = true
 
   if (
     session.activated &&
-    (!session.atBottom || session.hasNewer || !windowFocused) &&
     session.unreadLineTime === undefined &&
     session.lastReadTime !== undefined
   ) {
@@ -193,6 +207,12 @@ function dropMessageWindow(session: WhisperSession) {
 interface LiveArrival {
   /** Whether the app window was focused at the moment the message arrived. */
   windowFocused: boolean
+  /**
+   * The server-recorded time (epoch ms) of the arriving message: a message read on arrival advances
+   * the read position over it. Optional only to mirror the chat reducer's arrivals, whose
+   * client-only banners carry no server time; every whisper message has one.
+   */
+  time?: number
 }
 
 /**
@@ -229,7 +249,7 @@ function updateMessages(
   }
 
   if (arrival) {
-    markSessionUnread(session, arrival.windowFocused)
+    recordLiveArrival(session, arrival)
   }
 
   session.hasHistory = session.hasHistory || sliced
@@ -248,12 +268,12 @@ export default immerKeyedReducer(DEFAULT_STATE, {
     }
 
     // Seeds the unread badge from the server's recorded read position, so it survives a restart
-    // instead of resetting to "read" until the next message arrives. The seed only concerns
-    // sessions that aren't on screen: an activated session's flag is driven by what arrives live
-    // and what the view reads, both of which know things this seed doesn't.
+    // instead of resetting to "read" until the next message arrives. Whether the session is on
+    // screen doesn't enter into it: the flag follows the read position either way, and the view's
+    // read report lowers it once that position covers the newest message.
     for (const target of action.payload.unreadSessions ?? []) {
       const session = state.byId.get(target)
-      if (session && !session.activated) {
+      if (session) {
         session.hasUnread = true
       }
     }
@@ -311,13 +331,18 @@ export default immerKeyedReducer(DEFAULT_STATE, {
         newMessage.time,
       )
       if (!isSelfMessage) {
-        markSessionUnread(session, windowFocused)
+        recordLiveArrival(session, { windowFocused, time: newMessage.time })
       }
     } else {
-      updateMessages(state, target, isSelfMessage ? undefined : { windowFocused }, m => {
-        m.push(newMessage)
-        return m
-      })
+      updateMessages(
+        state,
+        target,
+        isSelfMessage ? undefined : { windowFocused, time: newMessage.time },
+        m => {
+          m.push(newMessage)
+          return m
+        },
+      )
     }
   },
 
@@ -499,9 +524,11 @@ export default immerKeyedReducer(DEFAULT_STATE, {
     // reported yet and counts as away from the bottom, which is where it's headed.
     const atBottom = session.atBottom
 
-    // Freeze the unread divider at the read position before clearing the unread flag, so the
-    // divider marks where the user left off instead of where the read position ends up after the
-    // eager mark-read opening at the newest messages triggers.
+    // Freeze the unread divider at the read position, so it marks where the user left off instead
+    // of where the read position ends up after the eager mark-read opening at the newest messages
+    // triggers. Activation itself never lowers the unread flag: the flag follows the read position,
+    // and `@whispers/updateLastReadTime` lowers it once the view's read report covers every known
+    // message.
     if (
       session.hasUnread &&
       session.unreadLineTime === undefined &&
@@ -523,7 +550,6 @@ export default immerKeyedReducer(DEFAULT_STATE, {
     }
 
     session.activated = true
-    session.hasUnread = false
   },
 
   ['@whispers/deactivateWhisperSession'](state, action) {
@@ -607,14 +633,14 @@ export default immerKeyedReducer(DEFAULT_STATE, {
   // This arrives both from this session's own optimistic mark-read reports (dispatched only while
   // the session is activated) and from the socket handler relaying a mark-read made in one of the
   // user's other sessions (which can arrive for a session this session isn't currently viewing).
-  // The unread flag is re-evaluated either way: an activated session can carry the flag, since a
-  // message arriving while the app window is unfocused counts as unread no matter what's on screen,
-  // and this is what lowers it once the read position covers that message. The frozen divider is
-  // only re-evaluated for a session that isn't activated: while one is being viewed the divider has
-  // to hold still where it is, and `deactivateWhisperSession` is what re-evaluates it. An explicit
-  // mark-read carries `dismissUnreadLine`, which drops the divider whether or not the session is
-  // activated, because the user asked for the unread state to go rather than merely scrolling past
-  // it.
+  // The unread flag is re-evaluated either way: an activated session carries the flag whenever a
+  // message arrived that wasn't read on arrival — the view scrolled up, its window detached from
+  // the present, or the app window unfocused — and this is what lowers it once the read position
+  // covers every message known to exist. The frozen divider is only re-evaluated for a session that
+  // isn't activated: while one is being viewed the divider has to hold still where it is, and
+  // `deactivateWhisperSession` is what re-evaluates it. An explicit mark-read carries
+  // `dismissUnreadLine`, which drops the divider whether or not the session is activated, because
+  // the user asked for the unread state to go rather than merely scrolling past it.
   ['@whispers/updateLastReadTime'](state, action) {
     const { targetId, lastReadTime, dismissUnreadLine } = action.payload
 


### PR DESCRIPTION
The sidebar's unread flag and urgent mention mark now mean one thing for every conversation, open or not: a message from another user is newer than the read position. A message arriving while the user is in the conversation but scrolled up, in a detached window, or with the app window unfocused marks it, and the read report on reaching the bottom with the window focused clears it. A message that lands in front of the user (open, focused, at the bottom of an attached window) is read on arrival: the reducer advances the read position over it in the same dispatch, so nothing shows as unread even for a frame, and the view still reports that position to the server. Activation no longer clears the flag; `updateLastReadTime` does, once the position covers every known message, so opening at a restored mid-backlog position keeps the marks up until the user scrolls down. Channels and whispers share the rule.

Fixes #1492

## Acceptance criteria

- [x] Unread mark is up whenever a message from another user is newer than the read position, open or not. T3: scrolled-up (channel and whisper), real Alt+Tab (channel and whisper), and away-from-channel arrivals all raised it; reaching the bottom focused cleared it. Reducer tests.
- [x] A message arriving open, focused, at the bottom of an attached window never shows as unread, not even for a frame. T3: a store subscriber (fires on every dispatch) saw only the read position advance, in the arrival's own dispatch, for a plain message and for a mention. Reducer tests.
- [x] The urgent mention mark follows the same rule on the entry, the social button, and the tray's tracked state. T3: a mention in the open channel while blurred turned the entry and the social button red; refocus cleared both. Tray verified at the selector level only (see Verification).
- [x] Opening clears marks only once the read position covers the newest message. T3: reopening at a restored scrolled-up position kept the flag through activation; scrolling down cleared it. Opening a seeded-unread whisper at the bottom cleared it through the read report. Reducer tests.
- [x] Mention sound and taskbar flash unchanged. Socket handlers untouched.
- [x] Channels and whispers behave identically; reducer tests cover scrolled-up, detached, unfocused, and read-on-arrival for both.

## Drift

Written against 637273795; master has #1498 and #1499 since. Pointers moved by line only. #1499's `newestKnownChannelTime` and `dismissUnreadLine` fit the new model unchanged.

## Calls made

- **Read on arrival advances the read position in the reducer.** Without it, a mention arriving in the open, focused, at-bottom channel derives as urgent for the one render between arrival and the view's report effect, and the tray IPC would flicker. The view still reports the same time to the server (the coalescer doesn't consult Redux), so the server position is unaffected.
- **Join/leave/kick/ban/owner-change banners keep raising the flag** under the not-read-on-arrival rule, as they always have. Only server-origin arrivals (text messages and the join banner) advance the read position; the client-only banners carry local-clock times and never do. Since the server never counts banners as unread, a banner-only flag in a channel with no text messages stays up until a message arrives or the user marks it read. That mismatch predates this change; a spin-off issue is drafted.

## Verification

T0: `vitest run client/chat client/whispers` (8 files, 228 passed), `tsc` clean, eslint and prettier clean on the changed files.

T3: two dev Electron clients. claude-1 as observer with a Redux store subscriber logging every flag transition plus a `requestAnimationFrame` DOM sampler for the entry and social-button indicators; claude-2 as sender through a live socket and the messages API. Blurred phases used a real Alt+Tab via `SendKeys` with the OS foreground confirmed first; `channel_users.last_read_time` and `whisper_sessions.last_read_time` were checked before and after refocus. Not verified end to end: the tray icon itself. The contextBridge `ipcRenderer.send` is non-writable and non-configurable, so the `chatUnreadState` IPC can't be observed from the page; its inputs (`channelHasUnreadMention` for the open channel, whisper `hasUnread`) were asserted at every store state and the sync component is unchanged.
