### PR TITLE
Let the issue skills keep board status, assignee and labels accurate.

### DIFF
--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -12,8 +12,11 @@ have none of that: then step 2 is where you build the missing spec, in chat, bef
 
 ## Rules
 
-- **Never edit the issue.** No body edits, comments, labels, assignees or board moves. Drift,
-  questions and progress go in chat and in the PR body.
+- **Never speak as the user on the issue.** No comments. No body edits either, unless the issue
+  is one you filed yourself through the `issue` skill: that body is your own text and you may keep
+  it current. Drift, questions and progress go in chat and in the PR body regardless. Board
+  status, assignee and labels are metadata, not speech; keep them accurate (step 3 moves the issue
+  to In Progress, merging moves it to Done).
 - **Premise before code.** Nothing is written until the drift report (step 2) is in chat.
 - **Scope is the issue.** Desired behavior in, Out of scope out. Anything else you find becomes a
   spin-off issue via the `issue` skill, not part of this PR.
@@ -86,6 +89,22 @@ stay linear: each carries only its own commits on top of its parent, so when the
 `git rebase --onto <parent-tip> <old-parent-tip>` the child and push with `--force-with-lease`;
 never merge the parent in. When a stack merges bottom-up, retarget the child PR's base to master
 before the parent's branch is deleted, or GitHub auto-closes the child.
+
+Once the branch exists, mark the issue as being worked on: assign the user and move its board item
+to In Progress, so the board reflects reality while the PR is open. IDs are resolved at run time
+because option IDs change whenever the Status field is rebuilt:
+
+```bash
+gh issue edit N --add-assignee "$(gh api user --jq .login)"
+PROJECT=$(gh project view 1 --owner ShieldBattery --format json --jq .id)
+FIELD=$(gh project field-list 1 --owner ShieldBattery --format json --jq '.fields[] | select(.name=="Status") | .id')
+OPTION=$(gh project field-list 1 --owner ShieldBattery --format json --jq '.fields[] | select(.name=="Status") | .options[] | select(.name=="In Progress") | .id')
+ITEM=$(gh project item-list 1 --owner ShieldBattery --format json --limit 500 --jq '.items[] | select(.content.number==N) | .id')
+gh project item-edit --project-id "$PROJECT" --id "$ITEM" --field-id "$FIELD" --single-select-option-id "$OPTION"
+```
+
+An issue with no area label has no board item; assign it and move on. Closing or reopening an issue
+is a bigger act than a column move and still waits for the user to ask.
 
 ### 4. Build
 

--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: implement
-description: Implement a GitHub issue end to end (`/implement #N`) - read the issue and its parent, verify its premise against the pinned commit and current master BEFORE writing code, report drift in chat, build on a short branch within the issue's stated scope, verify at the tier the issue names, and open a PR with `Fixes #N`. Never edits the issue. Use when asked to implement, work on, pick up, build, or fix an issue by number.
+description: Implement a GitHub issue end to end (`/implement #N`) - read the issue and its parent, verify its premise against the pinned commit and current master BEFORE writing code, report drift in chat, build on a short branch within the issue's stated scope, verify at the tier the issue names, and open a PR with `Fixes #N`. Never comments on the issue or edits a body a person wrote; keeps assignee and board status accurate. Use when asked to implement, work on, pick up, build, or fix an issue by number.
 ---
 
 # Implementing an issue
@@ -53,9 +53,9 @@ anything else:
   line each and which one you would build.
 
 Then ask once whether to proceed. A go-ahead, in chat or in the invocation itself ("implement #N,
-go with your calls"), means: build on your recommendations, leave the issue untouched, and list
-every call in the PR body under **Calls made** so the author can override at review. A go-ahead
-does not skip step 2 and does not widen the scope.
+go with your calls"), means: build on your recommendations, leave the issue's body and `needs-*`
+labels as they are, and list every call in the PR body under **Calls made** so the author can
+override at review. A go-ahead does not skip step 2 and does not widen the scope.
 
 ### 2. Verify the premise and report drift
 

--- a/.claude/skills/issue/SKILL.md
+++ b/.claude/skills/issue/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: issue
-description: File a GitHub issue for ShieldBattery the way this repo wants them - read the code first, dedupe against the whole backlog, draft seven fixed sections pinned to a commit, show the draft, then create it with type, area label, parent and milestone set at creation. Use whenever asked to file, open, create or write up an issue or ticket; to turn a roadmap item, review finding, design decision or Discord thread into an issue; or to raise a side-issue discovered while working on something else (spin-off mode). Creates issues only - never comments, edits, relabels, assigns, closes or moves them.
+description: File a GitHub issue for ShieldBattery the way this repo wants them - read the code first, dedupe against the whole backlog, draft seven fixed sections pinned to a commit, show the draft, then create it with type, area label, parent and milestone set at creation. Use whenever asked to file, open, create or write up an issue or ticket; to turn a roadmap item, review finding, design decision or Discord thread into an issue; or to raise a side-issue discovered while working on something else (spin-off mode). Creates issues and keeps their metadata honest (labels, assignee, board column); may edit the body of an issue it filed itself, but never comments and never edits a body a person wrote, since those would read as the user's words.
 ---
 
 # Filing an issue
@@ -14,10 +14,12 @@ filed examples of it.
 
 ## Write rules (non-negotiable)
 
-- You may **create** issues, with type, labels, parent and milestone set at creation. You may
-  create a milestone when filing a multi-phase plan. Nothing else: no comments, body edits,
-  relabeling, assigning, closing, reopening or board moves unless the user explicitly asks for that
-  action in the current session. Comments are for humans.
+- You may **create** issues, with type, labels, parent and milestone set at creation, and create
+  a milestone when filing a multi-phase plan. Metadata is yours to keep accurate: labels, assignee
+  and board column are state, not speech. An issue you filed is your own text: you may edit its
+  body later (a stale pointer, a decision the user made in chat). What you never do is speak as
+  the user: no comments, and no body edits on an issue a person wrote. Closing or reopening an
+  issue waits for the user to ask. Comments are for humans.
 - **Discord is private; the repo is public.** Anything from Discord is input only: restate the
   need in your own words with the person's name and the date. Never quote, paraphrase closely,
   paste, or link Discord messages. Public sources (PR reviews, existing issues) may be quoted.

--- a/.claude/skills/issue/SKILL.md
+++ b/.claude/skills/issue/SKILL.md
@@ -124,8 +124,9 @@ python .claude/skills/issue/file_issues.py <draft-dir>            # dry run
 python .claude/skills/issue/file_issues.py --create <draft-dir>
 ```
 
-Report the URLs. An issue with an area label lands on the board in Todo by itself; whether it moves
-to Ready is the maintainers' call after they read Decisions. Don't touch the board.
+Report the URLs. An issue with an area label lands on the board in Todo by itself. Ready means the
+maintainers have read Decisions and locked everything, so that move is theirs; the `implement`
+skill moves it to In Progress once a branch exists.
 
 ## Spin-off mode
 
@@ -138,8 +139,9 @@ spin-offs this session).
 
 ## Don'ts
 
-- Don't relabel, comment on, edit, assign, close or reopen anything, including issues you created
-  earlier in the session, unless asked.
+- Don't speak as the user: no comments anywhere, no body edits on an issue a person wrote, no
+  closing or reopening unless asked. Labels, assignee and board column are metadata, not speech;
+  keep them accurate.
 - Don't add "raised by Claude" or any attribution lines; the account filing it is the author.
 - Don't put Discord text, links or message ids anywhere in an issue.
 - Don't describe branches, memory files, chat transcripts or "the plan doc"; the issue stands on


### PR DESCRIPTION
The issue skills' write rule was broader than intended. The thing never to do is speak as the user: no comments, and no body edits on an issue a person wrote. Metadata is state, not speech, so the skills now keep labels, assignee and board column accurate on their own, and an issue the `issue` skill filed itself stays editable as Claude's own text. The `implement` skill assigns the user and moves the board item to In Progress right after the branch is created, resolving the project, field, option and item IDs at run time so a rebuilt Status field can't break it. Closing or reopening an issue still waits for the user to ask.
