### PR TITLE
Add a /me command that sends emote-flagged text messages in every chat surface.

### DIFF
--- a/client/chat/action-creators.ts
+++ b/client/chat/action-creators.ts
@@ -387,23 +387,22 @@ export function transferChannelOwnership(
   })
 }
 
-export function sendMessage(channelId: SbChannelId, message: string): ThunkAction {
-  return dispatch => {
-    const params = { channelId, message }
-    dispatch({
-      type: '@chat/sendMessageBegin',
-      payload: params,
-    })
-
-    dispatch({
-      type: '@chat/sendMessage',
-      payload: fetchJson<void>(apiUrl`chat/${channelId}/messages`, {
-        method: 'POST',
-        body: encodeBodyAsParams<SendChatMessageServerRequest>({ message }),
+export function sendMessage(
+  channelId: SbChannelId,
+  message: string,
+  spec: RequestHandlingSpec,
+  options: { emote?: boolean } = {},
+): ThunkAction {
+  return abortableThunk(spec, async () => {
+    await fetchJson<void>(apiUrl`chat/${channelId}/messages`, {
+      method: 'POST',
+      body: encodeBodyAsParams<SendChatMessageServerRequest>({
+        message,
+        emote: options.emote ? true : undefined,
       }),
-      meta: params,
+      signal: spec.signal,
     })
-  }
+  })
 }
 
 export function deleteMessageAsAdmin(

--- a/client/chat/actions.ts
+++ b/client/chat/actions.ts
@@ -32,9 +32,6 @@ export type ChatActions =
   | LeaveChannelBegin
   | LeaveChannel
   | LeaveChannelFailure
-  | SendMessageBegin
-  | SendMessage
-  | SendMessageFailure
   | LoadMessageHistoryBegin
   | LoadMessageHistory
   | LoadMessageHistoryFailure
@@ -131,34 +128,6 @@ export interface LeaveChannel {
 export interface LeaveChannelFailure extends BaseFetchFailure<'@chat/leaveChannel'> {
   meta: {
     channelId: SbChannelId
-  }
-}
-
-export interface SendMessageBegin {
-  type: '@chat/sendMessageBegin'
-  payload: {
-    channelId: SbChannelId
-    message: string
-  }
-}
-
-/**
- * Send a chat message to a chat channel.
- */
-export interface SendMessage {
-  type: '@chat/sendMessage'
-  payload: void
-  meta: {
-    channelId: SbChannelId
-    message: string
-  }
-  error?: false
-}
-
-export interface SendMessageFailure extends BaseFetchFailure<'@chat/sendMessage'> {
-  meta: {
-    channelId: SbChannelId
-    message: string
   }
 }
 

--- a/client/chat/channel.tsx
+++ b/client/chat/channel.tsx
@@ -8,10 +8,12 @@ import {
   ServerChatMessageType,
   isServerChatMessage,
 } from '../../common/chat'
+import { getErrorStack } from '../../common/errors'
 import { SbUserId } from '../../common/users/sb-user-id'
 import { useHasAnyPermission } from '../admin/admin-permissions'
 import { useSelfUser } from '../auth/auth-utils'
 import { useWindowFocus } from '../dom/window-focus'
+import logger from '../logging/logger'
 import { Chat } from '../messaging/chat'
 import { anchorNeedsFetch, chatViewAnchorStore } from '../messaging/chat-view-anchor'
 import { ChannelCommandContext } from '../messaging/commands/command-context'
@@ -514,7 +516,14 @@ export function ConnectedChatChannel({
   }
 
   const onSendChatMessage = useStableCallback((msg: string) =>
-    dispatch(sendMessage(channelId, msg)),
+    dispatch(
+      sendMessage(channelId, msg, {
+        onSuccess: () => {},
+        onError: err => {
+          logger.error(`Error sending a chat message: ${getErrorStack(err)}`)
+        },
+      }),
+    ),
   )
 
   const onLeaveChannel = useStableCallback((channelId: SbChannelId) => {

--- a/client/lobbies/action-creators.ts
+++ b/client/lobbies/action-creators.ts
@@ -233,13 +233,27 @@ export function startCountdown(): ThunkAction {
   )
 }
 
-export function sendChat(text: string): ThunkAction {
-  return currentLobbyRequest('sending a lobby chat message', lobbyId =>
-    fetchJson<void>(apiUrl`lobbies/${lobbyId}/chat`, {
+export function sendChat(
+  text: string,
+  spec: RequestHandlingSpec,
+  options: { emote?: boolean } = {},
+): ThunkAction {
+  return abortableThunk(spec, async (_dispatch, getState) => {
+    const { lobby } = getState()
+    if (!isInLobby(lobby)) {
+      return
+    }
+
+    await fetchJson<void>(apiUrl`lobbies/${lobby.info.id}/chat`, {
       method: 'POST',
-      body: encodeBodyAsParams<SendLobbyChatRequest>({ clientId, text }),
-    }),
-  )
+      body: encodeBodyAsParams<SendLobbyChatRequest>({
+        clientId,
+        text,
+        emote: options.emote ? true : undefined,
+      }),
+      signal: spec.signal,
+    })
+  })
 }
 
 const STATE_CACHE_TIMEOUT = 20 * 1000

--- a/client/lobbies/lobby-reducer.test.ts
+++ b/client/lobbies/lobby-reducer.test.ts
@@ -70,12 +70,18 @@ function initAction(): LobbyActions {
   return { type: '@lobbies/init', payload: { type: 'init', lobby: LOBBY, userInfos: [] } }
 }
 
-function chatAction(text: string): LobbyActions {
+function chatAction(text: string, emote?: boolean): LobbyActions {
   return {
     type: '@lobbies/updateChatMessage',
     payload: {
       type: 'chat',
-      message: { lobbyName: LOBBY.name, time: 27, from: HOST_SLOT.userId!, text },
+      message: {
+        lobbyName: LOBBY.name,
+        time: 27,
+        from: HOST_SLOT.userId!,
+        text,
+        ...(emote ? { emote: true } : {}),
+      },
       mentions: [],
       channelMentions: [],
     },
@@ -183,6 +189,13 @@ describe('client/lobbies/lobby-reducer', () => {
     expect(state.chat).toHaveLength(0)
     expect(state.activated).toBe(false)
     expect(state.hasUnread).toBe(true)
+  })
+
+  test('an arriving action line keeps its emote flag', () => {
+    let state = lobbyReducer(undefined, initAction())
+    state = lobbyReducer(state, chatAction('waves', true))
+
+    expect(state.chat[state.chat.length - 1]).toMatchObject({ emote: true })
   })
 
   test('chat while deactivated marks unread; activating clears it', () => {

--- a/client/lobbies/lobby-reducer.ts
+++ b/client/lobbies/lobby-reducer.ts
@@ -243,6 +243,7 @@ const lobbyHandlers = {
       time: message.time,
       from: message.from,
       text: message.text,
+      ...(message.emote ? { emote: true } : {}),
     })
   },
 

--- a/client/lobbies/view.tsx
+++ b/client/lobbies/view.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 import { Route, Switch } from 'wouter'
 import { assertUnreachable } from '../../common/assert-unreachable'
+import { getErrorStack } from '../../common/errors'
 import { LobbyState } from '../../common/lobbies'
 import { LobbyJoinErrorCode } from '../../common/lobbies/lobby-network'
 import { makeSbLobbyId, SbLobbyId } from '../../common/lobbies/sb-lobby-id'
@@ -11,6 +12,7 @@ import { useRequireLogin, useSelfUser } from '../auth/auth-utils'
 import { navigateToGameResults } from '../games/action-creators'
 import { ResultsSubPage } from '../games/results-sub-page'
 import { MaterialIcon } from '../icons/material/material-icon'
+import logger from '../logging/logger'
 import { openMapPreviewDialog } from '../maps/action-creators'
 import { FilledButton } from '../material/button'
 import { LobbyCommandContext } from '../messaging/commands/command-context'
@@ -199,7 +201,14 @@ function ConnectedLobby() {
         dispatch(startCountdown())
       }}
       onSendChatMessage={message => {
-        dispatch(sendChat(message))
+        dispatch(
+          sendChat(message, {
+            onSuccess: () => {},
+            onError: err => {
+              logger.error(`Error while sending a lobby chat message: ${getErrorStack(err)}`)
+            },
+          }),
+        )
       }}
       onMapPreview={() => {
         dispatch(openMapPreviewDialog(lobby.map!.id))

--- a/client/messaging/__snapshots__/common-message-layout.test.tsx.snap
+++ b/client/messaging/__snapshots__/common-message-layout.test.tsx.snap
@@ -124,6 +124,63 @@ exports[`client/messaging/common-message-layout/TextMessage > message mixing emo
 </div>
 `;
 
+exports[`client/messaging/common-message-layout/TextMessage > message sent as an emote reads as an action line 1`] = `
+<div
+  data-testid="message-container"
+>
+  <div
+    class="sc-djDiuc jOQYWn"
+    data-message-id="MESSAGE_ID"
+    role="document"
+  >
+    <div
+      class="sc-ikrMhg iRLQJB sc-ewKWQi ekGrcY"
+      tabindex="0"
+    >
+      <span
+        class="sc-eillgj hCvGOa"
+      >
+        <i
+          aria-hidden="true"
+          class="sc-hKOsxR HaWPv"
+        >
+          [
+        </i>
+        12:00 AM
+        <i
+          aria-hidden="true"
+          class="sc-hKOsxR HaWPv"
+        >
+          ] 
+        </i>
+      </span>
+    </div>
+    <span
+      class="sc-dxdKQw cuWvaS"
+    >
+      * 
+    </span>
+    <span
+      class="sc-edvVIM BgKKj sc-egVbnM sc-gVZcgN heJhVC ijAExg"
+      tabindex="0"
+    >
+      <span
+        aria-label="Username loading…"
+        class="sc-jmvSDW kJMgdI"
+      >
+                   
+      </span>
+    </span>
+     
+    <span
+      class="sc-hFQsEd sc-hKlkwe hNjprR ipLGyN"
+    >
+      waves at everyone
+    </span>
+  </div>
+</div>
+`;
+
 exports[`client/messaging/common-message-layout/TextMessage > message with a link 1`] = `
 <div
   data-testid="message-container"

--- a/client/messaging/commands/command-registry.test.tsx
+++ b/client/messaging/commands/command-registry.test.tsx
@@ -57,6 +57,7 @@ describe('messaging/commands/command-registry', () => {
       'close',
       'kick',
       'ban',
+      'me',
     ])
   })
 
@@ -68,18 +69,21 @@ describe('messaging/commands/command-registry', () => {
       'leave',
       'kick',
       'ban',
+      'me',
     ])
     expect(getSurfaceCommands(ALL_COMMANDS, 'whisper').map(c => c.name)).toEqual([
       'help',
       'join',
       'whisper',
       'close',
+      'me',
     ])
     expect(getSurfaceCommands(ALL_COMMANDS, 'lobby').map(c => c.name)).toEqual([
       'help',
       'join',
       'whisper',
       'leave',
+      'me',
     ])
   })
 
@@ -181,6 +185,12 @@ describe('messaging/commands/command-registry', () => {
             ],
             description: 'Bans a user from this channel.',
             unavailableReason: "You don't have permission to ban users from this channel.",
+          },
+          {
+            name: 'me',
+            aliases: ['emote'],
+            args: [{ label: 'action', optional: false }],
+            description: 'Sends an action line, shown as "* YourName does something".',
           },
         ],
       },

--- a/client/messaging/commands/command-registry.ts
+++ b/client/messaging/commands/command-registry.ts
@@ -4,6 +4,7 @@ import { helpCommand } from './commands/help'
 import { joinCommand } from './commands/join'
 import { banCommand, kickCommand } from './commands/kick-ban'
 import { leaveCommand } from './commands/leave'
+import { meCommand } from './commands/me'
 import { whisperCommand } from './commands/whisper'
 
 /** Every command there is, in the order help lists them. */
@@ -15,6 +16,7 @@ export const ALL_COMMANDS: ReadonlyArray<ChatCommand> = [
   closeCommand,
   kickCommand,
   banCommand,
+  meCommand,
 ]
 
 /**

--- a/client/messaging/commands/commands/me.test.tsx
+++ b/client/messaging/commands/commands/me.test.tsx
@@ -1,0 +1,186 @@
+import { render, screen } from '@testing-library/react'
+import i18next, { TFunction } from 'i18next'
+import * as React from 'react'
+import { initReactI18next } from 'react-i18next'
+import { beforeAll, beforeEach, describe, expect, test, vi } from 'vitest'
+import { ChatServiceErrorCode, makeSbChannelId } from '../../../../common/chat'
+import { asMockedFunction } from '../../../../common/testing/mocks'
+import { makeSbUserId } from '../../../../common/users/sb-user-id'
+import { WhisperServiceErrorCode } from '../../../../common/whispers'
+import { sendMessage as sendChannelMessage } from '../../../chat/action-creators'
+import { sendChat as sendLobbyChat } from '../../../lobbies/action-creators'
+import { FetchError } from '../../../network/fetch-errors'
+import { sendMessage as sendWhisperMessage } from '../../../whispers/action-creators'
+import {
+  ChannelCommandContext,
+  CommandContext,
+  LobbyCommandContext,
+  WhisperCommandContext,
+} from '../command-context'
+import { LocalLineContent } from '../local-output'
+import { runChatCommandWith } from '../run-chat-command'
+import { meCommand } from './me'
+
+vi.mock('../../../logging/logger', () => ({
+  default: { verbose: vi.fn(), debug: vi.fn(), warning: vi.fn(), error: vi.fn() },
+}))
+
+// Only the senders the command reaches for are stubbed; the rest of each module stays real, since
+// the command registry these run against pulls in every command's action creators.
+vi.mock('../../../chat/action-creators', async importOriginal => ({
+  ...(await importOriginal<typeof import('../../../chat/action-creators')>()),
+  sendMessage: vi.fn(() => ({ type: 'TEST/channelSend' })),
+}))
+vi.mock('../../../whispers/action-creators', async importOriginal => ({
+  ...(await importOriginal<typeof import('../../../whispers/action-creators')>()),
+  sendMessage: vi.fn(() => ({ type: 'TEST/whisperSend' })),
+}))
+vi.mock('../../../lobbies/action-creators', async importOriginal => ({
+  ...(await importOriginal<typeof import('../../../lobbies/action-creators')>()),
+  sendChat: vi.fn(() => ({ type: 'TEST/lobbySend' })),
+}))
+
+// The command layer builds its lines with `Trans`, which needs an i18next instance to render
+// against even though every line hands it a `t` of its own. `escapeValue` matches how the app
+// initializes i18next: React escapes what it renders, so escaping again would put entities on
+// screen in place of the angle brackets and slashes these lines are made of.
+beforeAll(async () => {
+  await i18next
+    .use(initReactI18next)
+    .init({ lng: 'en', resources: {}, interpolation: { escapeValue: false } })
+})
+
+// Answers with whatever default value the caller supplied, which is what the real translations
+// hold for English anyway.
+const t = ((key: string, options?: string | { defaultValue?: string }) =>
+  typeof options === 'string' ? options : (options?.defaultValue ?? key)) as unknown as TFunction
+
+const CHANNEL_ID = makeSbChannelId(1)
+const SELF_ID = makeSbUserId(1)
+const TARGET_ID = makeSbUserId(2)
+
+const channelContext: ChannelCommandContext = {
+  surface: 'channel',
+  channelId: CHANNEL_ID,
+  selfUserId: SELF_ID,
+  members: [{ id: TARGET_ID, name: 'tec27' }],
+  canKick: false,
+  canBan: false,
+}
+
+const whisperContext: WhisperCommandContext = {
+  surface: 'whisper',
+  selfUserId: SELF_ID,
+  targetId: TARGET_ID,
+}
+
+const lobbyContext: LobbyCommandContext = {
+  surface: 'lobby',
+  selfUserId: SELF_ID,
+}
+
+function runInput(input: string, context: CommandContext = channelContext) {
+  const emit = vi.fn<(line: LocalLineContent) => void>()
+  const dispatch = vi.fn()
+  const result = runChatCommandWith([meCommand], input, { context, dispatch, t, emit })
+
+  return { result, emit, dispatch }
+}
+
+function renderLine(content: React.ReactNode): string {
+  render(<div data-testid='line'>{content}</div>)
+  return screen.getByTestId('line').textContent ?? ''
+}
+
+/** Builds the error a failed send hands back, carrying the code the server answered with. */
+function fetchErrorWithCode(code: string): FetchError {
+  const bodyText = JSON.stringify({ code })
+  return new FetchError(new Response(bodyText, { status: 403, statusText: 'Forbidden' }), bodyText)
+}
+
+const CHAT_RESTRICTED_LINE = "You're currently restricted from sending chat messages."
+
+describe('messaging/commands/commands/me', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('sends the action as a channel message flagged as an emote', () => {
+    const { result, dispatch } = runInput('/me waves')
+
+    expect(result).toEqual({ kind: 'command' })
+    expect(sendChannelMessage).toHaveBeenCalledWith(CHANNEL_ID, 'waves', expect.anything(), {
+      emote: true,
+    })
+    expect(dispatch).toHaveBeenCalledWith({ type: 'TEST/channelSend' })
+  })
+
+  test('sends the action as a whisper flagged as an emote', () => {
+    const { dispatch } = runInput('/me waves', whisperContext)
+
+    expect(sendWhisperMessage).toHaveBeenCalledWith(TARGET_ID, 'waves', expect.anything(), {
+      emote: true,
+    })
+    expect(dispatch).toHaveBeenCalledWith({ type: 'TEST/whisperSend' })
+  })
+
+  test('sends the action as lobby chat flagged as an emote', () => {
+    const { dispatch } = runInput('/me waves', lobbyContext)
+
+    expect(sendLobbyChat).toHaveBeenCalledWith('waves', expect.anything(), { emote: true })
+    expect(dispatch).toHaveBeenCalledWith({ type: 'TEST/lobbySend' })
+  })
+
+  test('the emote alias reaches the same command', () => {
+    runInput('/emote waves at everyone')
+
+    expect(sendChannelMessage).toHaveBeenCalledWith(
+      CHANNEL_ID,
+      'waves at everyone',
+      expect.anything(),
+      { emote: true },
+    )
+  })
+
+  test('an action with no text sends nothing and answers with the usage', () => {
+    const { emit, dispatch } = runInput('/me')
+
+    expect(sendChannelMessage).not.toHaveBeenCalled()
+    expect(dispatch).not.toHaveBeenCalled()
+    expect(emit.mock.calls[0][0].kind).toBe('error')
+
+    const text = renderLine(emit.mock.calls[0][0].content)
+    expect(text).toContain('Missing <action>')
+    expect(text).toContain('/me <action>')
+  })
+
+  test('a chat restriction answers with a line saying so', () => {
+    const { emit } = runInput('/me waves')
+    const spec = asMockedFunction(sendChannelMessage).mock.calls[0][2]
+
+    spec.onError(fetchErrorWithCode(ChatServiceErrorCode.UserChatRestricted))
+
+    expect(emit.mock.calls[0][0].kind).toBe('error')
+    expect(renderLine(emit.mock.calls[0][0].content)).toContain(CHAT_RESTRICTED_LINE)
+  })
+
+  test('the differently spelled whisper restriction code answers the same way', () => {
+    const { emit } = runInput('/me waves', whisperContext)
+    const spec = asMockedFunction(sendWhisperMessage).mock.calls[0][2]
+
+    spec.onError(fetchErrorWithCode(WhisperServiceErrorCode.UserChatRestricted))
+
+    expect(renderLine(emit.mock.calls[0][0].content)).toContain(CHAT_RESTRICTED_LINE)
+  })
+
+  test('any other failure answers with the error it carried', () => {
+    const { emit } = runInput('/me waves', lobbyContext)
+    const spec = asMockedFunction(sendLobbyChat).mock.calls[0][1]
+
+    spec.onError(new Error('the lobby is gone'))
+
+    expect(renderLine(emit.mock.calls[0][0].content)).toContain(
+      "Couldn't send your emote: the lobby is gone",
+    )
+  })
+})

--- a/client/messaging/commands/commands/me.tsx
+++ b/client/messaging/commands/commands/me.tsx
@@ -1,0 +1,70 @@
+import { TFunction } from 'i18next'
+import * as React from 'react'
+import { Trans } from 'react-i18next'
+import { assertUnreachable } from '../../../../common/assert-unreachable'
+import { ChatServiceErrorCode } from '../../../../common/chat'
+import { WhisperServiceErrorCode } from '../../../../common/whispers'
+import { sendMessage as sendChannelMessage } from '../../../chat/action-creators'
+import { TransInterpolation } from '../../../i18n/i18next'
+import { sendChat as sendLobbyChat } from '../../../lobbies/action-creators'
+import { RequestHandlingSpec } from '../../../network/abortable-thunk'
+import { isFetchError } from '../../../network/fetch-errors'
+import { sendMessage as sendWhisperMessage } from '../../../whispers/action-creators'
+import { ALL_COMMAND_SURFACES, defineCommand } from '../command-schema'
+
+function sendFailedLine(err: Error, t: TFunction): React.ReactNode {
+  const code = isFetchError(err) ? err.code : undefined
+
+  // The channel and whisper services spell their chat-restriction code differently. The lobby
+  // service's equivalent code lives only in server code, so a lobby restriction falls through to
+  // the generic line below.
+  if (
+    code === ChatServiceErrorCode.UserChatRestricted ||
+    code === WhisperServiceErrorCode.UserChatRestricted
+  ) {
+    return t(
+      'chat.commands.me.chatRestricted',
+      "You're currently restricted from sending chat messages.",
+    )
+  }
+
+  const errorMessage = err.message
+  return (
+    <Trans t={t} i18nKey='chat.commands.me.sendError'>
+      Couldn't send your emote: {{ errorMessage } as TransInterpolation}
+    </Trans>
+  )
+}
+
+export const meCommand = defineCommand({
+  name: 'me',
+  aliases: ['emote'],
+  description: t =>
+    t(
+      'chat.commands.me.description',
+      'Sends an action line, shown as "* YourName does something".',
+    ),
+  surfaces: ALL_COMMAND_SURFACES,
+  args: [{ kind: 'rest', name: 'action' }],
+
+  run({ args, context, dispatch, t, emit }) {
+    const spec: RequestHandlingSpec = {
+      onSuccess: () => {},
+      onError: err => emit({ kind: 'error', content: sendFailedLine(err, t) }),
+    }
+
+    switch (context.surface) {
+      case 'channel':
+        dispatch(sendChannelMessage(context.channelId, args.action, spec, { emote: true }))
+        break
+      case 'whisper':
+        dispatch(sendWhisperMessage(context.targetId, args.action, spec, { emote: true }))
+        break
+      case 'lobby':
+        dispatch(sendLobbyChat(args.action, spec, { emote: true }))
+        break
+      default:
+        assertUnreachable(context)
+    }
+  },
+})

--- a/client/messaging/common-message-layout.test.tsx
+++ b/client/messaging/common-message-layout.test.tsx
@@ -33,7 +33,10 @@ describe('client/messaging/common-message-layout/TextMessage', () => {
   })
 
   const store = createStore()
-  const doRender = (text: string, { time = 0 }: { time?: number } = {}): HTMLElement => {
+  const doRender = (
+    text: string,
+    { time = 0, emote }: { time?: number; emote?: boolean } = {},
+  ): HTMLElement => {
     render(
       <ReduxProvider store={store}>
         <div data-testid='message-container'>
@@ -43,6 +46,7 @@ describe('client/messaging/common-message-layout/TextMessage', () => {
             selfUserId={selfUserId}
             time={time}
             text={text}
+            emote={emote}
           />
         </div>
       </ReduxProvider>,
@@ -52,6 +56,15 @@ describe('client/messaging/common-message-layout/TextMessage', () => {
 
   test('message as a normal text', () => {
     expect(doRender('This is test message')).toMatchSnapshot()
+  })
+
+  test('message sent as an emote reads as an action line', () => {
+    const container = doRender('waves at everyone', { emote: true })
+
+    // The name is still loading in this store, so the glyph and its space are what precede it.
+    expect(container.textContent).toContain('* ')
+    expect(container.textContent).not.toContain(': ')
+    expect(container).toMatchSnapshot()
   })
 
   test('message with a link', () => {

--- a/client/messaging/common-message-layout.tsx
+++ b/client/messaging/common-message-layout.tsx
@@ -63,6 +63,30 @@ const MentionedChannelName = styled(ConnectedChannelName)`
   color: var(--color-blue95);
 `
 
+/** The `*` that opens an action line, plus the space that separates it from the name. */
+const EmoteGlyph = styled.span`
+  line-height: inherit;
+
+  color: var(--theme-on-surface-variant);
+  font-style: italic;
+`
+
+/**
+ * The name in an action line, which reads `* Name action`. A real space separates it from the text,
+ * so it carries no margin of its own.
+ */
+const EmoteUsername = styled(Username)`
+  margin-right: 0;
+
+  color: var(--theme-on-surface-variant);
+  font-style: italic;
+`
+
+const EmoteText = styled(Text)`
+  color: var(--theme-on-surface-variant);
+  font-style: italic;
+`
+
 const MAX_JUMBO_EMOJI_COUNT = 10
 
 /**
@@ -107,10 +131,23 @@ export interface TextMessageProps {
   selfUserId: SbUserId
   time: number
   text: string
+  /**
+   * Whether the message is an action line (sent with `/me`), which reads `* Name action` rather
+   * than `Name: text`.
+   */
+  emote?: boolean
   testId?: string
 }
 
-export function TextMessage({ msgId, userId, selfUserId, time, text, testId }: TextMessageProps) {
+export function TextMessage({
+  msgId,
+  userId,
+  selfUserId,
+  time,
+  text,
+  emote,
+  testId,
+}: TextMessageProps) {
   const filterClick = useMentionFilterClick()
   const { UserMenu, MessageMenu, disallowMentionInteraction } = useContext(ChatContext)
   // The invite-card age gate needs the current time, which a pure render can't read directly;
@@ -206,6 +243,9 @@ export function TextMessage({ msgId, userId, selfUserId, time, text, testId }: T
     parsedText.push(text.substring(lastIndex))
   }
 
+  const UsernameComponent = emote ? EmoteUsername : Username
+  const TextComponent = emote ? EmoteText : Text
+
   return (
     <>
       <TimestampMessageLayout
@@ -215,14 +255,15 @@ export function TextMessage({ msgId, userId, selfUserId, time, text, testId }: T
         highlighted={isHighlighted}
         onContextMenu={onContextMenu}
         testId={testId}>
-        <Username
+        {emote ? <EmoteGlyph>{'* '}</EmoteGlyph> : undefined}
+        <UsernameComponent
           userId={userId}
           filterClick={filterClick}
           UserMenu={UserMenu}
           interactive={!disallowMentionInteraction}
         />
-        <Separator>{': '}</Separator>
-        <Text ref={textRef}>{parsedText}</Text>
+        {emote ? ' ' : <Separator>{': '}</Separator>}
+        <TextComponent ref={textRef}>{parsedText}</TextComponent>
         {inviteLobbyId !== undefined &&
         !disallowMentionInteraction &&
         mountTime - time < LOBBY_INVITE_CARD_MAX_AGE_MS ? (
@@ -276,6 +317,7 @@ export const BlockedMessage = React.memo<{
   selfUserId: SbUserId
   time: number
   text: string
+  emote?: boolean
 }>(props => {
   const { t } = useTranslation()
   const [show, setShow] = useState(false)
@@ -297,6 +339,7 @@ export const BlockedMessage = React.memo<{
             selfUserId={props.selfUserId}
             time={props.time}
             text={props.text}
+            emote={props.emote}
           />
         </VisibleBlockedMessage>
       ) : undefined}

--- a/client/messaging/message-list.tsx
+++ b/client/messaging/message-list.tsx
@@ -123,7 +123,10 @@ function CommonMessageOrFallback({
       return <LocalLineMessage key={message.id} kind={message.kind} content={message.content} />
     // TODO(2Pac): Reconcile these types into one when everything is moved to immer
     case CommonMessageType.TextMessage:
-    case ServerChatMessageType.TextMessage:
+    case ServerChatMessageType.TextMessage: {
+      // Several text message shapes share this type value, and only the ones that come from a
+      // surface with a `/me` command carry an action-line flag.
+      const emote = 'emote' in message && message.emote === true
       // TODO(tec27): Would probably be nice to collect adjacent blocked messages into a single
       // item?
       return blockedUsers.has(message.from) ? (
@@ -134,6 +137,7 @@ function CommonMessageOrFallback({
           selfUserId={selfUserId}
           time={message.time}
           text={message.text}
+          emote={emote}
         />
       ) : (
         <TextMessage
@@ -143,8 +147,10 @@ function CommonMessageOrFallback({
           selfUserId={selfUserId}
           time={message.time}
           text={message.text}
+          emote={emote}
         />
       )
+    }
     default:
       return FallbackComponent ? (
         <FallbackComponent

--- a/client/messaging/message-records.ts
+++ b/client/messaging/message-records.ts
@@ -21,6 +21,11 @@ export interface CommonTextMessage extends BaseMessage {
   readonly type: CommonMessageType.TextMessage
   readonly from: SbUserId
   readonly text: string
+  /**
+   * Present and `true` for an action line the user sent with `/me`, which renders as
+   * `* Name action` instead of `Name: text`. Never carried as `false`.
+   */
+  readonly emote?: boolean
 }
 
 export interface CommonNewDayMessage extends BaseMessage {

--- a/client/whispers/action-creators.ts
+++ b/client/whispers/action-creators.ts
@@ -132,11 +132,16 @@ export function sendMessage(
   target: SbUserId,
   message: string,
   spec: RequestHandlingSpec,
+  options: { emote?: boolean } = {},
 ): ThunkAction {
   return abortableThunk(spec, async () => {
     return fetchJson<void>(apiUrl`whispers/${target}/messages`, {
       method: 'POST',
-      body: encodeBodyAsParams<SendWhisperMessageRequest>({ message }),
+      body: encodeBodyAsParams<SendWhisperMessageRequest>({
+        message,
+        emote: options.emote ? true : undefined,
+      }),
+      signal: spec.signal,
     })
   })
 }

--- a/client/whispers/whisper-reducer.test.ts
+++ b/client/whispers/whisper-reducer.test.ts
@@ -635,6 +635,24 @@ describe('client/whispers/whisper-reducer', () => {
   })
 
   describe('@whispers/updateMessage', () => {
+    test('an arriving action line keeps its emote flag', () => {
+      const state = makeState({ activated: true, atBottom: true })
+
+      const result = whisperReducer(state, {
+        type: '@whispers/updateMessage',
+        payload: {
+          action: 'message',
+          message: { ...serverMessage(500), emote: true },
+          users: [],
+          mentions: [],
+          channelMentions: [],
+        },
+        meta: { target: TARGET_ID, isSelfMessage: false, windowFocused: true },
+      })
+
+      expect(sessionOf(result).messages[0]).toMatchObject({ emote: true })
+    })
+
     test('a live message defers the trim of a pinned window while an older page is in flight', () => {
       const messages = Array.from({ length: 200 }, (_, i) => textMessage(i + 1))
       const state = makeState({ activated: true, atBottom: true, loadingHistory: true, messages })

--- a/client/whispers/whisper-reducer.ts
+++ b/client/whispers/whisper-reducer.ts
@@ -103,6 +103,7 @@ function toTextMessages(messages: WhisperMessage[]): CommonTextMessage[] {
     time: msg.time,
     from: msg.from,
     text: msg.text,
+    ...(msg.emote ? { emote: true } : {}),
   }))
 }
 
@@ -353,7 +354,7 @@ export default immerKeyedReducer(DEFAULT_STATE, {
     state,
     {
       payload: {
-        message: { id, time, from, text },
+        message: { id, time, from, text, emote },
       },
       meta: { target, isSelfMessage, windowFocused },
     },
@@ -364,6 +365,7 @@ export default immerKeyedReducer(DEFAULT_STATE, {
       time,
       from,
       text,
+      ...(emote ? { emote: true } : {}),
     }
 
     // Reorder the sessions to put the one that got the message on top of the list

--- a/common/chat.ts
+++ b/common/chat.ts
@@ -96,6 +96,11 @@ export interface ChannelTextMessage extends BaseChatMessage {
   type: typeof ServerChatMessageType.TextMessage
   from: SbUserId
   text: string
+  /**
+   * Present and `true` for an action line the user sent with `/me`, which renders as
+   * `* Name action` instead of `Name: text`. Never carried as `false`.
+   */
+  emote?: boolean
 }
 
 /** A message that is displayed in the chat when someone joins the channel. */
@@ -475,6 +480,11 @@ export interface EditChannelResponse {
 
 export interface SendChatMessageServerRequest {
   message: string
+  /**
+   * Present and `true` for an action line the user sent with `/me`, which renders as
+   * `* Name action` instead of `Name: text`. Never carried as `false`.
+   */
+  emote?: boolean
 }
 
 /**

--- a/common/lobbies/lobby-network.ts
+++ b/common/lobbies/lobby-network.ts
@@ -88,6 +88,11 @@ export interface JoinLobbyRequest extends LobbyClientRequest, LobbyNetworkParams
 /** The body of a request to send a chat message to a lobby. */
 export interface SendLobbyChatRequest extends LobbyClientRequest {
   text: string
+  /**
+   * Present and `true` for an action line the user sent with `/me`, which renders as
+   * `* Name action` instead of `Name: text`. Never carried as `false`.
+   */
+  emote?: boolean
 }
 
 /** The body of a request that acts on a single slot of a lobby. */
@@ -310,6 +315,11 @@ export interface LobbyChatMessage {
   time: number
   from: SbUserId
   text: string
+  /**
+   * Present and `true` for an action line the user sent with `/me`, which renders as
+   * `* Name action` instead of `Name: text`. Never carried as `false`.
+   */
+  emote?: boolean
 }
 
 export interface LobbyChatEvent {

--- a/common/whispers.ts
+++ b/common/whispers.ts
@@ -25,6 +25,11 @@ export interface BaseWhisperMessage {
 export interface WhisperTextMessage extends BaseWhisperMessage {
   type: typeof WhisperMessageType.TextMessage
   text: string
+  /**
+   * Present and `true` for an action line the user sent with `/me`, which renders as
+   * `* Name action` instead of `Name: text`. Never carried as `false`.
+   */
+  emote?: boolean
 }
 
 export type WhisperMessage = WhisperTextMessage
@@ -66,6 +71,11 @@ export type WhisperUserEvent = WhisperReadTimeChangedEvent
 
 export interface SendWhisperMessageRequest {
   message: string
+  /**
+   * Present and `true` for an action line the user sent with `/me`, which renders as
+   * `* Name action` instead of `Name: text`. Never carried as `false`.
+   */
+  emote?: boolean
 }
 
 /**

--- a/server/lib/chat/chat-api.ts
+++ b/server/lib/chat/chat-api.ts
@@ -343,14 +343,15 @@ export class ChatApi {
   async sendChatMessage(ctx: RouterContext): Promise<void> {
     const channelId = getValidatedChannelId(ctx)
     const {
-      body: { message },
+      body: { message, emote },
     } = validateRequest(ctx, {
       body: Joi.object<SendChatMessageServerRequest>({
         message: Joi.string().min(1).required(),
+        emote: Joi.boolean(),
       }),
     })
 
-    await this.chatService.sendChatMessage(channelId, ctx.session!.user.id, message)
+    await this.chatService.sendChatMessage(channelId, ctx.session!.user.id, message, { emote })
 
     ctx.status = 204
   }

--- a/server/lib/chat/chat-models.ts
+++ b/server/lib/chat/chat-models.ts
@@ -426,6 +426,11 @@ export interface TextMessageData extends BaseMessageData {
    * were no channels mentioned in this message.
    */
   channelMentions?: SbChannelId[]
+  /**
+   * Present and `true` for an action line the user sent with `/me`, which renders as
+   * `* Name action` instead of `Name: text`. Never stored as `false`.
+   */
+  emote?: boolean
 }
 
 export interface JoinChannelData extends BaseMessageData {

--- a/server/lib/chat/chat-service.test.ts
+++ b/server/lib/chat/chat-service.test.ts
@@ -196,6 +196,7 @@ function toTextMessageJson(dbMessage: FakeDbTextChannelMessage) {
     from: dbMessage.userId,
     time: Number(dbMessage.sent),
     text: dbMessage.data.text,
+    ...(dbMessage.data.emote ? { emote: true } : {}),
   }
 }
 
@@ -396,6 +397,7 @@ describe('chat/chat-service', () => {
     processedMessageString: string,
     userMentions: SbUser[],
     channelMentions: FullChannelInfo[],
+    emote?: boolean,
   ) {
     textMessage = {
       msgId: 'MESSAGE_ID',
@@ -407,6 +409,7 @@ describe('chat/chat-service', () => {
         text: processedMessageString,
         mentions: userMentions.length > 0 ? userMentions.map(m => m.id) : undefined,
         channelMentions: channelMentions.length > 0 ? channelMentions.map(c => c.id) : undefined,
+        ...(emote ? { emote: true } : {}),
       },
     }
     // NOTE(2Pac): The `joinUserToChannel` call already mocks the return value of this function,
@@ -1834,6 +1837,41 @@ describe('chat/chat-service', () => {
         await chatService.sendChatMessage(testChannel.id, user1.id, messageString)
 
         expectItWorks(processedText, [], channelMentions)
+      })
+
+      test('stores and publishes an action line with the emote flag', async () => {
+        const messageString = 'waves at everyone'
+        mockTextMessage(user1, testChannel, messageString, [], [], true)
+
+        await chatService.sendChatMessage(testChannel.id, user1.id, messageString, { emote: true })
+
+        expect(addMessageToChannelMock).toHaveBeenCalledWith(user1.id, testChannel.id, {
+          type: textMessage.data.type,
+          text: messageString,
+          mentions: undefined,
+          channelMentions: undefined,
+          emote: true,
+        })
+        expect(client2.publish).toHaveBeenCalledWith(getChannelPath(testChannel.id), {
+          action: 'message2',
+          message: expect.objectContaining({ text: messageString, emote: true }),
+          user: user1,
+          mentions: [],
+          channelMentions: [],
+        })
+      })
+
+      test('carries no emote key at all for an ordinary message', async () => {
+        const messageString = 'Hello World!'
+        mockTextMessage(user1, testChannel, messageString, [], [])
+
+        await chatService.sendChatMessage(testChannel.id, user1.id, messageString)
+
+        expect(addMessageToChannelMock.mock.calls[0][2]).not.toHaveProperty('emote')
+        const [, published] = asMockedFunction(client2.publish).mock.calls.find(
+          ([, data]) => data?.action === 'message2',
+        )!
+        expect(published.message).not.toHaveProperty('emote')
       })
 
       test('works when there are both user and channel mentions in a message', async () => {

--- a/server/lib/chat/chat-service.ts
+++ b/server/lib/chat/chat-service.ts
@@ -52,6 +52,7 @@ import { writeFile } from '../files'
 import { createImagePath, resizeImage } from '../files/images'
 import { ImageService } from '../images/image-service'
 import logger from '../logging/logger'
+import { emoteField } from '../messaging/emote-field'
 import filterChatMessage from '../messaging/filter-chat-message'
 import { processMessageContents } from '../messaging/process-chat-message'
 import NotificationService from '../notifications/notification-service'
@@ -790,7 +791,12 @@ export default class ChatService {
     })
   }
 
-  async sendChatMessage(channelId: SbChannelId, userId: SbUserId, message: string): Promise<void> {
+  async sendChatMessage(
+    channelId: SbChannelId,
+    userId: SbUserId,
+    message: string,
+    options: { emote?: boolean } = {},
+  ): Promise<void> {
     const userSockets = this.getUserSockets(userId)
     if (
       !this.state.users.has(userSockets.userId) ||
@@ -819,6 +825,7 @@ export default class ChatService {
       text: processedText,
       mentions: mentionedUserIds.length > 0 ? mentionedUserIds : undefined,
       channelMentions: mentionedChannelIds.length > 0 ? mentionedChannelIds : undefined,
+      ...emoteField(options.emote),
     })
     // The sender just posted a message, so they're guaranteed to exist
     const user = (await findUserById(result.userId))!
@@ -832,6 +839,7 @@ export default class ChatService {
         from: result.userId,
         time: Number(result.sent),
         text: result.data.text,
+        ...emoteField(result.data.emote),
       },
       user,
       mentions: userMentions,
@@ -1050,6 +1058,7 @@ export default class ChatService {
             from: msg.userId,
             time: Number(msg.sent),
             text: msg.data.text,
+            ...emoteField(msg.data.emote),
           })
           userIds.add(msg.userId)
           for (const mentionId of msg.data.mentions ?? []) {

--- a/server/lib/lobbies/lobby-api.ts
+++ b/server/lib/lobbies/lobby-api.ts
@@ -293,12 +293,18 @@ export class LobbyApi {
       body: Joi.object<SendLobbyChatRequest>({
         clientId: clientIdSchema,
         text: Joi.string().min(1).required(),
+        emote: Joi.boolean(),
       }),
     })
 
     const client = this.getClientSockets(ctx.session!.user.id, body.clientId)
 
-    await this.lobbyService.sendChat({ client, lobbyId: params.lobbyId, text: body.text })
+    await this.lobbyService.sendChat({
+      client,
+      lobbyId: params.lobbyId,
+      text: body.text,
+      emote: body.emote,
+    })
   }
 
   @httpPost('/:lobbyId/add-computer')

--- a/server/lib/lobbies/lobby-service.test.ts
+++ b/server/lib/lobbies/lobby-service.test.ts
@@ -11,6 +11,7 @@ import { RaceChar } from '../../../common/races'
 import { asMockedFunction } from '../../../common/testing/mocks'
 import { SbUser } from '../../../common/users/sb-user'
 import { makeSbUserId } from '../../../common/users/sb-user-id'
+import { findChannelsByName } from '../chat/chat-models'
 import { GameServerRegionsService } from '../game-server-regions/game-server-regions-service'
 import { GameLoader, GameLoadRequest } from '../games/game-loader'
 import { GameplayActivityRegistry } from '../games/gameplay-activity-registry'
@@ -107,6 +108,11 @@ vi.mock('../maps/map-operations', async () => {
 vi.mock('../users/user-model', async () => {
   const actual = await vi.importActual<typeof import('../users/user-model')>('../users/user-model')
   return { ...actual, findUsersById: vi.fn() }
+})
+// Chat messages resolve their channel mentions through this, which would otherwise reach the DB.
+vi.mock('../chat/chat-models', async () => {
+  const actual = await vi.importActual<typeof import('../chat/chat-models')>('../chat/chat-models')
+  return { ...actual, findChannelsByName: vi.fn() }
 })
 
 const HOST_USER: SbUser = { id: makeSbUserId(1), name: 'HostUser' } as SbUser
@@ -232,6 +238,7 @@ describe('lobbies/lobby-service', () => {
     asMockedFunction(getMapInfos).mockResolvedValue([BIG_GAME_HUNTERS])
     asMockedFunction(reparseMapsAsNeeded).mockResolvedValue([BIG_GAME_HUNTERS])
     asMockedFunction(findUsersById).mockResolvedValue([])
+    asMockedFunction(findChannelsByName).mockResolvedValue([])
 
     const connector = new NydusConnector(nydus, sessionLookup)
     connect = (user: SbUser, clientId: string): Sockets => {
@@ -864,6 +871,31 @@ describe('lobbies/lobby-service', () => {
 
       expect(getLobbyJoinCode(id)).toBeUndefined()
       expect(getLobbyIdByJoinCode(code)).toBeUndefined()
+    })
+  })
+
+  describe('sendChat', () => {
+    /** Returns the chat events published to a lobby's occupants, in order. */
+    function chatPublishes(lobbyId: SbLobbyId): Array<{ message: any }> {
+      return fakeNydus.publish.mock.calls
+        .filter(([path, data]) => path === `/lobbies/${lobbyId}` && data?.type === 'chat')
+        .map(([, data]) => data)
+    }
+
+    test('publishes an action line with the emote flag', async () => {
+      const { id } = await createLobby(host, 'Chatty lobby')
+
+      await lobbyService.sendChat({ client: host.client, text: 'waves', emote: true })
+
+      expect(chatPublishes(id)[0].message).toMatchObject({ text: 'waves', emote: true })
+    })
+
+    test('carries no emote key at all for an ordinary message', async () => {
+      const { id } = await createLobby(host, 'Chatty lobby')
+
+      await lobbyService.sendChat({ client: host.client, text: 'hello' })
+
+      expect(chatPublishes(id)[0].message).not.toHaveProperty('emote')
     })
   })
 

--- a/server/lib/lobbies/lobby-service.ts
+++ b/server/lib/lobbies/lobby-service.ts
@@ -42,6 +42,7 @@ import { GameplayActivityRegistry } from '../games/gameplay-activity-registry'
 import logger from '../logging/logger'
 import { getMapInfos } from '../maps/map-models'
 import { reparseMapsAsNeeded } from '../maps/map-operations'
+import { emoteField } from '../messaging/emote-field'
 import filterChatMessage from '../messaging/filter-chat-message'
 import { processMessageContents } from '../messaging/process-chat-message'
 import { NetcodeV2Service } from '../netcode-v2/netcode-v2-service'
@@ -581,10 +582,12 @@ export class LobbyService {
     client,
     lobbyId,
     text,
+    emote,
   }: {
     client: ClientSocketsGroup
     lobbyId?: SbLobbyId
     text: string
+    emote?: boolean
   }): Promise<void> {
     const lobby = this.getLobbyForClient(client, lobbyId)
     const time = Date.now()
@@ -609,6 +612,7 @@ export class LobbyService {
         time,
         from: client.userId,
         text: processedText,
+        ...emoteField(emote),
       },
       mentions: userMentions,
       channelMentions: channelMentions.map(c => toBasicChannelInfo(c)),

--- a/server/lib/messaging/emote-field.ts
+++ b/server/lib/messaging/emote-field.ts
@@ -1,0 +1,7 @@
+/**
+ * Spreads the action-line flag into a text message's stored or published shape. The flag only ever
+ * exists as `true`, so a message that isn't an action line carries no key for it at all.
+ */
+export function emoteField(emote?: boolean): { emote?: true } {
+  return emote ? { emote: true } : {}
+}

--- a/server/lib/whispers/whisper-api.ts
+++ b/server/lib/whispers/whisper-api.ts
@@ -151,17 +151,20 @@ export class WhisperApi {
   async sendWhisperMessage(ctx: RouterContext): Promise<void> {
     const {
       params: { targetId },
-      body: { message },
+      body: { message, emote },
     } = validateRequest(ctx, {
       params: Joi.object<{ targetId: SbUserId }>({
         targetId: joiUserId().required(),
       }),
       body: Joi.object<SendWhisperMessageRequest>({
         message: Joi.string().min(1).required(),
+        emote: Joi.boolean(),
       }),
     })
 
-    await this.whisperService.sendWhisperMessage(ctx.session!.user.id, targetId, message)
+    await this.whisperService.sendWhisperMessage(ctx.session!.user.id, targetId, message, {
+      emote,
+    })
 
     ctx.status = 204
   }

--- a/server/lib/whispers/whisper-models.ts
+++ b/server/lib/whispers/whisper-models.ts
@@ -196,6 +196,11 @@ interface WhisperTextMessageData extends BaseWhisperMessageData {
    * were no channels mentioned in this message.
    */
   channelMentions?: SbChannelId[]
+  /**
+   * Present and `true` for an action line the user sent with `/me`, which renders as
+   * `* Name action` instead of `Name: text`. Never stored as `false`.
+   */
+  emote?: boolean
 }
 
 type WhisperMessageData = WhisperTextMessageData

--- a/server/lib/whispers/whisper-service.test.ts
+++ b/server/lib/whispers/whisper-service.test.ts
@@ -3,17 +3,19 @@ import { beforeEach, describe, expect, test, vi } from 'vitest'
 import { asMockedFunction } from '../../../common/testing/mocks'
 import { SbUser } from '../../../common/users/sb-user'
 import { SbUserId } from '../../../common/users/sb-user-id'
-import { WhisperServiceErrorCode } from '../../../common/whispers'
+import { WhisperMessageType, WhisperServiceErrorCode } from '../../../common/whispers'
 import { RestrictionService } from '../users/restriction-service'
 import { RequestSessionLookup } from '../websockets/session-lookup'
 import { UserSocketsManager } from '../websockets/socket-groups'
 import {
   clearTestLogs,
   createFakeNydusServer,
+  FakeNydusServer,
   NydusConnector,
 } from '../websockets/testing/websockets'
 import { TypedPublisher } from '../websockets/typed-publisher'
 import {
+  addMessageToWhisper,
   getMessagesForWhisperSession,
   getUnreadWhisperTargets,
   getWhisperMessageParticipants,
@@ -40,6 +42,7 @@ vi.mock('../users/user-model', () => {
     findUsersById: vi.fn().mockImplementation(async (ids: ReadonlyArray<SbUserId>) => {
       return ids.map(id => USERS_BY_ID.get(id)).filter(u => !!u)
     }),
+    findUsersByName: vi.fn().mockResolvedValue([]),
   }
 })
 
@@ -48,6 +51,7 @@ vi.mock('../chat/chat-models', async () => {
     await vi.importActual<typeof import('../chat/chat-models')>('../chat/chat-models')
   return {
     getChannelInfos: vi.fn().mockResolvedValue([]),
+    findChannelsByName: vi.fn().mockResolvedValue([]),
     toBasicChannelInfo: originalModule.toBasicChannelInfo,
   }
 })
@@ -162,6 +166,59 @@ describe('whispers/whisper-service', () => {
           { targetId: user3.id, lastReadTime: user3StartDate.getTime() - 1 },
         ],
       })
+    })
+  })
+
+  describe('sendWhisperMessage', () => {
+    const addMessageToWhisperMock = asMockedFunction(addMessageToWhisper)
+
+    /** Makes the stored-message lookup answer with a message of the given text and flag. */
+    function mockStoredMessage(text: string, emote?: boolean) {
+      addMessageToWhisperMock.mockResolvedValue({
+        id: 'MESSAGE_ID',
+        from: user1.id,
+        to: user2.id,
+        sent: new Date('2023-03-11T00:00:00.000Z'),
+        data: {
+          type: WhisperMessageType.TextMessage,
+          text,
+          mentions: undefined,
+          channelMentions: undefined,
+          ...(emote ? { emote: true } : {}),
+        },
+      })
+    }
+
+    /** The data of the message event published to the conversation, if there was one. */
+    function publishedMessageEvent(): any {
+      const fakeNydus = nydus as unknown as FakeNydusServer
+      return fakeNydus.publish.mock.calls.find(
+        ([path, data]) => path === getSessionPath(user1.id, user2.id) && data?.action === 'message',
+      )?.[1]
+    }
+
+    test('stores and publishes an action line with the emote flag', async () => {
+      mockStoredMessage('waves', true)
+
+      await whisperService.sendWhisperMessage(user1.id, user2.id, 'waves', { emote: true })
+
+      expect(addMessageToWhisperMock).toHaveBeenCalledWith(user1.id, user2.id, {
+        type: WhisperMessageType.TextMessage,
+        text: 'waves',
+        mentions: undefined,
+        channelMentions: undefined,
+        emote: true,
+      })
+      expect(publishedMessageEvent().message).toMatchObject({ text: 'waves', emote: true })
+    })
+
+    test('carries no emote key at all for an ordinary message', async () => {
+      mockStoredMessage('hello')
+
+      await whisperService.sendWhisperMessage(user1.id, user2.id, 'hello')
+
+      expect(addMessageToWhisperMock.mock.calls[0][2]).not.toHaveProperty('emote')
+      expect(publishedMessageEvent().message).not.toHaveProperty('emote')
     })
   })
 

--- a/server/lib/whispers/whisper-service.ts
+++ b/server/lib/whispers/whisper-service.ts
@@ -20,6 +20,7 @@ import {
 } from '../../../common/whispers'
 import { getChannelInfos, HistoryCursor, toBasicChannelInfo } from '../chat/chat-models'
 import logger from '../logging/logger'
+import { emoteField } from '../messaging/emote-field'
 import filterChatMessage from '../messaging/filter-chat-message'
 import { processMessageContents } from '../messaging/process-chat-message'
 import { RestrictionService } from '../users/restriction-service'
@@ -166,7 +167,12 @@ export default class WhisperService {
     return true
   }
 
-  async sendWhisperMessage(userId: SbUserId, targetUser: SbUserId, message: string) {
+  async sendWhisperMessage(
+    userId: SbUserId,
+    targetUser: SbUserId,
+    message: string,
+    options: { emote?: boolean } = {},
+  ) {
     if (userId === targetUser) {
       throw new WhisperServiceError(
         WhisperServiceErrorCode.NoSelfMessaging,
@@ -208,6 +214,7 @@ export default class WhisperService {
       text: processedText,
       mentions: mentionedUserIds.length > 0 ? mentionedUserIds : undefined,
       channelMentions: mentionedChannelIds.length > 0 ? mentionedChannelIds : undefined,
+      ...emoteField(options.emote),
     })
     this.applyWhisperSessionState(user, target)
     this.applyWhisperSessionState(target, user)
@@ -221,6 +228,7 @@ export default class WhisperService {
         to: result.to,
         time: Number(result.sent),
         text: result.data.text,
+        ...emoteField(result.data.emote),
       },
       users: [user, target],
       mentions: userMentions,
@@ -288,6 +296,7 @@ export default class WhisperService {
             to: msg.to,
             time: Number(msg.sent),
             text: msg.data.text,
+            ...emoteField(msg.data.emote),
           })
           for (const mention of msg.data.mentions ?? []) {
             userMentionIds.add(mention)

--- a/server/public/locales/en/global.json
+++ b/server/public/locales/en/global.json
@@ -385,6 +385,11 @@
       "leave": {
         "description": "Leaves the channel or lobby you are in."
       },
+      "me": {
+        "chatRestricted": "You're currently restricted from sending chat messages.",
+        "description": "Sends an action line, shown as \"* YourName does something\".",
+        "sendError": "Couldn't send your emote: {{errorMessage}}"
+      },
       "surfaces": {
         "channel": "channels",
         "lobby": "lobbies",


### PR DESCRIPTION
Battle.net's `/me` is the one classic command every Brood War player types from muscle memory, and it needs a chat-native way to render an action line without disguising it as something the user literally said. This adds `/me <action>` (alias `/emote`) to the command framework for channels, whispers and lobbies. The emote is an ordinary text message carrying an `emote: true` presentation flag (stored in the existing JSONB `data`, no migration), so the mention, unread, block-collapse, delete and message-link pipelines are untouched. Lines render as `[time] * Name action`, italic, in `--theme-on-surface-variant`, with no `Name:` colon.

Fixes #1478

## Acceptance criteria

- [x] `/me <action>` (alias `emote`) sends the action as a channel message, a whisper, or a lobby broadcast depending on the surface. Verified live on two Electron clients: `/me waves` in #ShieldBattery, `/emote waves in the whisper` in a whisper, `/me waves in the lobby` in a custom lobby, each seen by the other client.
- [x] Stored as an ordinary text message plus a boolean `emote` field on `TextMessageData`, `WhisperTextMessage`, `LobbyChatMessage` and `CommonTextMessage`; no new `ServerChatMessageType`/`WhisperMessageType`, no migration. DB rows checked: `{"text": "waves", "type": "message", "emote": true}` in `channel_messages` and `whisper_messages`; a plain message has no `emote` key.
- [x] Channels and whispers persist the emote and it survives reload. Verified: after reloading client 2, both the channel and whisper emotes came back from history with the flag.
- [x] Lobbies reuse `LobbyChatMessage`/`LobbyChatEvent` with the added field, no DB write. Verified: emote seen live by the other lobby member, gone after leaving and rejoining.
- [x] Renders `[time] * Name action`, italic, `--theme-on-surface-variant`, no colon. Verified via computed styles on the receiving client (glyph, name and text `font-style: italic`, color `rgb(191, 217, 255)` = blue95; the timestamp gutter keeps its own colour and stays upright); copied text reads `[3:48 PM] * claude-1 waves`.
- [x] Low guard: plain feedback on failure, no confirm. Verified by routing the channel send to a 403 `UserChatRestricted`: the input answers with an only-you red line "You're currently restricted from sending chat messages." A bare `/me` answers with the framework's "Missing <action>. Usage: /me <action>" line in both a channel and a lobby.
- [x] `@user`/`#channel` mentions inside the action still resolve and notify. Verified: `/me high-fives @claude-2` stored as `high-fives <@11>`, rendered as a highlighted mention line on claude-2's client and set the channel's latest-mention time; `/me waves` set none.
- [x] All copy through i18next (`chat.commands.me.*`); name and alias stay English.

Also verified per the issue's recipe: blocking the sender collapses the emote into the same `BlockedMessage` treatment (Show reveals the emote rendering, unblocking restores it); an admin delete of the emote removed it from both clients; a `?m=<uuid>` link to the emote resolved and scrolled it into view.

## Drift notes

Written against c104da263, before the command framework landed. #1477 merged as #1510, so `/me` registers through `defineCommand` and `ALL_COMMANDS` rather than needing the `onEnterKeyDown` hook the issue describes. One gap the issue didn't cover: the channel sender dispatched `@chat/sendMessageBegin`/`@chat/sendMessage` promise actions that no reducer consumed, and the lobby sender swallowed errors into a log, so neither could report a failed `/me`. Both now take a `RequestHandlingSpec` like the whisper sender; plain-text sends keep today's behaviour (the surfaces log on error) and the three dead action types are deleted.

## Calls made

The issue sat in Todo with the presentation-flag decision marked as working direction rather than formally locked. Built the flag as the issue's Desired behavior specifies; the new-message-type alternative is the rejected one.

- Lobby chat-restriction code lives only in server code (`LobbyServiceErrorCode`), so a restricted lobby `/me` gets the generic "Couldn't send your emote: …" line rather than the specific one channels and whispers get.
- `/me` is listed last in `/help`, matching the catalog order in #1476.

## Verification

- T0: `pnpm run typecheck`, `pnpm run lint`, `pnpm run check-circular` clean; vitest over `client/messaging`, `client/whispers`, `client/lobbies`, `client/chat`, `server/lib/chat`, `server/lib/whispers`, `server/lib/lobbies`: 32 files, 844 tests passed. New tests: `commands/me.test.tsx`, an emote snapshot in `common-message-layout.test.tsx`, service tests for the stored/published flag in all three services, reducer tests for whispers and lobbies.
- T3: two Electron clients (claude-1, claude-2) over CDP, the full recipe from the issue as listed above.
