### PR TITLE
Show an emoji's shortcode in a tooltip when hovering it in a chat message.

### DIFF
--- a/client/messaging/__snapshots__/common-message-layout.test.tsx.snap
+++ b/client/messaging/__snapshots__/common-message-layout.test.tsx.snap
@@ -5,34 +5,34 @@ exports[`client/messaging/common-message-layout/TextMessage > message as a norma
   data-testid="message-container"
 >
   <div
-    class="sc-ewKWQi lczqpc"
+    class="sc-djDiuc jOQYWn"
     data-message-id="MESSAGE_ID"
     role="document"
   >
     <div
-      class="sc-ikrMhg iRLQJB sc-hZoehQ gpXEYv"
+      class="sc-ikrMhg iRLQJB sc-ewKWQi ekGrcY"
       tabindex="0"
     >
       <span
-        class="sc-hKOsxR bpFDMS"
+        class="sc-eillgj hCvGOa"
       >
         <i
           aria-hidden="true"
-          class="sc-iXWgTX cKQkDT"
+          class="sc-hKOsxR HaWPv"
         >
           [
         </i>
         12:00 AM
         <i
           aria-hidden="true"
-          class="sc-iXWgTX cKQkDT"
+          class="sc-hKOsxR HaWPv"
         >
           ] 
         </i>
       </span>
     </div>
     <span
-      class="sc-edvVIM BgKKj sc-iuKxBX dcHVMW"
+      class="sc-edvVIM BgKKj sc-egVbnM heJhVC"
       tabindex="0"
     >
       <span
@@ -44,12 +44,12 @@ exports[`client/messaging/common-message-layout/TextMessage > message as a norma
     </span>
     <i
       aria-hidden="true"
-      class="sc-iXWgTX cKQkDT"
+      class="sc-hKOsxR HaWPv"
     >
       : 
     </i>
     <span
-      class="sc-dcDmxq joZYTb"
+      class="sc-hFQsEd hNjprR"
     >
       This is test message
     </span>
@@ -62,34 +62,34 @@ exports[`client/messaging/common-message-layout/TextMessage > message mixing emo
   data-testid="message-container"
 >
   <div
-    class="sc-ewKWQi lczqpc"
+    class="sc-djDiuc jOQYWn"
     data-message-id="MESSAGE_ID"
     role="document"
   >
     <div
-      class="sc-ikrMhg iRLQJB sc-hZoehQ gpXEYv"
+      class="sc-ikrMhg iRLQJB sc-ewKWQi ekGrcY"
       tabindex="0"
     >
       <span
-        class="sc-hKOsxR bpFDMS"
+        class="sc-eillgj hCvGOa"
       >
         <i
           aria-hidden="true"
-          class="sc-iXWgTX cKQkDT"
+          class="sc-hKOsxR HaWPv"
         >
           [
         </i>
         12:00 AM
         <i
           aria-hidden="true"
-          class="sc-iXWgTX cKQkDT"
+          class="sc-hKOsxR HaWPv"
         >
           ] 
         </i>
       </span>
     </div>
     <span
-      class="sc-edvVIM BgKKj sc-iuKxBX dcHVMW"
+      class="sc-edvVIM BgKKj sc-egVbnM heJhVC"
       tabindex="0"
     >
       <span
@@ -101,19 +101,24 @@ exports[`client/messaging/common-message-layout/TextMessage > message mixing emo
     </span>
     <i
       aria-hidden="true"
-      class="sc-iXWgTX cKQkDT"
+      class="sc-hKOsxR HaWPv"
     >
       : 
     </i>
     <span
-      class="sc-dcDmxq joZYTb"
+      class="sc-hFQsEd hNjprR"
     >
       nice game 
-      <span
-        class="sc-iucATu bAwULp"
+      <div
+        class="sc-ikrMhg iRLQJB sc-hZoehQ gpXEYv"
+        tabindex="-1"
       >
-        🔥
-      </span>
+        <span
+          class="sc-iXWgTX flSFEz"
+        >
+          🔥
+        </span>
+      </div>
     </span>
   </div>
 </div>
@@ -124,34 +129,34 @@ exports[`client/messaging/common-message-layout/TextMessage > message with a lin
   data-testid="message-container"
 >
   <div
-    class="sc-ewKWQi lczqpc"
+    class="sc-djDiuc jOQYWn"
     data-message-id="MESSAGE_ID"
     role="document"
   >
     <div
-      class="sc-ikrMhg iRLQJB sc-hZoehQ gpXEYv"
+      class="sc-ikrMhg iRLQJB sc-ewKWQi ekGrcY"
       tabindex="0"
     >
       <span
-        class="sc-hKOsxR bpFDMS"
+        class="sc-eillgj hCvGOa"
       >
         <i
           aria-hidden="true"
-          class="sc-iXWgTX cKQkDT"
+          class="sc-hKOsxR HaWPv"
         >
           [
         </i>
         12:00 AM
         <i
           aria-hidden="true"
-          class="sc-iXWgTX cKQkDT"
+          class="sc-hKOsxR HaWPv"
         >
           ] 
         </i>
       </span>
     </div>
     <span
-      class="sc-edvVIM BgKKj sc-iuKxBX dcHVMW"
+      class="sc-edvVIM BgKKj sc-egVbnM heJhVC"
       tabindex="0"
     >
       <span
@@ -163,12 +168,12 @@ exports[`client/messaging/common-message-layout/TextMessage > message with a lin
     </span>
     <i
       aria-hidden="true"
-      class="sc-iXWgTX cKQkDT"
+      class="sc-hKOsxR HaWPv"
     >
       : 
     </i>
     <span
-      class="sc-dcDmxq joZYTb"
+      class="sc-hFQsEd hNjprR"
     >
       here is a link 
       <a
@@ -188,34 +193,34 @@ exports[`client/messaging/common-message-layout/TextMessage > message with a lin
   data-testid="message-container"
 >
   <div
-    class="sc-ewKWQi lczqpc"
+    class="sc-djDiuc jOQYWn"
     data-message-id="MESSAGE_ID"
     role="document"
   >
     <div
-      class="sc-ikrMhg iRLQJB sc-hZoehQ gpXEYv"
+      class="sc-ikrMhg iRLQJB sc-ewKWQi ekGrcY"
       tabindex="0"
     >
       <span
-        class="sc-hKOsxR bpFDMS"
+        class="sc-eillgj hCvGOa"
       >
         <i
           aria-hidden="true"
-          class="sc-iXWgTX cKQkDT"
+          class="sc-hKOsxR HaWPv"
         >
           [
         </i>
         12:00 AM
         <i
           aria-hidden="true"
-          class="sc-iXWgTX cKQkDT"
+          class="sc-hKOsxR HaWPv"
         >
           ] 
         </i>
       </span>
     </div>
     <span
-      class="sc-edvVIM BgKKj sc-iuKxBX dcHVMW"
+      class="sc-edvVIM BgKKj sc-egVbnM heJhVC"
       tabindex="0"
     >
       <span
@@ -227,12 +232,12 @@ exports[`client/messaging/common-message-layout/TextMessage > message with a lin
     </span>
     <i
       aria-hidden="true"
-      class="sc-iXWgTX cKQkDT"
+      class="sc-hKOsxR HaWPv"
     >
       : 
     </i>
     <span
-      class="sc-dcDmxq joZYTb"
+      class="sc-hFQsEd hNjprR"
     >
       <a
         href="http://www.example.com"
@@ -244,7 +249,7 @@ exports[`client/messaging/common-message-layout/TextMessage > message with a lin
        go here
        
       <span
-        class="sc-edvVIM BgKKj sc-egVbnM hxTwgj"
+        class="sc-edvVIM BgKKj sc-iucATu fnZuOR"
         tabindex="0"
       >
         @
@@ -265,34 +270,34 @@ exports[`client/messaging/common-message-layout/TextMessage > message with a lin
   data-testid="message-container"
 >
   <div
-    class="sc-ewKWQi lczqpc"
+    class="sc-djDiuc jOQYWn"
     data-message-id="MESSAGE_ID"
     role="document"
   >
     <div
-      class="sc-ikrMhg iRLQJB sc-hZoehQ gpXEYv"
+      class="sc-ikrMhg iRLQJB sc-ewKWQi ekGrcY"
       tabindex="0"
     >
       <span
-        class="sc-hKOsxR bpFDMS"
+        class="sc-eillgj hCvGOa"
       >
         <i
           aria-hidden="true"
-          class="sc-iXWgTX cKQkDT"
+          class="sc-hKOsxR HaWPv"
         >
           [
         </i>
         12:00 AM
         <i
           aria-hidden="true"
-          class="sc-iXWgTX cKQkDT"
+          class="sc-hKOsxR HaWPv"
         >
           ] 
         </i>
       </span>
     </div>
     <span
-      class="sc-edvVIM BgKKj sc-iuKxBX dcHVMW"
+      class="sc-edvVIM BgKKj sc-egVbnM heJhVC"
       tabindex="0"
     >
       <span
@@ -304,17 +309,17 @@ exports[`client/messaging/common-message-layout/TextMessage > message with a lin
     </span>
     <i
       aria-hidden="true"
-      class="sc-iXWgTX cKQkDT"
+      class="sc-hKOsxR HaWPv"
     >
       : 
     </i>
     <span
-      class="sc-dcDmxq joZYTb"
+      class="sc-hFQsEd hNjprR"
     >
       hey
        
       <span
-        class="sc-edvVIM BgKKj sc-egVbnM hxTwgj"
+        class="sc-edvVIM BgKKj sc-iucATu fnZuOR"
         tabindex="0"
       >
         @
@@ -336,7 +341,7 @@ exports[`client/messaging/common-message-layout/TextMessage > message with a lin
        go here
        
       <span
-        class="sc-edvVIM BgKKj sc-egVbnM hxTwgj"
+        class="sc-edvVIM BgKKj sc-iucATu fnZuOR"
         tabindex="0"
       >
         @
@@ -357,34 +362,34 @@ exports[`client/messaging/common-message-layout/TextMessage > message with a men
   data-testid="message-container"
 >
   <div
-    class="sc-ewKWQi lczqpc"
+    class="sc-djDiuc jOQYWn"
     data-message-id="MESSAGE_ID"
     role="document"
   >
     <div
-      class="sc-ikrMhg iRLQJB sc-hZoehQ gpXEYv"
+      class="sc-ikrMhg iRLQJB sc-ewKWQi ekGrcY"
       tabindex="0"
     >
       <span
-        class="sc-hKOsxR bpFDMS"
+        class="sc-eillgj hCvGOa"
       >
         <i
           aria-hidden="true"
-          class="sc-iXWgTX cKQkDT"
+          class="sc-hKOsxR HaWPv"
         >
           [
         </i>
         12:00 AM
         <i
           aria-hidden="true"
-          class="sc-iXWgTX cKQkDT"
+          class="sc-hKOsxR HaWPv"
         >
           ] 
         </i>
       </span>
     </div>
     <span
-      class="sc-edvVIM BgKKj sc-iuKxBX dcHVMW"
+      class="sc-edvVIM BgKKj sc-egVbnM heJhVC"
       tabindex="0"
     >
       <span
@@ -396,17 +401,17 @@ exports[`client/messaging/common-message-layout/TextMessage > message with a men
     </span>
     <i
       aria-hidden="true"
-      class="sc-iXWgTX cKQkDT"
+      class="sc-hKOsxR HaWPv"
     >
       : 
     </i>
     <span
-      class="sc-dcDmxq joZYTb"
+      class="sc-hFQsEd hNjprR"
     >
       hey
        
       <span
-        class="sc-edvVIM BgKKj sc-egVbnM hxTwgj"
+        class="sc-edvVIM BgKKj sc-iucATu fnZuOR"
         tabindex="0"
       >
         @
@@ -427,34 +432,34 @@ exports[`client/messaging/common-message-layout/TextMessage > message with a men
   data-testid="message-container"
 >
   <div
-    class="sc-ewKWQi lczqpc"
+    class="sc-djDiuc jOQYWn"
     data-message-id="MESSAGE_ID"
     role="document"
   >
     <div
-      class="sc-ikrMhg iRLQJB sc-hZoehQ gpXEYv"
+      class="sc-ikrMhg iRLQJB sc-ewKWQi ekGrcY"
       tabindex="0"
     >
       <span
-        class="sc-hKOsxR bpFDMS"
+        class="sc-eillgj hCvGOa"
       >
         <i
           aria-hidden="true"
-          class="sc-iXWgTX cKQkDT"
+          class="sc-hKOsxR HaWPv"
         >
           [
         </i>
         12:00 AM
         <i
           aria-hidden="true"
-          class="sc-iXWgTX cKQkDT"
+          class="sc-hKOsxR HaWPv"
         >
           ] 
         </i>
       </span>
     </div>
     <span
-      class="sc-edvVIM BgKKj sc-iuKxBX dcHVMW"
+      class="sc-edvVIM BgKKj sc-egVbnM heJhVC"
       tabindex="0"
     >
       <span
@@ -466,15 +471,15 @@ exports[`client/messaging/common-message-layout/TextMessage > message with a men
     </span>
     <i
       aria-hidden="true"
-      class="sc-iXWgTX cKQkDT"
+      class="sc-hKOsxR HaWPv"
     >
       : 
     </i>
     <span
-      class="sc-dcDmxq joZYTb"
+      class="sc-hFQsEd hNjprR"
     >
       <span
-        class="sc-edvVIM BgKKj sc-egVbnM hxTwgj"
+        class="sc-edvVIM BgKKj sc-iucATu fnZuOR"
         tabindex="0"
       >
         @
@@ -503,34 +508,34 @@ exports[`client/messaging/common-message-layout/TextMessage > message with a men
   data-testid="message-container"
 >
   <div
-    class="sc-ewKWQi lczqpc"
+    class="sc-djDiuc jOQYWn"
     data-message-id="MESSAGE_ID"
     role="document"
   >
     <div
-      class="sc-ikrMhg iRLQJB sc-hZoehQ gpXEYv"
+      class="sc-ikrMhg iRLQJB sc-ewKWQi ekGrcY"
       tabindex="0"
     >
       <span
-        class="sc-hKOsxR bpFDMS"
+        class="sc-eillgj hCvGOa"
       >
         <i
           aria-hidden="true"
-          class="sc-iXWgTX cKQkDT"
+          class="sc-hKOsxR HaWPv"
         >
           [
         </i>
         12:00 AM
         <i
           aria-hidden="true"
-          class="sc-iXWgTX cKQkDT"
+          class="sc-hKOsxR HaWPv"
         >
           ] 
         </i>
       </span>
     </div>
     <span
-      class="sc-edvVIM BgKKj sc-iuKxBX dcHVMW"
+      class="sc-edvVIM BgKKj sc-egVbnM heJhVC"
       tabindex="0"
     >
       <span
@@ -542,12 +547,12 @@ exports[`client/messaging/common-message-layout/TextMessage > message with a men
     </span>
     <i
       aria-hidden="true"
-      class="sc-iXWgTX cKQkDT"
+      class="sc-hKOsxR HaWPv"
     >
       : 
     </i>
     <span
-      class="sc-dcDmxq joZYTb"
+      class="sc-hFQsEd hNjprR"
     >
       <a
         href="http://www.example.com"
@@ -559,7 +564,7 @@ exports[`client/messaging/common-message-layout/TextMessage > message with a men
        go here
        
       <span
-        class="sc-edvVIM BgKKj sc-egVbnM hxTwgj"
+        class="sc-edvVIM BgKKj sc-iucATu fnZuOR"
         tabindex="0"
       >
         @
@@ -588,34 +593,34 @@ exports[`client/messaging/common-message-layout/TextMessage > message with a men
   data-testid="message-container"
 >
   <div
-    class="sc-ewKWQi btpJXv"
+    class="sc-djDiuc DSCMc"
     data-message-id="MESSAGE_ID"
     role="document"
   >
     <div
-      class="sc-ikrMhg iRLQJB sc-hZoehQ gpXEYv"
+      class="sc-ikrMhg iRLQJB sc-ewKWQi ekGrcY"
       tabindex="0"
     >
       <span
-        class="sc-hKOsxR bpFDMS"
+        class="sc-eillgj hCvGOa"
       >
         <i
           aria-hidden="true"
-          class="sc-iXWgTX cKQkDT"
+          class="sc-hKOsxR HaWPv"
         >
           [
         </i>
         12:00 AM
         <i
           aria-hidden="true"
-          class="sc-iXWgTX cKQkDT"
+          class="sc-hKOsxR HaWPv"
         >
           ] 
         </i>
       </span>
     </div>
     <span
-      class="sc-edvVIM BgKKj sc-iuKxBX dcHVMW"
+      class="sc-edvVIM BgKKj sc-egVbnM heJhVC"
       tabindex="0"
     >
       <span
@@ -627,17 +632,17 @@ exports[`client/messaging/common-message-layout/TextMessage > message with a men
     </span>
     <i
       aria-hidden="true"
-      class="sc-iXWgTX cKQkDT"
+      class="sc-hKOsxR HaWPv"
     >
       : 
     </i>
     <span
-      class="sc-dcDmxq joZYTb"
+      class="sc-hFQsEd hNjprR"
     >
       Hey
        
       <span
-        class="sc-edvVIM BgKKj sc-egVbnM hxTwgj"
+        class="sc-edvVIM BgKKj sc-iucATu fnZuOR"
         tabindex="0"
       >
         @
@@ -658,34 +663,34 @@ exports[`client/messaging/common-message-layout/TextMessage > message with only 
   data-testid="message-container"
 >
   <div
-    class="sc-ewKWQi lczqpc"
+    class="sc-djDiuc jOQYWn"
     data-message-id="MESSAGE_ID"
     role="document"
   >
     <div
-      class="sc-ikrMhg iRLQJB sc-hZoehQ gpXEYv"
+      class="sc-ikrMhg iRLQJB sc-ewKWQi ekGrcY"
       tabindex="0"
     >
       <span
-        class="sc-hKOsxR bpFDMS"
+        class="sc-eillgj hCvGOa"
       >
         <i
           aria-hidden="true"
-          class="sc-iXWgTX cKQkDT"
+          class="sc-hKOsxR HaWPv"
         >
           [
         </i>
         12:00 AM
         <i
           aria-hidden="true"
-          class="sc-iXWgTX cKQkDT"
+          class="sc-hKOsxR HaWPv"
         >
           ] 
         </i>
       </span>
     </div>
     <span
-      class="sc-edvVIM BgKKj sc-iuKxBX dcHVMW"
+      class="sc-edvVIM BgKKj sc-egVbnM heJhVC"
       tabindex="0"
     >
       <span
@@ -697,24 +702,44 @@ exports[`client/messaging/common-message-layout/TextMessage > message with only 
     </span>
     <i
       aria-hidden="true"
-      class="sc-iXWgTX cKQkDT"
+      class="sc-hKOsxR HaWPv"
     >
       : 
     </i>
     <span
-      class="sc-dcDmxq joZYTb"
+      class="sc-hFQsEd hNjprR"
     >
-      <span
-        class="sc-iucATu bLJJAa"
+      <div
+        class="sc-ikrMhg iRLQJB sc-hZoehQ gpXEYv"
+        tabindex="-1"
       >
-        🔥🔥
-      </span>
+        <span
+          class="sc-iXWgTX eipxVU"
+        >
+          🔥
+        </span>
+      </div>
+      <div
+        class="sc-ikrMhg iRLQJB sc-hZoehQ gpXEYv"
+        tabindex="-1"
+      >
+        <span
+          class="sc-iXWgTX eipxVU"
+        >
+          🔥
+        </span>
+      </div>
        
-      <span
-        class="sc-iucATu bLJJAa"
+      <div
+        class="sc-ikrMhg iRLQJB sc-hZoehQ gpXEYv"
+        tabindex="-1"
       >
-        🎉
-      </span>
+        <span
+          class="sc-iXWgTX eipxVU"
+        >
+          🎉
+        </span>
+      </div>
     </span>
   </div>
 </div>
@@ -725,34 +750,34 @@ exports[`client/messaging/common-message-layout/TextMessage > message with too m
   data-testid="message-container"
 >
   <div
-    class="sc-ewKWQi lczqpc"
+    class="sc-djDiuc jOQYWn"
     data-message-id="MESSAGE_ID"
     role="document"
   >
     <div
-      class="sc-ikrMhg iRLQJB sc-hZoehQ gpXEYv"
+      class="sc-ikrMhg iRLQJB sc-ewKWQi ekGrcY"
       tabindex="0"
     >
       <span
-        class="sc-hKOsxR bpFDMS"
+        class="sc-eillgj hCvGOa"
       >
         <i
           aria-hidden="true"
-          class="sc-iXWgTX cKQkDT"
+          class="sc-hKOsxR HaWPv"
         >
           [
         </i>
         12:00 AM
         <i
           aria-hidden="true"
-          class="sc-iXWgTX cKQkDT"
+          class="sc-hKOsxR HaWPv"
         >
           ] 
         </i>
       </span>
     </div>
     <span
-      class="sc-edvVIM BgKKj sc-iuKxBX dcHVMW"
+      class="sc-edvVIM BgKKj sc-egVbnM heJhVC"
       tabindex="0"
     >
       <span
@@ -764,18 +789,123 @@ exports[`client/messaging/common-message-layout/TextMessage > message with too m
     </span>
     <i
       aria-hidden="true"
-      class="sc-iXWgTX cKQkDT"
+      class="sc-hKOsxR HaWPv"
     >
       : 
     </i>
     <span
-      class="sc-dcDmxq joZYTb"
+      class="sc-hFQsEd hNjprR"
     >
-      <span
-        class="sc-iucATu bAwULp"
+      <div
+        class="sc-ikrMhg iRLQJB sc-hZoehQ gpXEYv"
+        tabindex="-1"
       >
-        😀😀😀😀😀😀😀😀😀😀😀
-      </span>
+        <span
+          class="sc-iXWgTX flSFEz"
+        >
+          😀
+        </span>
+      </div>
+      <div
+        class="sc-ikrMhg iRLQJB sc-hZoehQ gpXEYv"
+        tabindex="-1"
+      >
+        <span
+          class="sc-iXWgTX flSFEz"
+        >
+          😀
+        </span>
+      </div>
+      <div
+        class="sc-ikrMhg iRLQJB sc-hZoehQ gpXEYv"
+        tabindex="-1"
+      >
+        <span
+          class="sc-iXWgTX flSFEz"
+        >
+          😀
+        </span>
+      </div>
+      <div
+        class="sc-ikrMhg iRLQJB sc-hZoehQ gpXEYv"
+        tabindex="-1"
+      >
+        <span
+          class="sc-iXWgTX flSFEz"
+        >
+          😀
+        </span>
+      </div>
+      <div
+        class="sc-ikrMhg iRLQJB sc-hZoehQ gpXEYv"
+        tabindex="-1"
+      >
+        <span
+          class="sc-iXWgTX flSFEz"
+        >
+          😀
+        </span>
+      </div>
+      <div
+        class="sc-ikrMhg iRLQJB sc-hZoehQ gpXEYv"
+        tabindex="-1"
+      >
+        <span
+          class="sc-iXWgTX flSFEz"
+        >
+          😀
+        </span>
+      </div>
+      <div
+        class="sc-ikrMhg iRLQJB sc-hZoehQ gpXEYv"
+        tabindex="-1"
+      >
+        <span
+          class="sc-iXWgTX flSFEz"
+        >
+          😀
+        </span>
+      </div>
+      <div
+        class="sc-ikrMhg iRLQJB sc-hZoehQ gpXEYv"
+        tabindex="-1"
+      >
+        <span
+          class="sc-iXWgTX flSFEz"
+        >
+          😀
+        </span>
+      </div>
+      <div
+        class="sc-ikrMhg iRLQJB sc-hZoehQ gpXEYv"
+        tabindex="-1"
+      >
+        <span
+          class="sc-iXWgTX flSFEz"
+        >
+          😀
+        </span>
+      </div>
+      <div
+        class="sc-ikrMhg iRLQJB sc-hZoehQ gpXEYv"
+        tabindex="-1"
+      >
+        <span
+          class="sc-iXWgTX flSFEz"
+        >
+          😀
+        </span>
+      </div>
+      <div
+        class="sc-ikrMhg iRLQJB sc-hZoehQ gpXEYv"
+        tabindex="-1"
+      >
+        <span
+          class="sc-iXWgTX flSFEz"
+        >
+          😀
+        </span>
+      </div>
     </span>
   </div>
 </div>

--- a/client/messaging/common-message-layout.tsx
+++ b/client/messaging/common-message-layout.tsx
@@ -5,7 +5,7 @@ import { makeSbChannelId } from '../../common/chat'
 import { SbLobbyId } from '../../common/lobbies/sb-lobby-id'
 import { matchChannelMentionsMarkup } from '../../common/text/channel-mentions'
 import { matchLinks } from '../../common/text/links'
-import { countEmojisIn, matchUnicodeEmojis } from '../../common/text/unicode-emojis'
+import { countEmojisIn, matchUnicodeEmojis, splitEmojiRun } from '../../common/text/unicode-emojis'
 import { matchUserMentionsMarkup } from '../../common/text/user-mentions'
 import { makeSbUserId, SbUserId } from '../../common/users/sb-user-id'
 import { ConnectedChannelName } from '../chat/connected-channel-name'
@@ -22,6 +22,7 @@ import { ConnectedUsername } from '../users/connected-username'
 import { ChatContext } from './chat-context'
 import { useMentionFilterClick } from './mention-hooks'
 import { MessageContextMenu } from './message-context-menu'
+import { MessageEmoji } from './message-emoji'
 import {
   InfoImportant,
   SeparatedInfoMessage,
@@ -60,17 +61,6 @@ const MentionedUsername = styled(ConnectedUsername)`
 
 const MentionedChannelName = styled(ConnectedChannelName)`
   color: var(--color-blue95);
-`
-
-/**
- * A run of unicode emoji, rendered larger than the surrounding text. Normally it stays inline-sized
- * so the fixed 20px message line box doesn't grow (the glyph may paint slightly beyond the box).
- * When a message is nothing but emoji (and whitespace), it renders jumbo-sized instead, growing the
- * line, so it reads as a sticker rather than a sentence.
- */
-const UnicodeEmoji = styled.span<{ $jumbo?: boolean }>`
-  font-size: ${props => (props.$jumbo ? '32px' : '20px')};
-  line-height: ${props => (props.$jumbo ? '1.2' : 'inherit')};
 `
 
 const MAX_JUMBO_EMOJI_COUNT = 10
@@ -199,11 +189,11 @@ export function TextMessage({ msgId, userId, selfUserId, time, text, testId }: T
         )
       }
     } else if (match.type === 'unicodeEmoji') {
-      parsedText.push(
-        <UnicodeEmoji key={match.index} $jumbo={jumboEmoji}>
-          {match.text}
-        </UnicodeEmoji>,
-      )
+      let emojiIndex = match.index
+      for (const emoji of splitEmojiRun(match.text)) {
+        parsedText.push(<MessageEmoji key={emojiIndex} emoji={emoji} jumbo={jumboEmoji} />)
+        emojiIndex += emoji.length
+      }
     } else {
       match satisfies never
     }

--- a/client/messaging/emoji-shortcodes.test.ts
+++ b/client/messaging/emoji-shortcodes.test.ts
@@ -1,0 +1,91 @@
+import { beforeAll, describe, expect, test, vi } from 'vitest'
+import {
+  areShortcodesLoaded,
+  getShortcodeForEmoji,
+  loadShortcodes,
+  subscribeToShortcodesLoaded,
+} from './emoji-shortcodes'
+
+describe('messaging/emoji-shortcodes', () => {
+  describe('before the dataset has loaded', () => {
+    test('areShortcodesLoaded is false', () => {
+      expect(areShortcodesLoaded()).toBe(false)
+    })
+
+    test('getShortcodeForEmoji returns undefined', () => {
+      expect(getShortcodeForEmoji('😅')).toBeUndefined()
+    })
+
+    test('a subscribed listener is called once the dataset loads', async () => {
+      const listener = vi.fn()
+      subscribeToShortcodesLoaded(listener)
+
+      await loadShortcodes()
+
+      expect(listener).toHaveBeenCalledTimes(1)
+      expect(areShortcodesLoaded()).toBe(true)
+    }, 30_000)
+
+    test('an unsubscribed listener is not called', async () => {
+      const listener = vi.fn()
+      const unsubscribe = subscribeToShortcodesLoaded(listener)
+      unsubscribe()
+
+      // The dataset is already cached from the previous test, so this resolves immediately
+      // without notifying anyone either way; the point of this test is that the listener count
+      // stays put, proving the returned unsubscribe function took effect.
+      await loadShortcodes()
+
+      expect(listener).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('getShortcodeForEmoji against the real dataset', () => {
+    // The first call dynamically imports and parses the full shortcode dataset, which can take
+    // longer than the per-test timeout on a cold CI runner — pay that cost here, with a timeout
+    // to match, so the tests below only measure the lookup logic.
+    beforeAll(async () => {
+      await loadShortcodes()
+    }, 30_000)
+
+    test('plain emoji', () => {
+      expect(getShortcodeForEmoji('😅')).toBe('sweat_smile')
+    })
+
+    test('another plain emoji', () => {
+      expect(getShortcodeForEmoji('🏆')).toBe('trophy')
+    })
+
+    test('FE0F sequence falls back to the base codepoint', () => {
+      expect(getShortcodeForEmoji('☺️')).toBe('relaxed')
+    })
+
+    test('keycap sequence keeps its FE0F segment', () => {
+      expect(getShortcodeForEmoji('1️⃣')).toBe('one')
+    })
+
+    test('short codepoint gets zero-padded before lookup', () => {
+      expect(getShortcodeForEmoji('©️')).toBe('copyright')
+    })
+
+    test('skin-tone variant falls back to the base emoji shortcode', () => {
+      expect(getShortcodeForEmoji('👍🏽')).toBe('+1')
+    })
+
+    test('ZWJ sequence', () => {
+      expect(getShortcodeForEmoji('👨‍👩‍👦')).toBe('man-woman-boy')
+    })
+
+    test('ZWJ sequence with a skin tone falls back to the untoned sequence', () => {
+      expect(getShortcodeForEmoji('👨🏽‍💻')).toBe('male-technologist')
+    })
+
+    test('emoji with no shortcode returns undefined', () => {
+      expect(getShortcodeForEmoji('🦰')).toBeUndefined()
+    })
+
+    test('non-emoji text returns undefined', () => {
+      expect(getShortcodeForEmoji('abc')).toBeUndefined()
+    })
+  })
+})

--- a/client/messaging/emoji-shortcodes.ts
+++ b/client/messaging/emoji-shortcodes.ts
@@ -3,7 +3,9 @@
  * "iamcal" shortcode preset. This is a separate dataset from the one `emoji-data.ts` builds
  * entries from, so unified hexcodes need to be reconciled between the two: the picker dataset's
  * `u` values sometimes carry the FE0F variation selector (e.g. "263a-fe0f") while this dataset's
- * keys never do, so a lookup should retry with FE0F segments stripped before giving up.
+ * keys never do, so a lookup should retry with FE0F segments stripped before giving up. The
+ * dataset also only keys the untoned base form of an emoji, so skin-tone modifier segments are
+ * dropped as a further, last-resort retry.
  */
 
 /** Maps UPPERCASE dash-separated hexcode to a shortcode, or an array when more than one applies. */
@@ -12,10 +14,22 @@ type ShortcodesDataFile = Record<string, string | string[]>
 let cache: Map<string, string[]> | undefined
 let pendingLoad: Promise<Map<string, string[]>> | undefined
 
+/** Listeners notified once, when the shortcode dataset finishes loading. */
+const loadListeners = new Set<() => void>()
+
 function stripFe0f(unified: string): string {
   return unified
     .split('-')
     .filter(segment => segment !== 'fe0f')
+    .join('-')
+}
+
+const SKIN_TONE_SEGMENTS = new Set(['1f3fb', '1f3fc', '1f3fd', '1f3fe', '1f3ff'])
+
+function stripSkinTones(unified: string): string {
+  return unified
+    .split('-')
+    .filter(segment => !SKIN_TONE_SEGMENTS.has(segment))
     .join('-')
 }
 
@@ -36,6 +50,9 @@ export function loadShortcodes(): Promise<Map<string, string[]>> {
         map.set(hexcode.toLowerCase(), Array.isArray(value) ? value : [value])
       }
       cache = map
+      for (const listener of loadListeners) {
+        listener()
+      }
       return map
     },
     err => {
@@ -66,5 +83,39 @@ export function getAllShortcodes(unified: string): string[] {
     return []
   }
   const lower = unified.toLowerCase()
-  return cache.get(lower) ?? cache.get(stripFe0f(lower)) ?? []
+  const withoutFe0f = stripFe0f(lower)
+  return cache.get(lower) ?? cache.get(withoutFe0f) ?? cache.get(stripSkinTones(withoutFe0f)) ?? []
+}
+
+/**
+ * Converts an emoji string to its dash-separated hexcode and looks up its primary shortcode. Both
+ * datasets zero-pad each codepoint segment to four hex digits (e.g. `0031-fe0f-20e3`, `00a9`), so
+ * short codepoints are padded before lookup. Returns `undefined` both when there's no match and
+ * when the dataset hasn't finished loading yet (call `loadShortcodes` first).
+ */
+export function getShortcodeForEmoji(emoji: string): string | undefined {
+  const segments = Array.from(emoji, ch => ch.codePointAt(0)!.toString(16).padStart(4, '0'))
+  return getShortcode(segments.join('-'))
+}
+
+/**
+ * Whether the shortcode dataset has finished loading. Intended for `useSyncExternalStore`
+ * alongside `subscribeToShortcodesLoaded`, so a component that shows shortcodes re-renders itself
+ * once the dataset arrives instead of polling or re-rendering its parents.
+ */
+export function areShortcodesLoaded(): boolean {
+  return cache !== undefined
+}
+
+/**
+ * Subscribes a listener to be called once, when the shortcode dataset finishes loading. Returns an
+ * unsubscribe function. Intended for `useSyncExternalStore` alongside `areShortcodesLoaded`, so a
+ * component that shows shortcodes re-renders itself once the dataset arrives instead of polling or
+ * re-rendering its parents.
+ */
+export function subscribeToShortcodesLoaded(listener: () => void): () => void {
+  loadListeners.add(listener)
+  return () => {
+    loadListeners.delete(listener)
+  }
 }

--- a/client/messaging/message-emoji.tsx
+++ b/client/messaging/message-emoji.tsx
@@ -1,0 +1,62 @@
+import { useEffect, useSyncExternalStore } from 'react'
+import styled from 'styled-components'
+import logger from '../logging/logger'
+import { Tooltip } from '../material/tooltip'
+import {
+  areShortcodesLoaded,
+  getShortcodeForEmoji,
+  loadShortcodes,
+  subscribeToShortcodesLoaded,
+} from './emoji-shortcodes'
+
+/**
+ * A run of unicode emoji, rendered larger than the surrounding text. Normally it stays inline-sized
+ * so the fixed 20px message line box doesn't grow (the glyph may paint slightly beyond the box).
+ * When a message is nothing but emoji (and whitespace), it renders jumbo-sized instead, growing the
+ * line, so it reads as a sticker rather than a sentence.
+ */
+const UnicodeEmoji = styled.span<{ $jumbo?: boolean }>`
+  font-size: ${props => (props.$jumbo ? '32px' : '20px')};
+  line-height: ${props => (props.$jumbo ? '1.2' : 'inherit')};
+`
+
+// The Tooltip wraps its trigger in a container; keeping it inline means the emoji keeps flowing
+// with the surrounding text, so the message's line box and wrapping are unaffected.
+const EmojiTooltip = styled(Tooltip)`
+  display: inline;
+`
+
+/**
+ * Kicks off the (once-per-session, lazy) shortcode dataset load the first time a message emoji
+ * mounts, and re-renders the caller when it arrives, so a hover that started before the data was
+ * there starts showing the shortcode without the message list re-rendering.
+ */
+function useShortcodesLoaded(): boolean {
+  useEffect(() => {
+    loadShortcodes().catch((err: Error) =>
+      logger.error(`Failed to load emoji shortcodes: ${String(err)}`),
+    )
+  }, [])
+  return useSyncExternalStore(subscribeToShortcodesLoaded, areShortcodesLoaded)
+}
+
+/**
+ * A single unicode emoji sequence inside a text message, with a hover tooltip naming its
+ * `:shortcode:` in the same format the emote picker's preview bar uses. `disabled` when there is
+ * no shortcode (either not loaded yet or none in the dataset) so no empty bubble ever shows.
+ * `tabIndex={-1}` keeps emoji out of the tab order (a message with ten emoji must not add ten
+ * stops); the tooltip only opens on hover or keyboard focus, and keyboard focus can't reach it.
+ */
+export function MessageEmoji({ emoji, jumbo }: { emoji: string; jumbo?: boolean }) {
+  const loaded = useShortcodesLoaded()
+  const shortcode = loaded ? getShortcodeForEmoji(emoji) : undefined
+  return (
+    <EmojiTooltip
+      text={shortcode ? `:${shortcode}:` : undefined}
+      disabled={!shortcode}
+      position='top'
+      tabIndex={-1}>
+      <UnicodeEmoji $jumbo={jumbo}>{emoji}</UnicodeEmoji>
+    </EmojiTooltip>
+  )
+}

--- a/common/text/unicode-emojis.test.ts
+++ b/common/text/unicode-emojis.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest'
-import { countEmojisIn, matchUnicodeEmojis } from './unicode-emojis'
+import { countEmojisIn, matchUnicodeEmojis, splitEmojiRun } from './unicode-emojis'
 
 describe('common/text/unicode-emojis/matchUnicodeEmojis', () => {
   const doMatch = (text: string): Array<{ text: string; index: number }> => {
@@ -72,5 +72,31 @@ describe('common/text/unicode-emojis/countEmojisIn', () => {
 
   test('counts emoji across multiple runs', () => {
     expect(countEmojisIn('😀 wp 🎉🎉')).toBe(3)
+  })
+})
+
+describe('common/text/unicode-emojis/splitEmojiRun', () => {
+  test('single emoji', () => {
+    expect(splitEmojiRun('😀')).toEqual(['😀'])
+  })
+
+  test('a run of distinct emoji splits into each one', () => {
+    expect(splitEmojiRun('😀😂🎉')).toEqual(['😀', '😂', '🎉'])
+  })
+
+  test('multi-codepoint ZWJ sequence stays one item', () => {
+    expect(splitEmojiRun('👨‍👩‍👦')).toEqual(['👨‍👩‍👦'])
+  })
+
+  test('skin-tone variant stays one item', () => {
+    expect(splitEmojiRun('👍🏽')).toEqual(['👍🏽'])
+  })
+
+  test('keycap sequence stays one item', () => {
+    expect(splitEmojiRun('1️⃣')).toEqual(['1️⃣'])
+  })
+
+  test('two flags split into each one', () => {
+    expect(splitEmojiRun('🇫🇷🇩🇪')).toEqual(['🇫🇷', '🇩🇪'])
   })
 })

--- a/common/text/unicode-emojis.ts
+++ b/common/text/unicode-emojis.ts
@@ -8,8 +8,12 @@
  */
 const UNICODE_EMOJI_REGEX = /(?:\p{RGI_Emoji})+/gv
 
-/** Matches individual emoji sequences (not grouped into runs), used to count emoji in a string. */
-const UNICODE_EMOJI_COUNT_REGEX = /\p{RGI_Emoji}/gv
+/**
+ * Matches a single (ungrouped) emoji sequence. Used both to split a run of adjacent emoji (as
+ * produced by `matchUnicodeEmojis`) back into its individual sequences and to count emoji in a
+ * string.
+ */
+const SINGLE_UNICODE_EMOJI_REGEX = /\p{RGI_Emoji}/gv
 
 export interface UnicodeEmojiMatch {
   type: 'unicodeEmoji'
@@ -32,5 +36,13 @@ export function* matchUnicodeEmojis(text: string): Generator<UnicodeEmojiMatch> 
 
 /** Counts the number of individual emoji sequences present in a string. */
 export function countEmojisIn(text: string): number {
-  return Array.from(text.matchAll(UNICODE_EMOJI_COUNT_REGEX)).length
+  return Array.from(text.matchAll(SINGLE_UNICODE_EMOJI_REGEX)).length
+}
+
+/**
+ * Splits a run of adjacent emoji (as produced by `matchUnicodeEmojis`) into its individual RGI
+ * emoji sequences, in order.
+ */
+export function splitEmojiRun(run: string): string[] {
+  return Array.from(run.matchAll(SINGLE_UNICODE_EMOJI_REGEX), match => match[0])
 }


### PR DESCRIPTION
The emote picker and `:` autocomplete both show an emoji's `:shortcode:`, but once a message is on screen there was no way to find out what an emoji in it is called. Hovering an emoji in a channel, whisper or lobby message now shows the app's `Tooltip` with the same `:shortcode:` the picker preview bar shows, per emoji, without changing message layout or the tab order. The shortcode dataset stays lazily loaded (first message emoji triggers it, fetched once), and lookups now also fall back past skin-tone modifier segments since the dataset only keys the untoned base form.

Fixes #1489

## Acceptance criteria

- [x] Hovering an emoji in a channel, whisper or lobby text message shows a tooltip with its primary `:shortcode:`, identical to the picker preview bar. Verified in all three surfaces with `hi 😅👍🏽 ☺️` → `:sweat_smile:`, `:+1:`, `:relaxed:`.
- [x] The tooltip is the app's `Tooltip`, styled inline and delayed like the timestamp tooltip. No native `title` attribute.
- [x] Adjacent emoji each get their own tooltip. `🏆🏆` shows two `:trophy:` tooltips, each centered on its own glyph (measured tooltip center x == emoji center x for both).
- [x] Skin-tone variants show the base shortcode (`👍🏽` → `:+1:`). Unit test + live.
- [x] FE0F sequences resolve (`☺️` → `:relaxed:`). Unit test + live.
- [x] An emoji with no shortcode shows no tooltip (`🦰` U+1F9B0 → no tooltip, live; unit test returns `undefined`).
- [x] Jumbo messages behave the same (the `🏆🏆` check above rendered at 32px).
- [x] Message layout unchanged: unwrapping the tooltip containers in the live DOM left the message height identical, and selecting the message yields `[3:54 PM] claude-1: hi 😅👍🏽 ☺️` as plain text.
- [x] Emoji are not tab stops: 12 Shift+Tab presses from the input cycle through timestamps/usernames only; zero emoji wrappers have `tabIndex >= 0`.
- [x] Shortcode file stays lazy: at app start and after 50 emoji-free messages rendered there was no request for it; it was requested exactly once, immediately after the first emoji message rendered (request #102 right after the send POST #101), and hovering worked without a re-render of the list.
- [x] No new dataset loaded: only the iamcal shortcode JSON is requested, not the picker's emoji data.

## Drift notes

All Current behavior claims held at master; `message-list.tsx` line pointers moved by one line from #1499/#1503 (cosmetic).

## Verification

- T0: `pnpm run lint`, `pnpm run typecheck` clean. `vitest run` on `common/text/unicode-emojis`, `client/messaging/emoji-shortcodes` (new, loads the real dataset: plain, FE0F, keycap, padded short codepoint, skin tone, ZWJ, ZWJ+skin tone, no-shortcode, non-emoji), `emote-suggestions`, `message-list`, `common-message-layout`: 7 files, 132 tests passed. The `common-message-layout` snapshot was regenerated for the new per-emoji wrapper.
- T2: one Electron client (`claude-1`) in `#ShieldBattery`, a whisper to `claude-2`, and a custom lobby, driven over CDP. All five recipe steps pass as listed above.
