### PR TITLE
Add per-channel notification settings.

### DIFF
--- a/client/chat/channel-header.tsx
+++ b/client/chat/channel-header.tsx
@@ -32,6 +32,7 @@ import { useSnackbarController } from '../snackbars/snackbar-overlay'
 import { BodySmall, labelLarge, singleLine, titleLarge } from '../styles/typography'
 import { updateChannelUserPreferences } from './action-creators'
 import { ChannelBadge } from './channel-badge'
+import { useChannelNotificationMenuItems } from './channel-notification-menu-items'
 import { openChannelSettings } from './channel-settings/channel-settings-action-creators'
 
 export const CHANNEL_HEADER_HEIGHT = 72
@@ -146,6 +147,12 @@ export function ChannelHeader({
 
   const [channelTopicRef, isChannelTopicOverflowing] = useOverflowingElement()
 
+  const notificationMenuItems = useChannelNotificationMenuItems(
+    basicChannelInfo.id,
+    closeOverflowMenu,
+    { dense: true },
+  )
+
   // TODO(2Pac): Figure out if we can share this with common-message-layout somehow.
   const parsedChannelTopic = useMemo(() => {
     if (!joinedChannelInfo.topic) {
@@ -241,6 +248,15 @@ export function ChannelHeader({
       />,
     )
   }
+  if (isServerModerator) {
+    actions.push(
+      <MenuItem
+        key='open-admin-view'
+        text={t('chat.channelHeader.actionItems.openAdminView', 'Open admin view')}
+        onClick={onOpenAdminViewClick}
+      />,
+    )
+  }
   if (detailedChannelInfo.bannerPath) {
     actions.push(
       <CheckableMenuItem
@@ -251,19 +267,9 @@ export function ChannelHeader({
       />,
     )
   }
-  if (isServerModerator) {
-    actions.push(
-      <MenuItem
-        key='open-admin-view'
-        text={t('chat.channelHeader.actionItems.openAdminView', 'Open admin view')}
-        onClick={onOpenAdminViewClick}
-      />,
-    )
-  }
-  // The divider sets the destructive leave action apart from the management items above it.
-  if (actions.length > 0) {
-    actions.push(<Divider key='divider' />)
-  }
+  actions.push(...notificationMenuItems)
+  // The divider sets the destructive leave action apart from the items above it.
+  actions.push(<Divider key='divider' $dense={true} />)
   actions.push(
     <DestructiveMenuItem
       key='leave-channel'

--- a/client/chat/channel-notification-menu-items.tsx
+++ b/client/chat/channel-notification-menu-items.tsx
@@ -1,0 +1,87 @@
+import { TFunction } from 'i18next'
+import * as React from 'react'
+import { useTranslation } from 'react-i18next'
+import { assertUnreachable } from '../../common/assert-unreachable'
+import {
+  ALL_CHANNEL_NOTIFICATION_LEVELS,
+  ChannelNotificationLevel,
+  DEFAULT_CHANNEL_PREFERENCES,
+  SbChannelId,
+  UpdateChannelUserPreferencesRequest,
+} from '../../common/chat'
+import { CheckableMenuItem } from '../material/menu/checkable-item'
+import { Divider } from '../material/menu/divider'
+import { SelectableMenuItem } from '../material/menu/selectable-item'
+import { useAppDispatch, useAppSelector } from '../redux-hooks'
+import { useSnackbarController } from '../snackbars/snackbar-overlay'
+import { updateChannelUserPreferences } from './action-creators'
+
+function notificationLevelText(level: ChannelNotificationLevel, t: TFunction): string {
+  switch (level) {
+    case ChannelNotificationLevel.All:
+      return t('chat.notifications.level.all', 'Notify for all messages')
+    case ChannelNotificationLevel.Mentions:
+      return t('chat.notifications.level.mentions', 'Notify for mentions only')
+    case ChannelNotificationLevel.Nothing:
+      return t('chat.notifications.level.nothing', 'Never notify')
+    default:
+      return assertUnreachable(level)
+  }
+}
+
+/**
+ * Builds the menu items that control how a chat channel notifies the current user: a mute toggle,
+ * then one item per notification level.
+ *
+ * These are returned as a flat array rather than wrapped in a component because `MenuList` reads
+ * the menu items out of its own children, and anything that hides them inside another component
+ * would be treated as decorative content instead. Spread the result into a `MenuList` (directly or
+ * inside another array of items). `dense` only affects the divider between the mute toggle and the
+ * levels, since `MenuList` passes its density down to the items itself.
+ */
+export function useChannelNotificationMenuItems(
+  channelId: SbChannelId,
+  onDismiss: () => void,
+  { dense }: { dense?: boolean } = {},
+): React.ReactNode[] {
+  const { t } = useTranslation()
+  const dispatch = useAppDispatch()
+  const snackbarController = useSnackbarController()
+  const preferences =
+    useAppSelector(s => s.chat.idToSelfPreferences.get(channelId)) ?? DEFAULT_CHANNEL_PREFERENCES
+
+  const updatePreferences = (changes: UpdateChannelUserPreferencesRequest) => {
+    onDismiss()
+    dispatch(
+      updateChannelUserPreferences(channelId, changes, {
+        onSuccess: () => {},
+        onError: () => {
+          snackbarController.showSnackbar(
+            t(
+              'chat.notifications.errors.updateFailed',
+              'Something went wrong updating the notification settings',
+            ),
+          )
+        },
+      }),
+    )
+  }
+
+  return [
+    <CheckableMenuItem
+      key='mute-channel'
+      checked={preferences.muted}
+      text={t('chat.notifications.muteChannel', 'Mute channel')}
+      onClick={() => updatePreferences({ muted: !preferences.muted })}
+    />,
+    <Divider key='notification-level-divider' $dense={dense} />,
+    ...ALL_CHANNEL_NOTIFICATION_LEVELS.map(level => (
+      <SelectableMenuItem
+        key={level}
+        selected={preferences.notificationLevel === level}
+        text={notificationLevelText(level, t)}
+        onClick={() => updatePreferences({ notificationLevel: level })}
+      />
+    )),
+  ]
+}

--- a/client/chat/chat-reducer.test.ts
+++ b/client/chat/chat-reducer.test.ts
@@ -6,6 +6,7 @@ import {
   ChatMessage,
   ChatMessageEvent,
   ClientChatMessageType,
+  DEFAULT_CHANNEL_PREFERENCES,
   GetBatchedChannelInfosResponse,
   GetChannelHistoryServerResponse,
   InitialChannelData,
@@ -22,6 +23,8 @@ import { ChatActions } from './actions'
 import chatReducerImport, {
   ChatState,
   channelHasUnreadMention,
+  channelNeedsAttention,
+  isChannelMuted,
   oldestServerOriginTime,
 } from './chat-reducer'
 
@@ -77,6 +80,7 @@ function makeState(
     lastReadTime?: number
     latestMentionTime?: number
     unreadLineTime?: number
+    muted?: boolean
     hasHistory?: boolean
     loadingHistory?: boolean
     loadingNewer?: boolean
@@ -118,7 +122,11 @@ function makeState(
       ],
     ]),
     idToUserProfiles: new Map(),
-    idToSelfPreferences: new Map(),
+    idToSelfPreferences: new Map(
+      overrides.muted !== undefined
+        ? [[CHANNEL_ID, { ...DEFAULT_CHANNEL_PREFERENCES, muted: overrides.muted }]]
+        : [],
+    ),
     idToSelfPermissions: new Map(),
     activatedChannels: new Set(overrides.activated ? [CHANNEL_ID] : []),
     atBottomChannels: new Set(overrides.atBottom ? [CHANNEL_ID] : []),
@@ -162,7 +170,7 @@ function initialChannelData(
     channelInfo: CHANNEL_BASIC_INFO,
     detailedChannelInfo: { id: CHANNEL_ID, userCount: 1 },
     joinedChannelInfo: { id: CHANNEL_ID },
-    selfPreferences: { hideBanner: false },
+    selfPreferences: { ...DEFAULT_CHANNEL_PREFERENCES },
     selfPermissions: {
       kick: false,
       ban: false,
@@ -501,6 +509,68 @@ describe('client/chat/chat-reducer', () => {
       const state = makeState({ activated: true, lastReadTime: 100, latestMentionTime: 200 })
 
       expect(channelHasUnreadMention(state, CHANNEL_ID)).toBe(true)
+    })
+  })
+
+  describe('isChannelMuted', () => {
+    test('is false for a channel with no stored preferences', () => {
+      const state = makeState()
+
+      expect(isChannelMuted(state, CHANNEL_ID)).toBe(false)
+    })
+
+    test('is false when the stored preferences say unmuted', () => {
+      const state = makeState({ muted: false })
+
+      expect(isChannelMuted(state, CHANNEL_ID)).toBe(false)
+    })
+
+    test('is true when the stored preferences say muted', () => {
+      const state = makeState({ muted: true })
+
+      expect(isChannelMuted(state, CHANNEL_ID)).toBe(true)
+    })
+  })
+
+  describe('channelNeedsAttention', () => {
+    test('is false when nothing is unread', () => {
+      const state = makeState({ lastReadTime: 100 })
+
+      expect(channelNeedsAttention(state, CHANNEL_ID)).toBe(false)
+    })
+
+    test('is true for an unread channel that is not muted', () => {
+      const state = makeState({ unread: true })
+
+      expect(channelNeedsAttention(state, CHANNEL_ID)).toBe(true)
+    })
+
+    test('is false for an unread channel that is muted', () => {
+      const state = makeState({ unread: true, muted: true })
+
+      expect(channelNeedsAttention(state, CHANNEL_ID)).toBe(false)
+    })
+
+    test('is true for a muted channel with an unread mention', () => {
+      const state = makeState({
+        unread: true,
+        muted: true,
+        lastReadTime: 100,
+        latestMentionTime: 200,
+      })
+
+      expect(channelNeedsAttention(state, CHANNEL_ID)).toBe(true)
+    })
+
+    test('is false for a muted channel whose mention has been read', () => {
+      const state = makeState({
+        unread: true,
+        muted: true,
+        lastReadTime: 200,
+        latestMentionTime: 200,
+      })
+
+      expect(channelNeedsAttention(state, CHANNEL_ID)).toBe(false)
     })
   })
 

--- a/client/chat/chat-reducer.ts
+++ b/client/chat/chat-reducer.ts
@@ -177,6 +177,33 @@ export function channelHasUnreadMention(
   return latestMentionTime > (chatState.idToLastReadTime.get(channelId) ?? Infinity)
 }
 
+/**
+ * Returns whether the current user has muted `channelId`. Channels the user hasn't loaded
+ * preferences for are treated as unmuted, matching the default preferences.
+ */
+export function isChannelMuted(chatState: Immutable<ChatState>, channelId: SbChannelId): boolean {
+  return chatState.idToSelfPreferences.get(channelId)?.muted ?? false
+}
+
+/**
+ * Returns whether `channelId` should be pulling the user's attention passively: the sidebar's
+ * unread dot, the social button's indicator, and the tray's tracked unread state. A muted channel
+ * qualifies only through an unread mention, since a mention is aimed at the user personally while
+ * mute is about the channel's ambient traffic.
+ *
+ * Mute is applied here, at read time, rather than when unread state is recorded, so that unmuting
+ * immediately surfaces whatever accumulated while the channel was muted.
+ */
+export function channelNeedsAttention(
+  chatState: Immutable<ChatState>,
+  channelId: SbChannelId,
+): boolean {
+  return (
+    (chatState.unreadChannels.has(channelId) && !isChannelMuted(chatState, channelId)) ||
+    channelHasUnreadMention(chatState, channelId)
+  )
+}
+
 function removeUserFromChannel(
   state: ChatState,
   channelId: SbChannelId,

--- a/client/chat/socket-handlers.test.ts
+++ b/client/chat/socket-handlers.test.ts
@@ -1,6 +1,13 @@
 ﻿import type { NydusClient } from 'nydus-client'
 import { beforeEach, describe, expect, test, vi } from 'vitest'
-import { type ChatMessageEvent, makeSbChannelId, ServerChatMessageType } from '../../common/chat'
+import {
+  ChannelNotificationLevel,
+  type ChannelPreferences,
+  type ChatMessageEvent,
+  DEFAULT_CHANNEL_PREFERENCES,
+  makeSbChannelId,
+  ServerChatMessageType,
+} from '../../common/chat'
 import { makeSbUserId } from '../../common/users/sb-user-id'
 import { registerDispatch } from '../dispatch-registry'
 import type { RootState } from '../root-reducer'
@@ -24,17 +31,142 @@ const OTHER = { id: makeSbUserId(2), name: 'other', created: 0 }
 
 beforeEach(() => vi.clearAllMocks())
 
+interface MessageCase {
+  name: string
+  fromSelf?: boolean
+  blocked?: boolean
+  mentionsSelf?: boolean
+  /** Omitted to leave the channel without a preferences entry, exercising the defaults. */
+  level?: ChannelNotificationLevel
+  muted?: boolean
+  /** Whether the message should be recorded as mentioning the current user. */
+  mention: boolean
+  /** Whether the message should alert: the attention IPC plus the alert sound. */
+  alerts: boolean
+  /** Whether an alert should ask for the urgent (taskbar-flashing) treatment. */
+  urgent?: boolean
+}
+
 describe('channel message echoes', () => {
-  test.each([
-    { fromSelf: true, blocked: false, mentionsSelf: true, alerts: false },
-    { fromSelf: false, blocked: false, mentionsSelf: true, alerts: true },
-    { fromSelf: false, blocked: false, mentionsSelf: false, alerts: false },
-    { fromSelf: false, blocked: true, mentionsSelf: true, alerts: false },
-  ])('classifies $fromSelf self / $blocked blocked / $mentionsSelf mention', options => {
+  test.each<MessageCase>([
+    {
+      name: 'a self message never alerts, even when it mentions self',
+      fromSelf: true,
+      mentionsSelf: true,
+      level: ChannelNotificationLevel.All,
+      mention: false,
+      alerts: false,
+    },
+    {
+      name: 'a blocked sender never alerts, even when they mention self',
+      blocked: true,
+      mentionsSelf: true,
+      level: ChannelNotificationLevel.All,
+      mention: false,
+      alerts: false,
+    },
+    {
+      name: 'mentions level alerts urgently for a mention',
+      mentionsSelf: true,
+      level: ChannelNotificationLevel.Mentions,
+      mention: true,
+      alerts: true,
+      urgent: true,
+    },
+    {
+      name: 'mentions level stays silent for a message that mentions no one',
+      level: ChannelNotificationLevel.Mentions,
+      mention: false,
+      alerts: false,
+    },
+    {
+      name: 'mentions level still alerts for a mention while muted',
+      mentionsSelf: true,
+      level: ChannelNotificationLevel.Mentions,
+      muted: true,
+      mention: true,
+      alerts: true,
+      urgent: true,
+    },
+    {
+      name: 'mentions level stays silent for a non-mention while muted',
+      level: ChannelNotificationLevel.Mentions,
+      muted: true,
+      mention: false,
+      alerts: false,
+    },
+    {
+      name: 'all level alerts non-urgently for a message that mentions no one',
+      level: ChannelNotificationLevel.All,
+      mention: false,
+      alerts: true,
+      urgent: false,
+    },
+    {
+      name: 'all level alerts urgently for a mention',
+      mentionsSelf: true,
+      level: ChannelNotificationLevel.All,
+      mention: true,
+      alerts: true,
+      urgent: true,
+    },
+    {
+      name: 'all level muted stays silent for a message that mentions no one',
+      level: ChannelNotificationLevel.All,
+      muted: true,
+      mention: false,
+      alerts: false,
+    },
+    {
+      name: 'all level muted still alerts urgently for a mention',
+      mentionsSelf: true,
+      level: ChannelNotificationLevel.All,
+      muted: true,
+      mention: true,
+      alerts: true,
+      urgent: true,
+    },
+    {
+      name: 'nothing level stays silent for a mention',
+      mentionsSelf: true,
+      level: ChannelNotificationLevel.Nothing,
+      mention: true,
+      alerts: false,
+    },
+    {
+      name: 'nothing level stays silent for a message that mentions no one',
+      level: ChannelNotificationLevel.Nothing,
+      mention: false,
+      alerts: false,
+    },
+    {
+      name: 'a channel with no stored preferences alerts urgently for a mention',
+      mentionsSelf: true,
+      mention: true,
+      alerts: true,
+      urgent: true,
+    },
+    {
+      name: 'a channel with no stored preferences stays silent for a non-mention',
+      mention: false,
+      alerts: false,
+    },
+  ])('$name', options => {
     const sender = options.fromSelf ? SELF : OTHER
+    const preferences: ChannelPreferences | undefined =
+      options.level !== undefined
+        ? {
+            ...DEFAULT_CHANNEL_PREFERENCES,
+            notificationLevel: options.level,
+            muted: options.muted ?? false,
+          }
+        : undefined
     const state = {
       auth: { self: { user: SELF } },
-      chat: { activatedChannels: new Set() },
+      chat: {
+        activatedChannels: new Set(),
+        idToSelfPreferences: new Map(preferences ? [[CHANNEL_ID, preferences]] : []),
+      },
       relationships: { blocks: new Map(options.blocked ? [[sender.id, {}]] : []) },
     } as unknown as RootState
     const dispatched = vi.fn()
@@ -69,12 +201,14 @@ describe('channel message echoes', () => {
       payload: event,
       meta: {
         channelId: CHANNEL_ID,
-        isSelfMessage: options.fromSelf,
-        mentionsSelf: options.alerts,
+        isSelfMessage: options.fromSelf ?? false,
+        mentionsSelf: options.mention,
         windowFocused: false,
       },
     })
-    expect(mocks.send).toHaveBeenCalledTimes(options.alerts ? 1 : 0)
+    expect(mocks.send.mock.calls).toEqual(
+      options.alerts ? [['chatNewMessage', { urgent: options.urgent }]] : [],
+    )
     expect(mocks.playSound).toHaveBeenCalledTimes(options.alerts ? 1 : 0)
   })
 })

--- a/client/chat/socket-handlers.ts
+++ b/client/chat/socket-handlers.ts
@@ -1,5 +1,12 @@
 import { NydusClient, RouteInfo } from 'nydus-client'
-import { ChatEvent, ChatUserEvent, SbChannelId, makeSbChannelId } from '../../common/chat'
+import {
+  ChannelNotificationLevel,
+  ChatEvent,
+  ChatUserEvent,
+  DEFAULT_CHANNEL_PREFERENCES,
+  SbChannelId,
+  makeSbChannelId,
+} from '../../common/chat'
 import { TypedIpcRenderer } from '../../common/ipc'
 import { AvailableSound, audioManager } from '../audio/audio-manager'
 import { Dispatchable, dispatch } from '../dispatch-registry'
@@ -98,31 +105,41 @@ const eventToChatAction: EventToChatActionMap = {
     return (dispatch, getState) => {
       const {
         auth,
-        chat: { activatedChannels },
+        chat: { activatedChannels, idToSelfPreferences },
         relationships: { blocks },
       } = getState()
 
       const isSelfMessage = event.message.from === auth.self!.user.id
       const isBlocked = blocks.has(event.message.from)
-      const isUrgent =
+      const isMention =
         !isSelfMessage && !isBlocked && event.mentions.some(m => m.id === auth.self!.user.id)
+      const preferences = idToSelfPreferences.get(channelId) ?? DEFAULT_CHANNEL_PREFERENCES
+      // Muting silences everything but a mention; only the `Nothing` level silences mentions too.
+      const shouldAlert =
+        !isSelfMessage &&
+        !isBlocked &&
+        preferences.notificationLevel !== ChannelNotificationLevel.Nothing &&
+        (isMention ||
+          (preferences.notificationLevel === ChannelNotificationLevel.All && !preferences.muted))
       const windowFocused = windowFocus.isFocused()
-      if (isUrgent) {
-        // Mentions get the main process's transient attention treatment (urgent tray icon +
-        // taskbar flash); regular messages reach it through the tracked unread state instead.
+      if (shouldAlert) {
+        // The main process shows a transient tray icon for every alert but only flashes the taskbar
+        // for urgent ones, which is reserved for messages aimed at this user.
         ipcRenderer.send('chatNewMessage', {
-          urgent: true,
+          urgent: isMention,
         })
       }
 
+      // Unread and mention tracking record what happened in the channel regardless of what the
+      // user chose to be alerted about, so that muting or unmuting reveals the true state.
       dispatch({
         type: '@chat/updateMessage',
         payload: event,
-        meta: { channelId, isSelfMessage, mentionsSelf: isUrgent, windowFocused },
+        meta: { channelId, isSelfMessage, mentionsSelf: isMention, windowFocused },
       })
 
       const isChannelActivated = activatedChannels.has(channelId)
-      if (isUrgent && (!isChannelActivated || !windowFocused)) {
+      if (shouldAlert && (!isChannelActivated || !windowFocused)) {
         audioManager.playSound(AvailableSound.MessageAlert)
       }
     }

--- a/client/messaging/unread-tray-sync.tsx
+++ b/client/messaging/unread-tray-sync.tsx
@@ -1,13 +1,15 @@
 import { useEffect } from 'react'
 import { TypedIpcRenderer } from '../../common/ipc'
-import { channelHasUnreadMention } from '../chat/chat-reducer'
+import { channelHasUnreadMention, channelNeedsAttention } from '../chat/chat-reducer'
 import { useAppSelector } from '../redux-hooks'
 
 const ipcRenderer = new TypedIpcRenderer()
 
 function UnreadTraySyncImpl() {
   const hasUnread = useAppSelector(
-    s => s.chat.unreadChannels.size > 0 || s.whispers.byId.values().some(w => w.hasUnread),
+    s =>
+      s.chat.joinedChannels.values().some(id => channelNeedsAttention(s.chat, id)) ||
+      s.whispers.byId.values().some(w => w.hasUnread),
   )
   // A whisper is inherently directed at the current user, so any unread whisper counts as urgent
   // alongside a channel message that mentions them.

--- a/client/social/social-sidebar-button.tsx
+++ b/client/social/social-sidebar-button.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
-import { channelHasUnreadMention } from '../chat/chat-reducer'
+import { channelHasUnreadMention, channelNeedsAttention } from '../chat/chat-reducer'
 import { IconButton } from '../material/button'
 import { Tooltip } from '../material/tooltip'
 import { useAppSelector } from '../redux-hooks'
@@ -41,7 +41,9 @@ export interface SocialSidebarButtonProps {
 export function SocialSidebarButton({ onClick, icon, isOpen }: SocialSidebarButtonProps) {
   const { t } = useTranslation()
 
-  const hasUnreadChat = useAppSelector(s => s.chat.unreadChannels.size > 0)
+  const hasUnreadChat = useAppSelector(s =>
+    s.chat.joinedChannels.values().some(id => channelNeedsAttention(s.chat, id)),
+  )
   const hasUnreadWhispers = useAppSelector(s => s.whispers.byId.values().some(w => w.hasUnread))
   // Whisper unread counts as urgent since a whisper is inherently directed at the current user,
   // matching how the tray's tracked-unread state treats it.

--- a/client/social/social-sidebar.tsx
+++ b/client/social/social-sidebar.tsx
@@ -21,7 +21,12 @@ import {
   markChannelReadNow,
 } from '../chat/action-creators'
 import { ConnectedChannelBadge } from '../chat/channel-badge'
-import { channelHasUnreadMention } from '../chat/chat-reducer'
+import { useChannelNotificationMenuItems } from '../chat/channel-notification-menu-items'
+import {
+  channelHasUnreadMention,
+  channelNeedsAttention,
+  isChannelMuted,
+} from '../chat/chat-reducer'
 import { openDialog } from '../dialogs/action-creators'
 import { DialogType } from '../dialogs/dialog-type'
 import { useWindowSize } from '../dom/dimension-hooks'
@@ -539,9 +544,16 @@ function ChannelEntry({
   const hasUnread = useAppSelector(s => s.chat.unreadChannels.has(channelId))
   const hasUnreadMention = useAppSelector(s => channelHasUnreadMention(s.chat, channelId))
   const hasUnreadLine = useAppSelector(s => s.chat.idToUnreadLineTime.has(channelId))
+  const needsAttention = useAppSelector(s => channelNeedsAttention(s.chat, channelId))
+  const isMuted = useAppSelector(s => isChannelMuted(s.chat, channelId))
   const canMarkRead = hasUnread || hasUnreadMention || hasUnreadLine
   const { onNavigation } = useNavigationTracker()
   const { onContextMenu, contextMenuPopoverProps } = useContextMenu()
+  const notificationMenuItems = useChannelNotificationMenuItems(
+    channelId,
+    contextMenuPopoverProps.onDismiss,
+    { dense: true },
+  )
 
   useEffect(() => {
     dispatch(getBatchChannelInfo(channelId))
@@ -559,7 +571,7 @@ function ChannelEntry({
   )
 
   const displayName = basicInfo?.name ? (
-    <span>#{basicInfo.name}</span>
+    <ChannelNameText $muted={isMuted}>#{basicInfo.name}</ChannelNameText>
   ) : (
     <LoadingName aria-label={t('common.loading.channelName', 'Channel name loading…')}>
       &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
@@ -578,6 +590,7 @@ function ChannelEntry({
               dispatch(markChannelReadNow(channelId))
             }}
           />
+          {notificationMenuItems}
           <Divider $dense={true} />
           <DestructiveMenuItem
             text={t('chat.navEntry.leaveChannel', 'Leave channel')}
@@ -591,11 +604,18 @@ function ChannelEntry({
 
       <Entry
         link={urlPath`/chat/${channelId}/${basicInfo?.name}`}
-        needsAttention={hasUnread || hasUnreadMention}
+        needsAttention={needsAttention}
         urgentAttention={hasUnreadMention}
         title={basicInfo ? `#${basicInfo.name}` : undefined}
         button={button}
         icon={<ConnectedChannelBadge channelId={channelId} />}
+        trailing={
+          isMuted ? (
+            <MutedGlyph title={t('chat.notifications.mutedTitle', 'Muted')}>
+              <MaterialIcon icon='notifications_off' size={20} />
+            </MutedGlyph>
+          ) : undefined
+        }
         isActive={contextMenuPopoverProps.open}
         onContextMenu={onContextMenu}
         onClick={event => {
@@ -719,6 +739,20 @@ const LoadingName = styled.span`
 
 const WhisperActivityGlyph = styled(FriendActivityStatusGlyph)`
   margin-left: 8px;
+`
+
+const MutedGlyph = styled.div`
+  margin-left: 8px;
+  flex-shrink: 0;
+
+  display: flex;
+  align-items: center;
+
+  color: var(--theme-on-surface-variant);
+`
+
+const ChannelNameText = styled.span<{ $muted?: boolean }>`
+  opacity: ${props => (props.$muted ? 0.6 : 1)};
 `
 
 const EntryRoot = styled(Link)<{ $isCurrentPath: boolean; $isActive?: boolean }>`

--- a/common/chat.ts
+++ b/common/chat.ts
@@ -204,9 +204,43 @@ export interface JoinedChannelInfo {
   topic?: string
 }
 
+/**
+ * Which messages in a channel actively alert the user (the alert sound, plus the transient tray
+ * icon and taskbar flash), as opposed to only marking the channel unread.
+ */
+export enum ChannelNotificationLevel {
+  /** Every message alerts. */
+  All = 'all',
+  /** Only messages that mention the user alert. */
+  Mentions = 'mentions',
+  /** No message alerts, mentions included. */
+  Nothing = 'nothing',
+}
+
+export const ALL_CHANNEL_NOTIFICATION_LEVELS: ReadonlyArray<ChannelNotificationLevel> =
+  Object.values(ChannelNotificationLevel)
+
 export interface ChannelPreferences {
   /** A flag indicating whether to show/hide the channel banner for a user. */
   hideBanner: boolean
+  /**
+   * Which messages alert the user. Mute doesn't change this: a mention still alerts at the
+   * `Mentions` and `All` levels while the channel is muted, and `Nothing` silences mentions too.
+   */
+  notificationLevel: ChannelNotificationLevel
+  /**
+   * Whether the channel is muted. A muted channel never alerts for a message that doesn't mention
+   * the user and doesn't show as unread for one, so a busy channel can stay joined without pulling
+   * attention. Mentions still show and (subject to `notificationLevel`) still alert, and messages
+   * keep arriving and rendering normally.
+   */
+  muted: boolean
+}
+
+export const DEFAULT_CHANNEL_PREFERENCES: Readonly<ChannelPreferences> = {
+  hideBanner: false,
+  notificationLevel: ChannelNotificationLevel.Mentions,
+  muted: false,
 }
 
 export interface ChannelPermissions {

--- a/migrations/20260910120000_add_channel_notification_preferences.sql
+++ b/migrations/20260910120000_add_channel_notification_preferences.sql
@@ -1,0 +1,11 @@
+-- Per-(user, channel) notification preferences. `notification_level` controls which messages alert
+-- the user (the alert sound, plus the transient tray icon and taskbar flash): 'all' alerts on every
+-- message, 'mentions' only on messages that mention the user, 'nothing' never alerts. `muted`
+-- silences the channel further: while true, a message that doesn't mention the user neither alerts
+-- nor marks the channel unread, regardless of `notification_level`; mentions still alert (subject to
+-- `notification_level`) and still show as unread.
+
+ALTER TABLE channel_users
+  ADD COLUMN notification_level text NOT NULL DEFAULT 'mentions'
+    CHECK (notification_level IN ('all', 'mentions', 'nothing')),
+  ADD COLUMN muted boolean NOT NULL DEFAULT false;

--- a/server/lib/chat/chat-api.ts
+++ b/server/lib/chat/chat-api.ts
@@ -4,6 +4,7 @@ import Joi from 'joi'
 import Koa, { ExtendableContext, Next } from 'koa'
 import { assertUnreachable } from '../../../common/assert-unreachable'
 import {
+  ALL_CHANNEL_NOTIFICATION_LEVELS,
   CHANNEL_BANS_LIMIT,
   CHANNEL_USER_PERMISSIONS_LIMIT,
   ChannelPermissions,
@@ -422,6 +423,8 @@ export class ChatApi {
       params: channelIdParamsSchema(),
       body: Joi.object<UpdateChannelUserPreferencesRequest>({
         hideBanner: Joi.boolean(),
+        notificationLevel: Joi.string().valid(...ALL_CHANNEL_NOTIFICATION_LEVELS),
+        muted: Joi.boolean(),
       }),
     })
 

--- a/server/lib/chat/chat-models.ts
+++ b/server/lib/chat/chat-models.ts
@@ -34,6 +34,8 @@ function convertUserChannelEntryFromDb(props: DbUserChannelEntry): UserChannelEn
     joinDate: props.join_date,
     channelPreferences: {
       hideBanner: props.hide_banner,
+      notificationLevel: props.notification_level,
+      muted: props.muted,
     },
     channelPermissions: {
       kick: props.kick,
@@ -786,6 +788,12 @@ export async function updateUserPreferences(
           switch (key) {
             case 'hideBanner':
               return sql`hide_banner = ${value}`
+
+            case 'notificationLevel':
+              return sql`notification_level = ${value}`
+
+            case 'muted':
+              return sql`muted = ${value}`
 
             default:
               return assertUnreachable(key)

--- a/server/lib/chat/chat-service.test.ts
+++ b/server/lib/chat/chat-service.test.ts
@@ -5,6 +5,7 @@ import {
   BasicChannelInfo,
   ChannelBanEntry,
   ChannelModerationAction,
+  ChannelNotificationLevel,
   ChannelPermissions,
   ChannelPreferences,
   ChatServiceErrorCode,
@@ -19,6 +20,7 @@ import {
   UserChannelEntry,
 } from '../../../common/chat'
 import { NotificationType } from '../../../common/notifications'
+import { Patch } from '../../../common/patch'
 import { asMockedFunction } from '../../../common/testing/mocks'
 import { SbUser } from '../../../common/users/sb-user'
 import { makeSbUserId, SbUserId } from '../../../common/users/sb-user-id'
@@ -248,6 +250,8 @@ describe('chat/chat-service', () => {
 
   const channelPreferences: ChannelPreferences = {
     hideBanner: false,
+    notificationLevel: ChannelNotificationLevel.Mentions,
+    muted: false,
   }
   const channelPermissions: ChannelPermissions = {
     kick: false,
@@ -3365,6 +3369,44 @@ describe('chat/chat-service', () => {
       expect(client1.publish).toHaveBeenCalledWith(getChannelUserPath(testChannel.id, user1.id), {
         action: 'preferencesChanged',
         selfPreferences: channelPreferences,
+      })
+    })
+
+    test('works when updating notification preferences', async () => {
+      await joinUserToChannel(
+        user1,
+        testChannel,
+        user1TestChannelEntry,
+        joinUser1TestChannelMessage,
+      )
+
+      asMockedFunction(getChannelInfo).mockResolvedValue(testChannel)
+      asMockedFunction(getUserChannelEntryForUser).mockResolvedValue(user1TestChannelEntry)
+
+      const notificationPreferences: Patch<ChannelPreferences> = {
+        notificationLevel: ChannelNotificationLevel.Nothing,
+        muted: true,
+      }
+      const updatedChannelEntry: UserChannelEntry = {
+        ...user1TestChannelEntry,
+        channelPreferences: {
+          ...channelPreferences,
+          notificationLevel: ChannelNotificationLevel.Nothing,
+          muted: true,
+        },
+      }
+      updateUserPreferencesMock.mockResolvedValueOnce(updatedChannelEntry)
+
+      await chatService.updateUserPreferences(testChannel.id, user1.id, notificationPreferences)
+
+      expect(updateUserPreferencesMock).toHaveBeenCalledWith(
+        testChannel.id,
+        user1.id,
+        notificationPreferences,
+      )
+      expect(client1.publish).toHaveBeenCalledWith(getChannelUserPath(testChannel.id, user1.id), {
+        action: 'preferencesChanged',
+        selfPreferences: updatedChannelEntry.channelPreferences,
       })
     })
   })

--- a/server/public/locales/en/global.json
+++ b/server/public/locales/en/global.json
@@ -408,7 +408,17 @@
     },
     "notifications": {
       "ban": "You have been banned from <1>#{{channelName}}</1>.",
+      "errors": {
+        "updateFailed": "Something went wrong updating the notification settings"
+      },
       "kick": "You have been kicked from <1>#{{channelName}}</1>.",
+      "level": {
+        "all": "Notify for all messages",
+        "mentions": "Notify for mentions only",
+        "nothing": "Never notify"
+      },
+      "muteChannel": "Mute channel",
+      "mutedTitle": "Muted",
       "unban": "Your ban from <1>#{{channelName}}</1> has been lifted."
     },
     "transferOwnership": {


### PR DESCRIPTION
Chat notification preferences are per channel, the way channel settings work in Discord: each joined channel gets a **mute** toggle and a **notification level** (notify for all messages / for mentions only / never). They live on the user's channel membership row next to the banner preference, so they are account-scoped and follow the user across installs, arrive with the channel's initial data, and every change is pushed to all of the account's sessions through the existing preferences-changed event. The level decides which messages play the alert sound and ask the main process for attention (a mention flashes the taskbar; an "all messages" alert only shows the transient tray icon). Mute additionally keeps the channel's unread mark and tray state quiet for messages that don't mention the user, while mentions still badge and (unless the level is "never") still alert. Both are reachable from the channel's sidebar context menu and the channel header's overflow menu, and a muted channel shows a muted glyph with a dimmed name in the sidebar.

Fixes #1461
Part of #1456 (the per-channel mute half; "quiet while in game" is not in this PR)

## Acceptance criteria

- [x] Notification settings are stored server-side, associated with the account. Verified: toggling from the menu updates `channel_users.muted` / `channel_users.notification_level` for the user (checked in the DB after each change).
- [x] Changing a setting on one session updates every other session live. Verified with two Electron instances logged into the same account: mute and level changes on A showed on B's Redux state and sidebar (muted glyph, dimmed name) within the same second, no reload.
- [x] On login to a new device the account's settings apply immediately. Verified: reloading B brought the stored values back in the channel's initial data, not defaults.
- [ ] If the server is unreachable the client falls back to the last-synced value. Not applicable to this shape: the settings arrive with the channel data itself, and without a server connection there is no chat to notify about, so there is no separate cache to keep.
- [x] `masterVolume` is untouched and stays local.

## Drift notes

The issue's premise holds at master (no per-conversation notification preference existed). The review on this PR's first revision rescoped it from account-global sound/flash toggles to per-channel settings; that revision, including its generic account-settings mechanism for #1460, is gone from this branch (it remains in history at `20f3a09c9` for whichever account-level setting lands first).

## Calls made

- **Model**: mute (until turned back on) plus a three-level notification setting. Passed on timed mute durations, a dedicated notification-settings dialog and a header bell button; the menu system has no submenus, so the options are flat items.
- **Mute vs. mentions**: a mention alerts through a mute at the "mentions" and "all" levels and always keeps its badge; only "never notify" silences mentions. Mute is applied when unread state is read (`channelNeedsAttention`), not when it is recorded, so unmuting immediately shows what accumulated.
- **"All messages" alerts** send the attention IPC non-urgent (transient tray icon, sound, no taskbar flash); mentions stay urgent.
- **Placement**: sidebar context menu (Mark as read · Mute channel · levels · Leave channel) and the header overflow menu after "Hide banner"; "Open admin view" moved up next to "Channel settings" so moderator items sit together, and that menu's divider is now dense like the list.
- **Whispers** are unchanged (exempt per #1456).

## Verification

- T0: lint, typecheck, `check-circular`, prettier clean; vitest over `client/chat`, `client/social`, `client/messaging`, `server/lib/chat` green (14-case alert matrix for the message handler, reducer selector tests, service test for the preferences push). Translations regenerated.
- Migration applied to the dev DB (`channel_users` gains `notification_level` with a CHECK and `muted`).
- T3: three Electron instances over CDP (claude-1 twice for cross-session sync, claude-2 sending through the API). Observed on the receiving client with the alert sound hooked: mentions level + normal message → unread mark, no sound; mention → urgent mark, sound. Muted: normal message → no mark, no sound; mention → urgent mark, sound. Never notify (muted): mention → urgent mark, no sound. All messages (unmuted): normal message → unread mark, sound. Both menus show the new items with the current level checked.
