### PR TITLE
Re-place a passed unread divider and clear it on send.

### DIFF
--- a/client/chat/channel.tsx
+++ b/client/chat/channel.tsx
@@ -483,6 +483,7 @@ export function ConnectedChatChannel({
             onSeekToUnread={onSeekToUnread}
             onMarkRead={onMarkRead}
             escapeJumpsToBottom
+            jumpToBottomOnSend
             header={
               // These are basically guaranteed to be defined here, but still doing the check instead
               // of asserting them with ! because better to be safe than sorry, or something.

--- a/client/chat/chat-reducer.test.ts
+++ b/client/chat/chat-reducer.test.ts
@@ -777,15 +777,57 @@ describe('client/chat/chat-reducer', () => {
       expect(result.idToLatestMentionTime.has(CHANNEL_ID)).toBe(false)
     })
 
-    test('an own echo preserves unread state created by another message', () => {
+    test('an own echo drops the divider and reads the channel through the echoed message', () => {
       const result = chatReducer(
         makeState({ unread: true, unreadLineTime: 100, lastReadTime: 100, latestMentionTime: 150 }),
         updateMessageAction(200, true, true, true),
       )
 
-      expect(result.unreadChannels.has(CHANNEL_ID)).toBe(true)
-      expect(result.idToUnreadLineTime.get(CHANNEL_ID)).toBe(100)
+      expect(result.unreadChannels.has(CHANNEL_ID)).toBe(false)
+      expect(result.idToUnreadLineTime.has(CHANNEL_ID)).toBe(false)
+      expect(result.idToLastReadTime.get(CHANNEL_ID)).toBe(200)
       expect(result.idToLatestMentionTime.get(CHANNEL_ID)).toBe(150)
+      expect(channelHasUnreadMention(result, CHANNEL_ID)).toBe(false)
+    })
+
+    test('an own echo does not regress the read position', () => {
+      const result = chatReducer(
+        makeState({ unread: true, unreadLineTime: 100, lastReadTime: 300 }),
+        updateMessageAction(200, false, true, true),
+      )
+
+      expect(result.idToLastReadTime.get(CHANNEL_ID)).toBe(300)
+      expect(result.idToUnreadLineTime.has(CHANNEL_ID)).toBe(false)
+      expect(result.unreadChannels.has(CHANNEL_ID)).toBe(false)
+    })
+
+    test('an own echo drops a divider the read position has not passed', () => {
+      const result = chatReducer(
+        makeState({
+          activated: true,
+          atBottom: false,
+          unread: true,
+          unreadLineTime: 100,
+          lastReadTime: 100,
+          messages: [textMessage(150)],
+        }),
+        updateMessageAction(200, false, true, true),
+      )
+
+      expect(result.idToUnreadLineTime.has(CHANNEL_ID)).toBe(false)
+      expect(result.unreadChannels.has(CHANNEL_ID)).toBe(false)
+      expect(result.idToLastReadTime.get(CHANNEL_ID)).toBe(200)
+    })
+
+    test('an own echo in a channel that is not being viewed still reads it', () => {
+      const result = chatReducer(
+        makeState({ activated: false, unread: true, unreadLineTime: 100, lastReadTime: 100 }),
+        updateMessageAction(200, false, true, true),
+      )
+
+      expect(result.idToUnreadLineTime.has(CHANNEL_ID)).toBe(false)
+      expect(result.unreadChannels.has(CHANNEL_ID)).toBe(false)
+      expect(result.idToLastReadTime.get(CHANNEL_ID)).toBe(200)
     })
 
     test('an own echo past a detached window still tracks the newest time', () => {
@@ -798,7 +840,73 @@ describe('client/chat/chat-reducer', () => {
       expect(windowOf(result).detachedNewestTime).toBe(200)
       expect(result.unreadChannels.has(CHANNEL_ID)).toBe(false)
       expect(result.idToUnreadLineTime.has(CHANNEL_ID)).toBe(false)
+      expect(result.idToLastReadTime.get(CHANNEL_ID)).toBe(200)
       expect(result.idToLatestMentionTime.has(CHANNEL_ID)).toBe(false)
+    })
+
+    test('a message arriving in an unfocused window re-freezes a divider the read position has passed', () => {
+      const state = makeState({
+        activated: true,
+        atBottom: true,
+        unreadLineTime: 100,
+        lastReadTime: 200,
+        messages: [textMessage(150), textMessage(200)],
+      })
+
+      const result = chatReducer(state, updateMessageAction(300, false, false))
+
+      expect(result.idToUnreadLineTime.get(CHANNEL_ID)).toBe(200)
+      expect(result.unreadChannels.has(CHANNEL_ID)).toBe(true)
+      expect(result.idToLastReadTime.get(CHANNEL_ID)).toBe(200)
+    })
+
+    test('a message arriving while scrolled up re-freezes a divider the read position has passed', () => {
+      const state = makeState({
+        activated: true,
+        atBottom: false,
+        unreadLineTime: 100,
+        lastReadTime: 200,
+        messages: [textMessage(150), textMessage(200)],
+      })
+
+      const result = chatReducer(state, updateMessageAction(300, false, true))
+
+      expect(result.idToUnreadLineTime.get(CHANNEL_ID)).toBe(200)
+    })
+
+    test('a message arriving while scrolled up keeps a divider the read position has not passed', () => {
+      const state = makeState({
+        activated: true,
+        atBottom: false,
+        unreadLineTime: 100,
+        lastReadTime: 100,
+      })
+
+      const result = chatReducer(state, updateMessageAction(300, false, true))
+
+      expect(result.idToUnreadLineTime.get(CHANNEL_ID)).toBe(100)
+    })
+
+    test('a message arriving while unfocused keeps a divider the read position has not passed', () => {
+      const state = makeState({
+        activated: true,
+        atBottom: true,
+        unreadLineTime: 100,
+        lastReadTime: 100,
+      })
+
+      const result = chatReducer(state, updateMessageAction(300, false, false))
+
+      expect(result.idToUnreadLineTime.get(CHANNEL_ID)).toBe(100)
+    })
+
+    test('a message arriving in a channel that is not being viewed does not re-freeze a passed divider', () => {
+      const state = makeState({ activated: false, unreadLineTime: 100, lastReadTime: 200 })
+
+      const result = chatReducer(state, updateMessageAction(300, false, true))
+
+      expect(result.idToUnreadLineTime.get(CHANNEL_ID)).toBe(100)
+      expect(result.unreadChannels.has(CHANNEL_ID)).toBe(true)
     })
   })
 
@@ -1047,6 +1155,22 @@ describe('client/chat/chat-reducer', () => {
       expect(result.unreadChannels.has(CHANNEL_ID)).toBe(true)
       expect(result.idToUnreadLineTime.get(CHANNEL_ID)).toBe(100)
       expect(result.idToLastReadTime.get(CHANNEL_ID)).toBe(100)
+    })
+
+    test('a live message past a detached window re-freezes a divider the read position has passed', () => {
+      const state = makeState({
+        hasNewer: true,
+        activated: true,
+        atBottom: true,
+        unreadLineTime: 100,
+        lastReadTime: 200,
+      })
+
+      const result = chatReducer(state, updateMessageAction(500, false))
+
+      expect(result.idToUnreadLineTime.get(CHANNEL_ID)).toBe(200)
+      expect(result.unreadChannels.has(CHANNEL_ID)).toBe(true)
+      expect(windowOf(result).detachedNewestTime).toBe(500)
     })
 
     test('a live mention at the bottom of the loaded window is an unread mention', () => {

--- a/client/chat/chat-reducer.ts
+++ b/client/chat/chat-reducer.ts
@@ -125,9 +125,12 @@ export interface ChatState {
   idToLatestMentionTime: Map<SbChannelId, number>
   /**
    * A map of channel ID -> the frozen position of the unread divider for the current activation.
-   * Captured when an unread channel activates, or when a message arrives while the channel is
-   * activated and scrolled up, and held until deactivation so the divider doesn't chase
-   * `idToLastReadTime` as it keeps advancing underneath it.
+   * Captured when an unread channel activates, or when a message goes unseen in an activated
+   * channel (its view scrolled up, its window detached from the present, or the app window
+   * unfocused) that either has no divider or has one the read position has already moved past. It
+   * then holds still while the user reads through it, so it doesn't chase `idToLastReadTime` as
+   * that keeps advancing underneath it, and is dropped when the user sends a message, explicitly
+   * marks the channel read, or leaves it from the bottom having read past the divider.
    */
   idToUnreadLineTime: Map<SbChannelId, number>
 }
@@ -335,8 +338,9 @@ function dedupeAgainst(incoming: ChatMessage[], existing: readonly ChatMessage[]
  * focused, the one combination that puts the message in front of the user's eyes — in which case
  * the read position advances over it here, ahead of the view reporting that same position, so the
  * channel never reads as unread for even a frame; or it went unseen, and the unread flag goes up.
- * A channel being viewed also freezes its unread divider at the read position, so the divider marks
- * where the user left off instead of chasing the read position as it keeps advancing underneath it.
+ * A channel being viewed also freezes its unread divider at the read position whenever a new run of
+ * unread messages starts, so the divider marks where the user left off instead of chasing the read
+ * position as it keeps advancing underneath it.
  *
  * Kept separate from `updateMessages` because a message arriving while the loaded window is
  * detached from the present isn't added to the window at all, yet counts as unread exactly the same.
@@ -362,12 +366,60 @@ function recordLiveArrival(state: ChatState, channelId: SbChannelId, arrival: Li
 
   state.unreadChannels.add(channelId)
 
-  if (isChannelActivated && !state.idToUnreadLineTime.has(channelId)) {
+  if (isChannelActivated) {
+    // A new run of unread messages starts both where there is no divider yet and where the read
+    // position has moved past the one that is there: the user read through that divider and then
+    // looked away, scrolled up, or paged into history, so it no longer marks anything they haven't
+    // seen and this message is where what they haven't seen begins. A divider the read position has
+    // not passed marks a run that is still growing, and stays where it is.
     const lastReadTime = state.idToLastReadTime.get(channelId)
-    if (lastReadTime !== undefined) {
+    const unreadLineTime = state.idToUnreadLineTime.get(channelId)
+    if (
+      lastReadTime !== undefined &&
+      (unreadLineTime === undefined || lastReadTime > unreadLineTime)
+    ) {
       state.idToUnreadLineTime.set(channelId, lastReadTime)
     }
   }
+}
+
+/**
+ * Advances a channel's read position to `time`, never backwards, and lowers the unread flag once the
+ * position in effect covers everything the client knows exists. Returns that effective position.
+ *
+ * A detached window's present has run ahead of what's loaded, so the newest loaded message isn't the
+ * newest one known to exist; the helper covers that along with a mention newer than anything loaded.
+ * Clearing the flag against the loaded window alone would call the channel read on the strength of a
+ * position that only covers that window.
+ */
+function advanceReadPosition(state: ChatState, channelId: SbChannelId, time: number): number {
+  const existing = state.idToLastReadTime.get(channelId)
+  if (existing === undefined || time > existing) {
+    state.idToLastReadTime.set(channelId, time)
+  }
+  const effective = state.idToLastReadTime.get(channelId)!
+
+  const newestKnownTime = newestKnownChannelTime(state, channelId)
+  if (newestKnownTime === undefined || newestKnownTime <= effective) {
+    state.unreadChannels.delete(channelId)
+  }
+
+  return effective
+}
+
+/**
+ * Records that a message the user sent reached the channel. Having just spoken, the user is caught
+ * up: the read position advances over their own message, which lowers the unread flag once it covers
+ * everything known, and the unread divider is dropped, since nothing that came before their own
+ * message is news to them. This holds whether the message was sent from this session or from another
+ * of the user's sessions, since the read position is per user, and regardless of whether the channel
+ * is activated or where its view sits. The view moves to the bottom on send separately, and the read
+ * report from there is what persists the position taken optimistically here; the server does not
+ * advance the read position on send.
+ */
+function recordSelfMessage(state: ChatState, channelId: SbChannelId, time: number) {
+  advanceReadPosition(state, channelId, time)
+  state.idToUnreadLineTime.delete(channelId)
 }
 
 /**
@@ -460,9 +512,10 @@ function dropMessageWindow(channelMessages: MessagesState) {
 }
 
 /**
- * The conditions a message or system event arrived under when it reached the channel live. Pages
- * of history, deletions, and the sender's echoed message carry no arrival and do no unread
- * bookkeeping; other live events can go unseen.
+ * The conditions a message or system event arrived under when it reached the channel live. Pages of
+ * history and deletions carry no arrival and do no unread bookkeeping, and neither does the sender's
+ * echoed message, whose bookkeeping is `recordSelfMessage`'s instead; other live events can go
+ * unseen.
  */
 interface LiveArrival {
   /** Whether the app window was focused at the moment the message arrived. */
@@ -744,7 +797,9 @@ export default immerKeyedReducer(DEFAULT_CHAT_STATE, {
         channelMessages.detachedNewestTime ?? -Infinity,
         newMessage.time,
       )
-      if (!isSelfMessage) {
+      if (isSelfMessage) {
+        recordSelfMessage(state, channelId, newMessage.time)
+      } else {
         recordLiveArrival(state, channelId, { windowFocused, time: newMessage.time })
       }
     } else {
@@ -757,6 +812,9 @@ export default immerKeyedReducer(DEFAULT_CHAT_STATE, {
           return m
         },
       )
+      if (isSelfMessage && channelMessages) {
+        recordSelfMessage(state, channelId, newMessage.time)
+      }
     }
 
     updateChannelInfos(state, channelMentions)
@@ -1202,21 +1260,7 @@ export default immerKeyedReducer(DEFAULT_CHAT_STATE, {
   ['@chat/updateLastReadTime'](state, action) {
     const { channelId, lastReadTime, dismissUnreadLine } = action.payload
 
-    const existing = state.idToLastReadTime.get(channelId)
-    if (existing === undefined || lastReadTime > existing) {
-      state.idToLastReadTime.set(channelId, lastReadTime)
-    }
-    const effective = state.idToLastReadTime.get(channelId)!
-
-    // A detached window's present has run ahead of what's loaded, so the newest loaded message
-    // isn't the newest one known to exist; the helper covers that along with a mention newer than
-    // anything loaded. Clearing the flag against the loaded window alone would call the channel
-    // read on the strength of a position that only covers that window.
-    const newestKnownTime = newestKnownChannelTime(state, channelId)
-
-    if (newestKnownTime === undefined || newestKnownTime <= effective) {
-      state.unreadChannels.delete(channelId)
-    }
+    const effective = advanceReadPosition(state, channelId, lastReadTime)
 
     if (dismissUnreadLine) {
       state.idToUnreadLineTime.delete(channelId)

--- a/client/messaging/chat.tsx
+++ b/client/messaging/chat.tsx
@@ -350,6 +350,12 @@ export interface ChatProps {
    * there is nothing for it to do there. Defaults to false.
    */
   escapeJumpsToBottom?: boolean
+  /**
+   * If true, sending a message moves the list to the newest message the same way the jump-to-bottom
+   * button does, loading the newest page first when the loaded window is detached from the present,
+   * so the sender sees their message land. Defaults to false.
+   */
+  jumpToBottomOnSend?: boolean
 }
 
 /**
@@ -361,7 +367,7 @@ export interface ChatProps {
 export function Chat({
   className,
   listProps,
-  inputProps,
+  inputProps: { onSendChatMessage, ...inputProps },
   header,
   backgroundContent,
   extraContent,
@@ -375,6 +381,7 @@ export function Chat({
   onSeekToUnread,
   onMarkRead,
   escapeJumpsToBottom = false,
+  jumpToBottomOnSend = false,
 }: ChatProps) {
   const { t } = useTranslation()
   const dispatch = useAppDispatch()
@@ -884,6 +891,14 @@ export function Chat({
     jumpToBottom()
   }
 
+  const onSendMessage = (msg: string) => {
+    onSendChatMessage(msg)
+
+    if (jumpToBottomOnSend) {
+      jumpToBottom()
+    }
+  }
+
   useKeyListener({
     onKeyDown: event => {
       // An Escape during IME composition cancels the composition; it isn't meant for the list.
@@ -1031,6 +1046,7 @@ export function Chat({
           </MessageListContainer>
           <MessageInput
             {...inputProps}
+            onSendChatMessage={onSendMessage}
             ref={messageInputRef}
             showDivider={isScrolledUp}
             key={inputProps.storageKey}

--- a/client/messaging/message-list.tsx
+++ b/client/messaging/message-list.tsx
@@ -446,7 +446,11 @@ export class MessageList extends React.Component<MessageListProps> {
       return
     }
 
-    if (scrollable.scrollHeight === snapshot.lastScrollHeight) {
+    // A divider that moves to a different spot in the same window changes nothing about the scroll
+    // height, but it does change what the owner's unread affordances should say, so it's reported
+    // like any other change to the content.
+    const unreadLineMoved = prevProps.unreadLineTime !== this.props.unreadLineTime
+    if (scrollable.scrollHeight === snapshot.lastScrollHeight && !unreadLineMoved) {
       return
     }
 

--- a/client/whispers/whisper-reducer.test.ts
+++ b/client/whispers/whisper-reducer.test.ts
@@ -584,6 +584,23 @@ describe('client/whispers/whisper-reducer', () => {
       expect(session.lastReadTime).toBe(100)
     })
 
+    test('a live message past a detached window re-freezes a divider the read position has passed', () => {
+      const state = makeState({
+        hasNewer: true,
+        activated: true,
+        atBottom: true,
+        unreadLineTime: 100,
+        lastReadTime: 200,
+      })
+
+      const result = whisperReducer(state, updateMessageAction(500))
+
+      const session = sessionOf(result)
+      expect(session.unreadLineTime).toBe(200)
+      expect(session.hasUnread).toBe(true)
+      expect(session.detachedNewestTime).toBe(500)
+    })
+
     test('an attached session at the bottom does not freeze the divider', () => {
       const state = makeState({ activated: true, atBottom: true, lastReadTime: 100 })
 
@@ -714,15 +731,59 @@ describe('client/whispers/whisper-reducer', () => {
       expect(session.unreadLineTime).toBeUndefined()
     })
 
-    test('an own echo preserves unread state created by another message', () => {
+    test('an own echo drops the divider and reads the session through the echoed message', () => {
       const result = whisperReducer(
         makeState({ unread: true, unreadLineTime: 100, lastReadTime: 100 }),
         updateMessageAction(200, true, true),
       )
 
       const session = sessionOf(result)
-      expect(session.hasUnread).toBe(true)
-      expect(session.unreadLineTime).toBe(100)
+      expect(session.hasUnread).toBe(false)
+      expect(session.unreadLineTime).toBeUndefined()
+      expect(session.lastReadTime).toBe(200)
+    })
+
+    test('an own echo does not regress the read position', () => {
+      const result = whisperReducer(
+        makeState({ unread: true, unreadLineTime: 100, lastReadTime: 300 }),
+        updateMessageAction(200, true, true),
+      )
+
+      const session = sessionOf(result)
+      expect(session.lastReadTime).toBe(300)
+      expect(session.unreadLineTime).toBeUndefined()
+      expect(session.hasUnread).toBe(false)
+    })
+
+    test('an own echo drops a divider the read position has not passed', () => {
+      const result = whisperReducer(
+        makeState({
+          activated: true,
+          atBottom: false,
+          unread: true,
+          unreadLineTime: 100,
+          lastReadTime: 100,
+          messages: [textMessage(150)],
+        }),
+        updateMessageAction(200, true, true),
+      )
+
+      const session = sessionOf(result)
+      expect(session.unreadLineTime).toBeUndefined()
+      expect(session.hasUnread).toBe(false)
+      expect(session.lastReadTime).toBe(200)
+    })
+
+    test('an own echo in a session that is not being viewed still reads it', () => {
+      const result = whisperReducer(
+        makeState({ activated: false, unread: true, unreadLineTime: 100, lastReadTime: 100 }),
+        updateMessageAction(200, true, true),
+      )
+
+      const session = sessionOf(result)
+      expect(session.unreadLineTime).toBeUndefined()
+      expect(session.hasUnread).toBe(false)
+      expect(session.lastReadTime).toBe(200)
     })
 
     test('an own echo past a detached window still tracks the newest time', () => {
@@ -736,6 +797,74 @@ describe('client/whispers/whisper-reducer', () => {
       expect(session.detachedNewestTime).toBe(200)
       expect(session.hasUnread).toBe(false)
       expect(session.unreadLineTime).toBeUndefined()
+      expect(session.lastReadTime).toBe(200)
+    })
+
+    test('a message arriving in an unfocused window re-freezes a divider the read position has passed', () => {
+      const state = makeState({
+        activated: true,
+        atBottom: true,
+        unreadLineTime: 100,
+        lastReadTime: 200,
+        messages: [textMessage(150), textMessage(200)],
+      })
+
+      const result = whisperReducer(state, updateMessageAction(300, false))
+
+      const session = sessionOf(result)
+      expect(session.unreadLineTime).toBe(200)
+      expect(session.hasUnread).toBe(true)
+      expect(session.lastReadTime).toBe(200)
+    })
+
+    test('a message arriving while scrolled up re-freezes a divider the read position has passed', () => {
+      const state = makeState({
+        activated: true,
+        atBottom: false,
+        unreadLineTime: 100,
+        lastReadTime: 200,
+        messages: [textMessage(150), textMessage(200)],
+      })
+
+      const result = whisperReducer(state, updateMessageAction(300, true))
+
+      expect(sessionOf(result).unreadLineTime).toBe(200)
+    })
+
+    test('a message arriving while scrolled up keeps a divider the read position has not passed', () => {
+      const state = makeState({
+        activated: true,
+        atBottom: false,
+        unreadLineTime: 100,
+        lastReadTime: 100,
+      })
+
+      const result = whisperReducer(state, updateMessageAction(300, true))
+
+      expect(sessionOf(result).unreadLineTime).toBe(100)
+    })
+
+    test('a message arriving while unfocused keeps a divider the read position has not passed', () => {
+      const state = makeState({
+        activated: true,
+        atBottom: true,
+        unreadLineTime: 100,
+        lastReadTime: 100,
+      })
+
+      const result = whisperReducer(state, updateMessageAction(300, false))
+
+      expect(sessionOf(result).unreadLineTime).toBe(100)
+    })
+
+    test('a message arriving in a session that is not being viewed does not re-freeze a passed divider', () => {
+      const state = makeState({ activated: false, unreadLineTime: 100, lastReadTime: 200 })
+
+      const result = whisperReducer(state, updateMessageAction(300, true))
+
+      const session = sessionOf(result)
+      expect(session.unreadLineTime).toBe(100)
+      expect(session.hasUnread).toBe(true)
     })
   })
 

--- a/client/whispers/whisper-reducer.ts
+++ b/client/whispers/whisper-reducer.ts
@@ -57,9 +57,12 @@ export interface WhisperSession {
   lastReadTime?: number
   /**
    * The frozen position of the unread divider for the current activation. Captured when an unread
-   * session activates, or when a message arrives while the session is activated and scrolled up,
-   * and held until deactivation so the divider doesn't chase `lastReadTime` as it keeps advancing
-   * underneath it.
+   * session activates, or when a message goes unseen in an activated session (its view scrolled up,
+   * its window detached from the present, or the app window unfocused) that either has no divider or
+   * has one the read position has already moved past. It then holds still while the user reads
+   * through it, so it doesn't chase `lastReadTime` as that keeps advancing underneath it, and is
+   * dropped when the user sends a message, explicitly marks the session read, or leaves it from the
+   * bottom having read past the divider.
    */
   unreadLineTime?: number
 }
@@ -154,8 +157,9 @@ function dedupeAgainst(
  * focused, the one combination that puts the message in front of the user's eyes — in which case
  * the read position advances over it here, ahead of the view reporting that same position, so the
  * session never reads as unread for even a frame; or it went unseen, and the unread flag goes up.
- * A session being viewed also freezes its unread divider at the read position, so the divider marks
- * where the user left off instead of chasing the read position as it keeps advancing underneath it.
+ * A session being viewed also freezes its unread divider at the read position whenever a new run of
+ * unread messages starts, so the divider marks where the user left off instead of chasing the read
+ * position as it keeps advancing underneath it.
  *
  * Kept separate from `updateMessages` because a message arriving while the loaded window is
  * detached from the present isn't added to the window at all, yet counts as unread exactly the same.
@@ -173,13 +177,57 @@ function recordLiveArrival(session: WhisperSession, arrival: LiveArrival) {
 
   session.hasUnread = true
 
-  if (
-    session.activated &&
-    session.unreadLineTime === undefined &&
-    session.lastReadTime !== undefined
-  ) {
-    session.unreadLineTime = session.lastReadTime
+  if (session.activated) {
+    // A new run of unread messages starts both where there is no divider yet and where the read
+    // position has moved past the one that is there: the user read through that divider and then
+    // looked away, scrolled up, or paged into history, so it no longer marks anything they haven't
+    // seen and this message is where what they haven't seen begins. A divider the read position has
+    // not passed marks a run that is still growing, and stays where it is.
+    const { lastReadTime, unreadLineTime } = session
+    if (
+      lastReadTime !== undefined &&
+      (unreadLineTime === undefined || lastReadTime > unreadLineTime)
+    ) {
+      session.unreadLineTime = lastReadTime
+    }
   }
+}
+
+/**
+ * Advances a session's read position to `time`, never backwards, and lowers the unread flag once the
+ * position in effect covers everything the client knows exists. Returns that effective position.
+ *
+ * A detached window's present has run ahead of what's loaded, so the newest loaded message isn't the
+ * newest one known to exist; the helper covers that. Clearing the flag against the loaded window
+ * alone would call the session read on the strength of a position that only covers that window.
+ */
+function advanceReadPosition(session: WhisperSession, time: number): number {
+  if (session.lastReadTime === undefined || time > session.lastReadTime) {
+    session.lastReadTime = time
+  }
+  const effective = session.lastReadTime!
+
+  const newestKnownTime = newestKnownWhisperTime(session)
+  if (newestKnownTime === undefined || newestKnownTime <= effective) {
+    session.hasUnread = false
+  }
+
+  return effective
+}
+
+/**
+ * Records that a message the user sent reached the session. Having just spoken, the user is caught
+ * up: the read position advances over their own message, which lowers the unread flag once it covers
+ * everything known, and the unread divider is dropped, since nothing that came before their own
+ * message is news to them. This holds whether the message was sent from this client or from another
+ * of the user's, since the read position is per user, and regardless of whether the whisper session
+ * is activated or where its view sits. The view moves to the bottom on send separately, and
+ * the read report from there is what persists the position taken optimistically here; the server
+ * does not advance the read position on send.
+ */
+function recordSelfMessage(session: WhisperSession, time: number) {
+  advanceReadPosition(session, time)
+  session.unreadLineTime = undefined
 }
 
 /**
@@ -200,9 +248,9 @@ function dropMessageWindow(session: WhisperSession) {
 }
 
 /**
- * The conditions a message arrived under when it reached the session live. Pages of history and
- * the sender's echoed message carry no arrival and do no unread bookkeeping; other live messages
- * can go unseen.
+ * The conditions a message arrived under when it reached the session live. Pages of history carry no
+ * arrival and do no unread bookkeeping, and neither does the sender's echoed message, whose
+ * bookkeeping is `recordSelfMessage`'s instead; other live messages can go unseen.
  */
 interface LiveArrival {
   /** Whether the app window was focused at the moment the message arrived. */
@@ -330,7 +378,9 @@ export default immerKeyedReducer(DEFAULT_STATE, {
         session.detachedNewestTime ?? -Infinity,
         newMessage.time,
       )
-      if (!isSelfMessage) {
+      if (isSelfMessage) {
+        recordSelfMessage(session, newMessage.time)
+      } else {
         recordLiveArrival(session, { windowFocused, time: newMessage.time })
       }
     } else {
@@ -343,6 +393,9 @@ export default immerKeyedReducer(DEFAULT_STATE, {
           return m
         },
       )
+      if (isSelfMessage && session) {
+        recordSelfMessage(session, newMessage.time)
+      }
     }
   },
 
@@ -649,20 +702,7 @@ export default immerKeyedReducer(DEFAULT_STATE, {
       return
     }
 
-    if (session.lastReadTime === undefined || lastReadTime > session.lastReadTime) {
-      session.lastReadTime = lastReadTime
-    }
-    const effective = session.lastReadTime!
-
-    // A detached window's present has run ahead of what's loaded, so the newest loaded message
-    // isn't the newest one known to exist; the helper covers that. Clearing the flag against the
-    // loaded window alone would call the session read on the strength of a position that only
-    // covers that window.
-    const newestKnownTime = newestKnownWhisperTime(session)
-
-    if (newestKnownTime === undefined || newestKnownTime <= effective) {
-      session.hasUnread = false
-    }
+    const effective = advanceReadPosition(session, lastReadTime)
 
     if (dismissUnreadLine) {
       session.unreadLineTime = undefined

--- a/client/whispers/whisper.tsx
+++ b/client/whispers/whisper.tsx
@@ -414,6 +414,7 @@ export function ConnectedWhisper({
         onSeekToUnread={onSeekToUnread}
         onMarkRead={onMarkRead}
         escapeJumpsToBottom
+        jumpToBottomOnSend
         extraContent={
           <UserInfoContainer>
             <UserProfileOverlayContents userId={targetId} showHintText={false} />


### PR DESCRIPTION
The "New messages" divider went stale while a conversation stayed open: messages arriving while the app window was unfocused, after the user had already read past the divider, left it at the old spot with nothing marking the messages that were actually new, and sending a message left the divider in place even though the sender was plainly caught up. A divider the read position has already passed is now re-placed at the read position when a new unread run starts (window unfocused, view scrolled up, or window detached), and sending a message scrolls to the bottom (jumping to the present first when the loaded window is detached), drops the divider, and advances the read position over the sent message.

Fixes #1493

## Acceptance criteria

- [x] A message arriving unseen in an activated conversation re-freezes a divider the read position has passed, at the current read position. Reducer tests, plus live: on the first blurred arrival the divider moved from the old position to A-msg3's time and rendered between A-msg3 and A-msg4 after refocus, with the sidebar unread mark clearing on refocus (channel and whisper).
- [x] Under the same conditions a divider the read position has not passed stays. Reducer tests, plus live: with B scrolled up, two arrivals from A left the divider at its first freeze.
- [x] Sending scrolls to the bottom (jump to present first when detached), clears the divider, and leaves the read position at or past the sent message. Live: sent with the divider showing, sent from mid-backlog (view landed at the bottom with the message in view), and sent from a detached window opened via `?m=<oldest message>` (window reattached to the present). `last_read_time` in the DB equalled the sent message's time each time.
- [x] The jump banner re-arms for a re-frozen divider. Its one-shot state stays keyed by `{refreshToken, unreadLineTime}`; `MessageList` now also reports a content update when only the divider time changes, so a divider moving inside a detached window (same scroll height) re-evaluates the banner instead of leaving it stale.
- [x] Channels and whispers behave identically. Mirrored reducer changes and tests; the whole recipe was repeated in the whisper pair.
- [x] Reducer unit tests cover both cases for both. Nine new tests per reducer, and the own-echo test inverted to the new behavior.

## Drift from the pinned commit

Written against 637273795; #1498, #1499 and #1501 landed since. `markChannelUnread` is now `recordLiveArrival`, `Chat` already had a `jumpToBottom()` helper that handles the detached case (the send path reuses it), and `updateLastReadTime` gained `dismissUnreadLine`. None of it changed the design.

## Notes

- The echo of a message the user sent from another of their sessions gets the same treatment, since the read position is per user.
- Scroll-on-send is an opt-in `jumpToBottomOnSend` prop on `Chat`, enabled for channels and whispers only, following the `escapeJumpsToBottom` precedent. Lobby, party and draft chat are unchanged.
- The server still does not advance the read position on send; the client's read report from the bottom is what persists it.

## Verification

- T0: `pnpm run test` (164 files, 2689 passed), `pnpm run typecheck`, `pnpm run lint`, `pnpm run gen-translations` (no catalog change).
- T3: two dev Electron clients (claude-1 as a curl-driven sender, claude-2 as the observer) with real Alt+Tab blurs, an in-page store and focus recorder, DOM divider placement checks, and `channel_users` / `whisper_sessions.last_read_time` as ground truth. Recipe as written in the issue, plus the detached-window send.
