### PR TITLE
Recall previously sent messages with Up/Down in the chat input.

### DIFF
--- a/client/messaging/message-input.tsx
+++ b/client/messaging/message-input.tsx
@@ -38,6 +38,7 @@ import {
   recordEmoteUsage,
   searchUnicodeEmojis,
 } from './emote-suggestions'
+import { SentMessageHistory } from './sent-message-history'
 
 // We limit the number of users we display in user mention popup to 10 so we don't need to have
 // scrollbars; and usually the person who is trying to mention someone is interested in only one
@@ -139,6 +140,29 @@ function useStorageSyncedState(
   return [value, syncedSetValue]
 }
 
+/** The sent-message history for each chat instance, keyed the same way as `messageInputMap`. */
+const sentMessageHistoryMap = new Map<string, SentMessageHistory>()
+
+/**
+ * Returns the sent-message history for a chat instance. With a key, the history is shared across
+ * mounts of that instance (so it survives navigating away and back); without one it lives only as
+ * long as this component. Like `useStorageSyncedState`, the key is read on mount only.
+ */
+function useSentMessageHistory(key?: string): SentMessageHistory {
+  const [history] = useState(() => {
+    if (!key) {
+      return new SentMessageHistory()
+    }
+    let history = sentMessageHistoryMap.get(key)
+    if (!history) {
+      history = new SentMessageHistory()
+      sentMessageHistoryMap.set(key, history)
+    }
+    return history
+  })
+  return history
+}
+
 export interface MessageInputProps {
   className?: string
   showDivider?: boolean
@@ -148,7 +172,8 @@ export interface MessageInputProps {
    * A key to store the current message input contents under (in a global Map). If provided, the
    * previous message input contents will be restored when the component is mounted (so the key
    * should uniquely identify the type + instance of the chat container). The key is prefixed with
-   * the user's ID to handle user changing their account.
+   * the user's ID to handle user changing their account. The sent-message history used for
+   * Up/Down recall is stored under this same key.
    */
   storageKey?: string
   /**
@@ -188,6 +213,7 @@ export const MessageInput = React.forwardRef<MessageInputHandle, MessageInputPro
     const chatRestriction = useAppSelector(s => s.auth.self?.restrictions.get(RestrictionKind.Chat))
     const combinedStorageKey = user && storageKey ? `${user.id}-${storageKey}` : undefined
     const [message, setMessage] = useStorageSyncedState('', combinedStorageKey)
+    const sentHistory = useSentMessageHistory(combinedStorageKey)
     const inputRef = useRef<HTMLInputElement>(null)
     const [containerElem, setContainerElem] = useState<HTMLDivElement | null>(null)
 
@@ -452,6 +478,7 @@ export const MessageInput = React.forwardRef<MessageInputHandle, MessageInputPro
         }
 
         onSendChatMessage(toSend)
+        sentHistory.push(toSend)
         setMessage('')
       }
     })
@@ -540,6 +567,35 @@ export const MessageInput = React.forwardRef<MessageInputHandle, MessageInputPro
                 )
                 setVirtuallyFocusedMentionIndex(0)
               }
+            } else if (event.key === 'ArrowUp' || event.key === 'ArrowDown') {
+              if (
+                event.shiftKey ||
+                event.ctrlKey ||
+                event.altKey ||
+                event.metaKey ||
+                event.nativeEvent.isComposing
+              ) {
+                return
+              }
+              if (emotesOpen || userMentionsOpen) {
+                // The open suggestion list owns the arrow keys (it moves its highlighted item on
+                // them)
+                return
+              }
+
+              const recalled =
+                event.key === 'ArrowUp' ? sentHistory.older(message) : sentHistory.newer(message)
+              if (recalled === undefined) {
+                return
+              }
+
+              event.preventDefault()
+              setMessage(recalled)
+              // The caret goes to the end of the recalled text once the new value has been applied,
+              // which happens after this handler returns
+              queueMicrotask(() => {
+                inputRef.current?.setSelectionRange(recalled.length, recalled.length)
+              })
             }
           }}
           onEnterKeyDown={onEnterKeyDown}

--- a/client/messaging/sent-message-history.test.ts
+++ b/client/messaging/sent-message-history.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, test } from 'vitest'
+import { MAX_SENT_MESSAGE_HISTORY, SentMessageHistory } from './sent-message-history'
+
+describe('messaging/sent-message-history', () => {
+  describe('older', () => {
+    test('returns undefined when nothing has been sent', () => {
+      const history = new SentMessageHistory()
+      expect(history.older('')).toBeUndefined()
+    })
+
+    test('steps backward through sent messages, stopping at the oldest', () => {
+      const history = new SentMessageHistory()
+      history.push('a')
+      history.push('b')
+      history.push('c')
+
+      expect(history.older('')).toBe('c')
+      expect(history.older('c')).toBe('b')
+      expect(history.older('b')).toBe('a')
+      expect(history.older('a')).toBeUndefined()
+    })
+
+    test('restarts from the newest entry when the input is cleared mid-recall', () => {
+      const history = new SentMessageHistory()
+      history.push('a')
+      history.push('b')
+      history.push('c')
+
+      expect(history.older('')).toBe('c')
+      expect(history.older('c')).toBe('b')
+      expect(history.older('')).toBe('c')
+    })
+
+    test('does not step when the recalled text has been edited', () => {
+      const history = new SentMessageHistory()
+      history.push('a')
+      history.push('b')
+      history.push('c')
+
+      expect(history.older('')).toBe('c')
+      expect(history.older('c edited')).toBeUndefined()
+    })
+  })
+
+  describe('newer', () => {
+    test('returns undefined when no recall is in progress', () => {
+      const history = new SentMessageHistory()
+      history.push('a')
+
+      expect(history.newer('a')).toBeUndefined()
+    })
+
+    test('steps forward and ends the recall past the newest entry', () => {
+      const history = new SentMessageHistory()
+      history.push('a')
+      history.push('b')
+      history.push('c')
+      history.older('')
+      history.older('c')
+      history.older('b')
+
+      expect(history.newer('a')).toBe('b')
+      expect(history.newer('b')).toBe('c')
+      expect(history.newer('c')).toBe('')
+      expect(history.newer('')).toBeUndefined()
+      expect(history.older('')).toBe('c')
+    })
+
+    test('does not step when the recalled text has been edited', () => {
+      const history = new SentMessageHistory()
+      history.push('a')
+      history.push('b')
+      history.push('c')
+
+      expect(history.older('')).toBe('c')
+      expect(history.older('c edited')).toBeUndefined()
+      expect(history.newer('c edited')).toBeUndefined()
+    })
+  })
+
+  describe('push', () => {
+    test('ends any recall in progress', () => {
+      const history = new SentMessageHistory()
+      history.push('a')
+      history.push('b')
+      history.push('c')
+
+      expect(history.older('')).toBe('c')
+      history.push('d')
+      expect(history.newer('c')).toBeUndefined()
+      expect(history.older('')).toBe('d')
+    })
+
+    test('skips a consecutive duplicate', () => {
+      const history = new SentMessageHistory()
+      history.push('a')
+      history.push('a')
+
+      expect(history.older('')).toBe('a')
+      expect(history.older('a')).toBeUndefined()
+    })
+
+    test('keeps non-consecutive duplicates as separate entries', () => {
+      const history = new SentMessageHistory()
+      history.push('a')
+      history.push('b')
+      history.push('a')
+
+      expect(history.older('')).toBe('a')
+      expect(history.older('a')).toBe('b')
+      expect(history.older('b')).toBe('a')
+    })
+
+    test('drops the oldest entry once the history exceeds its cap', () => {
+      const history = new SentMessageHistory()
+      for (let i = 0; i <= MAX_SENT_MESSAGE_HISTORY; i++) {
+        history.push(`m${i}`)
+      }
+
+      let current = history.older('')
+      expect(current).toBe(`m${MAX_SENT_MESSAGE_HISTORY}`)
+
+      for (let i = 0; i < MAX_SENT_MESSAGE_HISTORY - 1; i++) {
+        current = history.older(current!)
+      }
+      expect(current).toBe('m1')
+      expect(history.older(current!)).toBeUndefined()
+    })
+  })
+})

--- a/client/messaging/sent-message-history.ts
+++ b/client/messaging/sent-message-history.ts
@@ -1,0 +1,67 @@
+/** Upper bound on remembered messages per conversation; the oldest are dropped past it. */
+export const MAX_SENT_MESSAGE_HISTORY = 100
+
+/**
+ * The messages a user has sent in one conversation, newest last, plus a cursor for recalling them
+ * into the input with the arrow keys. Recall starts from an empty input and steps through entries
+ * only while the input still holds exactly the entry it was last given, so anything the user has
+ * typed or edited is never replaced.
+ */
+export class SentMessageHistory {
+  private entries: string[] = []
+  /** Index of the entry currently shown in the input, or -1 when not recalling. */
+  private index = -1
+
+  /** Records a sent message as the newest entry and ends any recall in progress. */
+  push(text: string): void {
+    if (text !== this.entries[this.entries.length - 1]) {
+      this.entries.push(text)
+      if (this.entries.length > MAX_SENT_MESSAGE_HISTORY) {
+        this.entries.shift()
+      }
+    }
+    this.index = -1
+  }
+
+  /**
+   * Handles an Up press. Returns the text to put in the input, or undefined if the press should be
+   * left to the input's normal handling.
+   */
+  older(current: string): string | undefined {
+    if (this.entries.length === 0) {
+      return undefined
+    }
+
+    if (current === '') {
+      this.index = this.entries.length - 1
+      return this.entries[this.index]
+    } else if (this.index >= 0 && current === this.entries[this.index] && this.index > 0) {
+      this.index--
+      return this.entries[this.index]
+    } else {
+      return undefined
+    }
+  }
+
+  /**
+   * Handles a Down press. Returns the text to put in the input, or undefined if the press should
+   * be left to the input's normal handling. Stepping past the newest entry ends the recall and
+   * returns an empty string, which is what the input held when recall began.
+   */
+  newer(current: string): string | undefined {
+    if (this.index < 0) {
+      return undefined
+    }
+    if (current !== this.entries[this.index]) {
+      return undefined
+    }
+
+    if (this.index < this.entries.length - 1) {
+      this.index++
+      return this.entries[this.index]
+    } else {
+      this.index = -1
+      return ''
+    }
+  }
+}


### PR DESCRIPTION
Pressing Up in an empty chat input now recalls the messages you previously sent in that conversation, terminal-style, and Down steps forward again. This is the first piece of the chat-commands work: correcting a typo in the last thing you sent, or re-running a command, no longer means retyping it.

Fixes #1457

## Acceptance criteria

- [x] Up in an empty input recalls the most recently sent message — verified live (Electron, `#ShieldBattery`): sent `hist-one`/`hist-two`/`hist-three`, Up → `hist-three`, caret at end.
- [x] Repeated Up steps further back, oldest last — Up, Up → `hist-two`, `hist-one`; a further Up at the oldest leaves the input as is.
- [x] Down steps forward; past the newest returns the input to what it held before Up — Down ×3 → `hist-two`, `hist-three`, empty; a further Down is a no-op.
- [x] Editing a recalled message and sending appends the edited text as the newest entry — recalled `hist-three`, typed ` edited`, Enter; Up → `hist-three edited`, Up → `hist-three`.
- [x] History is scoped per conversation — `#unban-test` and a whisper to `claude-2` each started empty, recalled only their own `other-one` / `whisp-one`, and `#ShieldBattery` still recalled `hist-three edited` after navigating back.
- [x] Up/Down do nothing while an emote or mention popover is open — typed `@cl` (mention list open) and `:smil` (emote list open): Up/Down left the input text unchanged and the popover open; Tab-accept still works afterwards.

## Implementation notes

- `SentMessageHistory` (`client/messaging/sent-message-history.ts`) holds the entries and the recall cursor, with unit tests. The input only asks it what to show on Up/Down.
- Histories live in a module-level map keyed like the draft map (`${userId}-${storageKey}`), so they survive navigating away and back. Inputs without a `storageKey` (lobby chat, draft screen) get an instance-scoped history so Up still works there for the life of the view.
- Recall only steps while the input still holds exactly the recalled entry. A typed draft, or a recalled entry the user has edited, is never replaced by Up/Down (those keys fall through to normal caret movement). Clearing the input mid-recall restarts from the newest entry.

## Calls made

The issue's Decisions section proposed but did not lock these; built as follows, all easy to change at review:

- **In-memory, app-session scoped** (mirrors the draft map; no localStorage) — as proposed.
- **Recall starts only from an empty input.** Because of that gate, "what the input held before Up" is always empty, so Down past the newest clears the input. Stashing a non-empty draft and recalling over it (bash-style) was passed on: it would also hijack Up/Down caret movement in multi-line drafts.
- **A consecutive duplicate is not appended** (sending the same text twice in a row yields one entry); non-consecutive duplicates are kept.
- **Capped at 100 entries per conversation**, oldest dropped.

## Drift

`message-input.tsx` is unchanged since the pinned commit; all pointers hold. One Current-behavior claim was inaccurate but harmless: the suggestion popovers' highlighted index *is* keyboard-driven — `MenuList` with `virtualFocus` consumes Up/Down through the document-level key listener while open. That is exactly why the input handler defers to an open popover; the textarea's handler runs before the document listener, so an open-check is sufficient.

## Verification

T0: `pnpm run lint` clean, `pnpm run typecheck` clean, `pnpm exec vitest run client/messaging` 7 files / 112 tests passed (11 new).
T2: one Electron client (`claude-1`) driven over CDP, recipe above run as written in the issue plus a typed-draft guard check (`draft text` untouched by Up/Down) and Tab-accept after the popover check. No new console errors.

Not covered: pre-existing behaviour that a message ending in a mention (`gg @Bob`) opens the mention popover when the caret lands after it — recalling such a message does the same, so the first Enter accepts the mention and the second sends, exactly as when typing it.
