### PR TITLE
Show a snackbar when a channel message or user-list fetch fails.

### DIFF
--- a/client/chat/action-creators.test.ts
+++ b/client/chat/action-creators.test.ts
@@ -15,6 +15,7 @@ import { RootState } from '../root-reducer'
 import {
   ChannelLeaveSeverity,
   getChannelLeaveSeverity,
+  getMessageHistory,
   markChannelRead,
   markChannelReadNow,
 } from './action-creators'
@@ -276,6 +277,34 @@ function runMarkReadNow(state: RootState) {
 
   return { dispatched }
 }
+
+describe('chat/action-creators/getMessageHistory', () => {
+  beforeEach(() => {
+    fetchJsonMock.mockReset()
+  })
+
+  test('reports a fetch failure through the spec, having already dispatched the begin action', async () => {
+    const error = new Error('network go boom')
+    fetchJsonMock.mockRejectedValue(error)
+
+    const dispatched: unknown[] = []
+    const dispatch = ((action: unknown) => {
+      dispatched.push(action)
+    }) as DispatchFunction<any>
+    // No entry for the channel: the creator tolerates that, treating it the same as "nothing
+    // loaded yet".
+    const state = { chat: { idToMessages: new Map() } } as unknown as RootState
+
+    const onError = vi.fn()
+    getMessageHistory(CHANNEL_ID, 50, { onSuccess: () => {}, onError })(dispatch, () => state)
+
+    await vi.waitFor(() => expect(onError).toHaveBeenCalledWith(error))
+
+    expect(dispatched).toEqual(
+      expect.arrayContaining([expect.objectContaining({ type: '@chat/loadMessageHistoryBegin' })]),
+    )
+  })
+})
 
 describe('chat/action-creators/markChannelReadNow', () => {
   beforeEach(() => {

--- a/client/chat/action-creators.ts
+++ b/client/chat/action-creators.ts
@@ -413,8 +413,12 @@ export function deleteMessageAsAdmin(
   })
 }
 
-export function getMessageHistory(channelId: SbChannelId, limit: number): ThunkAction {
-  return (dispatch, getStore) => {
+export function getMessageHistory(
+  channelId: SbChannelId,
+  limit: number,
+  spec: RequestHandlingSpec,
+): ThunkAction {
+  return abortableThunk(spec, async (dispatch, getStore) => {
     const {
       chat: { idToMessages },
     } = getStore()
@@ -434,19 +438,21 @@ export function getMessageHistory(channelId: SbChannelId, limit: number): ThunkA
       windowGen: channelMessages?.windowGen ?? 0,
     }
 
+    const promise = fetchJson<GetChannelHistoryServerResponse>(
+      apiUrl`chat/${channelId}/messages2?limit=${limit}&beforeTime=${earliestMessageTime}`,
+      { method: 'GET', signal: spec.signal },
+    )
     dispatch({
       type: '@chat/loadMessageHistoryBegin',
       payload: params,
     })
     dispatch({
       type: '@chat/loadMessageHistory',
-      payload: fetchJson<GetChannelHistoryServerResponse>(
-        apiUrl`chat/${channelId}/messages2?limit=${limit}&beforeTime=${earliestMessageTime}`,
-        { method: 'GET' },
-      ),
+      payload: promise,
       meta: params,
     })
-  }
+    await promise
+  })
 }
 
 /**
@@ -454,8 +460,12 @@ export function getMessageHistory(channelId: SbChannelId, limit: number): ThunkA
  * window that sits behind the present a page closer to it. Does nothing if the channel holds no
  * message with a server-recorded time, since there'd be nothing the server could seek from.
  */
-export function getNewerMessages(channelId: SbChannelId, limit: number): ThunkAction {
-  return (dispatch, getStore) => {
+export function getNewerMessages(
+  channelId: SbChannelId,
+  limit: number,
+  spec: RequestHandlingSpec,
+): ThunkAction {
+  return abortableThunk(spec, async (dispatch, getStore) => {
     const {
       chat: { idToMessages },
     } = getStore()
@@ -477,19 +487,21 @@ export function getNewerMessages(channelId: SbChannelId, limit: number): ThunkAc
       knownNewestTime: Math.max(afterTime, channelMessages.detachedNewestTime ?? -Infinity),
     }
 
+    const promise = fetchJson<GetChannelHistoryServerResponse>(
+      apiUrl`chat/${channelId}/messages2?limit=${limit}&afterTime=${afterTime}`,
+      { method: 'GET', signal: spec.signal },
+    )
     dispatch({
       type: '@chat/loadNewerMessagesBegin',
       payload: params,
     })
     dispatch({
       type: '@chat/loadNewerMessages',
-      payload: fetchJson<GetChannelHistoryServerResponse>(
-        apiUrl`chat/${channelId}/messages2?limit=${limit}&afterTime=${afterTime}`,
-        { method: 'GET' },
-      ),
+      payload: promise,
       meta: params,
     })
-  }
+    await promise
+  })
 }
 
 /**
@@ -501,8 +513,9 @@ export function getMessagesAround(
   channelId: SbChannelId,
   limit: number,
   aroundTime: number,
+  spec: RequestHandlingSpec,
 ): ThunkAction {
-  return (dispatch, getStore) => {
+  return abortableThunk(spec, async (dispatch, getStore) => {
     const {
       chat: { idToMessages },
     } = getStore()
@@ -523,19 +536,21 @@ export function getMessagesAround(
       knownNewestTime: knownNewest === -Infinity ? undefined : knownNewest,
     }
 
+    const promise = fetchJson<GetChannelHistoryServerResponse>(
+      apiUrl`chat/${channelId}/messages2?limit=${limit}&aroundTime=${aroundTime}`,
+      { method: 'GET', signal: spec.signal },
+    )
     dispatch({
       type: '@chat/loadMessagesAroundBegin',
       payload: params,
     })
     dispatch({
       type: '@chat/loadMessagesAround',
-      payload: fetchJson<GetChannelHistoryServerResponse>(
-        apiUrl`chat/${channelId}/messages2?limit=${limit}&aroundTime=${aroundTime}`,
-        { method: 'GET' },
-      ),
+      payload: promise,
       meta: params,
     })
-  }
+    await promise
+  })
 }
 
 /**
@@ -600,15 +615,19 @@ export function resetMessageWindow(channelId: SbChannelId): ResetMessageWindow {
  * is dropped and the newest page requested in the same tick, so the list never renders an empty
  * channel in between.
  */
-export function jumpToPresent(channelId: SbChannelId, limit: number): ThunkAction {
+export function jumpToPresent(
+  channelId: SbChannelId,
+  limit: number,
+  spec: RequestHandlingSpec,
+): ThunkAction {
   return dispatch => {
     dispatch(resetMessageWindow(channelId))
-    dispatch(getMessageHistory(channelId, limit))
+    dispatch(getMessageHistory(channelId, limit, spec))
   }
 }
 
-export function retrieveUserList(channelId: SbChannelId): ThunkAction {
-  return (dispatch, getStore) => {
+export function retrieveUserList(channelId: SbChannelId, spec: RequestHandlingSpec): ThunkAction {
+  return abortableThunk(spec, async (dispatch, getStore) => {
     const {
       chat: { idToUsers },
     } = getStore()
@@ -618,18 +637,21 @@ export function retrieveUserList(channelId: SbChannelId): ThunkAction {
     }
 
     const params = { channelId }
+    const promise = fetchJson<SbUser[]>(apiUrl`chat/${channelId}/users2`, {
+      method: 'GET',
+      signal: spec.signal,
+    })
     dispatch({
       type: '@chat/retrieveUserListBegin',
       payload: params,
     })
     dispatch({
       type: '@chat/retrieveUserList',
-      payload: fetchJson<SbUser[]>(apiUrl`chat/${channelId}/users2`, {
-        method: 'GET',
-      }),
+      payload: promise,
       meta: params,
     })
-  }
+    await promise
+  })
 }
 
 const getChatUserProfileRequestCoalescer = new RequestCoalescer<`${SbChannelId}|${SbUserId}`>()

--- a/client/chat/channel.tsx
+++ b/client/chat/channel.tsx
@@ -182,6 +182,16 @@ export function ConnectedChatChannel({
   // has acted on it the param goes away, so reloading the page afterwards is an ordinary visit.
   const [linkedMessageId, setLinkedMessageId] = useLocationSearchParam(MESSAGE_LINK_PARAM)
 
+  const showMessageLoadError = (err: Error) => {
+    snackbarController.showSnackbar(
+      t('chat.errors.loadingHistory', {
+        defaultValue: 'Error loading message history: {{errorMessage}}',
+        errorMessage: err.message,
+      }),
+      DURATION_LONG,
+    )
+  }
+
   // NOTE(2Pac): When user types the single @ character in chat, we show the ten most recent
   // chatters in the channel as an option to mention.
   const recentChatters = useMemo(() => {
@@ -271,7 +281,19 @@ export function ConnectedChatChannel({
   const viewStateKey = `chat.${channelId}`
 
   const onActivate = useEffectEvent(() => {
-    dispatch(retrieveUserList(channelId))
+    dispatch(
+      retrieveUserList(channelId, {
+        onSuccess: () => {},
+        onError: err =>
+          snackbarController.showSnackbar(
+            t('chat.errors.loadingUserList', {
+              defaultValue: 'Error loading user list: {{errorMessage}}',
+              errorMessage: err.message,
+            }),
+            DURATION_LONG,
+          ),
+      }),
+    )
 
     const anchor = chatViewAnchorStore.get(viewStateKey)
     dispatch(activateChannel(channelId))
@@ -290,7 +312,12 @@ export function ConnectedChatChannel({
       // it in place would show the user a spot they weren't (its bottom) only to yank them away once
       // the requested window lands, whereas an empty window renders as loading for that same wait.
       dispatch(resetMessageWindow(channelId))
-      dispatch(getMessagesAround(channelId, MESSAGES_LIMIT, anchor.sentTime))
+      dispatch(
+        getMessagesAround(channelId, MESSAGES_LIMIT, anchor.sentTime, {
+          onSuccess: () => {},
+          onError: showMessageLoadError,
+        }),
+      )
     }
   })
 
@@ -323,19 +350,18 @@ export function ConnectedChatChannel({
               DURATION_LONG,
             )
           } else {
-            snackbarController.showSnackbar(
-              t('chat.errors.loadingHistory', {
-                defaultValue: 'Error loading message history: {{errorMessage}}',
-                errorMessage: err.message,
-              }),
-              DURATION_LONG,
-            )
+            showMessageLoadError(err)
           }
 
           // The window was dropped to make room for one that can't be had, so the channel goes back
           // to the newest messages rather than being left empty.
           setLinkedMessageId('')
-          dispatch(jumpToPresent(channelId, MESSAGES_LIMIT))
+          dispatch(
+            jumpToPresent(channelId, MESSAGES_LIMIT, {
+              onSuccess: () => {},
+              onError: showMessageLoadError,
+            }),
+          )
         },
       }),
     )
@@ -418,20 +444,40 @@ export function ConnectedChatChannel({
   }, [basicChannelInfo, channelNameFromRoute])
 
   const onLoadMoreMessages = useStableCallback(() =>
-    dispatch(getMessageHistory(channelId, MESSAGES_LIMIT)),
+    dispatch(
+      getMessageHistory(channelId, MESSAGES_LIMIT, {
+        onSuccess: () => {},
+        onError: showMessageLoadError,
+      }),
+    ),
   )
 
   const onLoadNewerMessages = useStableCallback(() => {
-    dispatch(getNewerMessages(channelId, MESSAGES_LIMIT))
+    dispatch(
+      getNewerMessages(channelId, MESSAGES_LIMIT, {
+        onSuccess: () => {},
+        onError: showMessageLoadError,
+      }),
+    )
   })
 
   const onJumpToPresent = () => {
-    dispatch(jumpToPresent(channelId, MESSAGES_LIMIT))
+    dispatch(
+      jumpToPresent(channelId, MESSAGES_LIMIT, {
+        onSuccess: () => {},
+        onError: showMessageLoadError,
+      }),
+    )
   }
 
   const onSeekToUnread = () => {
     if (unreadLineTime !== undefined) {
-      dispatch(getMessagesAround(channelId, MESSAGES_LIMIT, unreadLineTime))
+      dispatch(
+        getMessagesAround(channelId, MESSAGES_LIMIT, unreadLineTime, {
+          onSuccess: () => {},
+          onError: showMessageLoadError,
+        }),
+      )
     }
   }
 

--- a/client/chat/channel.tsx
+++ b/client/chat/channel.tsx
@@ -189,6 +189,7 @@ export function ConnectedChatChannel({
         errorMessage: err.message,
       }),
       DURATION_LONG,
+      { dedupe: true },
     )
   }
 
@@ -291,6 +292,7 @@ export function ConnectedChatChannel({
               errorMessage: err.message,
             }),
             DURATION_LONG,
+            { dedupe: true },
           ),
       }),
     )

--- a/client/chat/chat-reducer.test.ts
+++ b/client/chat/chat-reducer.test.ts
@@ -1654,6 +1654,34 @@ describe('client/chat/chat-reducer', () => {
     })
   })
 
+  describe('@chat/retrieveUserList', () => {
+    function retrieveUserListBeginAction(): ChatActions {
+      return {
+        type: '@chat/retrieveUserListBegin',
+        payload: { channelId: CHANNEL_ID },
+      }
+    }
+
+    function retrieveUserListAction(payload: SbUser[] = []): ChatActions {
+      return {
+        type: '@chat/retrieveUserList',
+        payload,
+        meta: { channelId: CHANNEL_ID },
+      }
+    }
+
+    test('a failure clears both the loading and loaded flags so the list can be requested again', () => {
+      const loading = chatReducer(makeState(), retrieveUserListBeginAction())
+      expect(loading.idToUsers.get(CHANNEL_ID)?.loadingUserList).toBe(true)
+      expect(loading.idToUsers.get(CHANNEL_ID)?.hasLoadedUserList).toBe(true)
+
+      const result = chatReducer(loading, asFailure(retrieveUserListAction()))
+
+      expect(result.idToUsers.get(CHANNEL_ID)?.loadingUserList).toBe(false)
+      expect(result.idToUsers.get(CHANNEL_ID)?.hasLoadedUserList).toBe(false)
+    })
+  })
+
   describe('oldestServerOriginTime', () => {
     test('returns the oldest server-recorded time, skipping a client-only message at the head', () => {
       expect(

--- a/client/chat/chat-reducer.ts
+++ b/client/chat/chat-reducer.ts
@@ -891,7 +891,6 @@ export default immerKeyedReducer(DEFAULT_CHAT_STATE, {
     channelMessages.loadingHistory = false
 
     if (action.error) {
-      // TODO(2Pac): Handle errors
       return
     }
 
@@ -933,7 +932,6 @@ export default immerKeyedReducer(DEFAULT_CHAT_STATE, {
     channelMessages.loadingNewer = false
 
     if (action.error) {
-      // TODO(2Pac): Handle errors
       return
     }
 
@@ -997,7 +995,6 @@ export default immerKeyedReducer(DEFAULT_CHAT_STATE, {
     channelMessages.loadingNewer = false
 
     if (action.error) {
-      // TODO(2Pac): Handle errors
       return
     }
 
@@ -1082,7 +1079,14 @@ export default immerKeyedReducer(DEFAULT_CHAT_STATE, {
 
   ['@chat/retrieveUserList'](state, action) {
     if (action.error) {
-      // TODO(2Pac): Handle errors
+      // `retrieveUserListBegin` marks the list as loaded when the request starts, and the action
+      // creator skips the fetch while either flag is set, so a failed request clears both: the
+      // next channel activation asks for the list again.
+      const channelUsers = state.idToUsers.get(action.meta.channelId)
+      if (channelUsers) {
+        channelUsers.loadingUserList = false
+        channelUsers.hasLoadedUserList = false
+      }
       return
     }
 

--- a/client/lists/infinite-scroll-list.test.tsx
+++ b/client/lists/infinite-scroll-list.test.tsx
@@ -1,0 +1,114 @@
+import { render } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import InfiniteList, { InfiniteListProps } from './infinite-scroll-list'
+
+/** Matches the minimum spacing between two loads of the same edge in the list implementation. */
+const MIN_LOAD_INTERVAL_MS = 1000
+
+/**
+ * An observer that reports its target as intersecting the moment it starts being observed, which is
+ * what the real one does for an element that's already in view.
+ */
+class ImmediateIntersectionObserver {
+  constructor(private callback: IntersectionObserverCallback) {}
+
+  observe(target: Element) {
+    this.callback(
+      [{ target, isIntersecting: true } as IntersectionObserverEntry],
+      this as unknown as IntersectionObserver,
+    )
+  }
+
+  unobserve() {}
+
+  disconnect() {}
+
+  takeRecords(): IntersectionObserverEntry[] {
+    return []
+  }
+}
+
+describe('client/lists/infinite-scroll-list', () => {
+  let currentTime = 0
+  let savedIntersectionObserver: unknown
+
+  beforeEach(() => {
+    currentTime = 0
+    vi.useFakeTimers()
+    vi.spyOn(performance, 'now').mockImplementation(() => currentTime)
+
+    savedIntersectionObserver = (globalThis as any).IntersectionObserver
+    ;(globalThis as any).IntersectionObserver = ImmediateIntersectionObserver
+  })
+
+  afterEach(() => {
+    ;(globalThis as any).IntersectionObserver = savedIntersectionObserver
+    vi.restoreAllMocks()
+    vi.useRealTimers()
+  })
+
+  const advanceTime = (millis: number) => {
+    currentTime += millis
+    vi.advanceTimersByTime(millis)
+  }
+
+  const doRender = (props: Partial<InfiniteListProps>) => {
+    const baseProps: InfiniteListProps = {
+      children: <div>list contents</div>,
+      prevLoadingEnabled: true,
+      hasPrevData: true,
+      isLoadingPrev: false,
+      ...props,
+    }
+    const result = render(<InfiniteList {...baseProps} />)
+
+    return {
+      unmount: result.unmount,
+      rerender: (nextProps: Partial<InfiniteListProps>) =>
+        result.rerender(<InfiniteList {...baseProps} {...nextProps} />),
+    }
+  }
+
+  test('a page that leaves the sentinel in view is not re-requested before the interval', () => {
+    const onLoadPrevData = vi.fn()
+    const { rerender } = doRender({ onLoadPrevData })
+    expect(onLoadPrevData).toHaveBeenCalledTimes(1)
+
+    // A page that failed leaves the list exactly as it was, so the sentinel is still in view when
+    // the observer restarts for the cleared loading flag
+    rerender({ onLoadPrevData, isLoadingPrev: true })
+    rerender({ onLoadPrevData, isLoadingPrev: false })
+    expect(onLoadPrevData).toHaveBeenCalledTimes(1)
+
+    advanceTime(MIN_LOAD_INTERVAL_MS)
+    expect(onLoadPrevData).toHaveBeenCalledTimes(2)
+
+    rerender({ onLoadPrevData, isLoadingPrev: true })
+    rerender({ onLoadPrevData, isLoadingPrev: false })
+    rerender({ onLoadPrevData, isLoadingPrev: true })
+    rerender({ onLoadPrevData, isLoadingPrev: false })
+    expect(onLoadPrevData).toHaveBeenCalledTimes(2)
+  })
+
+  test('a refresh token change loads immediately', () => {
+    const onLoadPrevData = vi.fn()
+    const { rerender } = doRender({ onLoadPrevData, refreshToken: 'first' })
+    expect(onLoadPrevData).toHaveBeenCalledTimes(1)
+
+    rerender({ onLoadPrevData, refreshToken: 'second' })
+    expect(onLoadPrevData).toHaveBeenCalledTimes(2)
+  })
+
+  test('a deferred load is dropped when the list is torn down first', () => {
+    const onLoadPrevData = vi.fn()
+    const { rerender, unmount } = doRender({ onLoadPrevData })
+    expect(onLoadPrevData).toHaveBeenCalledTimes(1)
+
+    rerender({ onLoadPrevData, isLoadingPrev: true })
+    rerender({ onLoadPrevData, isLoadingPrev: false })
+    unmount()
+
+    advanceTime(MIN_LOAD_INTERVAL_MS * 5)
+    expect(onLoadPrevData).toHaveBeenCalledTimes(1)
+  })
+})

--- a/client/lists/infinite-scroll-list.test.tsx
+++ b/client/lists/infinite-scroll-list.test.tsx
@@ -66,6 +66,14 @@ describe('client/lists/infinite-scroll-list', () => {
       unmount: result.unmount,
       rerender: (nextProps: Partial<InfiniteListProps>) =>
         result.rerender(<InfiniteList {...baseProps} {...nextProps} />),
+      // jsdom always reports `scrollWidth`/`scrollHeight` as 0, so tests that care about content
+      // changing need to fake the sentinel parent's extent themselves.
+      setContentHeight: (height: number) => {
+        Object.defineProperty(result.container, 'scrollHeight', {
+          configurable: true,
+          get: () => height,
+        })
+      },
     }
   }
 
@@ -87,6 +95,55 @@ describe('client/lists/infinite-scroll-list', () => {
     rerender({ onLoadPrevData, isLoadingPrev: false })
     rerender({ onLoadPrevData, isLoadingPrev: true })
     rerender({ onLoadPrevData, isLoadingPrev: false })
+    expect(onLoadPrevData).toHaveBeenCalledTimes(2)
+  })
+
+  test('a page that added content is requested again immediately when the sentinel stays in view', () => {
+    const onLoadPrevData = vi.fn()
+    const { rerender, setContentHeight } = doRender({ onLoadPrevData })
+    expect(onLoadPrevData).toHaveBeenCalledTimes(1)
+
+    // The page that was loading added items, growing the content, so the retry isn't throttled even
+    // though no time has passed.
+    rerender({ onLoadPrevData, isLoadingPrev: true })
+    setContentHeight(500)
+    rerender({ onLoadPrevData, isLoadingPrev: false })
+    expect(onLoadPrevData).toHaveBeenCalledTimes(2)
+
+    rerender({ onLoadPrevData, isLoadingPrev: true })
+    setContentHeight(1000)
+    rerender({ onLoadPrevData, isLoadingPrev: false })
+    expect(onLoadPrevData).toHaveBeenCalledTimes(3)
+
+    // A load that leaves the content as it was goes back to being throttled.
+    rerender({ onLoadPrevData, isLoadingPrev: true })
+    rerender({ onLoadPrevData, isLoadingPrev: false })
+    expect(onLoadPrevData).toHaveBeenCalledTimes(3)
+
+    advanceTime(MIN_LOAD_INTERVAL_MS)
+    expect(onLoadPrevData).toHaveBeenCalledTimes(4)
+  })
+
+  test('a deferred load is superseded by a load for changed content', () => {
+    const onLoadPrevData = vi.fn()
+    const { rerender, setContentHeight } = doRender({ onLoadPrevData })
+    expect(onLoadPrevData).toHaveBeenCalledTimes(1)
+
+    // Unchanged content defers the retry to the end of the interval instead of loading immediately.
+    rerender({ onLoadPrevData, isLoadingPrev: true })
+    rerender({ onLoadPrevData, isLoadingPrev: false })
+    expect(onLoadPrevData).toHaveBeenCalledTimes(1)
+
+    // Before that deferred timer fires, a load that actually changed the content comes in and is
+    // requested immediately.
+    rerender({ onLoadPrevData, isLoadingPrev: true })
+    setContentHeight(500)
+    rerender({ onLoadPrevData, isLoadingPrev: false })
+    expect(onLoadPrevData).toHaveBeenCalledTimes(2)
+
+    // The effect teardown from that last render must have cleared the earlier deferred timer, so it
+    // never fires a third, stale load.
+    advanceTime(MIN_LOAD_INTERVAL_MS * 2)
     expect(onLoadPrevData).toHaveBeenCalledTimes(2)
   })
 

--- a/client/lists/infinite-scroll-list.tsx
+++ b/client/lists/infinite-scroll-list.tsx
@@ -4,16 +4,39 @@ import styled from 'styled-components'
 import LoadingIndicator from '../progress/dots'
 
 /**
- * The minimum time between two loads requested for the same edge of the list.
+ * The minimum time between two loads requested for the same edge of the list while the list's
+ * content hasn't changed.
  *
  * Restarting the observer (which happens whenever a loading flag changes) reports an edge as
  * intersecting again if nothing has moved it out of view, so a load that leaves the layout exactly
  * as it was — a page that failed, or one that came back empty — would otherwise be requested again
- * in the same frame, indefinitely. Spacing repeat loads for an edge bounds that to one attempt per
- * interval while still retrying, and a page that legitimately leaves the sentinel in view still
- * chains into the next one, just no sooner than the interval.
+ * in the same frame, indefinitely. Spacing repeat loads of an unchanged edge bounds that to one
+ * attempt per interval while still retrying. A load that did add content is requested as soon as
+ * the edge comes into view, so paging through a list is only limited by how fast pages arrive, and
+ * a page that leaves the sentinel in view chains straight into the next one.
  */
 const MIN_LOAD_INTERVAL_MS = 1000
+
+interface ContentExtent {
+  width: number
+  height: number
+}
+
+/**
+ * The size of the content the sentinel is a part of. Scrolling doesn't change it, loading a page
+ * that adds items does (in either axis, so horizontal lists like the carousel count too).
+ */
+function measureContentExtent(target: Element | null): ContentExtent | undefined {
+  const parent = target?.parentElement
+  return parent ? { width: parent.scrollWidth, height: parent.scrollHeight } : undefined
+}
+
+interface EdgeLoad {
+  /** `performance.now()` when the load was requested, `-Infinity` if it never was. */
+  time: number
+  /** The content extent when the load was requested, `undefined` if it never was. */
+  extent: ContentExtent | undefined
+}
 
 const LoadingArea = styled.div`
   display: flex;
@@ -101,10 +124,10 @@ export default function InfiniteList({
   const prevTargetRef = useRef<HTMLDivElement>(null)
   const nextTargetRef = useRef<HTMLDivElement>(null)
   const observer = useRef<IntersectionObserver>(undefined)
-  const lastLoadRef = useRef<{ token: unknown; prev: number; next: number }>({
+  const lastLoadRef = useRef<{ token: unknown; prev: EdgeLoad; next: EdgeLoad }>({
     token: refreshToken,
-    prev: -Infinity,
-    next: -Infinity,
+    prev: { time: -Infinity, extent: undefined },
+    next: { time: -Infinity, extent: undefined },
   })
 
   // NOTE(2Pac): We restart the observer in a couple of cases:
@@ -118,8 +141,8 @@ export default function InfiniteList({
       // A new token means the list was reset (a different channel, a new search, ...), so its first
       // page shouldn't be made to wait on loads that were requested for the content before it.
       lastLoad.token = refreshToken
-      lastLoad.prev = -Infinity
-      lastLoad.next = -Infinity
+      lastLoad.prev = { time: -Infinity, extent: undefined }
+      lastLoad.next = { time: -Infinity, extent: undefined }
     }
 
     const timers: {
@@ -127,15 +150,29 @@ export default function InfiniteList({
       next?: ReturnType<typeof setTimeout>
     } = {}
 
-    const requestLoad = (edge: 'prev' | 'next', load: () => void) => {
-      const elapsed = performance.now() - lastLoad[edge]
-      if (elapsed >= MIN_LOAD_INTERVAL_MS) {
-        lastLoad[edge] = performance.now()
+    const requestLoad = (
+      edge: 'prev' | 'next',
+      targetRef: React.RefObject<HTMLDivElement | null>,
+      load: () => void,
+    ) => {
+      const last = lastLoad[edge]
+      const extent = measureContentExtent(targetRef.current)
+      // An extent that can't be measured counts as unchanged, so the interval still bounds the loads
+      const contentChanged =
+        extent !== undefined &&
+        last.extent !== undefined &&
+        (extent.width !== last.extent.width || extent.height !== last.extent.height)
+      const elapsed = performance.now() - last.time
+      if (contentChanged || elapsed >= MIN_LOAD_INTERVAL_MS) {
+        lastLoad[edge] = { time: performance.now(), extent }
         load()
       } else {
         clearTimeout(timers[edge])
         timers[edge] = setTimeout(() => {
-          lastLoad[edge] = performance.now()
+          lastLoad[edge] = {
+            time: performance.now(),
+            extent: measureContentExtent(targetRef.current),
+          }
           load()
         }, MIN_LOAD_INTERVAL_MS - elapsed)
       }
@@ -165,12 +202,12 @@ export default function InfiniteList({
 
         if (prevLoadingEnabled && entry.target === prevTargetRef.current) {
           if (!isLoadingPrev && hasPrevData && onLoadPrevData) {
-            requestLoad('prev', onLoadPrevData)
+            requestLoad('prev', prevTargetRef, onLoadPrevData)
           }
         }
         if (nextLoadingEnabled && entry.target === nextTargetRef.current) {
           if (!isLoadingNext && hasNextData && onLoadNextData) {
-            requestLoad('next', onLoadNextData)
+            requestLoad('next', nextTargetRef, onLoadNextData)
           }
         }
       }

--- a/client/lists/infinite-scroll-list.tsx
+++ b/client/lists/infinite-scroll-list.tsx
@@ -3,6 +3,18 @@ import { useEffect, useRef } from 'react'
 import styled from 'styled-components'
 import LoadingIndicator from '../progress/dots'
 
+/**
+ * The minimum time between two loads requested for the same edge of the list.
+ *
+ * Restarting the observer (which happens whenever a loading flag changes) reports an edge as
+ * intersecting again if nothing has moved it out of view, so a load that leaves the layout exactly
+ * as it was — a page that failed, or one that came back empty — would otherwise be requested again
+ * in the same frame, indefinitely. Spacing repeat loads for an edge bounds that to one attempt per
+ * interval while still retrying, and a page that legitimately leaves the sentinel in view still
+ * chains into the next one, just no sooner than the interval.
+ */
+const MIN_LOAD_INTERVAL_MS = 1000
+
 const LoadingArea = styled.div`
   display: flex;
   flex-direction: row;
@@ -89,6 +101,11 @@ export default function InfiniteList({
   const prevTargetRef = useRef<HTMLDivElement>(null)
   const nextTargetRef = useRef<HTMLDivElement>(null)
   const observer = useRef<IntersectionObserver>(undefined)
+  const lastLoadRef = useRef<{ token: unknown; prev: number; next: number }>({
+    token: refreshToken,
+    prev: -Infinity,
+    next: -Infinity,
+  })
 
   // NOTE(2Pac): We restart the observer in a couple of cases:
   //   - `hasPrevData`/`hasNextData` has changed; this allows InfiniteScrollList to be rendered
@@ -96,6 +113,34 @@ export default function InfiniteList({
   //   - `refreshToken` has changed; this means the user of this component forcefully wants to
   //     restart observing for whatever reason.
   useEffect(() => {
+    const lastLoad = lastLoadRef.current
+    if (lastLoad.token !== refreshToken) {
+      // A new token means the list was reset (a different channel, a new search, ...), so its first
+      // page shouldn't be made to wait on loads that were requested for the content before it.
+      lastLoad.token = refreshToken
+      lastLoad.prev = -Infinity
+      lastLoad.next = -Infinity
+    }
+
+    const timers: {
+      prev?: ReturnType<typeof setTimeout>
+      next?: ReturnType<typeof setTimeout>
+    } = {}
+
+    const requestLoad = (edge: 'prev' | 'next', load: () => void) => {
+      const elapsed = performance.now() - lastLoad[edge]
+      if (elapsed >= MIN_LOAD_INTERVAL_MS) {
+        lastLoad[edge] = performance.now()
+        load()
+      } else {
+        clearTimeout(timers[edge])
+        timers[edge] = setTimeout(() => {
+          lastLoad[edge] = performance.now()
+          load()
+        }, MIN_LOAD_INTERVAL_MS - elapsed)
+      }
+    }
+
     const startObserving = () => {
       if (!observer.current) {
         return
@@ -120,12 +165,12 @@ export default function InfiniteList({
 
         if (prevLoadingEnabled && entry.target === prevTargetRef.current) {
           if (!isLoadingPrev && hasPrevData && onLoadPrevData) {
-            onLoadPrevData()
+            requestLoad('prev', onLoadPrevData)
           }
         }
         if (nextLoadingEnabled && entry.target === nextTargetRef.current) {
           if (!isLoadingNext && hasNextData && onLoadNextData) {
-            onLoadNextData()
+            requestLoad('next', onLoadNextData)
           }
         }
       }
@@ -140,6 +185,10 @@ export default function InfiniteList({
     startObserving()
 
     return () => {
+      // A deferred load belongs to the effect run that scheduled it: once that run is torn down,
+      // the callbacks it closed over are not necessarily the ones the list wants called.
+      clearTimeout(timers.prev)
+      clearTimeout(timers.next)
       observer.current?.disconnect()
       observer.current = undefined
     }

--- a/client/snackbars/snackbar-controller-registry.ts
+++ b/client/snackbars/snackbar-controller-registry.ts
@@ -10,6 +10,11 @@ export interface SnackbarOptions {
   signal?: AbortSignal
   /** A value that will be set as `data-testid` on the snackbar element. */
   testName?: string
+  /**
+   * If true, the snackbar is dropped when one with the same message is already showing or waiting
+   * to show.
+   */
+  dedupe?: boolean
 }
 
 export interface SnackbarController {

--- a/client/snackbars/snackbar-overlay.test.tsx
+++ b/client/snackbars/snackbar-overlay.test.tsx
@@ -1,0 +1,78 @@
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import { useEffect } from 'react'
+import { beforeEach, describe, expect, test } from 'vitest'
+import { SnackbarController } from './snackbar-controller-registry'
+import { DURATION_LONG } from './snackbar-durations'
+import { SnackbarOverlay, useSnackbarController } from './snackbar-overlay'
+
+let capturedController: SnackbarController | undefined
+
+function ControllerGrabber() {
+  const controller = useSnackbarController()
+
+  useEffect(() => {
+    capturedController = controller
+  }, [controller])
+
+  return null
+}
+
+describe('client/snackbars/snackbar-overlay', () => {
+  beforeEach(() => {
+    capturedController = undefined
+  })
+
+  const doRender = () => {
+    render(
+      <SnackbarOverlay>
+        <ControllerGrabber />
+      </SnackbarOverlay>,
+    )
+
+    return {
+      showSnackbar: (message: string, options?: { dedupe?: boolean }) => {
+        act(() => {
+          capturedController!.showSnackbar(message, DURATION_LONG, options)
+        })
+      },
+      // The only button on screen is the showing snackbar's close button
+      dismiss: () => {
+        fireEvent.click(screen.getByRole('button'))
+      },
+    }
+  }
+
+  test('a deduped snackbar is dropped while an identical one is showing or queued', () => {
+    const { showSnackbar, dismiss } = doRender()
+
+    showSnackbar('a', { dedupe: true })
+    showSnackbar('a', { dedupe: true })
+    showSnackbar('b')
+    showSnackbar('a', { dedupe: true })
+
+    expect(screen.getByText('a')).toBeDefined()
+
+    dismiss()
+    expect(screen.queryByText('a')).toBeNull()
+    expect(screen.getByText('b')).toBeDefined()
+
+    dismiss()
+    expect(screen.queryByText('a')).toBeNull()
+    expect(screen.queryByText('b')).toBeNull()
+  })
+
+  test('a snackbar without dedupe is queued even when an identical one is showing', () => {
+    const { showSnackbar, dismiss } = doRender()
+
+    showSnackbar('a')
+    showSnackbar('a')
+
+    expect(screen.getByText('a')).toBeDefined()
+
+    dismiss()
+    expect(screen.getByText('a')).toBeDefined()
+
+    dismiss()
+    expect(screen.queryByText('a')).toBeNull()
+  })
+})

--- a/client/snackbars/snackbar-overlay.tsx
+++ b/client/snackbars/snackbar-overlay.tsx
@@ -71,13 +71,25 @@ const transition: Transition = {
 export function SnackbarOverlay({ children }: { children: React.ReactNode }) {
   const idRef = useRef(0)
   const [displayedSnackbar, setDisplayedSnackbar] = useState<QueuedSnackbar>()
+  const displayedRef = useRef<QueuedSnackbar | undefined>(undefined)
   const [isHovering, setIsHovering] = useState(false)
   const timerRef = useRef<ReturnType<typeof setTimeout>>(undefined)
   const [queue, setQueue] = useState<QueuedSnackbar[]>([])
   const controller = useMemo<SnackbarController>(
     () => ({
       showSnackbar(message, durationMillis = DURATION_SHORT, options) {
-        setQueue(q => [...q, { id: idRef.current, message, durationMillis, options }])
+        // The dedupe check runs inside the updater so that it sees every snackbar requested this
+        // tick, not just the ones React has re-rendered for.
+        setQueue(q => {
+          if (
+            options?.dedupe &&
+            (displayedRef.current?.message === message || q.some(s => s.message === message))
+          ) {
+            return q
+          }
+
+          return [...q, { id: idRef.current, message, durationMillis, options }]
+        })
         idRef.current = (idRef.current + 1) % Number.MAX_SAFE_INTEGER
       },
     }),
@@ -124,6 +136,10 @@ export function SnackbarOverlay({ children }: { children: React.ReactNode }) {
       startDismissTimer(Math.round(displayedSnackbar.durationMillis / 2))
     }
   })
+
+  useLayoutEffect(() => {
+    displayedRef.current = displayedSnackbar
+  }, [displayedSnackbar])
 
   useEffect(() => {
     registerSnackbarController(controller)

--- a/client/whispers/whisper.tsx
+++ b/client/whispers/whisper.tsx
@@ -124,6 +124,7 @@ export function ConnectedWhisper({
         errorMessage: err.message,
       }),
       DURATION_LONG,
+      { dedupe: true },
     )
   }
 

--- a/server/public/locales/en/global.json
+++ b/server/public/locales/en/global.json
@@ -362,6 +362,7 @@
     },
     "errors": {
       "loadingHistory": "Error loading message history: {{errorMessage}}",
+      "loadingUserList": "Error loading user list: {{errorMessage}}",
       "messageNotFound": "That message couldn't be found. It may have been deleted."
     },
     "joinChannel": {


### PR DESCRIPTION
Whisper views show a snackbar when a message fetch fails, while channel views swallowed the same failures. The channel fetch action creators for older history, newer messages, a window around a time, jump-to-present and the channel user list now take a `RequestHandlingSpec` (the shape `getMessagesAroundMessage` and the whisper equivalents already use), and `channel.tsx` passes an `onError` that shows the existing loading-history snackbar (a new `chat.errors.loadingUserList` string for the user list). A failed user-list fetch also resets both user-list flags so the next activation can request the list again.

Verifying that surfaced a pre-existing loop in `InfiniteScrollList`, fixed here in a second commit: the observer is recreated whenever a loading flag changes, and `observe()` reports an edge still in view straight away, so a failed page (which leaves the layout unchanged) was re-requested in the same frame indefinitely (~150 requests/s measured; whispers on master behave the same and queued a 10 s snackbar per attempt). Loads for the same edge are spaced at least 1 s apart while the list's content (the sentinel parent's scroll extent) is unchanged since the last request for that edge, and reset on a `refreshToken` change so a reset list's first page never waits. A load that added content is requested as soon as the edge comes back into view, so successful paging and chaining run at the server's pace; only the no-op retry is bounded. Snackbars gain an opt-in `dedupe` option that drops a message already showing or queued; the chat and whisper load-error snackbars use it.

Fixes #1464

## Acceptance criteria

- [x] A failed request for older history, newer messages, a jump-to-present/seek-to-unread window, or the channel user list shows a snackbar. Verified live in the Electron client by routing `**/messages2**` / `**/users2**` to a 500 and driving each path: scroll to top (older), scroll to bottom of a detached window (newer), "Jump to present" button, "New messages" unread banner, and opening the channel (user list). Each showed `Error loading message history: Internal Server Error` or `Error loading user list: Internal Server Error`.
- [x] `retrieveUserList`'s failure clears `loadingUserList`. It also clears `hasLoadedUserList`, which `retrieveUserListBegin` sets when the request starts and which the action creator's guard also checks, so clearing only `loadingUserList` would still have blocked a retry. Verified live: both flags `false` after the 500; re-entering the channel with the route removed refetched `users2` (200) and populated the offline set. Reducer test added.
- [x] Success path unchanged. Verified live: older history pages load, a message sent from a second client arrives live, the user list loads with no snackbar, the channel list page renders. Existing chat/whisper unit tests unchanged and green.

## Drift

Cosmetic only: line numbers in `chat-reducer.ts`, `action-creators.ts` and `channel.tsx` shifted since 6367ffa99. The `hasLoadedUserList` point above is a refinement of the issue's second bullet, not a conflict.

## Beyond the issue (folded in on request)

The infinite-list loop fix and snackbar dedupe in `85db2571b`. With a `messages2` route returning 500 for 5 s: 8 requests instead of ~750, one snackbar on screen instead of a growing queue, and the window recovers on its own within a second of the route being removed (older history 51→101 messages; a jump-to-present that failed into an empty window refilled to 51; whispers 50→100). Unit tests cover the interval, the content-change bypass, the refresh-token reset, teardown of a deferred load, and the dedupe.

## Verification

- T0: `vitest run` for `client/lists`, `client/snackbars`, `client/chat`, `client/whispers`, `client/games` (282 tests) and the full client project green; `tsc` clean; `eslint`/`prettier` clean; `gen-translations` run.
- T3: two Electron instances (`claude-1`, `claude-2`) over CDP with `playwright-cli`, channel `ShieldBattery` (723 messages). Failure injection via `playwright-cli route ... --status 500`. Read position for `claude-1` moved back in the DB to produce the unread banner.

